### PR TITLE
R51: gazetta history / undo / rollback CLI commands

### DIFF
--- a/packages/gazetta/src/cli/history.ts
+++ b/packages/gazetta/src/cli/history.ts
@@ -1,0 +1,174 @@
+/**
+ * CLI history commands.
+ *
+ *   gazetta history [target]           — list revisions, newest first
+ *   gazetta undo [target]              — restore the revision just before
+ *                                        head (the "undo last write" shortcut)
+ *   gazetta rollback <rev> [target]    — restore an arbitrary revision by id
+ *
+ * All three reuse the admin-api's HistoryProvider + restoreRevision —
+ * CLI and web surface the same operations. SRP: this file glues the
+ * CLI to the core; no new domain logic.
+ *
+ * Destructive ops (undo, rollback) prompt for confirmation on prod
+ * targets when running interactively. `CI=true` disables the prompt
+ * and fails if `--yes` wasn't passed.
+ */
+
+import { createInterface } from 'node:readline/promises'
+import { createHistoryProvider } from '../history-provider.js'
+import { restoreRevision } from '../history-restorer.js'
+import { createContentRoot } from '../content-root.js'
+import { isHistoryEnabled, getHistoryRetention, getEnvironment } from '../types.js'
+import type { TargetConfig } from '../types.js'
+
+/** Shared context passed to every command handler. */
+export interface HistoryCommandContext {
+  siteDir: string
+  targetName: string
+  config: TargetConfig
+}
+
+/** Format an ISO timestamp as "Apr 16, 2026 · 11:05" for humans. */
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric',
+    hour: '2-digit', minute: '2-digit', hour12: false,
+  }).replace(',', ' ·')
+}
+
+/** Abbreviate an items list for single-line display. */
+function formatItems(items: readonly string[]): string {
+  if (items.length === 0) return '(none)'
+  if (items.length <= 3) return items.join(', ')
+  return `${items.slice(0, 3).join(', ')} + ${items.length - 3} more`
+}
+
+/**
+ * Buid a HistoryProvider for the given target. Throws with a friendly
+ * message when history is disabled — prevents the CLI from silently
+ * returning an empty list for a target the user explicitly targeted.
+ */
+async function buildHistory(ctx: HistoryCommandContext) {
+  if (!isHistoryEnabled(ctx.config)) {
+    throw new Error(`History disabled on target "${ctx.targetName}" (site.yaml: history.enabled: false)`)
+  }
+  const { createStorageProvider } = await import('../targets.js')
+  const storage = await createStorageProvider(ctx.config.storage, ctx.siteDir, ctx.targetName)
+  const maybeInit = storage as typeof storage & { init?: () => Promise<void> }
+  if (typeof maybeInit.init === 'function') await maybeInit.init()
+  const history = createHistoryProvider({ storage, retention: getHistoryRetention(ctx.config) })
+  const contentRoot = createContentRoot(storage)
+  return { history, contentRoot, storage }
+}
+
+/**
+ * `gazetta history [target]` — print the revision list, newest first.
+ */
+export async function runHistoryList(ctx: HistoryCommandContext, opts: { limit?: number } = {}): Promise<void> {
+  const { history } = await buildHistory(ctx)
+  const revisions = await history.listRevisions(opts.limit ?? 50)
+  if (revisions.length === 0) {
+    console.log(`\n  No revisions on "${ctx.targetName}" yet. Saves and publishes will record here.\n`)
+    return
+  }
+
+  console.log(`\n  History — ${ctx.targetName} (${revisions.length} revision${revisions.length === 1 ? '' : 's'})\n`)
+  for (const rev of revisions) {
+    const op = rev.operation.padEnd(8)
+    const time = formatTimestamp(rev.timestamp)
+    const suffix = rev.source ? `  (from ${rev.source})` : ''
+    const message = rev.message ? `  — ${rev.message}` : ''
+    console.log(`    ${rev.id}  ${op}  ${time}${suffix}${message}`)
+    console.log(`      items: ${formatItems(rev.items)}`)
+  }
+  console.log()
+}
+
+async function confirm(prompt: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    const ans = (await rl.question(`${prompt} [y/N] `)).trim().toLowerCase()
+    return ans === 'y' || ans === 'yes'
+  } finally {
+    rl.close()
+  }
+}
+
+/**
+ * Production targets require explicit confirmation. In CI (`CI=true`)
+ * the only way to confirm is `--yes` — we never prompt a non-tty.
+ */
+async function confirmDestructive(ctx: HistoryCommandContext, action: string, flagYes: boolean): Promise<boolean> {
+  const isProd = getEnvironment(ctx.config) === 'production'
+  if (!isProd) return true
+  if (flagYes) return true
+  if (process.env.CI) {
+    throw new Error(
+      `${action} on production target "${ctx.targetName}" in CI requires --yes to proceed`
+    )
+  }
+  return confirm(`  ${action} on production target "${ctx.targetName}" — continue?`)
+}
+
+/**
+ * `gazetta undo [target]` — restore the revision just before head.
+ * Needs at least two revisions (baseline + one write). Records a
+ * forward rollback.
+ */
+export async function runHistoryUndo(ctx: HistoryCommandContext, opts: { yes?: boolean } = {}): Promise<void> {
+  const { history, contentRoot } = await buildHistory(ctx)
+  const recent = await history.listRevisions(2)
+  if (recent.length < 2) {
+    throw new Error(`Nothing to undo — no prior revision on "${ctx.targetName}"`)
+  }
+  const [head, prior] = recent
+  const proceed = await confirmDestructive(ctx, 'Undo', !!opts.yes)
+  if (!proceed) {
+    console.log('  Cancelled.')
+    return
+  }
+  const restored = await restoreRevision({
+    history,
+    contentRoot,
+    revisionId: prior.id,
+    message: `Undo ${head.operation} (rev ${head.id})`,
+  })
+  console.log(`\n  ✓ Undone. ${ctx.targetName} is now at ${prior.id} (${prior.operation} @ ${formatTimestamp(prior.timestamp)})`)
+  console.log(`    Forward revision: ${restored.id}\n`)
+}
+
+/**
+ * `gazetta rollback <rev> [target]` — restore an arbitrary revision.
+ * Records a forward rollback.
+ */
+export async function runHistoryRollback(
+  ctx: HistoryCommandContext,
+  revisionId: string,
+  opts: { yes?: boolean } = {},
+): Promise<void> {
+  if (!revisionId) throw new Error('rollback: missing revision id (pass as positional, e.g. gazetta rollback rev-1776337441608)')
+  const { history, contentRoot } = await buildHistory(ctx)
+  // Fail early if the revision doesn't exist — readRevision gives a
+  // clear ENOENT-style error otherwise, but we can frame it better here.
+  let target
+  try {
+    target = await history.readRevision(revisionId)
+  } catch {
+    throw new Error(`Unknown revision "${revisionId}" on target "${ctx.targetName}"`)
+  }
+  const proceed = await confirmDestructive(ctx, `Rollback to ${revisionId}`, !!opts.yes)
+  if (!proceed) {
+    console.log('  Cancelled.')
+    return
+  }
+  const restored = await restoreRevision({
+    history,
+    contentRoot,
+    revisionId,
+    message: `Rollback to ${revisionId}`,
+  })
+  console.log(`\n  ✓ Rolled back. ${ctx.targetName} is now at ${revisionId} (${target.operation} @ ${formatTimestamp(target.timestamp)})`)
+  console.log(`    Forward revision: ${restored.id}\n`)
+}

