### PR TITLE
Add linear-history rule to team preferences

### DIFF
--- a/.claude/rules/team-preferences.md
+++ b/.claude/rules/team-preferences.md
@@ -59,3 +59,12 @@ Validated approaches and things to avoid. Each entry: rule, then why.
 15. **Apply SOLID principles to every change.**
    Single responsibility (one module = one reason to change — e.g. `sidecars.ts` owns sidecar I/O, nothing else), open/closed (extend via injection — `compareTargets` takes `scanTemplates` as an option rather than hard-coding the default), Liskov (substitutable providers — `StorageProvider` contract), interface segregation (narrow interfaces like `SourceSidecarWriter { writeFor, invalidate }` rather than god objects), dependency inversion (routes depend on the `SourceSidecarWriter` interface, not on `createSourceSidecarWriter`).
    Why: Explicit user preference, reinforced in every major refactor of the performance work.
+
+16. **Rebase is the default git strategy.**
+   Main is rebase/fast-forward only — no merge commits. Branch protection on main requires linear history. Apply at every level:
+   - **PR merge:** `gh pr merge --rebase` (never `--merge`). Use `--squash` only when the branch has messy intermediate commits.
+   - **Updating a PR branch against main:** `git fetch && git rebase origin/main && git push --force-with-lease`. Never `git merge origin/main` into a feature branch.
+   - **Resolving conflicts:** fix during rebase, `git add`, `git rebase --continue`. Don't abort to a merge.
+   - **Stacked PRs:** rebase each downstream branch on its updated parent, don't cross-merge.
+
+   Why: Linear history on main is what lets publish.yml and deploy-site.yml trust push events without re-running CI — every commit on main is a SHA that already passed CI on its PR. Merge commits create new SHAs whose validation didn't happen.


### PR DESCRIPTION
## Summary
Rule #16 — main is rebase/fast-forward only. No merge commits.

## Why
\`publish.yml\` and \`deploy-site.yml\` trust that every commit pushed to main already passed CI on its PR. That's only true if the merged SHA is the same SHA CI ran against — which is the case for rebase/FF, not for merge commits (those create a new SHA whose validation didn't happen).

## Enforcement
Already enforced via branch protection on main (Settings → Branches → Require linear history). This rule documents the policy so it survives repo migrations or settings changes, and so contributors know why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)