### PR TITLE
Sidecars unit tests + PBT for hash helpers (testing-plan 1.2 + 1.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6255,6 +6255,29 @@
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
+      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8593,6 +8616,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
@@ -10424,6 +10464,7 @@
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
         "@vitejs/plugin-vue": "^6.0.6",
+        "fast-check": "^4.6.0",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2",
         "vite": "^8.0.8",

--- a/packages/gazetta/package.json
+++ b/packages/gazetta/package.json
@@ -101,6 +101,7 @@
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-vue": "^6.0.6",
+    "fast-check": "^4.6.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
     "vite": "^8.0.8",

--- a/packages/gazetta/tests/hash-pbt.test.ts
+++ b/packages/gazetta/tests/hash-pbt.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Property-based tests for hash.ts helpers — focused on the round-trip
+ * and non-collision invariants for fragment/template name encoding and
+ * sidecar filename generation. Closes testing-plan.md Priority 1.3.
+ *
+ * Scope (explicitly narrow — complements existing example tests in
+ * hash.test.ts):
+ *   - encodeRefName / decodeRefName round-trip
+ *   - sidecarNameFor / parseSidecarName round-trip + rejection
+ *   - usesSidecarNameFor / parseUsesSidecarName round-trip
+ *   - templateSidecarNameFor / parseTemplateSidecarName round-trip
+ *   - Non-collision: the three sidecar regexes don't match each other's
+ *     outputs for typical inputs
+ *
+ * hashManifest stability and key-order invariance are already covered
+ * by hash.test.ts:55-68 — not repeated here.
+ */
+import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
+import {
+  encodeRefName, decodeRefName,
+  sidecarNameFor, parseSidecarName,
+  usesSidecarNameFor, parseUsesSidecarName,
+  templateSidecarNameFor, parseTemplateSidecarName,
+} from '../src/hash.js'
+
+/**
+ * Ref names are filesystem-safe identifiers — lowercase-kebab-case with
+ * optional `/` segments for subfolder grouping (e.g. `buttons/primary`).
+ * No leading/trailing slashes, no dots, no spaces.
+ */
+const refNameArb = fc.stringMatching(/^[a-z][a-z0-9-]*(\/[a-z][a-z0-9-]*)*$/)
+  .filter(s => s.length > 0 && s.length <= 80)
+
+/** 8-character lowercase hex hash — the output shape of hashManifest. */
+const hashArb = fc.stringMatching(/^[0-9a-f]{8}$/)
+
+describe('encodeRefName / decodeRefName', () => {
+  it('decode(encode(x)) === x for ref names with subfolders', () => {
+    fc.assert(
+      fc.property(refNameArb, (name) => {
+        expect(decodeRefName(encodeRefName(name))).toBe(name)
+      }),
+      { numRuns: 200 },
+    )
+  })
+
+  it('encode produces no / — always safe as a filename component', () => {
+    fc.assert(
+      fc.property(refNameArb, (name) => {
+        expect(encodeRefName(name)).not.toContain('/')
+      }),
+      { numRuns: 200 },
+    )
+  })
+
+  it('encode of a name without / is identity', () => {
+    fc.assert(
+      fc.property(fc.stringMatching(/^[a-z][a-z0-9-]*$/).filter(s => s.length > 0), (name) => {
+        expect(encodeRefName(name)).toBe(name)
+      }),
+      { numRuns: 100 },
+    )
+  })
+})
+
+describe('sidecarNameFor / parseSidecarName round-trip', () => {
+  it('parse(generate(h)) === h for every 8-hex hash', () => {
+    fc.assert(
+      fc.property(hashArb, (h) => {
+        expect(parseSidecarName(sidecarNameFor(h))).toBe(h)
+      }),
+      { numRuns: 200 },
+    )
+  })
+
+  it('rejects names that are not exactly .{8hex}.hash', () => {
+    fc.assert(
+      fc.property(fc.string(), (s) => {
+        // If the string doesn't match the expected pattern, parse must return null.
+        const isValid = /^\.[0-9a-f]{8}\.hash$/.test(s)
+        if (!isValid) expect(parseSidecarName(s)).toBeNull()
+      }),
+      { numRuns: 500 },
+    )
+  })
+})
+
+describe('usesSidecarNameFor / parseUsesSidecarName round-trip', () => {
+  it('parse(generate(name)) === name for every ref name', () => {
+    fc.assert(
+      fc.property(refNameArb, (name) => {
+        expect(parseUsesSidecarName(usesSidecarNameFor(name))).toBe(name)
+      }),
+      { numRuns: 200 },
+    )
+  })
+
+  it('produces filenames starting with .uses- and containing no /', () => {
+    fc.assert(
+      fc.property(refNameArb, (name) => {
+        const out = usesSidecarNameFor(name)
+        expect(out.startsWith('.uses-')).toBe(true)
+        expect(out).not.toContain('/')
+      }),
+      { numRuns: 200 },
+    )
+  })
+})
+
+describe('templateSidecarNameFor / parseTemplateSidecarName round-trip', () => {
+  it('parse(generate(name)) === name for every template name', () => {
+    fc.assert(
+      fc.property(refNameArb, (name) => {
+        expect(parseTemplateSidecarName(templateSidecarNameFor(name))).toBe(name)
+      }),
+      { numRuns: 200 },
+    )
+  })
+
+  it('produces filenames starting with .tpl- and containing no /', () => {
+    fc.assert(
+      fc.property(refNameArb, (name) => {
+        const out = templateSidecarNameFor(name)
+        expect(out.startsWith('.tpl-')).toBe(true)
+        expect(out).not.toContain('/')
+      }),
+      { numRuns: 200 },
+    )
+  })
+})
+
+describe('non-collision between sidecar kinds', () => {
+  it('a generated .hash name is not parsed as uses or tpl', () => {
+    fc.assert(
+      fc.property(hashArb, (h) => {
+        const name = sidecarNameFor(h)
+        expect(parseUsesSidecarName(name)).toBeNull()
+        expect(parseTemplateSidecarName(name)).toBeNull()
+      }),
+      { numRuns: 200 },
+    )
+  })
+
+  it('a generated uses-* name is not parsed as hash or tpl', () => {
+    fc.assert(
+      fc.property(refNameArb, (name) => {
+        const out = usesSidecarNameFor(name)
+        expect(parseSidecarName(out)).toBeNull()
+        expect(parseTemplateSidecarName(out)).toBeNull()
+      }),
+      { numRuns: 200 },
+    )
+  })
+
+  it('a generated tpl-* name is not parsed as hash or uses', () => {
+    fc.assert(
+      fc.property(refNameArb, (name) => {
+        const out = templateSidecarNameFor(name)
+        expect(parseSidecarName(out)).toBeNull()
+        expect(parseUsesSidecarName(out)).toBeNull()
+      }),
+      { numRuns: 200 },
+    )
+  })
+})

--- a/packages/gazetta/tests/sidecars.test.ts
+++ b/packages/gazetta/tests/sidecars.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Direct unit tests for sidecars.ts — the content-addressing I/O module.
+ *
+ * Closes the gap identified in testing-plan.md Priority 1.2: the module
+ * has 60+ LOC of logic centralized from publish/compare/publish-rendered
+ * but no dedicated test file. Tests use an in-memory StorageProvider
+ * fake — same pattern as history-recorder.test.ts.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { StorageProvider } from '../src/types.js'
+import {
+  readSidecars,
+  writeSidecars,
+  listSidecars,
+  collectFragmentRefs,
+  type SidecarState,
+} from '../src/sidecars.js'
+
+function memoryStorage(): StorageProvider & { dump(): Map<string, string>; seed(entries: Record<string, string>): void } {
+  const files = new Map<string, string>()
+  return {
+    async readFile(path) {
+      const v = files.get(path)
+      if (v === undefined) throw new Error(`ENOENT: ${path}`)
+      return v
+    },
+    async writeFile(path, content) { files.set(path, content) },
+    async exists(path) { return files.has(path) },
+    async readDir(path) {
+      const prefix = path.endsWith('/') ? path : path + '/'
+      // Directory is said to exist if at least one file lives under it.
+      let any = false
+      const dirs = new Set<string>()
+      const files_ = new Set<string>()
+      for (const p of files.keys()) {
+        if (!p.startsWith(prefix)) continue
+        any = true
+        const rest = p.slice(prefix.length)
+        const seg = rest.split('/')[0]
+        if (!seg) continue
+        if (rest.includes('/')) dirs.add(seg)
+        else files_.add(seg)
+      }
+      if (!any) throw new Error(`ENOENT: ${path}`)
+      return [
+        ...[...dirs].map(name => ({ name, isDirectory: true, isFile: false })),
+        ...[...files_].filter(n => !dirs.has(n)).map(name => ({ name, isDirectory: false, isFile: true })),
+      ]
+    },
+    async mkdir() {},
+    async rm(path) {
+      files.delete(path)
+      const prefix = path.endsWith('/') ? path : path + '/'
+      for (const p of [...files.keys()]) {
+        if (p.startsWith(prefix)) files.delete(p)
+      }
+    },
+    dump() { return files },
+    seed(entries) {
+      for (const [k, v] of Object.entries(entries)) files.set(k, v)
+    },
+  }
+}
+
+describe('readSidecars', () => {
+  let storage: ReturnType<typeof memoryStorage>
+  beforeEach(() => { storage = memoryStorage() })
+
+  it('returns null for a missing directory', async () => {
+    expect(await readSidecars(storage, 'pages/ghost')).toBeNull()
+  })
+
+  it('returns null for a directory with no .hash sidecar', async () => {
+    // A directory with the page.json but no sidecars yet — pre-publish state.
+    storage.seed({ 'pages/home/page.json': '{}' })
+    expect(await readSidecars(storage, 'pages/home')).toBeNull()
+  })
+
+  it('returns hash-only state when only the .hash sidecar is present', async () => {
+    storage.seed({
+      'pages/home/page.json': '{}',
+      'pages/home/.abcd1234.hash': '',
+    })
+    expect(await readSidecars(storage, 'pages/home')).toEqual({
+      hash: 'abcd1234',
+      uses: [],
+      template: null,
+    })
+  })
+
+  it('returns full state when hash + uses + tpl sidecars are all present', async () => {
+    storage.seed({
+      'pages/home/page.json': '{}',
+      'pages/home/.abcd1234.hash': '',
+      'pages/home/.uses-header': '',
+      'pages/home/.uses-footer': '',
+      'pages/home/.tpl-page-default': '',
+    })
+    const state = await readSidecars(storage, 'pages/home')
+    expect(state?.hash).toBe('abcd1234')
+    expect(state?.uses.sort()).toEqual(['footer', 'header'])
+    expect(state?.template).toBe('page-default')
+  })
+
+  it('ignores unrelated files in the directory', async () => {
+    storage.seed({
+      'pages/home/page.json': '{}',
+      'pages/home/.abcd1234.hash': '',
+      'pages/home/index.html': '<html>…</html>',
+      'pages/home/styles.foo.css': '.a{}',
+    })
+    expect(await readSidecars(storage, 'pages/home')).toEqual({
+      hash: 'abcd1234',
+      uses: [],
+      template: null,
+    })
+  })
+
+  it('decodes subfolder-qualified uses-* names (buttons__primary → buttons/primary)', async () => {
+    storage.seed({
+      'pages/home/page.json': '{}',
+      'pages/home/.abcd1234.hash': '',
+      'pages/home/.uses-buttons__primary': '',
+    })
+    const state = await readSidecars(storage, 'pages/home')
+    expect(state?.uses).toEqual(['buttons/primary'])
+  })
+})
+
+describe('writeSidecars', () => {
+  let storage: ReturnType<typeof memoryStorage>
+  beforeEach(() => { storage = memoryStorage() })
+
+  it('writes all three sidecar kinds for a full state', async () => {
+    const state: SidecarState = {
+      hash: 'deadbeef',
+      uses: ['header', 'footer'],
+      template: 'page-default',
+    }
+    await writeSidecars(storage, 'pages/home', state)
+    const files = [...storage.dump().keys()].filter(p => p.startsWith('pages/home/'))
+    expect(files).toContain('pages/home/.deadbeef.hash')
+    expect(files).toContain('pages/home/.uses-header')
+    expect(files).toContain('pages/home/.uses-footer')
+    expect(files).toContain('pages/home/.tpl-page-default')
+  })
+
+  it('skips tpl-* when template is null', async () => {
+    await writeSidecars(storage, 'pages/home', { hash: 'deadbeef', uses: [], template: null })
+    const files = [...storage.dump().keys()].filter(p => p.startsWith('pages/home/'))
+    expect(files).toContain('pages/home/.deadbeef.hash')
+    expect(files.some(f => f.includes('.tpl-'))).toBe(false)
+  })
+
+  it('is idempotent — writing the same state twice leaves the same files', async () => {
+    const state: SidecarState = { hash: 'aa11bb22', uses: ['nav'], template: 'layout' }
+    await writeSidecars(storage, 'pages/home', state)
+    const snap1 = new Set([...storage.dump().keys()])
+    await writeSidecars(storage, 'pages/home', state)
+    const snap2 = new Set([...storage.dump().keys()])
+    expect(snap2).toEqual(snap1)
+  })
+
+  it('removes stale sidecars that are no longer in the new state', async () => {
+    // Initial state: header + footer
+    await writeSidecars(storage, 'pages/home', {
+      hash: '11111111',
+      uses: ['header', 'footer'],
+      template: 'old-layout',
+    })
+    // New state: only header, different template, different hash
+    await writeSidecars(storage, 'pages/home', {
+      hash: '22222222',
+      uses: ['header'],
+      template: 'new-layout',
+    })
+    const files = [...storage.dump().keys()].filter(p => p.startsWith('pages/home/'))
+    expect(files).toContain('pages/home/.22222222.hash')
+    expect(files).toContain('pages/home/.uses-header')
+    expect(files).toContain('pages/home/.tpl-new-layout')
+    // Old sidecars are gone
+    expect(files).not.toContain('pages/home/.11111111.hash')
+    expect(files).not.toContain('pages/home/.uses-footer')
+    expect(files).not.toContain('pages/home/.tpl-old-layout')
+  })
+
+  it('leaves non-sidecar files alone (index.html, page.json, …)', async () => {
+    storage.seed({
+      'pages/home/page.json': '{}',
+      'pages/home/index.html': '<html>',
+      'pages/home/.01234567.hash': '',  // an old sidecar — this SHOULD be removed
+    })
+    await writeSidecars(storage, 'pages/home', { hash: 'abcdef01', uses: [], template: null })
+    const files = [...storage.dump().keys()].filter(p => p.startsWith('pages/home/'))
+    expect(files).toContain('pages/home/page.json')
+    expect(files).toContain('pages/home/index.html')
+    expect(files).toContain('pages/home/.abcdef01.hash')
+    // The old hash sidecar should be gone (stale sidecar cleanup)
+    expect(files).not.toContain('pages/home/.01234567.hash')
+  })
+})
+
+describe('listSidecars', () => {
+  let storage: ReturnType<typeof memoryStorage>
+  beforeEach(() => { storage = memoryStorage() })
+
+  it('returns an empty map when the root directory does not exist', async () => {
+    expect(await listSidecars(storage, 'does/not/exist')).toEqual(new Map())
+  })
+
+  it('collects sidecars from every sub-directory keyed by relative path', async () => {
+    storage.seed({
+      'pages/home/page.json': '{}',
+      'pages/home/.aaaaaaaa.hash': '',
+      'pages/about/page.json': '{}',
+      'pages/about/.bbbbbbbb.hash': '',
+      'pages/about/.uses-header': '',
+    })
+    const out = await listSidecars(storage, 'pages')
+    expect(out.size).toBe(2)
+    expect(out.get('home')?.hash).toBe('aaaaaaaa')
+    expect(out.get('about')?.hash).toBe('bbbbbbbb')
+    expect(out.get('about')?.uses).toEqual(['header'])
+  })
+
+  it('skips sub-directories without a .hash sidecar', async () => {
+    storage.seed({
+      'pages/home/.aaaaaaaa.hash': '',
+      'pages/home/page.json': '{}',
+      // pages/new exists (has a page.json) but no .hash sidecar → not in map
+      'pages/new/page.json': '{}',
+    })
+    const out = await listSidecars(storage, 'pages')
+    expect(out.size).toBe(1)
+    expect(out.has('home')).toBe(true)
+    expect(out.has('new')).toBe(false)
+  })
+
+  it('recurses into nested sub-directories (e.g. blog/[slug])', async () => {
+    storage.seed({
+      'pages/blog/[slug]/page.json': '{}',
+      'pages/blog/[slug]/.aaaaaaaa.hash': '',
+    })
+    const out = await listSidecars(storage, 'pages')
+    expect(out.has('blog/[slug]')).toBe(true)
+    expect(out.get('blog/[slug]')?.hash).toBe('aaaaaaaa')
+  })
+})
+
+describe('collectFragmentRefs', () => {
+  it('returns empty for undefined or empty input', () => {
+    expect(collectFragmentRefs(undefined)).toEqual([])
+    expect(collectFragmentRefs([])).toEqual([])
+  })
+
+  it('collects top-level @fragment refs', () => {
+    expect(collectFragmentRefs(['@header', '@footer'])).toEqual(['header', 'footer'])
+  })
+
+  it('ignores non-@ strings and inline components without fragment refs', () => {
+    expect(collectFragmentRefs([
+      '@header',
+      { name: 'hero', template: 'hero' },
+      'not-a-fragment',
+    ])).toEqual(['header'])
+  })
+
+  it('recurses into inline components\' nested components', () => {
+    expect(collectFragmentRefs([
+      {
+        name: 'layout',
+        template: 'layout',
+        components: [
+          '@nav',
+          { name: 'sidebar', template: 'sidebar', components: ['@widgets'] },
+        ],
+      },
+    ]).sort()).toEqual(['nav', 'widgets'])
+  })
+
+  it('deduplicates repeated fragment references', () => {
+    expect(collectFragmentRefs([
+      '@header',
+      { name: 'section', template: 's', components: ['@header', '@footer'] },
+    ]).sort()).toEqual(['footer', 'header'])
+  })
+})


### PR DESCRIPTION
## Summary

Closes two adjacent gaps from [testing-plan.md](.claude/rules/testing-plan.md):

### 1.2 — sidecars.ts direct unit tests (20 tests)

[packages/gazetta/tests/sidecars.test.ts](packages/gazetta/tests/sidecars.test.ts) covers the full public surface of the content-addressing I/O module:

- **\`readSidecars\`** — missing dir, no .hash, hash-only, full state, unrelated files, subfolder-qualified names
- **\`writeSidecars\`** — all three kinds, null template, idempotency, stale-sidecar cleanup, leaves non-sidecar files alone
- **\`listSidecars\`** — missing root, keyed-by-relative-path collection, skip sub-dirs without .hash, nested paths like \`blog/[slug]\`
- **\`collectFragmentRefs\`** — empty input, top-level @refs, non-@ strings, inline-component recursion, dedup

Uses an in-memory \`StorageProvider\` fake matching the pattern already in \`history-recorder.test.ts\` — no module mocks.

### 1.3 — property-based tests for hash.ts helpers (12 tests)

[packages/gazetta/tests/hash-pbt.test.ts](packages/gazetta/tests/hash-pbt.test.ts) uses \`fast-check\` (new devDependency, v4.6) on the encoding/parsing helpers that had zero test coverage:

- \`encodeRefName\` / \`decodeRefName\` round-trip (with and without subfolders); encode always produces /-free filenames
- \`sidecarNameFor\` / \`parseSidecarName\` round-trip and rejection
- \`usesSidecarNameFor\` / \`parseUsesSidecarName\` round-trip and shape
- \`templateSidecarNameFor\` / \`parseTemplateSidecarName\` round-trip and shape
- **Non-collision** — the three sidecar regexes never match each other's outputs for any valid input

Explicitly skips \`hashManifest\` key-order invariance — already covered by example tests at [hash.test.ts:55-68](packages/gazetta/tests/hash.test.ts#L55-L68).

## Tests

- 400 tests passing in \`packages/gazetta\` (was 368; +32 = 20 sidecars + 12 PBT)
- 155 in \`apps/admin\` unchanged

## Test plan

- [ ] \`npm test\` passes workspace-wide
- [ ] CI passes
- [ ] Reviewer sanity-checks the \`refNameArb\` regex in hash-pbt.test.ts (matches the design constraint of lowercase-kebab-case with optional subfolders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)