### PR TITLE
Add a11y scans in e2e with baseline allowlist (Priority 2.3)

### DIFF
--- a/.claude/rules/testing-plan.md
+++ b/.claude/rules/testing-plan.md
@@ -163,18 +163,24 @@ is a legitimate testcontainers approach — it manages lifecycle programmaticall
 
 ---
 
-#### ☐ 2.3 Accessibility scans in e2e
+#### ◐ 2.3 Accessibility scans in e2e
 
-Zero a11y assertions. PrimeVue claims WCAG 2.1 AA with
-[open issues](https://github.com/primefaces/primevue/issues/7949); custom chrome
-(env-colored indicators, read-only states) has no coverage.
+Landed via `@axe-core/playwright` in [tests/e2e/a11y.test.ts](../../tests/e2e/a11y.test.ts).
+Four surfaces scanned (site tree, editor view, Publish panel, active-target switcher).
 
-**Stack:** `@axe-core/playwright` (Deque-maintained) in the existing e2e suite.
+**Baseline allowlist pattern:** 5 known violations tracked in the test file's `BASELINE`
+array — each entry names a rule id + the reason it's deferred. New violations not in the
+allowlist fail CI; fixes remove entries. Known debt at introduction (2026-04-16):
 
-**Skip:** Vitest-level a11y via `@chialab/vitest-axe` — viable but adds a dependency for
-marginal gain over e2e coverage.
+- `color-contrast` — tinted state colors below 4.5:1 in dark mode
+- `button-name` — icon-only buttons need aria-label audit
+- `label` — rjsf inputs rendering without labels
+- `frame-title` — preview iframe missing dynamic title
+- `nested-interactive` — PrimeVue Checkbox inside clickable row
 
-**Estimate:** ~0.5 day.
+**Remaining work:** burn down the BASELINE entries as fixes land.
+
+**Skipped:** Vitest-level a11y via `@chialab/vitest-axe` — e2e coverage is sufficient.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "sites/*"
       ],
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.1",
         "@playwright/test": "^1.59.1",
         "playwright": "^1.59.1",
         "react": "^19.2.0",
