### PR TITLE
R46: scale target UI from flat to environment-grouped at 4+ targets

### DIFF
--- a/apps/admin/src/client/components/ActiveTargetIndicator.vue
+++ b/apps/admin/src/client/components/ActiveTargetIndicator.vue
@@ -21,6 +21,7 @@ import { useEditingStore } from '../stores/editing.js'
 import { useUnsavedGuardStore } from '../stores/unsavedGuard.js'
 import { useSelectionStore } from '../stores/selection.js'
 import { useToastStore } from '../stores/toast.js'
+import { groupedEntries } from '../composables/targetGrouping.js'
 import { api, type TargetInfo } from '../api/client.js'
 
 const activeTarget = useActiveTargetStore()
@@ -43,12 +44,34 @@ const environmentClass = computed(() => {
 
 const editableLabel = computed(() => activeTarget.isActiveEditable ? 'editable' : 'read-only')
 
-const menuItems = computed(() => activeTarget.targets.map((t: TargetInfo) => ({
-  label: t.name,
-  icon: iconFor(t),
-  class: t.name === activeTarget.activeTargetName ? 'active' : '',
-  command: () => switchTo(t.name),
-})))
+/**
+ * Switcher menu items. Flat at ≤3 targets; grouped by environment at
+ * 4+ (with single-member groups staying flat) — design-editor-ux.md
+ * "Scaling to 4+ targets". PrimeVue Menu renders nested `items` as
+ * a section header with child entries, which is close to the design's
+ * "sub-menus" rendering.
+ */
+const menuItems = computed(() => {
+  const entries = groupedEntries(activeTarget.targets, activeTarget.targets.length)
+  return entries.map(entry => {
+    if (entry.kind === 'single') return targetItem(entry.target)
+    return {
+      // PrimeVue Menu renders a label + nested items as a section.
+      // Keep the environment name as the header so grouping reads at a glance.
+      label: entry.group.environment,
+      items: entry.group.members.map(targetItem),
+    }
+  })
+})
+
+function targetItem(t: TargetInfo) {
+  return {
+    label: t.name,
+    icon: iconFor(t),
+    class: t.name === activeTarget.activeTargetName ? 'active' : '',
+    command: () => switchTo(t.name),
+  }
+}
 
 /**
  * Switch active target with two guards:

--- a/apps/admin/src/client/components/PublishPanel.vue
+++ b/apps/admin/src/client/components/PublishPanel.vue
@@ -26,6 +26,7 @@ import Select from 'primevue/select'
 import { api, type PublishResult } from '../api/client.js'
 import { useActiveTargetStore } from '../stores/activeTarget.js'
 import { useSyncStatusStore } from '../stores/syncStatus.js'
+import { groupedEntries, type TargetGroup } from '../composables/targetGrouping.js'
 import PublishItemList from './PublishItemList.vue'
 
 const props = defineProps<{
@@ -65,32 +66,23 @@ function toggleDestination(name: string) {
 }
 
 /**
- * Destinations grouped by environment. Groups with 2+ members render a
+ * Destinations as grouped render entries. At ≤3 total targets the
+ * picker stays flat (one row per destination, no group headers). At
+ * 4+ it groups by environment, and multi-member groups render a
  * "select all" header checkbox that toggles every member at once —
- * design-editor-ux.md "Multi-destination publish (fan-out)": selecting
- * an environment group selects all its members. Single-member groups
- * render flat (no header) so the UI stays quiet for simple setups.
+ * design-editor-ux.md "Scaling to 4+ targets" + "Multi-destination
+ * publish (fan-out)". The threshold lives in targetGrouping.ts so
+ * every target-referencing surface renders consistently.
  *
- * Iteration order is preserved from the target declaration order in
- * site.yaml, which matches the top-bar switcher and sync indicators.
+ * Iteration order is preserved from target declaration order in
+ * site.yaml, matching the top-bar switcher and sync indicators.
  */
-interface DestinationGroup {
-  environment: string
-  members: typeof destinationOptions.value
-}
-const destinationGroups = computed<DestinationGroup[]>(() => {
-  const groups = new Map<string, DestinationGroup>()
-  for (const t of destinationOptions.value) {
-    const env = t.environment ?? 'local'
-    let g = groups.get(env)
-    if (!g) { g = { environment: env, members: [] }; groups.set(env, g) }
-    g.members.push(t)
-  }
-  return [...groups.values()]
-})
+const destinationEntries = computed(() =>
+  groupedEntries(destinationOptions.value, activeTarget.targets.length),
+)
 
 /** Tri-state of a group's selection: 'none' | 'some' | 'all'. */
-function groupState(group: DestinationGroup): 'none' | 'some' | 'all' {
+function groupState(group: TargetGroup): 'none' | 'some' | 'all' {
   const selected = group.members.filter(m => selectedDestinations.value.has(m.name)).length
   if (selected === 0) return 'none'
   if (selected === group.members.length) return 'all'
@@ -98,7 +90,7 @@ function groupState(group: DestinationGroup): 'none' | 'some' | 'all' {
 }
 
 /** Toggle an entire group: if any member is unselected, select all; else deselect all. */
-function toggleGroup(group: DestinationGroup) {
+function toggleGroup(group: TargetGroup) {
   const next = new Set(selectedDestinations.value)
   const state = groupState(group)
   if (state === 'all') {
@@ -322,40 +314,56 @@ function envClass(env: string | undefined): string {
           (no other targets configured)
         </div>
         <div v-else class="destinations" data-testid="publish-destinations">
-          <template v-for="group in destinationGroups" :key="group.environment">
-            <!-- Group header — only when 2+ members. Single-member groups
-                 render flat, matching the design's "Groups of 1 stay flat"
-                 rule. Click anywhere on the header toggles the group. -->
-            <button v-if="group.members.length > 1"
-              type="button"
-              :class="['destination-group-header', envClass(group.environment)]"
-              :data-testid="`publish-dest-group-${group.environment}`"
-              @click="toggleGroup(group)">
-              <Checkbox
-                :modelValue="groupState(group) === 'all'"
-                :indeterminate="groupState(group) === 'some'"
-                :inputId="`dest-group-${group.environment}`"
-                :binary="true"
-                :tabindex="-1"
-              />
-              <span class="group-label">{{ group.environment }}</span>
-              <span class="group-count">{{ group.members.length }} targets</span>
-            </button>
+          <template v-for="entry in destinationEntries" :key="entry.kind === 'single' ? entry.target.name : entry.group.environment">
+            <!-- Flat single destination (≤3 targets, OR 1-member groups
+                 at 4+). No header. -->
             <label
-              v-for="t in group.members"
-              :key="t.name"
-              :class="['destination', envClass(t.environment), { grouped: group.members.length > 1 }]"
-              :data-testid="`publish-dest-${t.name}`">
+              v-if="entry.kind === 'single'"
+              :class="['destination', envClass(entry.target.environment)]"
+              :data-testid="`publish-dest-${entry.target.name}`">
               <Checkbox
-                :modelValue="selectedDestinations.has(t.name)"
-                @update:modelValue="() => toggleDestination(t.name)"
-                :inputId="`dest-${t.name}`"
+                :modelValue="selectedDestinations.has(entry.target.name)"
+                @update:modelValue="() => toggleDestination(entry.target.name)"
+                :inputId="`dest-${entry.target.name}`"
                 :binary="true"
               />
-              <span class="dest-name">{{ t.name }}</span>
-              <span v-if="!t.editable" class="dest-badge">read-only</span>
-              <span class="dest-status">{{ statusLabel(t.name) }}</span>
+              <span class="dest-name">{{ entry.target.name }}</span>
+              <span v-if="!entry.target.editable" class="dest-badge">read-only</span>
+              <span class="dest-status">{{ statusLabel(entry.target.name) }}</span>
             </label>
+            <!-- Group header + indented members (4+ targets, 2+ in env) -->
+            <template v-else>
+              <button
+                type="button"
+                :class="['destination-group-header', envClass(entry.group.environment)]"
+                :data-testid="`publish-dest-group-${entry.group.environment}`"
+                @click="toggleGroup(entry.group)">
+                <Checkbox
+                  :modelValue="groupState(entry.group) === 'all'"
+                  :indeterminate="groupState(entry.group) === 'some'"
+                  :inputId="`dest-group-${entry.group.environment}`"
+                  :binary="true"
+                  :tabindex="-1"
+                />
+                <span class="group-label">{{ entry.group.environment }}</span>
+                <span class="group-count">{{ entry.group.members.length }} targets</span>
+              </button>
+              <label
+                v-for="t in entry.group.members"
+                :key="t.name"
+                :class="['destination', envClass(t.environment), 'grouped']"
+                :data-testid="`publish-dest-${t.name}`">
+                <Checkbox
+                  :modelValue="selectedDestinations.has(t.name)"
+                  @update:modelValue="() => toggleDestination(t.name)"
+                  :inputId="`dest-${t.name}`"
+                  :binary="true"
+                />
+                <span class="dest-name">{{ t.name }}</span>
+                <span v-if="!t.editable" class="dest-badge">read-only</span>
+                <span class="dest-status">{{ statusLabel(t.name) }}</span>
+              </label>
+            </template>
           </template>
         </div>
       </div>

--- a/apps/admin/src/client/components/SyncIndicators.vue
+++ b/apps/admin/src/client/components/SyncIndicators.vue
@@ -3,24 +3,30 @@
  * Compact sync status chips for non-active targets.
  *
  * One chip per non-active target, showing "name · N behind" or "name · in sync".
+ * At 4+ total targets, members of the same `environment` collapse into a
+ * single group chip (e.g. "production (2) · 7 behind") that expands
+ * inline on click — design-editor-ux.md "Scaling to 4+ targets".
+ *
  * Environment chrome matches the ActiveTargetIndicator so the top bar reads
  * as a single row of related pills.
  *
  * Progressive disclosure: hidden entirely when there are no non-active
- * targets to report on. Each chip is a read-only summary — clicking it
- * (wired later) will jump to the changes drawer or publish panel.
+ * targets to report on.
  */
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useSyncStatusStore } from '../stores/syncStatus.js'
+import { useActiveTargetStore } from '../stores/activeTarget.js'
+import { groupedEntries, type TargetGroup } from '../composables/targetGrouping.js'
 import type { TargetInfo } from '../api/client.js'
 
 const sync = useSyncStatusStore()
+const activeTarget = useActiveTargetStore()
 
 const emit = defineEmits<{ (e: 'select', name: string): void }>()
 
-function environmentClass(t: TargetInfo): string {
-  if (t.environment === 'production') return 'env-production'
-  if (t.environment === 'staging') return 'env-staging'
+function environmentClass(env: string | undefined): string {
+  if (env === 'production') return 'env-production'
+  if (env === 'staging') return 'env-staging'
   return 'env-local'
 }
 
@@ -45,25 +51,111 @@ function statusClass(t: TargetInfo): string {
   return 'state-behind'
 }
 
-const chips = computed(() => sync.nonActiveTargets)
+/**
+ * Aggregate label for a collapsed group — "N behind" sums members,
+ * treating unpublished (firstPublish) members as their full item count.
+ * When every member is in sync, shows "in sync". When any member is
+ * still loading, shows "…".
+ */
+function groupStatusLabel(group: TargetGroup): string {
+  if (group.members.some(m => sync.isLoading(m.name))) return '…'
+  const statuses = group.members.map(m => sync.get(m.name))
+  if (statuses.some(s => !s)) return '—'
+  const total = statuses.reduce((n, s) => n + (s?.changedCount ?? 0), 0)
+  const anyUnpublished = statuses.some(s => s?.firstPublish)
+  if (total === 0 && !anyUnpublished) return 'in sync'
+  if (total === 0 && anyUnpublished) return 'not yet published'
+  return `${total} behind`
+}
+
+/**
+ * Worst-case state class for a group — drives border color and emphasis.
+ * "behind" beats "unpublished" beats "synced" so the chip visually
+ * surfaces anything that needs attention.
+ */
+function groupStatusClass(group: TargetGroup): string {
+  if (group.members.some(m => sync.isLoading(m.name))) return 'state-loading'
+  if (group.members.some(m => sync.errorFor(m.name))) return 'state-error'
+  const statuses = group.members.map(m => sync.get(m.name))
+  const totalChanged = statuses.reduce((n, s) => n + (s?.changedCount ?? 0), 0)
+  if (totalChanged > 0) return 'state-behind'
+  if (statuses.some(s => s?.firstPublish)) return 'state-unpublished'
+  return 'state-synced'
+}
+
+// Render shape: flat singles when the fleet is small, grouped when 4+.
+// Passes the TOTAL target count (not just non-active) so sync chips
+// match the rest of the UI's grouping decision.
+const entries = computed(() =>
+  groupedEntries(sync.nonActiveTargets, activeTarget.targets.length),
+)
+
+const expandedGroups = ref(new Set<string>())
+function toggleGroup(env: string) {
+  const next = new Set(expandedGroups.value)
+  if (next.has(env)) next.delete(env); else next.add(env)
+  expandedGroups.value = next
+}
+
+const hasAnything = computed(() => entries.value.length > 0)
 </script>
 
 <template>
-  <div v-if="chips.length > 0" class="sync-indicators" data-testid="sync-indicators">
-    <button
-      v-for="t in chips"
-      :key="t.name"
-      type="button"
-      class="sync-chip"
-      :class="[environmentClass(t), statusClass(t)]"
-      :data-testid="`sync-chip-${t.name}`"
-      :title="`${t.name}: ${statusLabel(t)} — click to see changes`"
-      @click="emit('select', t.name)">
-      <span class="dot" aria-hidden="true" />
-      <span class="name">{{ t.name }}</span>
-      <span class="sep" aria-hidden="true">·</span>
-      <span class="status">{{ statusLabel(t) }}</span>
-    </button>
+  <div v-if="hasAnything" class="sync-indicators" data-testid="sync-indicators">
+    <template v-for="entry in entries" :key="entry.kind === 'single' ? entry.target.name : entry.group.environment">
+      <!-- Flat single target chip (≤3 targets, OR 1-member groups in 4+) -->
+      <button
+        v-if="entry.kind === 'single'"
+        type="button"
+        class="sync-chip"
+        :class="[environmentClass(entry.target.environment), statusClass(entry.target)]"
+        :data-testid="`sync-chip-${entry.target.name}`"
+        :title="`${entry.target.name}: ${statusLabel(entry.target)} — click to see changes`"
+        @click="emit('select', entry.target.name)">
+        <span class="dot" aria-hidden="true" />
+        <span class="name">{{ entry.target.name }}</span>
+        <span class="sep" aria-hidden="true">·</span>
+        <span class="status">{{ statusLabel(entry.target) }}</span>
+      </button>
+
+      <!-- Group chip (4+ total, 2+ members in this env). Click expands
+           inline to show per-member chips underneath. -->
+      <template v-else>
+        <button
+          type="button"
+          class="sync-chip sync-chip-group"
+          :class="[environmentClass(entry.group.environment), groupStatusClass(entry.group), { expanded: expandedGroups.has(entry.group.environment) }]"
+          :data-testid="`sync-chip-group-${entry.group.environment}`"
+          :title="`${entry.group.environment}: ${entry.group.members.length} targets — click to expand`"
+          :aria-expanded="expandedGroups.has(entry.group.environment)"
+          @click="toggleGroup(entry.group.environment)">
+          <span class="dot" aria-hidden="true" />
+          <span class="name">{{ entry.group.environment }}</span>
+          <span class="group-count">({{ entry.group.members.length }})</span>
+          <span class="sep" aria-hidden="true">·</span>
+          <span class="status">{{ groupStatusLabel(entry.group) }}</span>
+          <i class="pi" :class="expandedGroups.has(entry.group.environment) ? 'pi-chevron-down' : 'pi-chevron-right'" aria-hidden="true" />
+        </button>
+        <!-- Expanded member chips. Rendered inline so they share the
+             top-bar row; parent handles overflow. -->
+        <template v-if="expandedGroups.has(entry.group.environment)">
+          <button
+            v-for="m in entry.group.members"
+            :key="m.name"
+            type="button"
+            class="sync-chip sync-chip-member"
+            :class="[environmentClass(m.environment), statusClass(m)]"
+            :data-testid="`sync-chip-${m.name}`"
+            :title="`${m.name}: ${statusLabel(m)} — click to see changes`"
+            @click="emit('select', m.name)">
+            <span class="dot" aria-hidden="true" />
+            <span class="name">{{ m.name }}</span>
+            <span class="sep" aria-hidden="true">·</span>
+            <span class="status">{{ statusLabel(m) }}</span>
+          </button>
+        </template>
+      </template>
+    </template>
   </div>
 </template>
 
@@ -126,4 +218,34 @@ const chips = computed(() => sync.nonActiveTargets)
 .sync-chip.env-production .dot { color: var(--color-env-prod-fg); }
 .sync-chip.env-staging { border-color: var(--color-env-staging-fg); }
 .sync-chip.env-staging .dot { color: var(--color-env-staging-fg); }
+
+/* Group chip — slightly heavier than individual chips, chevron on the end. */
+.sync-chip-group {
+  font-weight: 500;
+}
+.sync-chip-group .pi {
+  font-size: 0.625rem;
+  opacity: 0.7;
+  margin-left: 0.125rem;
+}
+.sync-chip-group .group-count {
+  font-weight: 400;
+  opacity: 0.65;
+  margin-left: -0.125rem;
+}
+.sync-chip-group.expanded {
+  background: var(--color-hover-bg);
+}
+
+/* Member chip — inset and slightly lighter so the group→members
+   relationship reads at a glance. */
+.sync-chip-member {
+  opacity: 0.85;
+  padding-left: 0.625rem;
+}
+.sync-chip-member .name::before {
+  content: '↳ ';
+  opacity: 0.5;
+  font-weight: 400;
+}
 </style>

--- a/apps/admin/src/client/composables/targetGrouping.ts
+++ b/apps/admin/src/client/composables/targetGrouping.ts
@@ -1,0 +1,83 @@
+/**
+ * Target grouping — shared logic for scaling from flat (≤3 targets) to
+ * environment-grouped (4+) across sync indicators, the switcher menu,
+ * and the Publish picker.
+ *
+ * Design (design-editor-ux.md "Scaling to 4+ targets"): when the total
+ * target count is ≥ 4, targets sharing an `environment` collapse into
+ * a group across all target-referencing surfaces. Groups of 1 stay
+ * flat; targets with no environment set display ungrouped alongside
+ * groups.
+ *
+ * Grouping is presentation only — environments remain non-hierarchical
+ * in the model. Keep this logic pure so the threshold lives in one
+ * place and every surface renders consistently.
+ */
+import type { TargetInfo } from '../api/client.js'
+
+/** Threshold above which targets collapse into environment groups. */
+export const GROUPING_THRESHOLD = 4
+
+/**
+ * A group of targets sharing the same `environment`. Members preserve
+ * declaration order from site.yaml.
+ */
+export interface TargetGroup {
+  /** Environment value, e.g. 'production'. */
+  environment: string
+  members: TargetInfo[]
+}
+
+/** Should the provided target list render as groups? */
+export function shouldGroup(totalTargetCount: number): boolean {
+  return totalTargetCount >= GROUPING_THRESHOLD
+}
+
+/**
+ * Group targets by environment, preserving declaration order both
+ * within groups and across groups (first appearance of each env
+ * defines the group's slot).
+ */
+export function groupByEnvironment(targets: TargetInfo[]): TargetGroup[] {
+  const groups = new Map<string, TargetGroup>()
+  for (const t of targets) {
+    const env = t.environment ?? 'local'
+    let g = groups.get(env)
+    if (!g) { g = { environment: env, members: [] }; groups.set(env, g) }
+    g.members.push(t)
+  }
+  return [...groups.values()]
+}
+
+/**
+ * Render-shape for a surface: either a single target (flat) or a group
+ * (collapsed). Used by sync indicators and the switcher menu to decide
+ * per-item whether to render a plain chip/item or a group affordance.
+ *
+ * A group with only one member is rendered flat regardless — the design
+ * rule "groups of 1 stay flat" means the author never sees a group
+ * affordance for a single-member env.
+ */
+export type GroupedEntry =
+  | { kind: 'single'; target: TargetInfo }
+  | { kind: 'group'; group: TargetGroup }
+
+/**
+ * Compute the render shape for a set of targets. When `totalTargetCount`
+ * is below the threshold, every target is returned as 'single'.
+ * Otherwise targets are grouped by environment, with 1-member groups
+ * flattened back to 'single' entries.
+ */
+export function groupedEntries(
+  targets: TargetInfo[],
+  totalTargetCount: number,
+): GroupedEntry[] {
+  if (!shouldGroup(totalTargetCount)) {
+    return targets.map(t => ({ kind: 'single', target: t }))
+  }
+  return groupByEnvironment(targets).map(g =>
+    g.members.length === 1
+      ? { kind: 'single', target: g.members[0] }
+      : { kind: 'group', group: g },
+  )
+}

--- a/apps/admin/tests/targetGrouping.test.ts
+++ b/apps/admin/tests/targetGrouping.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for targetGrouping helpers. Covers the "4+ targets →
+ * group by environment" rule from design-editor-ux.md.
+ */
+import { describe, it, expect } from 'vitest'
+import type { TargetInfo } from '../src/client/api/client.js'
+import {
+  GROUPING_THRESHOLD,
+  groupByEnvironment,
+  groupedEntries,
+  shouldGroup,
+} from '../src/client/composables/targetGrouping.js'
+
+function T(name: string, environment: 'local' | 'staging' | 'production'): TargetInfo {
+  return { name, environment, type: 'static', editable: environment === 'local' }
+}
+
+describe('shouldGroup', () => {
+  it(`false below threshold (< ${GROUPING_THRESHOLD})`, () => {
+    expect(shouldGroup(0)).toBe(false)
+    expect(shouldGroup(1)).toBe(false)
+    expect(shouldGroup(3)).toBe(false)
+  })
+  it(`true at and above threshold (>= ${GROUPING_THRESHOLD})`, () => {
+    expect(shouldGroup(GROUPING_THRESHOLD)).toBe(true)
+    expect(shouldGroup(10)).toBe(true)
+  })
+})
+
+describe('groupByEnvironment', () => {
+  it('groups targets sharing an environment, preserving declaration order', () => {
+    const targets = [T('local', 'local'), T('prod-us', 'production'), T('staging', 'staging'), T('prod-eu', 'production')]
+    const groups = groupByEnvironment(targets)
+    expect(groups.map(g => g.environment)).toEqual(['local', 'production', 'staging'])
+    const prod = groups.find(g => g.environment === 'production')!
+    expect(prod.members.map(m => m.name)).toEqual(['prod-us', 'prod-eu'])
+  })
+
+  it('empty input → empty output', () => {
+    expect(groupByEnvironment([])).toEqual([])
+  })
+})
+
+describe('groupedEntries', () => {
+  const starter: TargetInfo[] = [
+    T('local', 'local'),
+    T('staging', 'staging'),
+    T('esi-test', 'staging'),
+    T('production', 'production'),
+  ]
+
+  it('flat (single) entries when total count is below threshold', () => {
+    // Three targets → flat, even if two share an env.
+    const three = starter.slice(0, 3)
+    const entries = groupedEntries(three, three.length)
+    expect(entries).toHaveLength(3)
+    expect(entries.every(e => e.kind === 'single')).toBe(true)
+  })
+
+  it('groups multi-member environments at the 4+ threshold', () => {
+    const entries = groupedEntries(starter, starter.length)
+    // local (1) → single, staging (2) → group, production (1) → single.
+    expect(entries).toHaveLength(3)
+    expect(entries[0]).toEqual({ kind: 'single', target: starter[0] })
+    expect(entries[1].kind).toBe('group')
+    if (entries[1].kind === 'group') {
+      expect(entries[1].group.environment).toBe('staging')
+      expect(entries[1].group.members).toHaveLength(2)
+    }
+    expect(entries[2]).toEqual({ kind: 'single', target: starter[3] })
+  })
+
+  it('1-member groups render flat even when grouping is active', () => {
+    const entries = groupedEntries(starter, starter.length)
+    const production = entries.find(e => e.kind === 'single' && e.target.environment === 'production')
+    expect(production).toBeDefined()
+    expect(production?.kind).toBe('single')
+  })
+
+  it('uses the passed total count, not entries.length, for the threshold', () => {
+    // Non-active targets (3) below threshold individually, but total is 4 →
+    // still group. The caller passes the full fleet size so filtered views
+    // (e.g. sync indicators, which hide the active) share the same shape.
+    const nonActive = starter.slice(1)
+    const entries = groupedEntries(nonActive, starter.length)
+    // staging (2) should still collapse into a group.
+    const grouped = entries.find(e => e.kind === 'group')
+    expect(grouped).toBeDefined()
+  })
+})

--- a/tests/e2e/editor.test.ts
+++ b/tests/e2e/editor.test.ts
@@ -939,7 +939,7 @@ test.describe('Target switch preserves preview', () => {
     // Open the top-bar target switcher and select staging. The preview
     // should swap content via morphdom, preserving scroll.
     await page.locator('[data-testid="active-target-indicator"]').click()
-    await page.locator('[data-testid="active-target-menu"]').getByText('staging', { exact: true }).click()
+    await page.locator('[data-testid="active-target-menu"]').getByRole('menuitem', { name: 'staging' }).click()
 
     await expect.poll(async () => page.evaluate(() => {
       const f = document.querySelector('iframe[data-testid="preview-iframe"]') as HTMLIFrameElement | null
@@ -962,6 +962,30 @@ test.describe('Save button labeling', () => {
   })
 })
 
+test.describe('Sync indicator grouping', () => {
+  test('collapses 2+ members of an environment into a group chip at 4+ targets', async ({ page }) => {
+    // Starter has 4 targets; staging and esi-test both env=staging.
+    // That triggers grouping (threshold = 4) and collapses the two
+    // staging targets into a single expandable group chip.
+    await page.goto('/admin')
+    const group = page.locator('[data-testid="sync-chip-group-staging"]')
+    await expect(group).toBeVisible()
+    await expect(group).toContainText('staging')
+    await expect(group).toContainText('(2)')
+    // Individual member chips are hidden until the group expands.
+    await expect(page.locator('[data-testid="sync-chip-staging"]')).toHaveCount(0)
+    await expect(page.locator('[data-testid="sync-chip-esi-test"]')).toHaveCount(0)
+    // Click to expand — both member chips appear.
+    await group.click()
+    await expect(page.locator('[data-testid="sync-chip-staging"]')).toBeVisible()
+    await expect(page.locator('[data-testid="sync-chip-esi-test"]')).toBeVisible()
+    // Single-member groups (production) and the active target's
+    // non-group (local when active) don't get a group chip.
+    await expect(page.locator('[data-testid="sync-chip-group-production"]')).toHaveCount(0)
+    await expect(page.locator('[data-testid="sync-chip-production"]')).toBeVisible()
+  })
+})
+
 test.describe('Target switch with missing item', () => {
   async function wipeStaging(projectDir: string) {
     await rm(join(projectDir, 'sites/main/dist/staging'), { recursive: true, force: true })
@@ -979,7 +1003,7 @@ test.describe('Target switch with missing item', () => {
     await page.waitForSelector('[data-testid="site-page-home"]', { timeout: 10000 })
     // Switch to staging — home doesn't exist there.
     await page.locator('[data-testid="active-target-indicator"]').click()
-    await page.locator('[data-testid="active-target-menu"]').getByText('staging', { exact: true }).click()
+    await page.locator('[data-testid="active-target-menu"]').getByRole('menuitem', { name: 'staging' }).click()
     // Toast appears with a "back" action.
     const toast = page.locator('[data-testid="global-toast"]')
     await expect(toast).toBeVisible()
@@ -1007,7 +1031,7 @@ test.describe('Target switch with unsaved edits', () => {
 
     // Try to switch to staging → the unsaved-dialog opens.
     await page.locator('[data-testid="active-target-indicator"]').click()
-    await page.locator('[data-testid="active-target-menu"]').getByText('staging', { exact: true }).click()
+    await page.locator('[data-testid="active-target-menu"]').getByRole('menuitem', { name: 'staging' }).click()
     const dialog = page.getByRole('dialog', { name: /unsaved changes/i })
     await dialog.waitFor({ timeout: 5000 })
     await dialog.getByRole('button', { name: 'Cancel' }).click()


### PR DESCRIPTION
## Summary

Finishes the "Scaling to 4+ targets" story from [design-editor-ux.md](.claude/rules/design-editor-ux.md). Three target-referencing surfaces now collapse same-environment targets into groups when the fleet reaches 4+:

### 1. Sync indicators (top-bar)

Multi-member groups render as a single collapsible chip (`staging (2) · 3 behind`). Click expands inline to show per-member chips with indent arrows. Aggregate status sums members; worst-case chrome drives the border color so "what needs attention" still reads on the collapsed chip.

### 2. Active target switcher menu

Multi-member groups render as PrimeVue Menu sections with the environment as header and members nested. Single-member groups stay flat.

### 3. Publish panel "To" picker

R45 always grouped; now honors the threshold. Shared `groupedEntries` helper means the Publish picker and top bar use the exact same collapse rules.

## Shared helper

`apps/admin/src/client/composables/targetGrouping.ts` owns `GROUPING_THRESHOLD = 4` and `groupedEntries(targets, totalCount)`. Pure functions, 8 unit tests cover the threshold behavior, group order preservation, 1-member flattening, and the "use total count not filtered count" rule.

## Tests

- 56 e2e passing (1 new: sync-chip group + expand)
- 70 admin unit passing (+8 for targetGrouping)
- 324 gazetta unit passing

Existing menu-based e2e selectors updated from `getByText('staging')` to `getByRole('menuitem', { name: 'staging' })` — at 4+ targets "staging" now appears as both section header and menu item.

## Visual verification

Manually drove chromium against a 4-target starter fleet (swapped azure-blob prod for filesystem via the fixture's prod-test pattern). Captured screens of collapsed, expanded, switcher menu, and publish panel — all render cleanly.

## Test plan

- [ ] CI green
- [ ] Browser smoke: with 4+ targets (e.g. local, staging, esi-test, production), top-bar shows `staging (2)` group; clicking expands; switcher shows `staging` header with nested members; Publish panel "To" shows STAGING group header with indented members
- [ ] Browser smoke: with 3 targets, no grouping anywhere (all flat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)