### PR TITLE
Publish UX polish: save-to-prod label, missing-item banner, env group fan-out

### DIFF
--- a/apps/admin/src/client/App.vue
+++ b/apps/admin/src/client/App.vue
@@ -73,10 +73,16 @@ onMounted(() => {
 
     <!-- Global toast — visible over everything including fullscreen -->
     <Transition name="toast">
-      <div v-if="toast.current" class="global-toast" :class="toast.current.type === 'error' ? 'toast-error' : 'toast-success'" data-testid="global-toast">
-        <i :class="toast.current.type === 'error' ? 'pi pi-exclamation-circle' : 'pi pi-check-circle'" />
+      <div v-if="toast.current" class="global-toast"
+        :class="`toast-${toast.current.type}`" data-testid="global-toast">
+        <i :class="toast.current.type === 'error' ? 'pi pi-exclamation-circle'
+          : toast.current.type === 'info' ? 'pi pi-info-circle' : 'pi pi-check-circle'" />
         <a v-if="toast.current.link" :href="toast.current.link" target="_blank" rel="noopener" class="toast-link">{{ toast.current.message }}</a>
         <template v-else>{{ toast.current.message }}</template>
+        <button v-if="toast.current.action" type="button" class="toast-action"
+          data-testid="toast-action" @click="toast.runAction()">
+          {{ toast.current.action.label }}
+        </button>
         <button v-if="toast.current.type === 'error'" type="button" class="toast-dismiss" data-testid="toast-dismiss"
           aria-label="Dismiss" @click="toast.dismiss()">
           <i class="pi pi-times" />
@@ -95,7 +101,10 @@ body { font-family: system-ui, -apple-system, sans-serif; color: var(--color-fg)
 .global-toast { position: fixed; top: 0; left: 50%; transform: translateX(-50%); z-index: 1001; background: var(--color-bg); color: var(--color-fg); border: 1px solid var(--color-border); border-top: none; border-radius: 0 0 8px 8px; padding: 8px 20px; font-size: 13px; font-weight: 500; display: flex; align-items: center; gap: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); max-width: 400px; }
 .toast-success { color: var(--color-success-fg); }
 .toast-error { color: var(--color-danger-fg); }
+.toast-info { color: var(--color-info-fg); }
 .toast-link { color: inherit; text-decoration: underline; }
+.toast-action { background: transparent; border: 0; color: inherit; cursor: pointer; padding: 2px 6px; margin-left: 4px; font: inherit; font-weight: 600; text-decoration: underline; }
+.toast-action:hover { opacity: 0.8; }
 .toast-dismiss { background: transparent; border: 0; color: inherit; cursor: pointer; padding: 2px 4px; margin-left: 4px; opacity: 0.7; display: flex; align-items: center; }
 .toast-dismiss:hover { opacity: 1; }
 .toast-dismiss .pi { font-size: 11px; }

--- a/apps/admin/src/client/api/client.ts
+++ b/apps/admin/src/client/api/client.ts
@@ -162,12 +162,18 @@ export interface CompareResult {
 
 export const api = {
   getSite: () => request<SiteManifest>('/site'),
-  getPages: () => request<PageSummary[]>('/pages'),
+  /** List pages. Without `target`, uses the active target (auto-appended).
+   *  Pass `target` to list from a specific target — used when pre-checking
+   *  item availability before switching the active target. */
+  getPages: (opts?: { target?: string }) =>
+    request<PageSummary[]>(opts?.target ? `/pages?target=${encodeURIComponent(opts.target)}` : '/pages'),
   getPage: (name: string, options?: RequestInit) => request<PageDetail>(`/pages/${name}`, options),
   createPage: (data: { name: string; template: string }) => request<{ ok: boolean; name: string }>('/pages', { method: 'POST', body: JSON.stringify(data) }),
   deletePage: (name: string) => request<{ ok: boolean }>(`/pages/${name}`, { method: 'DELETE' }),
   updatePage: (name: string, data: Partial<PageDetail>) => request<{ ok: boolean }>(`/pages/${name}`, { method: 'PUT', body: JSON.stringify(data) }),
-  getFragments: () => request<FragmentSummary[]>('/fragments'),
+  /** List fragments. See getPages for the `target` option. */
+  getFragments: (opts?: { target?: string }) =>
+    request<FragmentSummary[]>(opts?.target ? `/fragments?target=${encodeURIComponent(opts.target)}` : '/fragments'),
   getFragment: (name: string, options?: RequestInit) => request<FragmentDetail>(`/fragments/${name}`, options),
   createFragment: (data: { name: string; template: string }) => request<{ ok: boolean; name: string }>('/fragments', { method: 'POST', body: JSON.stringify(data) }),
   deleteFragment: (name: string) => request<{ ok: boolean }>(`/fragments/${name}`, { method: 'DELETE' }),

--- a/apps/admin/src/client/components/ActiveTargetIndicator.vue
+++ b/apps/admin/src/client/components/ActiveTargetIndicator.vue
@@ -14,15 +14,21 @@
  * Editable vs read-only shows as a sub-badge on the pill.
  */
 import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import Menu from 'primevue/menu'
 import { useActiveTargetStore } from '../stores/activeTarget.js'
 import { useEditingStore } from '../stores/editing.js'
 import { useUnsavedGuardStore } from '../stores/unsavedGuard.js'
-import type { TargetInfo } from '../api/client.js'
+import { useSelectionStore } from '../stores/selection.js'
+import { useToastStore } from '../stores/toast.js'
+import { api, type TargetInfo } from '../api/client.js'
 
 const activeTarget = useActiveTargetStore()
 const editing = useEditingStore()
 const unsavedGuard = useUnsavedGuardStore()
+const selection = useSelectionStore()
+const toast = useToastStore()
+const router = useRouter()
 const menu = ref<InstanceType<typeof Menu> | null>(null)
 
 const visible = computed(() => activeTarget.targets.length > 0 && activeTarget.activeTarget !== null)
@@ -45,12 +51,15 @@ const menuItems = computed(() => activeTarget.targets.map((t: TargetInfo) => ({
 })))
 
 /**
- * Switch active target with an unsaved-changes guard — same pattern as
- * the router's route-leave hook. Without this, switching to another
- * target while the editor has pending edits would either silently drop
- * them (clear on switch) or save them against the new target (the save
- * closure resolves `?target=<active>` at call time). Forcing a Save /
- * Don't Save / Cancel decision keeps the author in control.
+ * Switch active target with two guards:
+ *
+ * 1. Unsaved edits → show the unsaved-changes dialog (Save / Don't Save
+ *    / Cancel), same pattern as the router's route-leave hook. Silent
+ *    drops and cross-target saves are both worse than friction here.
+ * 2. Focused item missing on destination → drop focus to site root and
+ *    surface an info toast with a one-click "back to X on <previous>"
+ *    action. Design-editor-ux.md "Switching active target". Keeps
+ *    rapid A/B from stranding the author on an empty workspace.
  */
 async function switchTo(name: string) {
   if (name === activeTarget.activeTargetName) return
@@ -60,7 +69,61 @@ async function switchTo(name: string) {
     if (result === 'save') await editing.save()
     editing.clear()
   }
+  const prevName = activeTarget.activeTargetName
+  const focused = selection.selection
+  // Pre-check item availability only when we have something selected —
+  // no selection means no focus to preserve, so skip the extra round-trip.
+  const missingCheck = focused
+    ? await checkItemOnTarget(name, focused.type, focused.name)
+    : 'ok' as const
   activeTarget.setActiveTarget(name)
+  if (missingCheck === 'missing' && focused && prevName) {
+    // Navigate to the site root on the new target and let the author
+    // one-click back if this wasn't what they meant.
+    router.push('/admin')
+    const itemLabel = focused.type === 'page'
+      ? `pages/${focused.name}`
+      : `@${focused.name}`
+    toast.show(
+      `${itemLabel} isn't on ${name} — showing site root`,
+      {
+        type: 'info',
+        action: {
+          label: `back to ${itemLabel} on ${prevName}`,
+          handler: async () => {
+            activeTarget.setActiveTarget(prevName)
+            const prefix = focused.type === 'page' ? '/pages' : '/fragments'
+            router.push(`${prefix}/${focused.name}`)
+          },
+        },
+      },
+    )
+  }
+}
+
+/**
+ * Check if an item exists on the destination target before switching to it.
+ * Returns 'ok' on success, 'missing' if the item isn't there, and 'ok' on
+ * any unexpected error (fail open — a false negative would block
+ * legitimate switches; the missing-item banner is purely a quality-of-
+ * -life nudge, not a correctness gate).
+ */
+async function checkItemOnTarget(
+  target: string,
+  type: 'page' | 'fragment',
+  itemName: string,
+): Promise<'ok' | 'missing'> {
+  try {
+    if (type === 'page') {
+      const list = await api.getPages({ target })
+      return list.some(p => p.name === itemName) ? 'ok' : 'missing'
+    } else {
+      const list = await api.getFragments({ target })
+      return list.some(f => f.name === itemName) ? 'ok' : 'missing'
+    }
+  } catch {
+    return 'ok'
+  }
 }
 
 function iconFor(t: TargetInfo): string {

--- a/apps/admin/src/client/components/CmsToolbar.vue
+++ b/apps/admin/src/client/components/CmsToolbar.vue
@@ -8,6 +8,8 @@ import { useSelectionStore } from '../stores/selection.js'
 import { useEditingStore } from '../stores/editing.js'
 import { useThemeStore } from '../stores/theme.js'
 import { useUiModeStore } from '../stores/uiMode.js'
+import { useActiveTargetStore } from '../stores/activeTarget.js'
+import { saveButtonLabel, saveButtonSeverity } from '../composables/saveButtonBinding.js'
 import PublishPanel from './PublishPanel.vue'
 import ActiveTargetIndicator from './ActiveTargetIndicator.vue'
 import SyncIndicators from './SyncIndicators.vue'
@@ -21,6 +23,7 @@ const selection = useSelectionStore()
 const editing = useEditingStore()
 const theme = useThemeStore()
 const uiMode = useUiModeStore()
+const activeTarget = useActiveTargetStore()
 
 const showPublish = ref(false)
 /** Destination to preselect in the panel (set by sync chip clicks). */
@@ -51,6 +54,13 @@ const publishTitle = computed(() => {
   if (editing.hasPendingEdits) return 'Save changes before publishing'
   return 'Publish'
 })
+
+// Save button label + severity reflect the active target when it's an
+// editable production target — every save click lands on live content.
+// Delegated to saveButtonBinding.ts so the logic is unit-testable
+// without mounting the component.
+const saveLabel = computed(() => saveButtonLabel(activeTarget.activeTarget))
+const saveSeverity = computed(() => saveButtonSeverity(activeTarget.activeTarget))
 
 function handleBack() {
   const prefix = selection.type === 'page' ? '/pages' : '/fragments'
@@ -85,7 +95,7 @@ function handleBack() {
         data-testid="dev-playground-link" @click="router.push('/dev')" size="small" class="cms-btn" />
       <Button :icon="theme.dark ? 'pi pi-sun' : 'pi pi-moon'" text rounded
         data-testid="theme-toggle" @click="theme.toggle()" size="small" class="cms-btn" />
-      <Button v-if="uiMode.mode === 'edit'" label="Save" icon="pi pi-save" severity="primary" :loading="editing.saving"
+      <Button v-if="uiMode.mode === 'edit'" :label="saveLabel" icon="pi pi-save" :severity="saveSeverity" :loading="editing.saving"
         data-testid="save-btn" :title="saveTitle" :disabled="!editing.hasPendingEdits" @click="editing.save()" size="small" class="cms-btn" />
       <Button label="Publish" icon="pi pi-cloud-upload" severity="success"
         data-testid="publish-btn" :title="publishTitle" :disabled="!canPublish" @click="openPublish" size="small" class="cms-btn" />

--- a/apps/admin/src/client/components/PublishPanel.vue
+++ b/apps/admin/src/client/components/PublishPanel.vue
@@ -64,6 +64,51 @@ function toggleDestination(name: string) {
   selectedDestinations.value = next
 }
 
+/**
+ * Destinations grouped by environment. Groups with 2+ members render a
+ * "select all" header checkbox that toggles every member at once —
+ * design-editor-ux.md "Multi-destination publish (fan-out)": selecting
+ * an environment group selects all its members. Single-member groups
+ * render flat (no header) so the UI stays quiet for simple setups.
+ *
+ * Iteration order is preserved from the target declaration order in
+ * site.yaml, which matches the top-bar switcher and sync indicators.
+ */
+interface DestinationGroup {
+  environment: string
+  members: typeof destinationOptions.value
+}
+const destinationGroups = computed<DestinationGroup[]>(() => {
+  const groups = new Map<string, DestinationGroup>()
+  for (const t of destinationOptions.value) {
+    const env = t.environment ?? 'local'
+    let g = groups.get(env)
+    if (!g) { g = { environment: env, members: [] }; groups.set(env, g) }
+    g.members.push(t)
+  }
+  return [...groups.values()]
+})
+
+/** Tri-state of a group's selection: 'none' | 'some' | 'all'. */
+function groupState(group: DestinationGroup): 'none' | 'some' | 'all' {
+  const selected = group.members.filter(m => selectedDestinations.value.has(m.name)).length
+  if (selected === 0) return 'none'
+  if (selected === group.members.length) return 'all'
+  return 'some'
+}
+
+/** Toggle an entire group: if any member is unselected, select all; else deselect all. */
+function toggleGroup(group: DestinationGroup) {
+  const next = new Set(selectedDestinations.value)
+  const state = groupState(group)
+  if (state === 'all') {
+    for (const m of group.members) next.delete(m.name)
+  } else {
+    for (const m of group.members) next.add(m.name)
+  }
+  selectedDestinations.value = next
+}
+
 // Items selected for publish. Managed via v-model:selected on the list;
 // list auto-populates when source/destinations change.
 const selectedItems = ref<Set<string>>(new Set())
@@ -277,21 +322,41 @@ function envClass(env: string | undefined): string {
           (no other targets configured)
         </div>
         <div v-else class="destinations" data-testid="publish-destinations">
-          <label
-            v-for="t in destinationOptions"
-            :key="t.name"
-            :class="['destination', envClass(t.environment)]"
-            :data-testid="`publish-dest-${t.name}`">
-            <Checkbox
-              :modelValue="selectedDestinations.has(t.name)"
-              @update:modelValue="() => toggleDestination(t.name)"
-              :inputId="`dest-${t.name}`"
-              :binary="true"
-            />
-            <span class="dest-name">{{ t.name }}</span>
-            <span v-if="!t.editable" class="dest-badge">read-only</span>
-            <span class="dest-status">{{ statusLabel(t.name) }}</span>
-          </label>
+          <template v-for="group in destinationGroups" :key="group.environment">
+            <!-- Group header — only when 2+ members. Single-member groups
+                 render flat, matching the design's "Groups of 1 stay flat"
+                 rule. Click anywhere on the header toggles the group. -->
+            <button v-if="group.members.length > 1"
+              type="button"
+              :class="['destination-group-header', envClass(group.environment)]"
+              :data-testid="`publish-dest-group-${group.environment}`"
+              @click="toggleGroup(group)">
+              <Checkbox
+                :modelValue="groupState(group) === 'all'"
+                :indeterminate="groupState(group) === 'some'"
+                :inputId="`dest-group-${group.environment}`"
+                :binary="true"
+                :tabindex="-1"
+              />
+              <span class="group-label">{{ group.environment }}</span>
+              <span class="group-count">{{ group.members.length }} targets</span>
+            </button>
+            <label
+              v-for="t in group.members"
+              :key="t.name"
+              :class="['destination', envClass(t.environment), { grouped: group.members.length > 1 }]"
+              :data-testid="`publish-dest-${t.name}`">
+              <Checkbox
+                :modelValue="selectedDestinations.has(t.name)"
+                @update:modelValue="() => toggleDestination(t.name)"
+                :inputId="`dest-${t.name}`"
+                :binary="true"
+              />
+              <span class="dest-name">{{ t.name }}</span>
+              <span v-if="!t.editable" class="dest-badge">read-only</span>
+              <span class="dest-status">{{ statusLabel(t.name) }}</span>
+            </label>
+          </template>
         </div>
       </div>
 
@@ -505,6 +570,51 @@ function envClass(env: string | undefined): string {
 }
 .destination.env-staging {
   border-left: 3px solid var(--color-env-staging-fg);
+}
+/* Members of a multi-target group — inset slightly and drop the colored
+   left border so the group header carries the environment chrome. */
+.destination.grouped {
+  margin-left: 1.25rem;
+  border-left: 1px solid var(--color-border);
+}
+
+.destination-group-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: var(--p-border-radius-sm);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  border: 1px solid var(--color-border);
+  margin-bottom: 0.125rem;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  color: inherit;
+  text-align: left;
+  width: 100%;
+}
+.destination-group-header:hover { opacity: 0.9; }
+.destination-group-header.env-production {
+  background: var(--color-env-prod-bg);
+  color: var(--color-env-prod-fg);
+  border-color: var(--color-env-prod-fg);
+}
+.destination-group-header.env-staging {
+  background: var(--color-env-staging-bg);
+  color: var(--color-env-staging-fg);
+  border-color: var(--color-env-staging-fg);
+}
+.group-label { flex: 1; }
+.group-count {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  opacity: 0.75;
 }
 
 .publish-confirm-banner {

--- a/apps/admin/src/client/composables/saveButtonBinding.ts
+++ b/apps/admin/src/client/composables/saveButtonBinding.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure helpers for the toolbar Save button's label + severity.
+ *
+ * Extracted from CmsToolbar.vue so the "save to prod" warning logic can
+ * be unit-tested without mounting the component.
+ *
+ * Design rule (design-editor-ux.md "Making the active target
+ * unmistakable"): when the active target is BOTH editable AND tagged
+ * environment: production, every save click lands on live content. The
+ * label and danger severity are a deliberate friction point — without
+ * them, the button is visually indistinguishable from a save-to-local
+ * and the author can easily forget which target they're pointed at.
+ */
+import type { TargetInfo } from '../api/client.js'
+
+/**
+ * True when saving this target will write to live production content —
+ * i.e., it's both editable and tagged environment: production.
+ */
+export function isSavingToProd(target: TargetInfo | null | undefined): boolean {
+  if (!target) return false
+  return target.environment === 'production' && target.editable
+}
+
+/**
+ * Label for the Save button: generic "Save" by default, or
+ * "Save to <name>" when saving would go to an editable production target.
+ */
+export function saveButtonLabel(target: TargetInfo | null | undefined): string {
+  if (!isSavingToProd(target)) return 'Save'
+  return `Save to ${target!.name}`
+}
+
+/** PrimeVue severity for the Save button — "danger" for editable-prod. */
+export function saveButtonSeverity(
+  target: TargetInfo | null | undefined,
+): 'primary' | 'danger' {
+  return isSavingToProd(target) ? 'danger' : 'primary'
+}

--- a/apps/admin/src/client/stores/toast.ts
+++ b/apps/admin/src/client/stores/toast.ts
@@ -1,8 +1,25 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
+/**
+ * Inline action attached to a toast — rendered as a button next to the
+ * message. Used for e.g. "back to pages/pricing on local" when an item-
+ * missing banner fires during target switch. Keep the handler side-effect-
+ * free from the toast's POV: the toast auto-dismisses after the handler
+ * runs (unless it throws).
+ */
+export interface ToastAction {
+  label: string
+  handler: () => void | Promise<void>
+}
+
 export const useToastStore = defineStore('toast', () => {
-  const current = ref<{ message: string; type: 'success' | 'error'; link?: string } | null>(null)
+  const current = ref<{
+    message: string
+    type: 'success' | 'error' | 'info'
+    link?: string
+    action?: ToastAction
+  } | null>(null)
   // Track the active timer so dismiss() can cancel it cleanly
   let timer: ReturnType<typeof setTimeout> | null = null
 
@@ -11,14 +28,21 @@ export const useToastStore = defineStore('toast', () => {
     current.value = null
   }
 
-  function show(message: string, opts?: { type?: 'success' | 'error'; link?: string; duration?: number }) {
+  function show(message: string, opts?: {
+    type?: 'success' | 'error' | 'info'
+    link?: string
+    action?: ToastAction
+    duration?: number
+  }) {
     const type = opts?.type ?? 'success'
     if (timer) { clearTimeout(timer); timer = null }
-    current.value = { message, type, link: opts?.link }
+    current.value = { message, type, link: opts?.link, action: opts?.action }
     // Errors stay until the user dismisses them — they need to be readable
-    // long enough to act on. Successes auto-dismiss.
+    // long enough to act on. Successes auto-dismiss. Info is transient but
+    // longer than success so the user has time to act on any attached action.
     const explicit = opts?.duration
-    const duration = explicit ?? (type === 'error' ? 0 : 3000)
+    const defaultDuration = type === 'error' ? 0 : type === 'info' ? 6000 : 3000
+    const duration = explicit ?? defaultDuration
     if (duration > 0) timer = setTimeout(() => { current.value = null; timer = null }, duration)
   }
 
@@ -30,5 +54,16 @@ export const useToastStore = defineStore('toast', () => {
     show(friendly, { type: 'error' })
   }
 
-  return { current, show, showError, dismiss }
+  /** Run the action (if any) and auto-dismiss on completion. */
+  async function runAction() {
+    const action = current.value?.action
+    if (!action) return
+    try {
+      await action.handler()
+    } finally {
+      dismiss()
+    }
+  }
+
+  return { current, show, showError, dismiss, runAction }
 })

--- a/apps/admin/tests/saveButtonBinding.test.ts
+++ b/apps/admin/tests/saveButtonBinding.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for saveButtonBinding helpers. Covers the rule from
+ * design-editor-ux.md: editable production → "Save to <name>" + danger;
+ * everything else → "Save" + primary.
+ */
+import { describe, it, expect } from 'vitest'
+import type { TargetInfo } from '../src/client/api/client.js'
+import {
+  isSavingToProd,
+  saveButtonLabel,
+  saveButtonSeverity,
+} from '../src/client/composables/saveButtonBinding.js'
+
+const LOCAL: TargetInfo = { name: 'local', environment: 'local', type: 'static', editable: true }
+const STAGING: TargetInfo = { name: 'staging', environment: 'staging', type: 'static', editable: true }
+const PROD_READONLY: TargetInfo = { name: 'prod', environment: 'production', type: 'static', editable: false }
+const PROD_HOTFIX: TargetInfo = { name: 'prod', environment: 'production', type: 'static', editable: true }
+
+describe('isSavingToProd', () => {
+  it('true only when target is editable AND environment is production', () => {
+    expect(isSavingToProd(PROD_HOTFIX)).toBe(true)
+  })
+
+  it('false for editable non-production targets (local, staging)', () => {
+    expect(isSavingToProd(LOCAL)).toBe(false)
+    expect(isSavingToProd(STAGING)).toBe(false)
+  })
+
+  it('false for read-only production (no save will happen anyway)', () => {
+    expect(isSavingToProd(PROD_READONLY)).toBe(false)
+  })
+
+  it('false for null / undefined target', () => {
+    expect(isSavingToProd(null)).toBe(false)
+    expect(isSavingToProd(undefined)).toBe(false)
+  })
+})
+
+describe('saveButtonLabel', () => {
+  it('"Save" for non-prod editable targets', () => {
+    expect(saveButtonLabel(LOCAL)).toBe('Save')
+    expect(saveButtonLabel(STAGING)).toBe('Save')
+  })
+
+  it('"Save to <name>" for editable production', () => {
+    expect(saveButtonLabel(PROD_HOTFIX)).toBe('Save to prod')
+  })
+
+  it('uses the target name so multi-region prod (e.g. prod-us) is unambiguous', () => {
+    const prodUs: TargetInfo = { name: 'prod-us', environment: 'production', type: 'static', editable: true }
+    expect(saveButtonLabel(prodUs)).toBe('Save to prod-us')
+  })
+
+  it('"Save" for null target (the button is usually hidden or disabled here)', () => {
+    expect(saveButtonLabel(null)).toBe('Save')
+  })
+})
+
+describe('saveButtonSeverity', () => {
+  it('danger only for editable production', () => {
+    expect(saveButtonSeverity(PROD_HOTFIX)).toBe('danger')
+  })
+
+  it('primary for everything else', () => {
+    expect(saveButtonSeverity(LOCAL)).toBe('primary')
+    expect(saveButtonSeverity(STAGING)).toBe('primary')
+    expect(saveButtonSeverity(PROD_READONLY)).toBe('primary')
+    expect(saveButtonSeverity(null)).toBe('primary')
+  })
+})

--- a/packages/gazetta/src/admin-api/index.ts
+++ b/packages/gazetta/src/admin-api/index.ts
@@ -107,18 +107,21 @@ export function createAdminApp(opts: AdminAppOptions): AdminApp {
     })
   }
 
-  // Build the per-request source resolver. When a target registry is
-  // available, routes can honor `?target=<name>` to read from any known
-  // target. Without a registry, the resolver is static — always returns
-  // the bootstrap source (legacy behavior).
+  // Build the per-request source resolver. When target configs are
+  // declared, routes honor `?target=<name>` to read from any known
+  // target. Providers are initialized lazily so dev startup doesn't
+  // pay the cost of connecting every cloud target just to serve the
+  // editable local one.
   //
-  // The static resolver is used when only `opts.source` or `opts.storage`
-  // is supplied (tests, single-target setups). The registry resolver is
-  // used when `opts.targets` + `opts.targetConfigs` are present (the
-  // production dev/admin path).
+  // Without target configs (tests, single-target setups), the resolver
+  // is static — always returns the bootstrap source.
   let resolveSource: SourceContextResolver
-  if (opts.targets && opts.targetConfigs && Object.keys(opts.targetConfigs).length > 0) {
-    const registry = createTargetRegistryView(opts.targets, opts.targetConfigs)
+  if (opts.targetConfigs && Object.keys(opts.targetConfigs).length > 0) {
+    // Start with whatever pre-initialized providers the caller supplied
+    // (typically the editable source target from bootstrap). Missing
+    // providers are built on demand via lazyInit below.
+    const providers = new Map(opts.targets ?? [])
+    const registry = createTargetRegistryView(providers, opts.targetConfigs)
     resolveSource = registrySourceResolver({
       registry,
       projectSiteDir: source.projectSiteDir,
@@ -126,6 +129,15 @@ export function createAdminApp(opts: AdminAppOptions): AdminApp {
       // The registry's filesystem targets are already content-rooted
       // (path=./targets/<key>); siteDir on the resolved context is empty.
       siteDir: '',
+      lazyInit: async (name) => {
+        const config = opts.targetConfigs![name]
+        if (!config) return
+        const { createStorageProvider } = await import('../targets.js')
+        const storage = await createStorageProvider(config.storage, source.projectSiteDir, name)
+        const maybeInit = storage as StorageProvider & { init?: () => Promise<void> }
+        if (typeof maybeInit.init === 'function') await maybeInit.init()
+        providers.set(name, storage)
+      },
     })
   } else {
     resolveSource = staticSourceResolver(source)

--- a/packages/gazetta/src/admin-api/routes/fragments.ts
+++ b/packages/gazetta/src/admin-api/routes/fragments.ts
@@ -8,12 +8,19 @@ export function fragmentRoutes(resolve: SourceContextResolver) {
 
   app.get('/api/fragments', async (c) => {
     const source = await resolve(c.req.query('target'))
-    const site = await loadSite({ contentRoot: source.contentRoot })
-    const fragments = [...site.fragments.entries()].map(([name, frag]) => ({
-      name,
-      template: frag.template,
-    }))
-    return c.json(fragments)
+    // Empty target → empty list. See pages.ts for rationale.
+    try {
+      const site = await loadSite({ contentRoot: source.contentRoot })
+      const fragments = [...site.fragments.entries()].map(([name, frag]) => ({
+        name,
+        template: frag.template,
+      }))
+      return c.json(fragments)
+    } catch (err) {
+      const msg = (err as Error).message
+      if (msg.includes('No site.yaml found')) return c.json([])
+      throw err
+    }
   })
 
   app.post('/api/fragments', async (c) => {

--- a/packages/gazetta/src/admin-api/routes/pages.ts
+++ b/packages/gazetta/src/admin-api/routes/pages.ts
@@ -8,13 +8,26 @@ export function pageRoutes(resolve: SourceContextResolver) {
 
   app.get('/api/pages', async (c) => {
     const source = await resolve(c.req.query('target'))
-    const site = await loadSite({ contentRoot: source.contentRoot })
-    const pages = [...site.pages.entries()].map(([name, page]) => ({
-      name,
-      route: page.route,
-      template: page.template,
-    }))
-    return c.json(pages)
+    // Empty target (e.g. a publish-target that's never received any
+    // content) is valid per the stateless-CMS model — return an empty
+    // list rather than erroring. Callers checking item availability
+    // across targets (e.g. the target-switch missing-item banner) rely
+    // on this: a 404/500 would force them to choose between "fail
+    // open" (wrong, reports items as present) and "fail closed" (wrong,
+    // hides legitimate targets the user might want to switch to).
+    try {
+      const site = await loadSite({ contentRoot: source.contentRoot })
+      const pages = [...site.pages.entries()].map(([name, page]) => ({
+        name,
+        route: page.route,
+        template: page.template,
+      }))
+      return c.json(pages)
+    } catch (err) {
+      const msg = (err as Error).message
+      if (msg.includes('No site.yaml found')) return c.json([])
+      throw err
+    }
   })
 
   app.post('/api/pages', async (c) => {

--- a/packages/gazetta/src/admin-api/routes/preview.ts
+++ b/packages/gazetta/src/admin-api/routes/preview.ts
@@ -34,7 +34,24 @@ async function renderPreview(
   overrides?: Record<string, Record<string, unknown>>,
   templatesDir?: string
 ) {
-  const site = await loadSite({ contentRoot: source.contentRoot, templatesDir })
+  // Empty target (no site.yaml) — preview returns a friendly placeholder
+  // so the admin can still show the iframe. Happens when the active
+  // target is a never-published publish-target.
+  let site: Awaited<ReturnType<typeof loadSite>>
+  try {
+    site = await loadSite({ contentRoot: source.contentRoot, templatesDir })
+  } catch (err) {
+    if ((err as Error).message.includes('No site.yaml found')) {
+      return c.html(
+        '<!doctype html><html><body style="font-family:system-ui;padding:2rem;color:#525252">' +
+        '<h2 style="margin:0 0 0.5rem">No content on this target yet</h2>' +
+        '<p style="margin:0;font-size:0.875rem">Publish from an editable target to see a preview here.</p>' +
+        '</body></html>',
+        404,
+      )
+    }
+    throw err
+  }
   const requestPath = c.req.path.replace(/^.*\/preview/, '') || '/'
 
   // Fragment preview: /preview/@fragmentName

--- a/packages/gazetta/src/admin-api/routes/site.ts
+++ b/packages/gazetta/src/admin-api/routes/site.ts
@@ -7,8 +7,18 @@ export function siteRoutes(resolve: SourceContextResolver) {
 
   app.get('/api/site', async (c) => {
     const source = await resolve(c.req.query('target'))
-    const site = await loadSite({ contentRoot: source.contentRoot })
-    return c.json(site.manifest)
+    // Empty target (no site.yaml yet — e.g. a never-published staging
+    // browsed via ?target=staging) returns a minimal manifest so the
+    // admin UI can render an empty tree instead of crashing.
+    try {
+      const site = await loadSite({ contentRoot: source.contentRoot })
+      return c.json(site.manifest)
+    } catch (err) {
+      if ((err as Error).message.includes('No site.yaml found')) {
+        return c.json({ name: '(empty)', targets: {} })
+      }
+      throw err
+    }
   })
 
   return app

--- a/packages/gazetta/src/admin-api/source-context.ts
+++ b/packages/gazetta/src/admin-api/source-context.ts
@@ -135,6 +135,16 @@ export interface RegistrySourceResolverOptions {
    * registry-sourced storage is already target-rooted.
    */
   siteDir?: string
+  /**
+   * Optional lazy-init hook. When the registry doesn't already have a
+   * provider for the requested target, the resolver calls this to build
+   * one (e.g., the dev bootstrap only pre-initializes the editable local
+   * target for speed; cross-target reads like `?target=staging` arrive
+   * lazily). The built provider is then retrieved via `registry.get` —
+   * implementations should insert it into the same provider map that
+   * backs the registry view.
+   */
+  lazyInit?: (targetName: string) => Promise<void>
 }
 
 /**
@@ -145,10 +155,23 @@ export interface RegistrySourceResolverOptions {
  */
 export function registrySourceResolver(opts: RegistrySourceResolverOptions): SourceContextResolver {
   const cache = new Map<string, SourceContext>()
-  return (targetName: string | undefined) => {
+  return async (targetName: string | undefined) => {
     const name = targetName ?? opts.registry.defaultEditable()
     const cached = cache.get(name)
     if (cached) return cached
+    // Cross-target reads may hit targets that weren't pre-initialized by
+    // the bootstrap (dev only inits the editable local target by default).
+    // If the target is configured but its provider hasn't been built yet,
+    // let the caller lazy-init. Unknown targets (not in site.yaml at all)
+    // fall through so registry.get throws a clean UnknownTargetError.
+    const isConfigured = opts.registry.list().includes(name)
+    if (opts.lazyInit && isConfigured) {
+      try {
+        opts.registry.get(name)
+      } catch {
+        await opts.lazyInit(name)
+      }
+    }
     const ctx = createSourceContextFromRegistry({
       registry: opts.registry,
       targetName: name,

--- a/packages/gazetta/src/compare.ts
+++ b/packages/gazetta/src/compare.ts
@@ -66,7 +66,30 @@ export async function compareTargets(opts: CompareOptions): Promise<CompareResul
   // Source-side sidecars (written on save) let us skip re-hashing for items
   // whose manifest + templates haven't changed since the last save. Fall
   // back to hashManifest for items without a source sidecar.
-  const site = await loadSite({ contentRoot: sourceRoot, templatesDir: opts.templatesDir })
+  //
+  // Empty source (no site.yaml) is a valid state when the "active" target
+  // is a publish-target that's never received content — e.g., the author
+  // just switched to an empty staging for a peek. Treat as zero items;
+  // everything on the destination target becomes "deleted" (present on
+  // target, absent from source), matching the logical diff semantics.
+  let site: Awaited<ReturnType<typeof loadSite>>
+  try {
+    site = await loadSite({ contentRoot: sourceRoot, templatesDir: opts.templatesDir })
+  } catch (err) {
+    if ((err as Error).message.includes('No site.yaml found')) {
+      site = {
+        manifest: { name: '(empty)', targets: {} },
+        pages: new Map(),
+        fragments: new Map(),
+        contentRoot: sourceRoot,
+        storage: sourceRoot.storage,
+        siteDir: sourceRoot.rootPath,
+        templatesDir: opts.templatesDir,
+      }
+    } else {
+      throw err
+    }
+  }
   const [sourcePagesSidecars, sourceFragmentsSidecars] = await Promise.all([
     listSidecars(sourceRoot.storage, sourceRoot.path('pages')),
     listSidecars(sourceRoot.storage, sourceRoot.path('fragments')),

--- a/tests/e2e/editor.test.ts
+++ b/tests/e2e/editor.test.ts
@@ -942,6 +942,36 @@ test.describe('Save button labeling', () => {
   })
 })
 
+test.describe('Target switch with missing item', () => {
+  async function wipeStaging(projectDir: string) {
+    await rm(join(projectDir, 'sites/main/dist/staging'), { recursive: true, force: true })
+  }
+
+  test('item missing on destination drops focus to root with a back-toast', async ({ page, testSite }) => {
+    // Preview on an empty target responds 404 with a friendly "No content
+    // on this target yet" placeholder — deliberate, but the browser logs
+    // it as a console error which the fixture's guard would otherwise
+    // fail the test on.
+    test.info().annotations.push({ type: 'allow-console-errors' })
+    await wipeStaging(testSite.projectDir)
+    // Select home on local.
+    await page.goto('/admin/pages/home')
+    await page.waitForSelector('[data-testid="site-page-home"]', { timeout: 10000 })
+    // Switch to staging — home doesn't exist there.
+    await page.locator('[data-testid="active-target-indicator"]').click()
+    await page.locator('[data-testid="active-target-menu"]').getByText('staging', { exact: true }).click()
+    // Toast appears with a "back" action.
+    const toast = page.locator('[data-testid="global-toast"]')
+    await expect(toast).toBeVisible()
+    await expect(toast).toContainText("pages/home isn't on staging")
+    await expect(toast).toContainText('showing site root')
+    // Clicking the action restores the previous target + selection.
+    await page.locator('[data-testid="toast-action"]').click()
+    await expect(page).toHaveURL(/\/admin\/pages\/home/)
+    await expect(page.locator('[data-testid="active-target-indicator"]')).toContainText('local')
+  })
+})
+
 test.describe('Target switch with unsaved edits', () => {
   test('Cancel keeps the user on the current target with edits intact', async ({ page }) => {
     // Enter edit mode and make a change to mark the editor dirty.

--- a/tests/e2e/editor.test.ts
+++ b/tests/e2e/editor.test.ts
@@ -931,6 +931,17 @@ test.describe('Target switch preserves preview', () => {
   })
 })
 
+test.describe('Save button labeling', () => {
+  test('generic "Save" label for local (non-production) active target', async ({ page }) => {
+    await openEditor(page, 'home')
+    const save = page.locator('[data-testid="save-btn"]')
+    await expect(save).toHaveText(/^\s*Save\s*$/)
+    // Primary severity — PrimeVue adds no class for p-button-primary, so
+    // assert the button is NOT the danger variant.
+    await expect(save).not.toHaveClass(/p-button-danger/)
+  })
+})
+
 test.describe('Target switch with unsaved edits', () => {
   test('Cancel keeps the user on the current target with edits intact', async ({ page }) => {
     // Enter edit mode and make a change to mark the editor dirty.

--- a/tests/e2e/editor.test.ts
+++ b/tests/e2e/editor.test.ts
@@ -829,6 +829,26 @@ test.describe('Publish panel', () => {
     await expect(html).not.toHaveClass(/dark/)
   })
 
+  test('environment group header selects all members in the group', async ({ page, testSite }) => {
+    await wipe(testSite.projectDir)
+    await openPublish(page)
+    // Starter has two staging-env targets: staging + esi-test. The group
+    // header appears when a group has 2+ members; single-member groups
+    // (local when source, production) render flat.
+    const groupHeader = page.locator('[data-testid="publish-dest-group-staging"]')
+    await expect(groupHeader).toBeVisible()
+    // Neither member selected initially → clicking the header selects both.
+    // PrimeVue Checkbox exposes state via the .p-checkbox-checked class on
+    // the wrapper rather than the native `checked` attribute.
+    await groupHeader.click()
+    await expect(page.locator('[data-testid="publish-dest-staging"] .p-checkbox-checked')).toHaveCount(1)
+    await expect(page.locator('[data-testid="publish-dest-esi-test"] .p-checkbox-checked')).toHaveCount(1)
+    // Clicking again deselects both.
+    await groupHeader.click()
+    await expect(page.locator('[data-testid="publish-dest-staging"] .p-checkbox-checked')).toHaveCount(0)
+    await expect(page.locator('[data-testid="publish-dest-esi-test"] .p-checkbox-checked')).toHaveCount(0)
+  })
+
   test('select-all and select-none toggle every selectable item', async ({ page, testSite }) => {
     await wipe(testSite.projectDir)
     await openPublish(page)


### PR DESCRIPTION
## Summary

Three small UX polish items from the phase-1 active-target UX design (see [design-editor-ux.md](.claude/rules/design-editor-ux.md)).

### R43 — "Save to &lt;target&gt;" label + danger severity for editable-prod

Save button label now reflects the active target when it's both editable and tagged `environment: production`. Generic "Save" otherwise. Logic extracted to `saveButtonBinding.ts` as pure helpers (10 unit tests cover every permutation).

### R44 — Item-missing-on-destination banner on target switch

Switching active target with a focused item that doesn't exist on the destination now:
1. Drops focus to the site root
2. Shows an info toast with a one-click **"back to X on &lt;previous&gt;"** action

Toast store gained an inline `action: { label, handler }` and an `info` type with 6s default duration.

**Bonus hardening**: several admin-api routes were throwing `No site.yaml found` when pointed at an empty publish-target — valid state in the stateless-CMS model, should be empty/placeholder instead of 500. Fixed: `GET /api/pages`, `GET /api/fragments`, `GET /api/site`, `GET /preview/*`, and `compareTargets`. Also fixed a dev-bootstrap oversight: the registry resolver now lazy-inits providers on first cross-target read (dev only pre-inited the editable local target, so `?target=staging` was hitting UnknownTargetError).

### R45 — Environment group multi-select in Publish destinations

Destinations in PublishPanel now group by environment. Groups with 2+ members get a clickable tri-state header checkbox that toggles every member at once. Single-member groups render flat (design: "groups of 1 stay flat"). Backend already fanned out — this is just the picker UI to match.

## Tests

- 54 e2e passing (3 new: save button label, missing-item banner, env group header)
- 62 admin unit passing (10 new: save button binding)
- 324 gazetta unit passing

## Test plan

- [ ] CI green
- [ ] Browser smoke: with a site that has `environment: production, editable: true`, active-target pill + Save button show "danger" red
- [ ] Browser smoke: wipe a publish-target, switch to it via top-bar → banner appears, click action → back to previous target + page
- [ ] Browser smoke: with 2+ staging targets, Publish panel shows a "staging" group header; clicking toggles all members

🤖 Generated with [Claude Code](https://claude.com/claude-code)