@@ -1016,6 +1017,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
+      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -5034,6 +5048,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/axe-core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/b4a": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
@@ -8191,6 +8215,7 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "smoke": "bash scripts/smoke-publish.sh"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@playwright/test": "^1.59.1",
     "playwright": "^1.59.1",
     "react": "^19.2.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,11 @@ export default defineConfig({
   projects: [
     {
       name: 'dev',
-      testMatch: 'editor.test.ts',
+      // editor.test.ts is the big feature suite; additional dev-admin spec
+      // files (e.g. a11y.test.ts) opt in by matching this glob. Excludes
+      // the production-* files which run against pre-built admins on fixed
+      // ports in their own projects.
+      testMatch: /^(?!production(?:-|\.)).*\.test\.ts$/,
       // baseURL is set per-worker by the testSite fixture in tests/e2e/fixtures.ts
     },
     {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,8 +24,11 @@ export default defineConfig({
       // editor.test.ts is the big feature suite; additional dev-admin spec
       // files (e.g. a11y.test.ts) opt in by matching this glob. Excludes
       // the production-* files which run against pre-built admins on fixed
-      // ports in their own projects.
-      testMatch: /^(?!production(?:-|\.)).*\.test\.ts$/,
+      // ports in their own projects. testIgnore applies to the basename
+      // consistently; a negative-lookahead on testMatch matches the full
+      // path and wouldn't catch `tests/e2e/production-esi.test.ts`.
+      testMatch: '**/*.test.ts',
+      testIgnore: ['**/production.test.ts', '**/production-*.test.ts'],
       // baseURL is set per-worker by the testSite fixture in tests/e2e/fixtures.ts
     },
     {

--- a/tests/e2e/a11y.test.ts
+++ b/tests/e2e/a11y.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Accessibility scans of the admin UI — testing-plan.md Priority 2.3.
+ *
+ * PrimeVue claims WCAG 2.1 AA compliance per their accessibility guide
+ * but has known open issues. The custom chrome Gazetta layers on top
+ * (env-colored indicators, read-only badges, unified Publish panel,
+ * history UI) had no a11y coverage — this file adds it.
+ *
+ * Strategy: scan each major surface with @axe-core/playwright and fail
+ * on any *new* violations not in the baseline allowlist. The baseline
+ * captures what the first scan found on 2026-04-16 — entries must be
+ * removed (not added) over time as fixes land. This is the standard
+ * pattern for introducing a11y tests into an existing codebase without
+ * blocking on a big-bang fix: regressions fail CI immediately, known
+ * debt is tracked and shrinking.
+ *
+ * Automated scans catch an estimated 30-40% of real WCAG issues. This
+ * is the floor, not the ceiling. Scoped to `wcag2a wcag2aa wcag21a
+ * wcag21aa` to match PrimeVue's stated target.
+ */
+import { test, expect } from './fixtures'
+import { AxeBuilder } from '@axe-core/playwright'
+
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
+
+/**
+ * Known violations to ignore for now. Each entry needs a rule id and a
+ * short reason. Remove entries as fixes land — don't add without a
+ * corresponding tracking note. Entries here are per-rule (not per-node)
+ * because the blast radius of each is typically across the admin: e.g.
+ * "color-contrast" fails on any tinted text below 4.5:1 ratio, which
+ * the dark-mode token work hasn't reached yet.
+ */
+const BASELINE: Array<{ id: string; reason: string }> = [
+  { id: 'color-contrast', reason: 'tinted state colors (muted labels, env badges) below 4.5:1 in dark mode — needs token-layer pass' },
+  { id: 'button-name', reason: 'icon-only PrimeVue buttons (tree chevrons, dialog close) need title/aria-label audit' },
+  { id: 'label', reason: 'several rjsf form inputs render without associated <label> — needs custom field wrapper fix' },
+  { id: 'frame-title', reason: 'preview <iframe> lacks title attr — trivial add but requires tying into ActiveTargetIndicator\'s dynamic label' },
+  { id: 'nested-interactive', reason: 'PrimeVue Checkbox inside a clickable row label; library-level issue with a clean fix via role=group' },
+]
+
+type Violation = { id: string; impact?: string | null; help: string; helpUrl: string; nodes: unknown[] }
+
+function newViolations(all: Violation[]): Violation[] {
+  const known = new Set(BASELINE.map(b => b.id))
+  return all.filter(v => !known.has(v.id))
+}
+
+async function scan(page: import('@playwright/test').Page) {
+  return new AxeBuilder({ page })
+    .withTags(WCAG_TAGS)
+    .analyze()
+}
+
+test.describe('accessibility', () => {
+  test('site tree view has no new WCAG violations', async ({ page }) => {
+    await page.goto('/admin')
+    await expect(page.locator('[data-testid="site-page-home"]')).toBeVisible()
+
+    const results = await scan(page)
+    const fresh = newViolations(results.violations)
+    expect(fresh, formatViolations(fresh)).toEqual([])
+  })
+
+  test('page editor view has no new WCAG violations', async ({ page }) => {
+    await page.goto('/admin/pages/home/edit')
+    await page.waitForSelector('[data-testid^="component-"]', { timeout: 10000 })
+
+    const results = await scan(page)
+    const fresh = newViolations(results.violations)
+    expect(fresh, formatViolations(fresh)).toEqual([])
+  })
+
+  test('Publish panel has no new WCAG violations', async ({ page }) => {
+    await page.goto('/admin')
+    await expect(page.locator('[data-testid="site-page-home"]')).toBeVisible()
+    await page.locator('[data-testid="publish-btn"]').click()
+    // Publish panel is a PrimeVue Dialog — rendered into body via Teleport.
+    await page.waitForSelector('[data-testid="publish-panel"]', { timeout: 5000 })
+
+    const results = await scan(page)
+    const fresh = newViolations(results.violations)
+    expect(fresh, formatViolations(fresh)).toEqual([])
+  })
+
+  test('active target indicator + switcher menu has no new WCAG violations', async ({ page }) => {
+    await page.goto('/admin')
+    await expect(page.locator('[data-testid="active-target-indicator"]')).toBeVisible()
+    await page.locator('[data-testid="active-target-indicator"]').click()
+    // The menu is a PrimeVue popup — wait for it to be rendered in the DOM.
+    await page.waitForSelector('.p-menu', { timeout: 3000 })
+
+    const results = await scan(page)
+    const fresh = newViolations(results.violations)
+    expect(fresh, formatViolations(fresh)).toEqual([])
+  })
+})
+
+/**
+ * Render axe violations as a readable failure message — the default
+ * deep-equal diff is unreadable for multi-violation output. Each entry
+ * gets rule id, impact, affected node count, and the help URL.
+ */
+function formatViolations(violations: Violation[]): string {
+  if (violations.length === 0) return 'No violations'
+  return '\n' + violations.map(v =>
+    `  [${v.impact ?? 'unknown'}] ${v.id} — ${v.help}\n    ${v.nodes.length} node(s)\n    ${v.helpUrl}`,
+  ).join('\n') + '\n'
+}


### PR DESCRIPTION
## Summary

Closes Priority 2.3 from [testing-plan.md](.claude/rules/testing-plan.md).

Introduces \`@axe-core/playwright\` scans against four admin surfaces: site tree, editor view, Publish panel, active-target switcher. Each surface runs an axe scan tagged \`wcag2a/aa/21a/21aa\` — matching PrimeVue's stated WCAG target.

## Baseline allowlist pattern

The first scan surfaced real violations across all four surfaces — expected for a UI introducing a11y tests retroactively. Rather than block this PR on a substantial fix sweep (some are library-level in PrimeVue), known rules are tracked in [tests/e2e/a11y.test.ts](tests/e2e/a11y.test.ts)'s \`BASELINE\` array with per-rule reasons.

**Contract:** new violations not in the allowlist fail CI. Fixes remove entries. The allowlist only shrinks — PR author must not grow it without a tracking note.

## Known debt at introduction

| Rule | Impact | Reason |
|------|--------|--------|
| \`color-contrast\` | serious | Tinted state colors below 4.5:1 in dark mode — needs token-layer pass |
| \`button-name\` | critical | Icon-only PrimeVue buttons need aria-label audit (tree chevrons, dialog close) |
| \`label\` | critical | rjsf form inputs render without associated \`<label>\` |
| \`frame-title\` | serious | Preview iframe lacks title — needs dynamic label |
| \`nested-interactive\` | serious | PrimeVue Checkbox inside a clickable row label — library-level |

Each is individually tractable; together they're a separate PR's worth of fix work, which is why the allowlist ships now.

## Config change

\`playwright.config.ts\`: \`dev\` project's \`testMatch\` broadened from a single file (\`editor.test.ts\`) to a glob that excludes the \`production-*\` files. Any new \`*.test.ts\` under \`tests/e2e/\` automatically opts into the dev project — the minimal change needed for \`a11y.test.ts\` to run.

## Stacking

Targets \`provider-conformance-tests\` (#155), not main.

## Test plan

- [ ] \`npx playwright test tests/e2e/a11y.test.ts --project=dev\` passes (4 tests)
- [ ] \`npx playwright test tests/e2e/editor.test.ts --project=dev\` still passes (59 tests — config glob change sanity)
- [ ] CI passes
- [ ] Reviewer sanity-checks the BASELINE entries — anything in there that looks wrong or should be fixed now?

🤖 Generated with [Claude Code](https://claude.com/claude-code)