--- a/packages/gazetta/src/cli/index.ts
+++ b/packages/gazetta/src/cli/index.ts
@@ -141,11 +141,18 @@ function printHelp() {
     gazetta serve [target] [site]   Serve published pages from target storage
     gazetta deploy [target] [site]  Deploy worker to hosting (one-time setup)
     gazetta validate [site]         Check site for broken references
+    gazetta history [target] [site] List revisions on a target
+    gazetta undo [target] [site]    Restore the previous revision (soft undo)
+    gazetta rollback <rev> [target] [site]
+                                    Restore an arbitrary revision by id
     gazetta help                    Show this help message
 
   Options:
     --port, -p <port>               Server port (default: 3000)
     --force, -f                     Publish all items (skip unchanged check)
+    --yes, -y                       Skip confirmation prompt (required in CI
+                                    for undo/rollback on production targets)
+    --limit <n>                     Max revisions to list (default: 50)
 
   Auto-detection:
     Site is auto-detected from sites/ directory. If multiple sites exist,
@@ -162,25 +169,34 @@ function printHelp() {
     gazetta publish production my-site  # publish specific site to production
     gazetta serve production -p 8080    # serve production on port 8080
     gazetta validate                    # check site for errors
+    gazetta history                     # list revisions on default target
+    gazetta undo production --yes       # undo last write on production (CI-safe)
+    gazetta rollback rev-1776337441608  # roll back to a specific revision
 `)
 }
 
-interface ParsedArgs { positional: string[]; port?: number; force?: boolean }
+interface ParsedArgs { positional: string[]; port?: number; force?: boolean; yes?: boolean; limit?: number }
 
 function parseArgs(input: string[]): ParsedArgs {
   const positional: string[] = []
   let port: number | undefined
   let force = false
+  let yes = false
+  let limit: number | undefined
   for (let i = 0; i < input.length; i++) {
     if (input[i] === '--port' || input[i] === '-p') {
       port = parseInt(input[++i], 10)
     } else if (input[i] === '--force' || input[i] === '-f') {
       force = true
+    } else if (input[i] === '--yes' || input[i] === '-y') {
+      yes = true
+    } else if (input[i] === '--limit') {
+      limit = parseInt(input[++i], 10)
     } else if (!input[i].startsWith('-')) {
       positional.push(input[i])
     }
   }
-  return { positional, port, force }
+  return { positional, port, force, yes, limit }
 }
 
 /**
@@ -1443,12 +1459,16 @@ async function main() {
   const parsed = parseArgs(args.slice(1))
 
   // Commands that take [target] [site] positional args
-  const targetFirstCommands = new Set(['publish', 'serve', 'deploy'])
+  const targetFirstCommands = new Set(['publish', 'serve', 'deploy', 'history', 'undo'])
   // Commands that take [site] positional arg
   const siteOnlyCommands = new Set(['dev', 'validate', 'admin'])
 
   let siteDir: string
   let targetName: string | undefined
+  // rollback: positional layout is `<rev> [target] [site]`. We stash
+  // the revision id here because the shared positional parser uses
+  // index 0 for target/site; rollback just consumes index 0 first.
+  let rollbackRevisionId: string | undefined
 
   if (command === 'init') {
     await runInit(parsed.positional[0] ?? '.')
@@ -1457,6 +1477,23 @@ async function main() {
     const siteDir = await resolveSiteDir(parsed.positional[0])
     await runBuild(siteDir)
     return
+  } else if (command === 'rollback') {
+    // gazetta rollback <rev> [target] [site]
+    const [rev, second, third] = parsed.positional
+    if (!rev || !rev.startsWith('rev-')) {
+      console.error(`\n  Error: rollback requires a revision id as the first argument (e.g. gazetta rollback rev-1776337441608 [target])\n`)
+      process.exit(1)
+      return
+    }
+    rollbackRevisionId = rev
+    const secondIsSite = second && (second.includes('/') || existsSync(join(resolve(second), 'site.yaml')))
+    if (secondIsSite) {
+      siteDir = await resolveSiteDir(second)
+      targetName = await resolveTarget(undefined, siteDir)
+    } else {
+      siteDir = await resolveSiteDir(third)
+      targetName = await resolveTarget(second, siteDir)
+    }
   } else if (targetFirstCommands.has(command)) {
     // gazetta publish [target] [site]
     const [first, second] = parsed.positional
@@ -1514,7 +1551,33 @@ async function main() {
     case 'admin':
       await runAdmin(siteDir, parsed.port ?? 3000)
       break
+    case 'history':
+    case 'undo':
+    case 'rollback': {
+      const { runHistoryList, runHistoryUndo, runHistoryRollback } = await import('./history.js')
+      const ctx = await resolveHistoryContext(siteDir, targetName!)
+      if (command === 'history') await runHistoryList(ctx, { limit: parsed.limit })
+      else if (command === 'undo') await runHistoryUndo(ctx, { yes: parsed.yes })
+      else await runHistoryRollback(ctx, rollbackRevisionId!, { yes: parsed.yes })
+      break
+    }
   }
+}
+
+/**
+ * Resolve site + target + config into the shape HistoryCommandContext
+ * expects. Lives here rather than in cli/history.ts so the target-
+ * resolution logic (site.yaml parsing, CI env handling) stays with
+ * the other CLI commands that already do it the same way.
+ */
+async function resolveHistoryContext(siteDir: string, targetName: string) {
+  const { bootstrapFromSiteYaml } = await import('./bootstrap.js')
+  const { targetConfigs } = await bootstrapFromSiteYaml(siteDir)
+  const config = targetConfigs[targetName]
+  if (!config) {
+    throw new Error(`Unknown target "${targetName}". Available: ${Object.keys(targetConfigs).join(', ')}`)
+  }
+  return { siteDir, targetName, config }
 }
 
 main().catch((err) => {

--- a/packages/gazetta/tests/cli-history.test.ts
+++ b/packages/gazetta/tests/cli-history.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Integration tests for `gazetta history`, `gazetta undo`, and
+ * `gazetta rollback`. Spawns the CLI against a temp copy of the
+ * starter site so we exercise argument parsing, target resolution,
+ * env loading, and the actual restore path.
+ *
+ * Fast-ish: each test runs ~3 subprocess calls + filesystem writes.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawn } from 'node:child_process'
+import { cp, rm, readFile, writeFile, mkdir } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { tempDir } from './_helpers/temp.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(here, '../../..')
+const starterDir = resolve(repoRoot, 'examples/starter')
+const cliPath = resolve(repoRoot, 'packages/gazetta/src/cli/index.ts')
+const tsxBin = resolve(repoRoot, 'node_modules/.bin/tsx')
+
+interface RunResult { stdout: string; stderr: string; code: number }
+
+/**
+ * Run the CLI against `cwd` with the given args. CI=true is set so
+ * we never hit the interactive site/target picker; all the tests
+ * pass the target explicitly.
+ */
+function runCli(cwd: string, args: string[], env: Record<string, string> = {}): Promise<RunResult> {
+  return new Promise(done => {
+    const child = spawn(tsxBin, [cliPath, ...args], {
+      cwd,
+      env: { ...process.env, CI: 'true', ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout?.on('data', d => stdout += d.toString())
+    child.stderr?.on('data', d => stderr += d.toString())
+    child.on('close', code => done({ stdout, stderr, code: code ?? 0 }))
+  })
+}
+
+/** Make N saves via the admin-api PUT route to seed history. */
+async function seedHistory(projectDir: string, count: number): Promise<void> {
+  // Use the history-recorder directly — spinning up a dev server per
+  // test is too slow. Mirrors what the PUT /api/pages route does.
+  const gazetta = await import('../src/index.js')
+  const storage = gazetta.createFilesystemProvider(resolve(projectDir, 'sites/main/targets/local'))
+  const history = gazetta.createHistoryProvider({ storage })
+  const contentRoot = gazetta.createContentRoot(storage)
+  for (let i = 0; i < count; i++) {
+    const path = 'pages/home/page.json'
+    const content = JSON.stringify({
+      template: 'page-default',
+      content: { title: `Edit ${i + 1}` },
+      components: ['@header'],
+    }, null, 2) + '\n'
+    await gazetta.recordWrite({
+      history, contentRoot, operation: 'save',
+      items: [{ path, content }],
+    })
+    await storage.writeFile(path, content)
+    // Small delay so successive timestamp ids are unique (millisecond
+    // resolution means same-ms writes collide and get -<seq> suffixes,
+    // which work but make list assertions noisier).
+    await new Promise(r => setTimeout(r, 5))
+  }
+}
+
+// Spawning the CLI per test is slow (tsx cold-import + env load +
+// bootstrap). Bump the per-test timeout so the slowest cases (tests
+// that do two spawns) have headroom even on CI under load.
+describe('gazetta history / undo / rollback', { timeout: 60000 }, () => {
+  let projectDir: string
+
+  beforeEach(async () => {
+    projectDir = tempDir(`cli-history-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await mkdir(projectDir, { recursive: true })
+    await cp(starterDir, projectDir, {
+      recursive: true,
+      filter: src => !src.includes('/node_modules') && !src.includes('/dist'),
+    })
+  })
+
+  afterEach(async () => {
+    await rm(projectDir, { recursive: true, force: true })
+  })
+
+  it('`history` lists the revisions on a target newest-first', async () => {
+    await seedHistory(projectDir, 2)
+    const res = await runCli(projectDir, ['history', 'local', 'sites/main'])
+    expect(res.code).toBe(0)
+    expect(res.stdout).toContain('History — local')
+    // Baseline + 2 saves = 3 revisions.
+    expect(res.stdout).toContain('3 revisions')
+    expect(res.stdout).toContain('Initial baseline')
+    // Newest first: the "Edit 2" state is head; the `Initial baseline`
+    // tag should appear AFTER the others in the output.
+    const baselineAt = res.stdout.indexOf('Initial baseline')
+    const firstSaveAt = res.stdout.search(/rev-\d+\s+save\s+/)
+    expect(baselineAt).toBeGreaterThan(firstSaveAt)
+  })
+
+  it('`history` reports friendly message on a target with no history', async () => {
+    const res = await runCli(projectDir, ['history', 'local', 'sites/main'])
+    expect(res.code).toBe(0)
+    expect(res.stdout).toContain('No revisions')
+  })
+
+  it('`undo` restores the previous revision and reports the new head', async () => {
+    await seedHistory(projectDir, 2)
+    const homePath = resolve(projectDir, 'sites/main/targets/local/pages/home/page.json')
+    const beforeUndo = JSON.parse(await readFile(homePath, 'utf-8'))
+    expect(beforeUndo.content.title).toBe('Edit 2')
+
+    const res = await runCli(projectDir, ['undo', 'local', 'sites/main'])
+    expect(res.code).toBe(0)
+    expect(res.stdout).toContain('✓ Undone')
+
+    const afterUndo = JSON.parse(await readFile(homePath, 'utf-8'))
+    expect(afterUndo.content.title).toBe('Edit 1')
+  })
+
+  it('`undo` errors when there is nothing to undo', async () => {
+    const res = await runCli(projectDir, ['undo', 'local', 'sites/main'])
+    expect(res.code).not.toBe(0)
+    expect(res.stderr).toContain('Nothing to undo')
+  })
+
+  it('`rollback <rev>` restores an arbitrary revision', async () => {
+    await seedHistory(projectDir, 3)
+    // Grab the baseline id from the history command output — tests
+    // shouldn't depend on internal file layout.
+    const listRes = await runCli(projectDir, ['history', 'local', 'sites/main'])
+    const baselineMatch = listRes.stdout.match(/(rev-\d+)\s+save\s+.*Initial baseline/)
+    expect(baselineMatch).toBeTruthy()
+    const baselineId = baselineMatch![1]
+
+    const res = await runCli(projectDir, ['rollback', baselineId, 'local', 'sites/main'])
+    expect(res.code).toBe(0)
+    expect(res.stdout).toContain('✓ Rolled back')
+
+    // Baseline captures the pristine starter content.
+    const homePath = resolve(projectDir, 'sites/main/targets/local/pages/home/page.json')
+    const restored = JSON.parse(await readFile(homePath, 'utf-8'))
+    expect(restored.content.title).toBe('Home')
+  })
+
+  it('`rollback` without an id errors clearly', async () => {
+    const res = await runCli(projectDir, ['rollback', 'local', 'sites/main'])
+    expect(res.code).not.toBe(0)
+    expect(res.stderr).toContain('rollback requires a revision id')
+  })
+
+  it('`rollback <unknown-rev>` errors with the revision id', async () => {
+    await seedHistory(projectDir, 1)
+    const res = await runCli(projectDir, ['rollback', 'rev-9999999999999', 'local', 'sites/main'])
+    expect(res.code).not.toBe(0)
+    expect(res.stderr).toContain('Unknown revision')
+  })
+
+  it('`undo` on production in CI requires --yes', async () => {
+    // Patch site.yaml: swap azure-blob production for a filesystem
+    // target with environment:production + editable:true (so our save-
+    // seed can land there) to mirror the e2e fixture.
+    const siteYamlPath = resolve(projectDir, 'sites/main/site.yaml')
+    const yaml = await readFile(siteYamlPath, 'utf-8')
+    await writeFile(
+      siteYamlPath,
+      yaml.replace(
+        /production:\s*\n\s*storage:\s*\n\s*type: azure-blob[\s\S]*?container: "[^"]*"\s*\n\s*environment: production/,
+        'production:\n    environment: production\n    editable: true\n    storage:\n      type: filesystem\n      path: ./dist/prod-test',
+      ),
+    )
+    // Seed history on production directly.
+    const gazetta = await import('../src/index.js')
+    const prodDir = resolve(projectDir, 'sites/main/dist/prod-test')
+    await mkdir(prodDir, { recursive: true })
+    const storage = gazetta.createFilesystemProvider(prodDir)
+    const history = gazetta.createHistoryProvider({ storage })
+    const contentRoot = gazetta.createContentRoot(storage)
+    for (let i = 0; i < 2; i++) {
+      await gazetta.recordWrite({
+        history, contentRoot, operation: 'publish',
+        items: [{ path: 'pages/home/page.json', content: `{"t":${i}}` }],
+      })
+      await new Promise(r => setTimeout(r, 5))
+    }
+
+    const blocked = await runCli(projectDir, ['undo', 'production', 'sites/main'])
+    expect(blocked.code).not.toBe(0)
+    expect(blocked.stderr).toContain('--yes')
+
+    const allowed = await runCli(projectDir, ['undo', 'production', 'sites/main', '--yes'])
+    expect(allowed.code).toBe(0)
+    expect(allowed.stdout).toContain('✓ Undone')
+  })
+})


