### PR TITLE
R47-R48: per-target history backend (record on save + publish)

### DIFF
--- a/.claude/rules/configurations.md
+++ b/.claude/rules/configurations.md
@@ -241,6 +241,9 @@ targets:                                   # required — at least one target
       purge:                               # CDN cache purge
         type: cloudflare
         apiToken: "${CLOUDFLARE_API_TOKEN}"
+    history:                               # optional — per-target undo / rollback (default: enabled, retain 50)
+      enabled: true                        # set to false to skip .gazetta/history/ writes entirely
+      retention: 50                        # keep at most N most-recent revisions; oldest evicted
 ```
 
 Custom site-level settings can be added as top-level fields — accessible to templates via

--- a/.claude/rules/design-publishing.md
+++ b/.claude/rules/design-publishing.md
@@ -165,9 +165,24 @@ never destroyed. Full audit trail preserved.
 
 ### Retention
 
-Per-target configurable, default **keep last 50 revisions**. When the limit is hit, the
-oldest revision is evicted (its manifest deleted from `revisions/`, removed from
-`index.json`). Orphaned blobs in `objects/` are garbage-collected (lazy or on eviction).
+Per-target configurable via the `history` block in `site.yaml`, default **keep last 50
+revisions**. When the limit is hit, the oldest revision is evicted (its manifest deleted
+from `revisions/`, removed from `index.json`). Orphaned blobs in `objects/` are
+garbage-collected lazily — a future `gazetta gc` command walks all manifests and prunes
+unreferenced blobs.
+
+```yaml
+targets:
+  staging:
+    storage: { type: filesystem, path: ./dist/staging }
+    history:
+      enabled: true      # default; set to false to skip .gazetta/history/ entirely
+      retention: 100     # default 50
+```
+
+Use `enabled: false` to disable history on a target where the storage cost isn't
+worth it (ephemeral CI preview targets, for example). Disabling on production
+removes the undo safety net — not recommended.
 
 ### Conflict handling
 

--- a/apps/admin/tests/history.test.ts
+++ b/apps/admin/tests/history.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Integration tests for history-on-save and history-on-publish in the
+ * admin-api. Uses a temp copy of the starter site so mutations don't
+ * leak between runs — the existing api.test.ts mutates in place, which
+ * is fine for single-item asserts but would clobber history state.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { cp, rm, readFile, readdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import type { Hono } from 'hono'
+import {
+  createFilesystemProvider,
+  createSourceContext,
+  createHistoryProvider,
+  type SourceContext,
+} from 'gazetta'
+import { createAdminApp } from '../src/server/index.js'
+
+const starterSiteDir = resolve(import.meta.dirname, '../../../examples/starter/sites/main')
+const templatesDir = resolve(import.meta.dirname, '../../../examples/starter/templates')
+
+/**
+ * Spin up an isolated copy of the starter's local target. We snapshot
+ * only the content root (sites/main/targets/local) since that's where
+ * history writes. The app config points at the real templates.
+ */
+async function setupWorkingCopy(name: string) {
+  const tempDir = resolve(import.meta.dirname, '../../../.tmp', name)
+  await rm(tempDir, { recursive: true, force: true })
+  await cp(resolve(starterSiteDir, 'targets/local'), tempDir, { recursive: true })
+  return tempDir
+}
+
+describe('History on save', () => {
+  let contentDir: string
+  let app: Hono
+  let source: SourceContext
+
+  beforeAll(async () => {
+    contentDir = await setupWorkingCopy('history-save-test')
+    const storage = createFilesystemProvider(contentDir)
+    const history = createHistoryProvider({ storage })
+    source = createSourceContext({ storage, siteDir: '', projectSiteDir: starterSiteDir, history })
+    app = createAdminApp({ source, siteDir: starterSiteDir, templatesDir })
+  })
+
+  afterAll(async () => {
+    await rm(contentDir, { recursive: true, force: true })
+  })
+
+  it('records a revision on PUT /api/pages/:name', async () => {
+    // First save — triggers the initial full-tree scan.
+    const res = await app.request('/api/pages/home', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: { title: 'Edited' } }),
+    })
+    expect(res.status).toBe(200)
+
+    const indexPath = resolve(contentDir, '.gazetta/history/index.json')
+    const index = JSON.parse(await readFile(indexPath, 'utf-8'))
+    expect(index.revisions).toEqual(['rev-0001'])
+
+    const manifestPath = resolve(contentDir, '.gazetta/history/revisions/rev-0001.json')
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'))
+    expect(manifest.operation).toBe('save')
+    // Full-tree baseline: every page + fragment manifest is captured,
+    // not just the one that was saved.
+    expect(Object.keys(manifest.snapshot).sort()).toEqual(expect.arrayContaining([
+      'pages/home/page.json',
+      'pages/about/page.json',
+      'fragments/header/fragment.json',
+      'fragments/footer/fragment.json',
+    ]))
+  })
+
+  it('second save writes delta onto the previous snapshot', async () => {
+    const res = await app.request('/api/pages/about', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: { title: 'About edited' } }),
+    })
+    expect(res.status).toBe(200)
+
+    const index = JSON.parse(await readFile(resolve(contentDir, '.gazetta/history/index.json'), 'utf-8'))
+    expect(index.revisions).toEqual(['rev-0001', 'rev-0002'])
+    const rev1 = JSON.parse(await readFile(resolve(contentDir, '.gazetta/history/revisions/rev-0001.json'), 'utf-8'))
+    const rev2 = JSON.parse(await readFile(resolve(contentDir, '.gazetta/history/revisions/rev-0002.json'), 'utf-8'))
+    // Unchanged items share blobs (same hash) across revisions.
+    expect(rev2.snapshot['pages/home/page.json']).toBe(rev1.snapshot['pages/home/page.json'])
+    // pages/about changed — different blob.
+    expect(rev2.snapshot['pages/about/page.json']).not.toBe(rev1.snapshot['pages/about/page.json'])
+  })
+
+  it('records a revision on DELETE /api/pages/:name with the item removed from the snapshot', async () => {
+    // Create a page so we can delete it cleanly.
+    await app.request('/api/pages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: '.history-delete-test', template: 'page-default' }),
+    })
+    const del = await app.request('/api/pages/.history-delete-test', { method: 'DELETE' })
+    expect(del.status).toBe(200)
+
+    const entries = await readdir(resolve(contentDir, '.gazetta/history/revisions'))
+    const latest = entries.sort().at(-1)!
+    const manifest = JSON.parse(
+      await readFile(resolve(contentDir, '.gazetta/history/revisions', latest), 'utf-8'),
+    )
+    expect(manifest.snapshot).not.toHaveProperty('pages/.history-delete-test/page.json')
+  })
+})
+
+describe('History disabled on save', () => {
+  let contentDir: string
+  let app: Hono
+
+  beforeAll(async () => {
+    contentDir = await setupWorkingCopy('history-disabled-test')
+    const storage = createFilesystemProvider(contentDir)
+    // No history provider → source.history is undefined → no revisions.
+    const source = createSourceContext({ storage, siteDir: '', projectSiteDir: starterSiteDir })
+    app = createAdminApp({ source, siteDir: starterSiteDir, templatesDir })
+  })
+
+  afterAll(async () => {
+    await rm(contentDir, { recursive: true, force: true })
+  })
+
+  it('does not create .gazetta/history/ when the source has no history provider', async () => {
+    const res = await app.request('/api/pages/home', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: { title: 'Quiet save' } }),
+    })
+    expect(res.status).toBe(200)
+
+    // Happy path — the history directory should not exist.
+    await expect(
+      readFile(resolve(contentDir, '.gazetta/history/index.json'), 'utf-8'),
+    ).rejects.toThrow()
+  })
+})
+
+describe('Retention', () => {
+  let contentDir: string
+  let app: Hono
+
+  beforeAll(async () => {
+    contentDir = await setupWorkingCopy('history-retention-test')
+    const storage = createFilesystemProvider(contentDir)
+    const history = createHistoryProvider({ storage, retention: 2 })
+    const source = createSourceContext({ storage, siteDir: '', projectSiteDir: starterSiteDir, history })
+    app = createAdminApp({ source, siteDir: starterSiteDir, templatesDir })
+  })
+
+  afterAll(async () => {
+    await rm(contentDir, { recursive: true, force: true })
+  })
+
+  it('evicts oldest revisions once retention is hit', async () => {
+    for (let i = 0; i < 5; i++) {
+      const res = await app.request('/api/pages/home', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: { title: `rev ${i}` } }),
+      })
+      expect(res.status).toBe(200)
+    }
+    const index = JSON.parse(await readFile(resolve(contentDir, '.gazetta/history/index.json'), 'utf-8'))
+    // Only the two most recent ids remain in the index; older manifests
+    // are deleted. nextId keeps climbing so restored ids never collide.
+    expect(index.revisions).toEqual(['rev-0004', 'rev-0005'])
+    expect(index.nextId).toBe(6)
+    await expect(
+      readFile(resolve(contentDir, '.gazetta/history/revisions/rev-0001.json'), 'utf-8'),
+    ).rejects.toThrow()
+  })
+})
+

--- a/packages/gazetta/src/admin-api/index.ts
+++ b/packages/gazetta/src/admin-api/index.ts
@@ -7,6 +7,8 @@ import { memoizeAsync } from '../concurrency.js'
 import { createSourceSidecarWriter, type SourceSidecarWriter } from '../source-sidecars.js'
 import { createContentRoot } from '../content-root.js'
 import { createTargetRegistryView } from '../targets.js'
+import { createHistoryProvider } from '../history-provider.js'
+import { isHistoryEnabled, getHistoryRetention } from '../types.js'
 import { createSourceContext, staticSourceResolver, registrySourceResolver, type SourceContext, type SourceContextResolver } from './source-context.js'
 import { authMiddleware } from './middleware/auth.js'
 import { siteRoutes } from './routes/site.js'
@@ -137,6 +139,14 @@ export function createAdminApp(opts: AdminAppOptions): AdminApp {
         const maybeInit = storage as StorageProvider & { init?: () => Promise<void> }
         if (typeof maybeInit.init === 'function') await maybeInit.init()
         providers.set(name, storage)
+      },
+      // Build a HistoryProvider per target, honoring the site.yaml
+      // `history` block (enabled/retention). Returns undefined when the
+      // target has history turned off — routes no-op on absent provider.
+      buildHistory: (name, storage) => {
+        const config = opts.targetConfigs![name]
+        if (!config || !isHistoryEnabled(config)) return undefined
+        return createHistoryProvider({ storage, retention: getHistoryRetention(config) })
       },
     })
   } else {

--- a/packages/gazetta/src/admin-api/routes/fragments.ts
+++ b/packages/gazetta/src/admin-api/routes/fragments.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { join } from 'node:path'
 import { loadSite } from '../../site-loader.js'
+import { recordWrite } from '../../history-recorder.js'
 import type { SourceContextResolver } from '../source-context.js'
 
 export function fragmentRoutes(resolve: SourceContextResolver) {
@@ -75,8 +76,19 @@ export function fragmentRoutes(resolve: SourceContextResolver) {
       components: body.components ?? fragment.components,
     }
 
-    await storage.writeFile(join(fragment.dir, 'fragment.json'), JSON.stringify(manifest, null, 2) + '\n')
+    const manifestPath = join(fragment.dir, 'fragment.json')
+    const serialized = JSON.stringify(manifest, null, 2) + '\n'
+    await storage.writeFile(manifestPath, serialized)
     await sidecarWriter?.writeFor('fragment', name)
+
+    if (source.history) {
+      await recordWrite({
+        history: source.history,
+        contentRoot: source.contentRoot,
+        operation: 'save',
+        items: [{ path: source.contentRoot.relative(manifestPath), content: serialized }],
+      })
+    }
     return c.json({ ok: true })
   })
 
@@ -88,7 +100,17 @@ export function fragmentRoutes(resolve: SourceContextResolver) {
     const fragment = site.fragments.get(name)
     if (!fragment) return c.json({ error: `Fragment "${name}" not found` }, 404)
 
+    const manifestPath = join(fragment.dir, 'fragment.json')
     await storage.rm(fragment.dir)
+
+    if (source.history) {
+      await recordWrite({
+        history: source.history,
+        contentRoot: source.contentRoot,
+        operation: 'save',
+        items: [{ path: source.contentRoot.relative(manifestPath), content: null }],
+      })
+    }
     return c.json({ ok: true })
   })
 

--- a/packages/gazetta/src/admin-api/routes/pages.ts
+++ b/packages/gazetta/src/admin-api/routes/pages.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { join } from 'node:path'
 import { loadSite } from '../../site-loader.js'
+import { recordWrite } from '../../history-recorder.js'
 import type { SourceContextResolver } from '../source-context.js'
 
 export function pageRoutes(resolve: SourceContextResolver) {
@@ -87,8 +88,22 @@ export function pageRoutes(resolve: SourceContextResolver) {
       components: body.components ?? page.components,
     }
 
-    await storage.writeFile(join(page.dir, 'page.json'), JSON.stringify(manifest, null, 2) + '\n')
+    const manifestPath = join(page.dir, 'page.json')
+    const serialized = JSON.stringify(manifest, null, 2) + '\n'
+    await storage.writeFile(manifestPath, serialized)
     await sidecarWriter?.writeFor('page', name)
+
+    // Record a history revision for this save — no-op when history is
+    // disabled for the target (source.history is undefined). Relative
+    // path for the snapshot key so revisions don't leak target-rooting.
+    if (source.history) {
+      await recordWrite({
+        history: source.history,
+        contentRoot: source.contentRoot,
+        operation: 'save',
+        items: [{ path: source.contentRoot.relative(manifestPath), content: serialized }],
+      })
+    }
     return c.json({ ok: true })
   })
 
@@ -100,7 +115,17 @@ export function pageRoutes(resolve: SourceContextResolver) {
     const page = site.pages.get(name)
     if (!page) return c.json({ error: `Page "${name}" not found` }, 404)
 
+    const manifestPath = join(page.dir, 'page.json')
     await storage.rm(page.dir)
+
+    if (source.history) {
+      await recordWrite({
+        history: source.history,
+        contentRoot: source.contentRoot,
+        operation: 'save',
+        items: [{ path: source.contentRoot.relative(manifestPath), content: null }],
+      })
+    }
     return c.json({ ok: true })
   })
 

--- a/packages/gazetta/src/admin-api/routes/publish.ts
+++ b/packages/gazetta/src/admin-api/routes/publish.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
-import { getType, getEnvironment, isEditable } from '../../types.js'
+import { getType, getEnvironment, isEditable, isHistoryEnabled, getHistoryRetention } from '../../types.js'
 import type { StorageProvider, TargetConfig } from '../../types.js'
 import { publishItems, resolveDependencies, findFragmentDependents, findDependentsFromSidecars } from '../../publish.js'
 import type { SourceContextResolver } from '../source-context.js'
@@ -12,6 +12,8 @@ import { resolveEnvVars } from '../../targets.js'
 import { scanTemplates, templateHashesFrom, type TemplateInfo } from '../../templates-scan.js'
 import { hashManifest } from '../../hash.js'
 import { createContentRoot } from '../../content-root.js'
+import { createHistoryProvider } from '../../history-provider.js'
+import { recordWrite, type WrittenItem } from '../../history-recorder.js'
 
 /**
  * Progress events streamed by runPublish. Consumed both by the SSE route
@@ -312,6 +314,35 @@ export function publishRoutes(
           yield { kind: 'progress', target: targetName, current, total, label: 'cache purge' }
         }
 
+        // Record a history revision on the destination target. Design
+        // decision #18: history lives on the destination, not the
+        // source — so undo works after the source has moved on. No-op
+        // when the target's site.yaml disables history.
+        if (config && isHistoryEnabled(config)) {
+          try {
+            const history = createHistoryProvider({
+              storage: targetStorage,
+              retention: getHistoryRetention(config),
+            })
+            const items = await collectPublishedItemsForHistory(
+              source.contentRoot,
+              targetRoot,
+              targetItems,
+            )
+            await recordWrite({
+              history,
+              contentRoot: targetRoot,
+              operation: 'publish',
+              source: sourceName,
+              items,
+            })
+          } catch (err) {
+            // History is a best-effort audit layer — a write failure here
+            // must not break the publish itself. Log and continue.
+            console.warn(`    ${targetName}: history record failed — ${(err as Error).message}`)
+          }
+        }
+
         const result: PublishResult = { target: targetName, success: true, copiedFiles: totalFiles }
         results.push(result)
         console.log(`    ${targetName}: ${totalFiles} files`)
@@ -426,4 +457,37 @@ export function publishRoutes(
   })
 
   return app
+}
+
+/**
+ * Build the history `items` for a publish — one entry per published
+ * item, content = the source-side manifest. Records semantic authored
+ * state (JSON manifests) rather than target-side artifacts (static
+ * HTML, fragment indexes), so Restore is a content-level operation.
+ *
+ * `_targetRoot` is accepted for symmetry with `recordWrite`'s other
+ * path-building needs; it's unused today because we hash source
+ * content directly and let recordWrite overlay paths relative to the
+ * target's rootPath (which is `''` for target-rooted storage, the
+ * common case).
+ */
+async function collectPublishedItemsForHistory(
+  sourceRoot: import('../../content-root.js').ContentRoot,
+  _targetRoot: import('../../content-root.js').ContentRoot,
+  publishedItems: string[],
+): Promise<WrittenItem[]> {
+  const out: WrittenItem[] = []
+  for (const item of publishedItems) {
+    const manifestName = item.startsWith('pages/') ? 'page.json' : 'fragment.json'
+    const key = `${item}/${manifestName}`
+    const sourcePath = sourceRoot.path(key)
+    try {
+      const content = await sourceRoot.storage.readFile(sourcePath)
+      out.push({ path: key, content })
+    } catch {
+      // Item missing on source (unusual — publish normally reads from
+      // source manifests). Skip; snapshot stays as-was for this item.
+    }
+  }
+  return out
 }

--- a/packages/gazetta/src/admin-api/source-context.ts
+++ b/packages/gazetta/src/admin-api/source-context.ts
@@ -13,6 +13,7 @@ import type { StorageProvider } from '../types.js'
 import { createContentRoot, type ContentRoot } from '../content-root.js'
 import type { SourceSidecarWriter } from '../source-sidecars.js'
 import type { TargetRegistry } from '../targets.js'
+import type { HistoryProvider } from '../history.js'
 
 export interface SourceContext {
   /** Storage provider for source reads and writes. */
@@ -44,6 +45,14 @@ export interface SourceContext {
    * source-side read path should be used (it can backfill sidecars).
    */
   readonly targetName?: string
+  /**
+   * Optional history provider for recording revisions on save. Absent
+   * when history is disabled for this target (via
+   * `history.enabled: false` in site.yaml) or when history isn't
+   * wired at the caller (tests, legacy setups). Save routes check for
+   * presence before recording — no-op if absent.
+   */
+  readonly history?: HistoryProvider
 }
 
 export interface CreateSourceContextOptions {
@@ -53,6 +62,7 @@ export interface CreateSourceContextOptions {
   /** Absolute project site directory. Defaults to `siteDir` for backward compat. */
   projectSiteDir?: string
   sidecarWriter?: SourceSidecarWriter
+  history?: HistoryProvider
 }
 
 export function createSourceContext(opts: CreateSourceContextOptions): SourceContext {
@@ -62,8 +72,18 @@ export function createSourceContext(opts: CreateSourceContextOptions): SourceCon
     projectSiteDir: opts.projectSiteDir ?? opts.siteDir,
     contentRoot: createContentRoot(opts.storage, opts.siteDir),
     sidecarWriter: opts.sidecarWriter,
+    history: opts.history,
   }
 }
+
+/**
+ * Build a HistoryProvider for a resolved target. Returns `undefined`
+ * when history is disabled (via site.yaml `history.enabled: false`).
+ * Injected via `SourceContextFromRegistryOptions.buildHistory` so the
+ * source-context module stays agnostic of target-config parsing — the
+ * caller (admin-api boot) owns the enabled/retention decision.
+ */
+export type BuildHistory = (targetName: string, storage: StorageProvider) => HistoryProvider | undefined
 
 export interface SourceContextFromRegistryOptions {
   registry: TargetRegistry
@@ -81,6 +101,8 @@ export interface SourceContextFromRegistryOptions {
    */
   projectSiteDir: string
   sidecarWriter?: SourceSidecarWriter
+  /** See BuildHistory — callable decides per-target history provider. */
+  buildHistory?: BuildHistory
 }
 
 /**
@@ -97,6 +119,7 @@ export function createSourceContextFromRegistry(opts: SourceContextFromRegistryO
       siteDir: opts.siteDir ?? '',
       projectSiteDir: opts.projectSiteDir,
       sidecarWriter: opts.sidecarWriter,
+      history: opts.buildHistory?.(name, storage),
     }),
     targetName: name,
   }
@@ -145,6 +168,8 @@ export interface RegistrySourceResolverOptions {
    * backs the registry view.
    */
   lazyInit?: (targetName: string) => Promise<void>
+  /** See BuildHistory — callable decides per-target history provider. */
+  buildHistory?: BuildHistory
 }
 
 /**
@@ -176,6 +201,7 @@ export function registrySourceResolver(opts: RegistrySourceResolverOptions): Sou
       registry: opts.registry,
       targetName: name,
       projectSiteDir: opts.projectSiteDir,
+      buildHistory: opts.buildHistory,
       siteDir: opts.siteDir,
       sidecarWriter: opts.sidecarWriter,
     })

--- a/packages/gazetta/src/content-root.ts
+++ b/packages/gazetta/src/content-root.ts
@@ -25,6 +25,16 @@ export interface ContentRoot {
   readonly rootPath: string
   /** Build a content-relative path, joining the root prefix with the given segments. */
   path(...segments: string[]): string
+  /**
+   * Inverse of `path(...)` — strip the root prefix from an absolute
+   * storage path, yielding the content-relative form. Useful when a
+   * caller has a fully-qualified path (e.g. from a site scan result)
+   * and needs the canonical "pages/home/page.json" shape for a
+   * snapshot key. Paths that don't live under `rootPath` pass through
+   * unchanged — callers should treat that as a programmer error rather
+   * than a runtime concern.
+   */
+  relative(path: string): string
 }
 
 /** Build a ContentRoot from a storage provider and an optional root prefix. */
@@ -34,6 +44,11 @@ export function createContentRoot(storage: StorageProvider, rootPath = ''): Cont
     rootPath,
     path(...segments) {
       return rootPath ? join(rootPath, ...segments) : join(...segments)
+    },
+    relative(path) {
+      if (!rootPath) return path
+      const prefix = rootPath.endsWith('/') ? rootPath : rootPath + '/'
+      return path.startsWith(prefix) ? path.slice(prefix.length) : path
     },
   }
 }

--- a/packages/gazetta/src/history-provider.ts
+++ b/packages/gazetta/src/history-provider.ts
@@ -83,8 +83,21 @@ export function createHistoryProvider(
     return JSON.parse(await storage.readFile(indexPath)) as HistoryIndex
   }
 
+  /**
+   * Ensure the parent directory exists before writing. Object-store
+   * providers (R2, S3) ignore mkdir. Filesystem requires it because
+   * `writeFile` fails on missing parents, and our sharded blob paths
+   * (objects/<hh>/<rest>) plus revisions/rev-NNNN.json live in dirs
+   * that don't exist until the first write.
+   */
+  async function writeWithParents(path: string, content: string): Promise<void> {
+    const parent = path.substring(0, path.lastIndexOf('/'))
+    if (parent) await storage.mkdir(parent)
+    await storage.writeFile(path, content)
+  }
+
   async function writeIndex(idx: HistoryIndex): Promise<void> {
-    await storage.writeFile(indexPath, JSON.stringify(idx, null, 2) + '\n')
+    await writeWithParents(indexPath, JSON.stringify(idx, null, 2) + '\n')
   }
 
   function blobPath(hash: string): string {
@@ -118,7 +131,7 @@ export function createHistoryProvider(
     const hash = hashContent(content)
     const path = blobPath(hash)
     if (!await storage.exists(path)) {
-      await storage.writeFile(path, content)
+      await writeWithParents(path, content)
     }
     return hash
   }
@@ -147,7 +160,7 @@ export function createHistoryProvider(
       restoredFrom: input.restoredFrom,
       snapshot,
     }
-    await storage.writeFile(revisionPath(id), JSON.stringify(manifest, null, 2) + '\n')
+    await writeWithParents(revisionPath(id), JSON.stringify(manifest, null, 2) + '\n')
 
     // Update the index (append, bump counter) then apply retention. Do
     // index writes last so a mid-write failure leaves orphan blobs and

--- a/packages/gazetta/src/history-provider.ts
+++ b/packages/gazetta/src/history-provider.ts
@@ -1,0 +1,238 @@
+/**
+ * HistoryProvider implementation on top of any StorageProvider.
+ *
+ * Layout per target (inside `.gazetta/history/` under the target's
+ * storage root):
+ *
+ *   index.json                     { nextId: N, revisions: ['rev-0001', ...] }
+ *   revisions/rev-NNNN.json        one manifest per revision — metadata +
+ *                                  items map (itemPath → blob hash)
+ *   objects/<hh>/<rest>            content-addressed blobs (SHA-256, sharded
+ *                                  by first 2 hex chars)
+ *
+ * Design-decisions.md #18:
+ *  - One uniform approach across all providers (no native versioning).
+ *  - Content-addressed blobs → unchanged items share storage across
+ *    revisions; storage scales with unique content, not revision count.
+ *  - Soft undo only — every restore writes a new forward revision.
+ *  - Retention default 50; oldest evicted on write.
+ *
+ * SRP: this module owns .gazetta/history/ layout and retention. Nothing
+ * else. The write pipeline (save/publish) calls `recordRevision`; undo/
+ * rollback call `readRevision` + `readBlob`. Restore happens outside —
+ * this module doesn't touch the content tree.
+ */
+
+import { createHash } from 'node:crypto'
+import type { StorageProvider } from './types.js'
+import type {
+  HistoryProvider,
+  Revision,
+  RevisionInput,
+  RevisionManifest,
+} from './history.js'
+import { DEFAULT_HISTORY_RETENTION } from './types.js'
+
+export interface CreateHistoryProviderOptions {
+  /** Storage under which `.gazetta/history/` lives. Usually the target's storage. */
+  storage: StorageProvider
+  /**
+   * Path prefix where history lives. Default: `.gazetta/history`. Callers
+   * with a rooted storage (filesystem target with `path:`) pass the
+   * default; anything more exotic (e.g. history under a sub-prefix)
+   * overrides.
+   */
+  rootPath?: string
+  /**
+   * Maximum number of revisions to keep; older ones evicted on write.
+   * Default: `DEFAULT_HISTORY_RETENTION` (50). Pass < 1 → clamped to 1
+   * (zero retention would self-evict every write).
+   */
+  retention?: number
+}
+
+/**
+ * Shape of the history index file. Kept minimal — the list is append-
+ * heavy and read-cheap, so we serialize the full ordered id list
+ * rather than try to be clever. Oldest first, newest last.
+ */
+interface HistoryIndex {
+  /** Counter for the next revision id. Monotonic; never decremented. */
+  nextId: number
+  /** Revision ids in creation order (oldest first). */
+  revisions: string[]
+}
+
+/**
+ * Build a HistoryProvider backed by the given storage. No I/O happens
+ * at construction time — everything is lazy on first call.
+ */
+export function createHistoryProvider(
+  opts: CreateHistoryProviderOptions,
+): HistoryProvider {
+  const { storage } = opts
+  const root = opts.rootPath ?? '.gazetta/history'
+  const retention = Math.max(1, opts.retention ?? DEFAULT_HISTORY_RETENTION)
+  const indexPath = join(root, 'index.json')
+
+  /** Read the index or return an empty one if it doesn't exist yet. */
+  async function readIndex(): Promise<HistoryIndex> {
+    if (!await storage.exists(indexPath)) {
+      return { nextId: 1, revisions: [] }
+    }
+    return JSON.parse(await storage.readFile(indexPath)) as HistoryIndex
+  }
+
+  async function writeIndex(idx: HistoryIndex): Promise<void> {
+    await storage.writeFile(indexPath, JSON.stringify(idx, null, 2) + '\n')
+  }
+
+  function blobPath(hash: string): string {
+    // Shard by first two hex chars — keeps any one `objects/` subdirectory
+    // from ballooning past a few thousand entries on large sites.
+    return join(root, 'objects', hash.slice(0, 2), hash.slice(2))
+  }
+
+  function revisionPath(id: string): string {
+    return join(root, 'revisions', `${id}.json`)
+  }
+
+  /** SHA-256 hex of the content — strong enough that collisions can be
+   *  ignored for practical purposes (blob identity), cheap enough at our
+   *  scale (tens of KB per item, hundreds of items per revision). */
+  function hashContent(content: string): string {
+    return createHash('sha256').update(content).digest('hex')
+  }
+
+  /** Format a numeric id as `rev-NNNN`, zero-padded to 4 digits minimum. */
+  function formatId(n: number): string {
+    return `rev-${String(n).padStart(4, '0')}`
+  }
+
+  /**
+   * Write any blob that's not already stored. Returns the hash. Dedup
+   * check is a single `exists()` — cheaper than reading the existing
+   * blob to confirm equal content (hashes collide vanishingly).
+   */
+  async function writeBlob(content: string): Promise<string> {
+    const hash = hashContent(content)
+    const path = blobPath(hash)
+    if (!await storage.exists(path)) {
+      await storage.writeFile(path, content)
+    }
+    return hash
+  }
+
+  async function recordRevision(input: RevisionInput): Promise<Revision> {
+    const idx = await readIndex()
+    const id = formatId(idx.nextId)
+
+    // Write blobs (dedup via content-addressing) and build the
+    // path → hash snapshot.
+    const snapshot: Record<string, string> = {}
+    // Deterministic order so rev manifests diff cleanly on inspection.
+    const sortedEntries = [...input.items.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+    for (const [path, content] of sortedEntries) {
+      snapshot[path] = await writeBlob(content)
+    }
+
+    const manifest: RevisionManifest = {
+      id,
+      timestamp: new Date().toISOString(),
+      operation: input.operation,
+      author: input.author,
+      source: input.source,
+      items: [...input.items.keys()].sort(),
+      message: input.message,
+      restoredFrom: input.restoredFrom,
+      snapshot,
+    }
+    await storage.writeFile(revisionPath(id), JSON.stringify(manifest, null, 2) + '\n')
+
+    // Update the index (append, bump counter) then apply retention. Do
+    // index writes last so a mid-write failure leaves orphan blobs and
+    // an orphan manifest (both harmless) rather than a dangling index
+    // entry pointing at a missing manifest.
+    idx.revisions.push(id)
+    idx.nextId += 1
+    await writeIndex(idx)
+    await applyRetention(idx)
+
+    // Return the public Revision shape (no snapshot).
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { snapshot: _snapshot, ...revision } = manifest
+    return revision
+  }
+
+  /**
+   * Evict oldest revisions to fit `retention`. Deletes manifests; blobs
+   * become eligible for GC if no remaining revision references them.
+   * GC is lazy — blob files stay until an explicit GC pass, which is
+   * fine for v1 (disk is cheap; a future `gazetta gc` command can walk
+   * all manifests and prune orphans).
+   */
+  async function applyRetention(idx: HistoryIndex): Promise<void> {
+    const excess = idx.revisions.length - retention
+    if (excess <= 0) return
+    const toEvict = idx.revisions.slice(0, excess)
+    idx.revisions = idx.revisions.slice(excess)
+    for (const id of toEvict) {
+      const path = revisionPath(id)
+      if (await storage.exists(path)) await storage.rm(path)
+    }
+    await writeIndex(idx)
+  }
+
+  async function listRevisions(limit?: number): Promise<Revision[]> {
+    const idx = await readIndex()
+    const ids = [...idx.revisions].reverse() // newest first
+    const sliced = typeof limit === 'number' ? ids.slice(0, limit) : ids
+    // Read manifests in parallel; strip snapshot for the summary list.
+    return Promise.all(sliced.map(async id => {
+      const m = await readManifest(id)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { snapshot: _snapshot, ...rev } = m
+      return rev
+    }))
+  }
+
+  async function readManifest(id: string): Promise<RevisionManifest> {
+    return JSON.parse(await storage.readFile(revisionPath(id))) as RevisionManifest
+  }
+
+  async function readRevision(id: string): Promise<RevisionManifest> {
+    return readManifest(id)
+  }
+
+  async function readBlob(hash: string): Promise<string> {
+    return storage.readFile(blobPath(hash))
+  }
+
+  async function deleteRevision(id: string): Promise<void> {
+    const idx = await readIndex()
+    const at = idx.revisions.indexOf(id)
+    if (at === -1) return
+    idx.revisions.splice(at, 1)
+    await writeIndex(idx)
+    const path = revisionPath(id)
+    if (await storage.exists(path)) await storage.rm(path)
+    // Orphan blobs left for lazy GC — see applyRetention rationale.
+  }
+
+  return {
+    recordRevision,
+    listRevisions,
+    readRevision,
+    readBlob,
+    deleteRevision,
+  }
+}
+
+/**
+ * `posix.join` behavior without importing it — keeps the module self-
+ * contained and works identically across platforms. Storage providers
+ * normalize separators internally, but our stored paths are POSIX.
+ */
+function join(...parts: string[]): string {
+  return parts.filter(Boolean).join('/').replace(/\/+/g, '/')
+}

--- a/packages/gazetta/src/history-recorder.ts
+++ b/packages/gazetta/src/history-recorder.ts
@@ -1,0 +1,222 @@
+/**
+ * Higher-level helper for recording revisions on a target.
+ *
+ * The bare `HistoryProvider.recordRevision` takes a full
+ * `items: Map<path, content>` snapshot. That's fine for testing but
+ * wasteful at runtime: every save of one page would re-hash and
+ * re-list every page + fragment on the target. This helper does the
+ * right thing:
+ *
+ *   - First revision on a target: walks the content tree once to
+ *     snapshot every manifest (page.json, fragment.json, site.yaml).
+ *   - Subsequent revisions: reads the previous snapshot and overlays
+ *     the delta (changed items the caller passes in). `readBlob` for
+ *     each carried-over path gives us the content for the new
+ *     revision's items map — at which point `recordRevision` dedupes
+ *     the unchanged blobs via content-addressing, so no new storage.
+ *
+ * SRP: this module owns the "what goes in a revision snapshot"
+ * decision. `HistoryProvider` owns layout. Callers (admin-api save /
+ * admin-api publish / CLI publish) just describe *what they wrote*
+ * and we construct the revision.
+ */
+
+import { join } from 'node:path'
+import type { StorageProvider } from './types.js'
+import type { HistoryProvider, RevisionInput, RevisionOperation } from './history.js'
+import type { ContentRoot } from './content-root.js'
+
+/** A single item that was written in this save/publish. */
+export interface WrittenItem {
+  /** Path relative to the content root, e.g. `pages/home/page.json`. */
+  path: string
+  /** Current content as stored. `null` marks a deletion. */
+  content: string | null
+}
+
+/**
+ * Location to scan when building the first revision's baseline
+ * snapshot. Each entry names a directory under the content root and
+ * the manifest filename to capture from every subdirectory.
+ */
+export interface ScanLocation {
+  /** Directory relative to the content root, e.g. `pages` or `fragments`. */
+  dir: string
+  /** Manifest filename to capture, e.g. `page.json` or `fragment.json`. */
+  manifest: string
+}
+
+/**
+ * Built-in content locations Gazetta knows about today. Callers can
+ * pass a superset (e.g. for future data/*, templates/*) — the list is
+ * part of `RecordWriteOptions` so this module stays open for extension
+ * without changes when new content kinds land.
+ */
+export const DEFAULT_SCAN_LOCATIONS: readonly ScanLocation[] = [
+  { dir: 'pages', manifest: 'page.json' },
+  { dir: 'fragments', manifest: 'fragment.json' },
+]
+
+/**
+ * Flat files at the content root to capture in the baseline snapshot
+ * (no per-subdirectory recursion). `site.yaml` is the only one today.
+ */
+export const DEFAULT_SCAN_ROOT_FILES: readonly string[] = ['site.yaml']
+
+export interface RecordWriteOptions {
+  /** HistoryProvider for the target we're recording on. */
+  history: HistoryProvider
+  /** Content root of the target — used to scan on first revision. */
+  contentRoot: ContentRoot
+  operation: RevisionOperation
+  /** Items the save/publish wrote (and optionally deleted). */
+  items: WrittenItem[]
+  /** Author identifier passed through to the manifest. */
+  author?: string
+  /** Source target name (for publish). */
+  source?: string
+  /** Optional human-readable note. */
+  message?: string
+  /** For rollback/restore: the revision id this one restored from. */
+  restoredFrom?: string
+  /**
+   * Override the directories walked during the first-revision baseline
+   * scan. Defaults to `DEFAULT_SCAN_LOCATIONS` (pages + fragments).
+   * Pass a superset if the site has extra authored content (e.g.
+   * custom `data/*.json` dirs); pass `[]` to skip directory scanning
+   * entirely (only root files + explicit items are captured).
+   */
+  scanLocations?: readonly ScanLocation[]
+  /**
+   * Override the flat files captured from the content root. Defaults
+   * to `DEFAULT_SCAN_ROOT_FILES` (`site.yaml`). Missing files are
+   * silently skipped so empty publish-targets still record cleanly.
+   */
+  scanRootFiles?: readonly string[]
+}
+
+/**
+ * Build + record a revision for the given write. Reads the previous
+ * snapshot (if any), overlays the delta, and calls
+ * `history.recordRevision`. Returns the recorded Revision.
+ *
+ * Callers are expected to have already written the items to the
+ * target's storage before invoking this; the recorder reads back via
+ * the HistoryProvider's dedup path (blobs it has already seen just
+ * `exists()` and skip) so the happy path is cheap on repeated saves
+ * of the same item.
+ */
+export async function recordWrite(opts: RecordWriteOptions) {
+  const prevItems = await loadPreviousSnapshot(
+    opts.history,
+    opts.contentRoot,
+    opts.scanLocations ?? DEFAULT_SCAN_LOCATIONS,
+    opts.scanRootFiles ?? DEFAULT_SCAN_ROOT_FILES,
+  )
+  const nextItems = new Map(prevItems)
+  for (const it of opts.items) {
+    if (it.content === null) nextItems.delete(it.path)
+    else nextItems.set(it.path, it.content)
+  }
+  const input: RevisionInput = {
+    operation: opts.operation,
+    author: opts.author,
+    source: opts.source,
+    message: opts.message,
+    restoredFrom: opts.restoredFrom,
+    items: nextItems,
+  }
+  return opts.history.recordRevision(input)
+}
+
+/**
+ * Materialize the previous revision's full content snapshot as
+ * `path → content`. If there is no previous revision, fall back to a
+ * one-time scan of the target's content tree (pages, fragments,
+ * site.yaml). That makes the first revision a proper baseline even
+ * when history was turned on after content already existed.
+ */
+async function loadPreviousSnapshot(
+  history: HistoryProvider,
+  contentRoot: ContentRoot,
+  scanLocations: readonly ScanLocation[],
+  scanRootFiles: readonly string[],
+): Promise<Map<string, string>> {
+  const [head] = await history.listRevisions(1)
+  if (head) {
+    const manifest = await history.readRevision(head.id)
+    const items = new Map<string, string>()
+    // Read blobs in parallel to avoid a big serial chain on large snapshots.
+    const entries = Object.entries(manifest.snapshot)
+    const contents = await Promise.all(entries.map(([, hash]) => history.readBlob(hash)))
+    entries.forEach(([path], i) => items.set(path, contents[i]))
+    return items
+  }
+  return scanContentTree(contentRoot, scanLocations, scanRootFiles)
+}
+
+/**
+ * One-time walk of a content root, capturing every content-defining
+ * manifest. Used only for the first revision on a target; subsequent
+ * revisions overlay deltas onto the previous snapshot.
+ *
+ * Locations walked come from `scanLocations` and `scanRootFiles` (see
+ * RecordWriteOptions) so this module stays open for extension: adding
+ * a new content kind is a caller-side change, not an edit here.
+ */
+async function scanContentTree(
+  root: ContentRoot,
+  scanLocations: readonly ScanLocation[],
+  scanRootFiles: readonly string[],
+): Promise<Map<string, string>> {
+  const items = new Map<string, string>()
+  const { storage } = root
+
+  for (const rel of scanRootFiles) {
+    const abs = root.path(rel)
+    if (await storage.exists(abs)) {
+      items.set(rel, await storage.readFile(abs))
+    }
+  }
+  for (const loc of scanLocations) {
+    await scanManifestsInto(storage, root.path(loc.dir), loc.dir, loc.manifest, items)
+  }
+
+  return items
+}
+
+/**
+ * Walk a `pages/` or `fragments/` tree, reading every matching manifest
+ * into `items` with relative-path keys. Recurses so nested dynamic
+ * routes (e.g. `blog/[slug]/page.json`) are captured.
+ *
+ * Cloud object stores (R2/S3/Azure Blob) have no "directory" concept —
+ * `exists()` on a prefix-only path returns false. Rely on `readDir`
+ * returning an empty array for missing paths instead of probing via
+ * `exists` first.
+ */
+async function scanManifestsInto(
+  storage: StorageProvider,
+  absDir: string,
+  relPrefix: string,
+  manifestName: string,
+  items: Map<string, string>,
+): Promise<void> {
+  let entries: Awaited<ReturnType<StorageProvider['readDir']>>
+  try {
+    entries = await storage.readDir(absDir)
+  } catch {
+    return // Directory doesn't exist (or provider threw) — nothing to scan.
+  }
+  for (const e of entries) {
+    if (!e.isDirectory) continue
+    const sub = join(absDir, e.name)
+    const relSub = `${relPrefix}/${e.name}`
+    const manifestPath = join(sub, manifestName)
+    if (await storage.exists(manifestPath)) {
+      items.set(`${relSub}/${manifestName}`, await storage.readFile(manifestPath))
+    }
+    // Recurse for nested routes (pages/blog/[slug]/page.json).
+    await scanManifestsInto(storage, sub, relSub, manifestName, items)
+  }
+}

