### PR TITLE
CI concurrency + drop duplicate validation from publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  # Cancel older runs on PR branches only. On main, let every commit's
+  # run finish — cancelling mid-flight could leave a push unvalidated
+  # and races with deploy/publish workflows that trust CI.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,9 @@ jobs:
 
       - run: npm run build:admin -w packages/gazetta
 
-      - run: npm test -w packages/gazetta
-
-      - name: Smoke test (pack → init → dev → curl)
-        run: npm run smoke
+      # CI already ran tests + smoke on the PR whose squash/rebase produced
+      # this tag commit — branch protection requires linear history, so the
+      # tagged SHA is the validated SHA. Publish proceeds directly.
 
       - run: npm publish -w packages/gazetta --provenance
         env:


### PR DESCRIPTION
## Summary
- Add CI concurrency group — newer PR pushes cancel older in-flight runs on the same branch. Main keeps every run to completion (deploy/publish workflows trust CI results per-commit)
- Drop `npm test` + smoke from `publish.yml` — the tagged SHA already passed CI when it landed on main, so re-running identical validation on tag push is wasted minutes
- `deploy-site.yml`: unchanged

## Assumption
Branch protection on `main` enforces **linear history** (rebase / fast-forward only). That guarantees a tag on main points at a SHA that already passed CI. If linear history is not enforced, revert the `publish.yml` change — merge commits on main could ship unvalidated code.

## Test plan
- [x] Push commits to this branch → older run cancelled, newer starts
- [ ] Merge this PR; tag a patch release → `Publish to npm` runs build + publish only
- [ ] Verify `Deploy gazetta.studio` still fires on main push touching `sites/gazetta.studio/**` or `packages/gazetta/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)