### PR DESCRIPTION
## Summary

Phase 6 final piece — CLI parity for the history surface added in R47–R50:

```
gazetta history [target] [site]       list revisions newest-first
gazetta undo [target] [site]          restore head-1 (last-write undo)
gazetta rollback <rev> [target] [site] restore an arbitrary revision
```

All three wrap `HistoryProvider` + `restoreRevision`. CLI and admin UI surface the same operations, same semantics. SRP: `cli/history.ts` is glue, no new domain logic.

### Behavior

- `--limit <n>` caps the history listing (default 50).
- `--yes` / `-y` skips the destructive-op confirmation prompt. In CI (`CI=true`), production targets **require** `--yes` — never prompt a non-tty, erroring loud beats silent rollbacks.
- Non-CI, non-prod: no prompt (matches `publish` behavior).
- `rollback` validates the first positional looks like `rev-*` so `gazetta rollback local sites/main` gives a clear "missing rev id" error instead of falling through to confusing target-resolution errors.

## Tests

8 integration tests spawn the CLI against a temp copy of the starter:
- history lists revisions, reports empty-state
- undo restores previous; errors when nothing to undo
- rollback restores an arbitrary rev; errors on missing id / unknown rev
- prod target in CI blocked without `--yes`, allowed with

376 gazetta unit + 81 admin unit + 59 e2e passing.

## Test plan

- [ ] CI green
- [ ] Manual: `gazetta undo local sites/main` on a project with a saved page reverts it
- [ ] `gazetta history` output is readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)