--- a/packages/gazetta/src/history.ts
+++ b/packages/gazetta/src/history.ts
@@ -61,36 +61,60 @@ export interface HistoryRetention {
   maxRevisions?: number
 }
 
+/** Input to `recordRevision` — metadata plus the current content tree. */
+export interface RevisionInput {
+  operation: RevisionOperation
+  /** Author identifier (free-form for v1). */
+  author?: string
+  /** Source target, when this revision was produced by a publish. */
+  source?: string
+  /** Optional human-readable note. */
+  message?: string
+  /** For rollback/restore: the revision id this one restored from. */
+  restoredFrom?: string
+  /**
+   * Full content tree snapshot at this revision: `itemPath → content string`.
+   * Content is stored as UTF-8 text — covers every item type Gazetta
+   * tracks today (JSON manifests, YAML, HTML, CSS, JS). Binary assets
+   * (images, fonts) would need a separate mechanism; revisit when those
+   * become first-class.
+   *
+   * Unchanged items should carry identical content across calls so the
+   * provider can dedupe via content-addressing.
+   */
+  items: Map<string, string>
+}
+
 /**
  * Uniform history API. Implemented on top of any StorageProvider — reads
- * and writes bytes under `.gazetta/history/`.
+ * and writes bytes under `.gazetta/history/`. No provider-native
+ * versioning (S3 object versions, git commits) is used.
  */
 export interface HistoryProvider {
   /**
    * Record a new revision on the target.
    *
-   * Implementation: writes any new item blobs to `objects/<hash>`, writes the
-   * revision manifest to `revisions/rev-NNNN.json`, appends to `index.json`,
-   * and applies retention (evicts oldest if over limit).
+   * Writes any new item blobs to `objects/<hash[:2]>/<hash[2:]>`, writes
+   * the revision manifest to `revisions/rev-NNNN.json`, updates
+   * `index.json`, and applies retention (evicts oldest if over limit).
+   *
+   * `items` parameter carries the full content tree; only blobs that
+   * don't already exist are written. Returns the recorded Revision.
    */
-  recordRevision(revision: Omit<Revision, 'id'>): Promise<Revision>
+  recordRevision(input: RevisionInput): Promise<Revision>
 
-  /** List revisions, newest first. */
+  /** List revisions, newest first. `limit` caps the list size. */
   listRevisions(limit?: number): Promise<Revision[]>
 
   /** Read a revision's full manifest (metadata + snapshot). */
   readRevision(id: string): Promise<RevisionManifest>
 
   /** Read a content blob by hash (e.g. to restore an item's state). */
-  readBlob(hash: string): Promise<Uint8Array>
+  readBlob(hash: string): Promise<string>
 
   /**
-   * Delete a revision and its manifest. Orphaned blobs are garbage-collected
-   * by the implementation (lazy or immediate, adapter's choice).
+   * Delete a revision and its manifest. Orphaned blobs are garbage-
+   * collected by the implementation (lazy or immediate, adapter's choice).
    */
   deleteRevision(id: string): Promise<void>
 }
-
-// Implementation (createHistoryProvider) lands in Phase 6. Earlier phases
-// depend only on the HistoryProvider interface above (dependency inversion),
-// so no factory stub is needed here.

--- a/packages/gazetta/src/index.ts
+++ b/packages/gazetta/src/index.ts
@@ -34,10 +34,19 @@ export type { SourceContext } from './admin-api/source-context.js'
 export type {
   HistoryProvider,
   Revision,
+  RevisionInput,
   RevisionManifest,
   RevisionOperation,
   HistoryRetention,
 } from './history.js'
+export { createHistoryProvider } from './history-provider.js'
+export type { CreateHistoryProviderOptions } from './history-provider.js'
+export {
+  isHistoryEnabled,
+  getHistoryRetention,
+  DEFAULT_HISTORY_RETENTION,
+} from './types.js'
+export type { HistoryConfig } from './types.js'
 
 // Renderer
 export { renderComponent, renderFragment, renderPage } from './renderer.js'

--- a/packages/gazetta/src/index.ts
+++ b/packages/gazetta/src/index.ts
@@ -42,6 +42,16 @@ export type {
 export { createHistoryProvider } from './history-provider.js'
 export type { CreateHistoryProviderOptions } from './history-provider.js'
 export {
+  recordWrite,
+  DEFAULT_SCAN_LOCATIONS,
+  DEFAULT_SCAN_ROOT_FILES,
+} from './history-recorder.js'
+export type {
+  RecordWriteOptions,
+  WrittenItem,
+  ScanLocation,
+} from './history-recorder.js'
+export {
   isHistoryEnabled,
   getHistoryRetention,
   DEFAULT_HISTORY_RETENTION,

--- a/packages/gazetta/src/types.ts
+++ b/packages/gazetta/src/types.ts
@@ -149,6 +149,25 @@ export interface TargetConfig {
   /** Base URL of the site (e.g. https://gazetta.studio) */
   siteUrl?: string
   cache?: CacheConfig
+  /**
+   * Per-target history / revisions (undo, rollback). Default: enabled
+   * with 50-revision retention. Set `{ enabled: false }` to disable
+   * entirely (no `.gazetta/history/` writes on save/publish) for
+   * targets where the storage cost isn't worth it (e.g., ephemeral CI
+   * preview targets).
+   */
+  history?: HistoryConfig
+}
+
+/** Per-target history configuration. */
+export interface HistoryConfig {
+  /** Record revisions on save/publish. Default: true. */
+  enabled?: boolean
+  /**
+   * Keep at most N most-recent revisions; oldest evicted on write.
+   * Default: 50.
+   */
+  retention?: number
 }
 
 /** Determine rendering type for a target — centralised logic used by CLI and admin API */
@@ -167,6 +186,25 @@ export function getEnvironment(target: TargetConfig): TargetEnvironment {
  */
 export function isEditable(target: TargetConfig): boolean {
   return target.editable ?? (getEnvironment(target) === 'local')
+}
+
+/** Default retention: keep the last 50 revisions. Matches design-publishing.md. */
+export const DEFAULT_HISTORY_RETENTION = 50
+
+/** Whether this target records history on save/publish. Default: true. */
+export function isHistoryEnabled(target: TargetConfig): boolean {
+  return target.history?.enabled ?? true
+}
+
+/**
+ * Effective retention (max revisions) for this target. Defaults to
+ * `DEFAULT_HISTORY_RETENTION`. Values ≤ 0 are clamped to 1 — retaining
+ * zero revisions would mean every write evicts itself, which is
+ * confusing; use `enabled: false` to disable entirely.
+ */
+export function getHistoryRetention(target: TargetConfig): number {
+  const raw = target.history?.retention ?? DEFAULT_HISTORY_RETENTION
+  return raw > 0 ? raw : 1
 }
 
 /** Site manifest (site.yaml) */

--- a/packages/gazetta/tests/history-config.test.ts
+++ b/packages/gazetta/tests/history-config.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for the history config helpers on TargetConfig.
+ */
+import { describe, it, expect } from 'vitest'
+import type { TargetConfig } from '../src/types.js'
+import {
+  isHistoryEnabled,
+  getHistoryRetention,
+  DEFAULT_HISTORY_RETENTION,
+} from '../src/types.js'
+
+function T(history?: TargetConfig['history']): TargetConfig {
+  return { storage: { type: 'filesystem' }, history }
+}
+
+describe('isHistoryEnabled', () => {
+  it('defaults to true when no history config is set', () => {
+    expect(isHistoryEnabled(T())).toBe(true)
+  })
+  it('defaults to true when history config is present but enabled is omitted', () => {
+    expect(isHistoryEnabled(T({ retention: 100 }))).toBe(true)
+  })
+  it('false when explicitly disabled', () => {
+    expect(isHistoryEnabled(T({ enabled: false }))).toBe(false)
+  })
+  it('true when explicitly enabled', () => {
+    expect(isHistoryEnabled(T({ enabled: true }))).toBe(true)
+  })
+})
+
+describe('getHistoryRetention', () => {
+  it(`defaults to ${DEFAULT_HISTORY_RETENTION} when unset`, () => {
+    expect(getHistoryRetention(T())).toBe(DEFAULT_HISTORY_RETENTION)
+    expect(getHistoryRetention(T({ enabled: true }))).toBe(DEFAULT_HISTORY_RETENTION)
+  })
+  it('uses the configured retention when set', () => {
+    expect(getHistoryRetention(T({ retention: 100 }))).toBe(100)
+    expect(getHistoryRetention(T({ retention: 5 }))).toBe(5)
+  })
+  it('clamps 0 and negatives to 1 (use enabled:false to disable)', () => {
+    expect(getHistoryRetention(T({ retention: 0 }))).toBe(1)
+    expect(getHistoryRetention(T({ retention: -5 }))).toBe(1)
+  })
+})

--- a/packages/gazetta/tests/history-provider.test.ts
+++ b/packages/gazetta/tests/history-provider.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Unit tests for createHistoryProvider. Uses an in-memory StorageProvider
+ * so we exercise the real layout logic (index.json, revisions/, objects/
+ * sharding) without touching disk.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { StorageProvider } from '../src/types.js'
+import { createHistoryProvider } from '../src/history-provider.js'
+import type { RevisionInput } from '../src/history.js'
+
+/**
+ * Bare-minimum in-memory storage. Mirrors filesystem semantics: reads
+ * of missing paths throw; exists returns false; writes to nested paths
+ * are fine (no mkdir needed since it's a flat Map keyed by full path).
+ */
+function memoryStorage(): StorageProvider & { dump(): Map<string, string> } {
+  const files = new Map<string, string>()
+  return {
+    async readFile(path: string): Promise<string> {
+      const v = files.get(path)
+      if (v === undefined) throw new Error(`ENOENT: ${path}`)
+      return v
+    },
+    async writeFile(path: string, content: string): Promise<void> {
+      files.set(path, content)
+    },
+    async exists(path: string): Promise<boolean> {
+      return files.has(path)
+    },
+    async readDir(path: string) {
+      const prefix = path.endsWith('/') ? path : path + '/'
+      const children = new Set<string>()
+      for (const p of files.keys()) {
+        if (!p.startsWith(prefix)) continue
+        const rest = p.slice(prefix.length)
+        const seg = rest.split('/')[0]
+        if (seg) children.add(seg)
+      }
+      return [...children].map(name => ({ name, isDirectory: false, isFile: true }))
+    },
+    async mkdir(): Promise<void> { /* no-op; memoryStorage is flat */ },
+    async rm(path: string): Promise<void> {
+      files.delete(path)
+      // Also handle dir deletes — remove everything under the prefix.
+      const prefix = path.endsWith('/') ? path : path + '/'
+      for (const p of [...files.keys()]) {
+        if (p.startsWith(prefix)) files.delete(p)
+      }
+    },
+    dump() { return files },
+  }
+}
+
+function input(
+  items: Record<string, string>,
+  overrides: Partial<RevisionInput> = {},
+): RevisionInput {
+  return {
+    operation: 'save',
+    items: new Map(Object.entries(items)),
+    ...overrides,
+  }
+}
+
+describe('createHistoryProvider', () => {
+  let storage: ReturnType<typeof memoryStorage>
+  beforeEach(() => { storage = memoryStorage() })
+
+  describe('recordRevision', () => {
+    it('assigns sequential ids (rev-0001, rev-0002, ...)', async () => {
+      const h = createHistoryProvider({ storage })
+      const r1 = await h.recordRevision(input({ 'pages/home': 'a' }))
+      const r2 = await h.recordRevision(input({ 'pages/home': 'b' }))
+      expect(r1.id).toBe('rev-0001')
+      expect(r2.id).toBe('rev-0002')
+    })
+
+    it('writes a manifest per revision under revisions/', async () => {
+      const h = createHistoryProvider({ storage })
+      await h.recordRevision(input({ 'pages/home': 'a' }))
+      expect(await storage.exists('.gazetta/history/revisions/rev-0001.json')).toBe(true)
+    })
+
+    it('stores items as content-addressed blobs (sharded by first 2 hex chars)', async () => {
+      const h = createHistoryProvider({ storage })
+      await h.recordRevision(input({ 'pages/home': 'hello' }))
+      // sha256('hello') = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+      const shardedPath = '.gazetta/history/objects/2c/f24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+      expect(await storage.exists(shardedPath)).toBe(true)
+      expect(await storage.readFile(shardedPath)).toBe('hello')
+    })
+
+    it('dedupes unchanged content across revisions (writes blob only once)', async () => {
+      const h = createHistoryProvider({ storage })
+      await h.recordRevision(input({ 'pages/home': 'same', 'pages/about': 'same' }))
+      await h.recordRevision(input({ 'pages/home': 'same', 'pages/about': 'changed' }))
+      // Two unique contents → two blobs, not four.
+      const blobs = [...storage.dump().keys()].filter(k => k.startsWith('.gazetta/history/objects/'))
+      expect(blobs).toHaveLength(2)
+    })
+
+    it('returns the recorded Revision metadata (without the snapshot)', async () => {
+      const h = createHistoryProvider({ storage })
+      const rev = await h.recordRevision(input(
+        { 'pages/home': 'a' },
+        { operation: 'publish', source: 'local', message: 'hotfix' },
+      ))
+      expect(rev).toMatchObject({
+        id: 'rev-0001',
+        operation: 'publish',
+        source: 'local',
+        message: 'hotfix',
+        items: ['pages/home'],
+      })
+      expect(rev).not.toHaveProperty('snapshot')
+      expect(rev.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    })
+
+    it('sorts item paths deterministically in the manifest', async () => {
+      const h = createHistoryProvider({ storage })
+      await h.recordRevision(input({ 'pages/z': 'z', 'pages/a': 'a', 'pages/m': 'm' }))
+      const manifest = JSON.parse(
+        await storage.readFile('.gazetta/history/revisions/rev-0001.json'),
+      )
+      expect(manifest.items).toEqual(['pages/a', 'pages/m', 'pages/z'])
+      expect(Object.keys(manifest.snapshot)).toEqual(['pages/a', 'pages/m', 'pages/z'])
+    })
+  })
+
+  describe('listRevisions', () => {
+    it('returns revisions newest-first', async () => {
+      const h = createHistoryProvider({ storage })
+      await h.recordRevision(input({ a: '1' }))
+      await h.recordRevision(input({ a: '2' }))
+      await h.recordRevision(input({ a: '3' }))
+      const list = await h.listRevisions()
+      expect(list.map(r => r.id)).toEqual(['rev-0003', 'rev-0002', 'rev-0001'])
+    })
+
+    it('honors the limit parameter', async () => {
+      const h = createHistoryProvider({ storage })
+      for (let i = 0; i < 5; i++) await h.recordRevision(input({ a: `${i}` }))
+      const list = await h.listRevisions(2)
+      expect(list).toHaveLength(2)
+      expect(list[0].id).toBe('rev-0005')
+    })
+
+    it('empty when no revisions exist yet', async () => {
+      const h = createHistoryProvider({ storage })
+      expect(await h.listRevisions()).toEqual([])
+    })
+  })
+
+  describe('readRevision', () => {
+    it('returns the full manifest with snapshot', async () => {
+      const h = createHistoryProvider({ storage })
+      await h.recordRevision(input({ 'pages/home': 'a', 'pages/about': 'b' }))
+      const m = await h.readRevision('rev-0001')
+      expect(m.items).toEqual(['pages/about', 'pages/home'])
+      expect(Object.keys(m.snapshot).sort()).toEqual(['pages/about', 'pages/home'])
+    })
+  })
+
+  describe('readBlob', () => {
+    it('returns the content for a given hash', async () => {
+      const h = createHistoryProvider({ storage })
+      await h.recordRevision(input({ 'pages/home': 'hello' }))
+      const m = await h.readRevision('rev-0001')
+      const content = await h.readBlob(m.snapshot['pages/home'])
+      expect(content).toBe('hello')
+    })
+  })
+
+  describe('retention', () => {
+    it('keeps only the most recent N revisions (default 50)', async () => {
+      const h = createHistoryProvider({ storage, retention: 3 })
+      for (let i = 0; i < 5; i++) await h.recordRevision(input({ a: `${i}` }))
+      const list = await h.listRevisions()
+      expect(list.map(r => r.id)).toEqual(['rev-0005', 'rev-0004', 'rev-0003'])
+    })
+
+    it('evicts manifests but keeps nextId monotonic', async () => {
+      const h = createHistoryProvider({ storage, retention: 2 })
+      await h.recordRevision(input({ a: '1' }))
+      await h.recordRevision(input({ a: '2' }))
+      await h.recordRevision(input({ a: '3' })) // evicts rev-0001
+      expect(await storage.exists('.gazetta/history/revisions/rev-0001.json')).toBe(false)
+      expect(await storage.exists('.gazetta/history/revisions/rev-0002.json')).toBe(true)
+      // Next revision should still advance the counter — never reuse rev-0001.
+      const r4 = await h.recordRevision(input({ a: '4' }))
+      expect(r4.id).toBe('rev-0004')
+    })
+
+    it('clamps retention <= 0 to 1 (disable via history.enabled instead)', async () => {
+      const h = createHistoryProvider({ storage, retention: 0 })
+      await h.recordRevision(input({ a: '1' }))
+      await h.recordRevision(input({ a: '2' }))
+      const list = await h.listRevisions()
+      expect(list).toHaveLength(1)
+      expect(list[0].id).toBe('rev-0002')
+    })
+  })
+
+  describe('deleteRevision', () => {
+    it('removes the manifest and drops from the index', async () => {
+      const h = createHistoryProvider({ storage })
+      await h.recordRevision(input({ a: '1' }))
+      await h.recordRevision(input({ a: '2' }))
+      await h.deleteRevision('rev-0001')
+      expect(await storage.exists('.gazetta/history/revisions/rev-0001.json')).toBe(false)
+      const list = await h.listRevisions()
+      expect(list.map(r => r.id)).toEqual(['rev-0002'])
+    })
+
+    it('no-op for unknown id', async () => {
+      const h = createHistoryProvider({ storage })
+      await h.recordRevision(input({ a: '1' }))
+      await h.deleteRevision('rev-9999') // should not throw
+      const list = await h.listRevisions()
+      expect(list).toHaveLength(1)
+    })
+  })
+
+  describe('rootPath option', () => {
+    it('stores history under the provided path', async () => {
+      const h = createHistoryProvider({ storage, rootPath: 'custom/path' })
+      await h.recordRevision(input({ a: '1' }))
+      expect(await storage.exists('custom/path/index.json')).toBe(true)
+      expect(await storage.exists('custom/path/revisions/rev-0001.json')).toBe(true)
+    })
+  })
+})

--- a/packages/gazetta/tests/history-recorder.test.ts
+++ b/packages/gazetta/tests/history-recorder.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for the history-recorder helper. Covers the two-phase
+ * behavior: first revision scans the tree, subsequent revisions
+ * overlay deltas from the previous snapshot.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { StorageProvider } from '../src/types.js'
+import { createContentRoot } from '../src/content-root.js'
+import { createHistoryProvider } from '../src/history-provider.js'
+import { recordWrite } from '../src/history-recorder.js'
+
+function memoryStorage(): StorageProvider & { dump(): Map<string, string>; seed(entries: Record<string, string>): void } {
+  const files = new Map<string, string>()
+  return {
+    async readFile(path) {
+      const v = files.get(path)
+      if (v === undefined) throw new Error(`ENOENT: ${path}`)
+      return v
+    },
+    async writeFile(path, content) { files.set(path, content) },
+    async exists(path) { return files.has(path) },
+    async readDir(path) {
+      const prefix = path.endsWith('/') ? path : path + '/'
+      const dirs = new Set<string>()
+      const files_ = new Set<string>()
+      for (const p of files.keys()) {
+        if (!p.startsWith(prefix)) continue
+        const rest = p.slice(prefix.length)
+        const seg = rest.split('/')[0]
+        if (!seg) continue
+        if (rest.includes('/')) dirs.add(seg)
+        else files_.add(seg)
+      }
+      return [
+        ...[...dirs].map(name => ({ name, isDirectory: true, isFile: false })),
+        ...[...files_].filter(n => !dirs.has(n)).map(name => ({ name, isDirectory: false, isFile: true })),
+      ]
+    },
+    async mkdir() {},
+    async rm(path) {
+      files.delete(path)
+      const prefix = path.endsWith('/') ? path : path + '/'
+      for (const p of [...files.keys()]) {
+        if (p.startsWith(prefix)) files.delete(p)
+      }
+    },
+    dump() { return files },
+    seed(entries) {
+      for (const [k, v] of Object.entries(entries)) files.set(k, v)
+    },
+  }
+}
+
+describe('recordWrite', () => {
+  let storage: ReturnType<typeof memoryStorage>
+  beforeEach(() => { storage = memoryStorage() })
+
+  it('first revision snapshots the full content tree', async () => {
+    // Seed some content before the first save.
+    storage.seed({
+      'site.yaml': 'name: demo\n',
+      'pages/home/page.json': '{"template":"page-default"}',
+      'pages/about/page.json': '{"template":"page-default"}',
+      'fragments/header/fragment.json': '{"template":"header-layout"}',
+    })
+    const history = createHistoryProvider({ storage })
+    const contentRoot = createContentRoot(storage)
+
+    // Simulate a save of pages/home: author just edited the manifest.
+    storage.seed({ 'pages/home/page.json': '{"template":"page-default","content":{"title":"Home"}}' })
+    const rev = await recordWrite({
+      history,
+      contentRoot,
+      operation: 'save',
+      items: [{
+        path: 'pages/home/page.json',
+        content: '{"template":"page-default","content":{"title":"Home"}}',
+      }],
+    })
+
+    expect(rev.id).toBe('rev-0001')
+    const manifest = await history.readRevision(rev.id)
+    // Full tree captured — not just the one item that was written.
+    expect(Object.keys(manifest.snapshot).sort()).toEqual([
+      'fragments/header/fragment.json',
+      'pages/about/page.json',
+      'pages/home/page.json',
+      'site.yaml',
+    ])
+  })
+
+  it('second revision overlays the delta onto the previous snapshot', async () => {
+    storage.seed({
+      'site.yaml': 'name: demo\n',
+      'pages/home/page.json': 'v1',
+      'pages/about/page.json': 'unchanged',
+    })
+    const history = createHistoryProvider({ storage })
+    const contentRoot = createContentRoot(storage)
+    await recordWrite({
+      history,
+      contentRoot,
+      operation: 'save',
+      items: [{ path: 'pages/home/page.json', content: 'v1' }],
+    })
+
+    // Second save — only pages/home changes, pages/about carries forward.
+    const rev2 = await recordWrite({
+      history,
+      contentRoot,
+      operation: 'save',
+      items: [{ path: 'pages/home/page.json', content: 'v2' }],
+    })
+
+    const m2 = await history.readRevision(rev2.id)
+    expect(Object.keys(m2.snapshot).sort()).toEqual([
+      'pages/about/page.json',
+      'pages/home/page.json',
+      'site.yaml',
+    ])
+    // pages/about carries forward with an unchanged hash (same blob).
+    const m1 = await history.readRevision('rev-0001')
+    expect(m2.snapshot['pages/about/page.json']).toBe(m1.snapshot['pages/about/page.json'])
+    // pages/home has a different hash.
+    expect(m2.snapshot['pages/home/page.json']).not.toBe(m1.snapshot['pages/home/page.json'])
+  })
+
+  it('null content marks a deletion in the next snapshot', async () => {
+    storage.seed({
+      'pages/home/page.json': 'v1',
+      'pages/old-contact/page.json': 'gone',
+    })
+    const history = createHistoryProvider({ storage })
+    const contentRoot = createContentRoot(storage)
+    await recordWrite({
+      history,
+      contentRoot,
+      operation: 'save',
+      items: [{ path: 'pages/home/page.json', content: 'v1' }],
+    })
+
+    const rev2 = await recordWrite({
+      history,
+      contentRoot,
+      operation: 'save',
+      items: [{ path: 'pages/old-contact/page.json', content: null }],
+    })
+
+    const m = await history.readRevision(rev2.id)
+    expect(m.snapshot).not.toHaveProperty('pages/old-contact/page.json')
+    expect(m.snapshot).toHaveProperty('pages/home/page.json')
+  })
+
+  it('publish revision passes source + operation through to the manifest', async () => {
+    storage.seed({ 'pages/home/page.json': 'local-content' })
+    const history = createHistoryProvider({ storage })
+    const contentRoot = createContentRoot(storage)
+
+    const rev = await recordWrite({
+      history,
+      contentRoot,
+      operation: 'publish',
+      source: 'local',
+      message: 'promote local → prod',
+      items: [{ path: 'pages/home/page.json', content: 'local-content' }],
+    })
+
+    const m = await history.readRevision(rev.id)
+    expect(m.operation).toBe('publish')
+    expect(m.source).toBe('local')
+    expect(m.message).toBe('promote local → prod')
+  })
+
+  it('nested page routes are captured in the initial scan', async () => {
+    storage.seed({
+      'pages/blog/[slug]/page.json': '{"template":"blog-post"}',
+      'pages/blog/hello/page.json': '{"template":"blog-post"}',
+      'pages/home/page.json': '{"template":"page-default"}',
+    })
+    const history = createHistoryProvider({ storage })
+    const contentRoot = createContentRoot(storage)
+    const rev = await recordWrite({
+      history,
+      contentRoot,
+      operation: 'save',
+      items: [{ path: 'pages/home/page.json', content: '{"template":"page-default"}' }],
+    })
+    const m = await history.readRevision(rev.id)
+    expect(Object.keys(m.snapshot).sort()).toEqual([
+      'pages/blog/[slug]/page.json',
+      'pages/blog/hello/page.json',
+      'pages/home/page.json',
+    ])
+  })
+
+  it('unchanged content across revisions dedupes via content-addressed blobs', async () => {
+    storage.seed({
+      'pages/home/page.json': 'same',
+      'pages/about/page.json': 'same',
+    })
+    const history = createHistoryProvider({ storage })
+    const contentRoot = createContentRoot(storage)
+    await recordWrite({
+      history,
+      contentRoot,
+      operation: 'save',
+      items: [{ path: 'pages/home/page.json', content: 'same' }],
+    })
+    await recordWrite({
+      history,
+      contentRoot,
+      operation: 'save',
+      items: [{ path: 'pages/home/page.json', content: 'same' }],
+    })
+    // Two items with identical content + two revisions, but only one blob.
+    const blobs = [...storage.dump().keys()].filter(k => k.startsWith('.gazetta/history/objects/'))
+    expect(blobs).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 6 backend — per-target revision history as specced in [design-publishing.md "History"](.claude/rules/design-publishing.md) and decision #18. No UI yet; every save and publish now records a revision on the target it wrote to. R49–R51 add the Undo toast, history panel, and CLI commands on top.

### R47 — HistoryProvider foundation

Pure storage layer. One uniform approach across every StorageProvider (no S3 object versions, no git commits):

```
.gazetta/history/
  index.json                       { nextId, revisions: [ids] }
  revisions/rev-NNNN.json          one manifest per revision
  objects/<hh>/<rest>              content-addressed SHA-256 blobs
```

Content-addressed blobs dedupe unchanged items across revisions — storage scales with unique content, not revision count.

### R48 — Wire save + publish

- Save routes (`PUT /api/pages/:name`, `PUT /api/fragments/:name`, DELETE variants) record a revision on the source target after the manifest write.
- Publish routes record on the **destination** (per decision #18: history on destination, not source — so undo survives the source moving on).
- Publish history is best-effort: a history write failure logs and continues, never breaks the publish itself.

### Config (site.yaml)

```yaml
targets:
  staging:
    storage: { type: filesystem, path: ./dist/staging }
    history:
      enabled: true      # default; set false to skip .gazetta/history/ entirely
      retention: 50      # default; oldest evicted on write
```

## Shape of the change

- `history.ts` — types + `HistoryProvider` interface
- `history-provider.ts` — storage layout impl (blobs, manifests, retention)
- `history-recorder.ts` — "what goes in a snapshot" policy (first-scan / overlay-delta). Injectable scan locations for extensibility.
- `content-root.ts` — gains `.relative(path)` (inverse of `.path(...)`)
- `types.ts` — `HistoryConfig`, `isHistoryEnabled`, `getHistoryRetention`
- Admin-api wiring: `SourceContext.history`, `buildHistory` hook, save/publish routes

## Tests

- 354 gazetta unit passing (+30 for history-provider + history-recorder + history-config)
- 75 admin unit passing (+5 integration tests: PUT records revision, delta overlay, DELETE snapshot, disabled-source no-op, retention eviction)
- 56 e2e passing (existing, unaffected)

Manually verified end-to-end: `PUT /api/pages/home` records `rev-0001` on local with full baseline. `POST /api/publish` records `rev-0001` on staging with `operation: 'publish'` and the full content snapshot.

## SOLID audit

- **SRP**: three new files, three responsibilities (types, layout, snapshot policy).
- **OCP**: `scanLocations`/`scanRootFiles` options make adding content kinds a caller-side change.
- **LSP**: `HistoryProvider` works over any `StorageProvider` (filesystem / R2 / S3 / Azure) — filesystem needed a mkdir helper, but the interface is unchanged.
- **ISP**: 5-method HistoryProvider, each distinct and minimal.
- **DIP**: admin-api depends on the `HistoryProvider` interface + `BuildHistory` hook; implementations inject.

## Test plan

- [ ] CI green
- [ ] Browser smoke: edit a page, save, confirm `.gazetta/history/revisions/rev-0001.json` written on the active target
- [ ] Browser smoke: publish to staging, confirm `.gazetta/history/` appears on the staging target with `operation: 'publish'`
- [ ] Site with `history: { enabled: false }` skips writes entirely

## Follow-ups

R49 (Undo toast), R50 (history panel), R51 (CLI `gazetta undo` / `rollback`) as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)