### PR TITLE
Documented-behavior tests + operations.md correctness (Priority 2.2)

### DIFF
--- a/.claude/rules/operations.md
+++ b/.claude/rules/operations.md
@@ -209,10 +209,11 @@ This is a Node.js concern, not Gazetta-specific.
 Used for pure layout templates (header-layout, footer-layout) that only arrange children.
 The editor shows "No editable content. Edit its children instead."
 
-**Render timeouts:** Templates that fetch external data during SSR may be slow. Per-page
-render timeout: `gazetta dev` 10 seconds (then error overlay), `gazetta publish` 30 seconds
-(then page skipped with error). Pre-fetch data and pass it as content, or use dynamic
-components (SSR at request time, not publish time).
+**Render timeouts (not implemented):** Templates that fetch external data during SSR can
+be slow. There is **no per-page render timeout today** — a hung template hangs the dev
+server or publish run until the process is killed. Future: configurable timeouts (e.g.
+10s dev / 30s publish) with error-overlay / skip-with-error behavior. For now, pre-fetch
+data and pass it as content, or use dynamic components (SSR at request time, not publish time).
 
 ## Content Operations
 
@@ -269,7 +270,8 @@ content should use markdown or rich text fields, not inline YAML blocks.
 
 **Component nesting depth:** No hard limit on nesting. The renderer is recursive. Extremely
 deep nesting (100+ levels) may overflow Node's call stack. In practice, sites rarely exceed
-5-10 levels. `gazetta validate` warns if nesting exceeds 20 levels.
+5-10 levels. **No nesting-depth warning is implemented today** — future: `gazetta validate`
+warns if nesting exceeds 20 levels.
 
 ## Publishing Details
 
@@ -311,9 +313,12 @@ CLI publish does not currently prompt. CI (`CI=true`) is unaffected.
 | S3 | Parallel | 10 | Yes (3 retries) | 3500 PUT/s |
 | Azure Blob | Parallel | 10 | Yes (3 retries) | 20000 req/s |
 
-**Storage connectivity check before publish:** `gazetta publish` checks storage connectivity
-before rendering (lightweight read on target storage). If it fails, errors with a clear
-message. This prevents wasting time rendering pages only to fail on upload.
+**Storage connectivity check before publish (not implemented):** Future: `gazetta publish`
+should check storage connectivity before rendering (lightweight read on target storage) so
+authors don't waste time rendering pages only to fail on upload. Today, connectivity is
+validated implicitly — the first write or list fails with the underlying SDK's error.
+`TARGET_INIT_TIMEOUT_MS` (see `targets.ts`) guards against hangs during provider init,
+which is the closest existing behavior.
 
 **Storage quota errors:** When target storage quota is exceeded, `gazetta publish` shows
 the error and stops — remaining pages are not uploaded.
@@ -331,12 +336,16 @@ invalid, or missing.
 
 **Keyboard shortcuts:**
 
-| Shortcut | Action |
-|----------|--------|
-| `Ctrl/Cmd + S` | Save current component |
-| `Ctrl/Cmd + Z` | Undo last edit |
-| `Ctrl/Cmd + Shift + Z` | Redo |
-| `Escape` | Close dialog / exit edit mode |
+| Shortcut | Action | Where |
+|----------|--------|-------|
+| `Ctrl/Cmd + S` | Save current component | EditorPanel.vue |
+| `Ctrl/Cmd + Z` | Undo last field edit (form-scoped, 50-entry stack) | packages/gazetta/src/editor/mount.tsx |
+| `Ctrl/Cmd + Shift + Z` | Redo field edit | packages/gazetta/src/editor/mount.tsx |
+| `Escape` | Close dialog / exit edit mode | UnsavedDialog, EditorView, DevPlayground |
+
+Undo/redo is scoped to the active form's field edits (the default `@rjsf` editor). It
+does not undo target-level writes — that's the save-toast Undo affordance or the history
+panel. Stack is reset when the editor remounts (e.g. switching to a different component).
 
 **Server disconnect:** If `gazetta dev` crashes while the admin UI is open, API calls fail
 and admin shows "Server disconnected. Waiting for reconnect..." SSE auto-reconnect attempts
@@ -411,7 +420,7 @@ all pages. Keep templates lightweight. Future: parallel rendering with worker th
 | Sites | 10+ | No hard limit — independent |
 | Components per page | 50+ | Deep nesting (100+) may stack overflow |
 | Custom editors | 20+ | No hard limit — loaded on demand |
-| Fragment nesting depth | 10+ | Circular detection, warn at 20 |
+| Fragment nesting depth | 10+ | Circular detection (implemented); depth warning at 20 is future |
 
 ## Dev Server
 

--- a/.claude/rules/testing-plan.md
+++ b/.claude/rules/testing-plan.md
@@ -147,19 +147,33 @@ is a legitimate testcontainers approach — it manages lifecycle programmaticall
 
 ---
 
-#### ☐ 2.2 Documented-behavior tests from operations.md
+#### ✓ 2.2 Documented-behavior tests from operations.md
 
-[operations.md](./operations.md) documents testable claims with no tests:
-- Circular fragment reference detection
-- Render timeouts (10s dev / 30s publish)
-- 20-level nesting-depth warning
-- Connectivity precheck before publish
-- Explicit `environment: production` confirmation
-- Keyboard shortcuts (Ctrl+S save, Ctrl+Z undo, Esc close)
+Audited the "testable claims" list against the source. Three of six were
+**aspirational entries in operations.md** — documented as current but unimplemented.
+Those have been corrected in operations.md rather than tested. Landed tests for the
+three real claims:
 
-**Approach:** one integration test per claim; tests double as executable docs.
+**Tested (real):**
+- Circular fragment reference detection — [resolver.test.ts](../../packages/gazetta/tests/resolver.test.ts)
+  added 4 tests: self-reference, 2-hop cycle, 3-hop cycle, diamond-without-cycle (no false positive)
+- Keyboard shortcut `Ctrl/Cmd+S` saves — [editor.test.ts](../../tests/e2e/editor.test.ts)
+  added 3 e2e tests: Control+S, Meta+S, clean-form no-op
+- Keyboard shortcut `Ctrl/Cmd+Z` undo / `Shift+Z` redo — added e2e tests against
+  the default `@rjsf` form editor (implementation lives at
+  [packages/gazetta/src/editor/mount.tsx](../../packages/gazetta/src/editor/mount.tsx)
+  lines 869-914, scoped to field-level edit history with a 50-entry stack)
+- `Escape` closes dialogs — already covered by the existing `Escape key behavior`
+  describe block in editor.test.ts
+- Explicit `environment: production` confirmation — already covered by
+  [PublishPanel.test.ts](../../apps/admin/tests/PublishPanel.test.ts) (PR #151)
 
-**Estimate:** ~2-3 days, incremental.
+**Corrected in operations.md (not implemented — documentation was aspirational):**
+- Render timeouts (10s dev / 30s publish) — marked as future work; today a hung
+  template hangs the process
+- 20-level nesting-depth warning — marked as future `gazetta validate` work
+- Connectivity precheck before publish — marked as future; today failures surface
+  through the underlying SDK error when the first write or list fails
 
 ---
 

--- a/packages/gazetta/tests/resolver.test.ts
+++ b/packages/gazetta/tests/resolver.test.ts
@@ -290,3 +290,132 @@ describe('resolveFragment', () => {
     }
   })
 })
+
+/**
+ * Circular-reference detection — documented in operations.md
+ * ("Fragment nesting: Circular references are detected and reported").
+ * Runtime uses resolver.ts:33-38 + 72-76 to throw before an infinite
+ * recursion can land. These tests cover the three shapes a cycle can
+ * take in authored content.
+ */
+describe('circular reference detection', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  it('detects a direct self-reference (A → A)', async () => {
+    // Fragment A lists itself — smallest possible cycle. Resolver must
+    // bail at the second visit, not crash the process.
+    await writeSite({
+      'site.yaml': 'name: "Test"',
+      'fragments/a/fragment.json': JSON.stringify({
+        template: 'echo',
+        components: ['@a'],
+      }),
+      'pages/home/page.json': JSON.stringify({
+        template: 'echo',
+        components: ['@a'],
+      }),
+    })
+    await writeTemplate('echo')
+
+    const site = await loadSite({ siteDir: testDir, storage })
+    await expect(resolvePage('home', site)).rejects.toThrow(/[Cc]ircular reference/)
+  })
+
+  it('detects a two-fragment cycle (A → B → A)', async () => {
+    // A references B, B references back to A. Resolver tracks visited
+    // refs across recursion depth — both fragments are valid in isolation
+    // but together form a cycle.
+    await writeSite({
+      'site.yaml': 'name: "Test"',
+      'fragments/a/fragment.json': JSON.stringify({
+        template: 'echo',
+        components: ['@b'],
+      }),
+      'fragments/b/fragment.json': JSON.stringify({
+        template: 'echo',
+        components: ['@a'],
+      }),
+      'pages/home/page.json': JSON.stringify({
+        template: 'echo',
+        components: ['@a'],
+      }),
+    })
+    await writeTemplate('echo')
+
+    const site = await loadSite({ siteDir: testDir, storage })
+    const err = await resolvePage('home', site).catch(e => e as Error)
+    expect(err).toBeInstanceOf(Error)
+    expect(err.message).toContain('Circular reference')
+    // The error message shows the resolution path so the author can
+    // trace the cycle (resolver.ts:35-36).
+    expect(err.message).toContain('@a')
+    expect(err.message).toContain('@b')
+  })
+
+  it('detects a three-fragment cycle (A → B → C → A)', async () => {
+    // Three-hop cycle — ensures the detector isn't just catching
+    // depth-2 loops.
+    await writeSite({
+      'site.yaml': 'name: "Test"',
+      'fragments/a/fragment.json': JSON.stringify({
+        template: 'echo',
+        components: ['@b'],
+      }),
+      'fragments/b/fragment.json': JSON.stringify({
+        template: 'echo',
+        components: ['@c'],
+      }),
+      'fragments/c/fragment.json': JSON.stringify({
+        template: 'echo',
+        components: ['@a'],
+      }),
+      'pages/home/page.json': JSON.stringify({
+        template: 'echo',
+        components: ['@a'],
+      }),
+    })
+    await writeTemplate('echo')
+
+    const site = await loadSite({ siteDir: testDir, storage })
+    await expect(resolvePage('home', site)).rejects.toThrow(/[Cc]ircular reference/)
+  })
+
+  it('allows a diamond (A → B, A → C, both B and C → D) without false positives', async () => {
+    // Diamond-shape dependency: D is referenced twice on independent
+    // branches, but there is NO cycle. The visited-set is popped when
+    // a branch completes (resolver.ts:45-46, 63-64, 89-90) — this test
+    // ensures we don't regress to a broken visited-set that would
+    // flag D as already-visited on the second branch.
+    await writeSite({
+      'site.yaml': 'name: "Test"',
+      'fragments/a/fragment.json': JSON.stringify({
+        template: 'echo',
+        components: ['@b', '@c'],
+      }),
+      'fragments/b/fragment.json': JSON.stringify({
+        template: 'echo',
+        components: ['@d'],
+      }),
+      'fragments/c/fragment.json': JSON.stringify({
+        template: 'echo',
+        components: ['@d'],
+      }),
+      'fragments/d/fragment.json': JSON.stringify({
+        template: 'echo',
+        content: { text: 'leaf' },
+      }),
+      'pages/home/page.json': JSON.stringify({
+        template: 'echo',
+        components: ['@a'],
+      }),
+    })
+    await writeTemplate('echo')
+
+    const site = await loadSite({ siteDir: testDir, storage })
+    // Should NOT throw — a diamond is not a cycle.
+    const resolved = await resolvePage('home', site)
+    expect(resolved.children).toHaveLength(1)  // @a at the root
+  })
+})

--- a/tests/e2e/editor.test.ts
+++ b/tests/e2e/editor.test.ts
@@ -1136,3 +1136,111 @@ test.describe('History panel', () => {
     await expect(page.locator('[data-testid="history-empty"]')).toBeVisible()
   })
 })
+
+/**
+ * Keyboard shortcuts — operations.md "Keyboard shortcuts" table.
+ * Ctrl/Cmd+S triggers save without clicking the save button.
+ * Escape closes dialogs (already covered by the "Escape key behavior"
+ * describe above — this block specifically covers save + platform-
+ * aware modifier handling).
+ */
+test.describe('Keyboard shortcuts', () => {
+  test('Control+S saves a dirty form without clicking the save button', async ({ page }) => {
+    await openEditor(page, 'home')
+    await page.locator('[data-testid="component-hero"]').click()
+    const titleField = page.locator('input[name="root_title"]').first()
+    await titleField.waitFor({ timeout: 5000 })
+    const original = await titleField.inputValue()
+    await titleField.fill(original + ' — ctrl+s test')
+
+    // Save button should be enabled (dirty form).
+    await expect(page.locator('[data-testid="save-btn"]')).toBeEnabled()
+
+    // Press Ctrl+S — the editor's onKeyStroke('s') handler checks
+    // metaKey||ctrlKey and calls editing.save(). We use Control
+    // because it works cross-platform in Playwright's key API.
+    await page.keyboard.press('Control+s')
+
+    // Saved state confirmed via toast + save-btn back to disabled.
+    await expect(page.locator('[data-testid="global-toast"]')).toBeVisible({ timeout: 5000 })
+    await expect(page.locator('[data-testid="save-btn"]')).toBeDisabled({ timeout: 5000 })
+  })
+
+  test('Meta+S (Cmd+S on Mac) saves a dirty form', async ({ page }) => {
+    // Same handler path (metaKey||ctrlKey) — verifies the Mac-style
+    // modifier is honored, not just the Linux/Windows Control.
+    await openEditor(page, 'home')
+    await page.locator('[data-testid="component-hero"]').click()
+    const titleField = page.locator('input[name="root_title"]').first()
+    await titleField.waitFor({ timeout: 5000 })
+    const original = await titleField.inputValue()
+    await titleField.fill(original + ' — cmd+s test')
+
+    await page.keyboard.press('Meta+s')
+
+    await expect(page.locator('[data-testid="global-toast"]')).toBeVisible({ timeout: 5000 })
+    await expect(page.locator('[data-testid="save-btn"]')).toBeDisabled({ timeout: 5000 })
+  })
+
+  test('Control+S on a clean form is a no-op (does not trigger toast)', async ({ page }) => {
+    // The handler guards with `if (editing.dirty)` — a save shortcut
+    // on an unmodified form should not fire the save pipeline.
+    await openEditor(page, 'home')
+    await page.locator('[data-testid="component-hero"]').click()
+    await page.locator('input[name="root_title"]').first().waitFor({ timeout: 5000 })
+
+    // Form is clean at this point — save button should be disabled.
+    await expect(page.locator('[data-testid="save-btn"]')).toBeDisabled()
+
+    await page.keyboard.press('Control+s')
+
+    // No toast should appear. Give it a moment, then confirm.
+    await page.waitForTimeout(500)
+    await expect(page.locator('[data-testid="global-toast"]')).not.toBeVisible()
+  })
+
+  test('Control+Z undoes the last field edit (form-scoped history)', async ({ page }) => {
+    // The default @rjsf editor (packages/gazetta/src/editor/mount.tsx:869-914)
+    // maintains a 50-entry undo stack per form. Ctrl/Cmd+Z reverts the
+    // most recent change without hitting the save pipeline.
+    await openEditor(page, 'home')
+    await page.locator('[data-testid="component-hero"]').click()
+    const titleField = page.locator('input[name="root_title"]').first()
+    await titleField.waitFor({ timeout: 5000 })
+    const original = await titleField.inputValue()
+
+    // Make two edits so there's real undo history.
+    await titleField.fill(original + ' first edit')
+    await titleField.blur()
+    await titleField.fill(original + ' second edit')
+    await titleField.blur()
+    await expect(titleField).toHaveValue(original + ' second edit')
+
+    // Undo last edit → field returns to "first edit" state.
+    await page.keyboard.press('Control+z')
+    await expect(titleField).toHaveValue(original + ' first edit', { timeout: 2000 })
+
+    // Undo again → returns to the original.
+    await page.keyboard.press('Control+z')
+    await expect(titleField).toHaveValue(original, { timeout: 2000 })
+  })
+
+  test('Control+Shift+Z redoes an undone field edit', async ({ page }) => {
+    await openEditor(page, 'home')
+    await page.locator('[data-testid="component-hero"]').click()
+    const titleField = page.locator('input[name="root_title"]').first()
+    await titleField.waitFor({ timeout: 5000 })
+    const original = await titleField.inputValue()
+
+    await titleField.fill(original + ' edited')
+    await titleField.blur()
+
+    // Undo → back to original.
+    await page.keyboard.press('Control+z')
+    await expect(titleField).toHaveValue(original, { timeout: 2000 })
+
+    // Redo → edited value restored.
+    await page.keyboard.press('Control+Shift+z')
+    await expect(titleField).toHaveValue(original + ' edited', { timeout: 2000 })
+  })
+})


### PR DESCRIPTION
## Summary

Closes Priority 2.2 from [testing-plan.md](.claude/rules/testing-plan.md).

Audited operations.md's "testable claims" list against the source. Four were real and now have tests; three were aspirational and are corrected in operations.md rather than tested — no point writing tests for features that don't exist.

## Tests added (9 new)

### Circular fragment reference detection (4 unit tests)

[resolver.ts:33-38](packages/gazetta/src/resolver.ts#L33) already detects cycles, but had no direct test. [resolver.test.ts](packages/gazetta/tests/resolver.test.ts) now covers:

- Direct self-reference (A → A)
- Two-fragment cycle (A → B → A) — verifies error path mentions both fragments
- Three-fragment cycle (A → B → C → A) — verifies detection isn't depth-2-specific
- **Diamond-without-cycle** (A → {B, C}, both → D) — false-positive guard; ensures the \`visited.delete\` after each branch (resolver.ts:45-46, 63-64, 89-90) isn't broken

### Keyboard shortcuts (5 e2e tests)

[editor.test.ts](tests/e2e/editor.test.ts) now covers:

- **Ctrl/Cmd+S saves** (EditorPanel.vue:48-54) — three tests: Control+S, Meta+S, clean-form no-op
- **Ctrl/Cmd+Z undo** (editor/mount.tsx:869-914) — field-scoped history, 50-entry stack in the default @rjsf editor
- **Ctrl/Cmd+Shift+Z redo** — same implementation

## operations.md corrections

Three claims were future-looking descriptions marked as current behavior:

| Claim | Status | Correction |
|-------|--------|------------|
| Render timeouts (10s dev / 30s publish) | Not implemented | No \`setTimeout\` / \`AbortController\` around render paths. \`TARGET_INIT_TIMEOUT_MS\` is for provider init only. Marked as future. |
| 20-level nesting-depth warning | Not implemented | No \`nesting\`/\`nestingDepth\` symbols in src/. Marked as future \`gazetta validate\` work. |
| Connectivity precheck before publish | Not implemented | No preflight read. Failures surface through the first SDK call. Marked as future. |

Plus a clarification to the keyboard shortcuts table: Ctrl+Z / Shift+Z are real but **form-scoped** (field edits within the active form, not target-level). Target-level undo is the save-toast Undo or the history panel.

## Rationale for correction-over-test

For the three unimplemented items, the alternative — implementing them to fit the doc — is scope creep for a testing-plan item. Documenting reality is correct and cheap. The items stay on future-work until a product decision promotes them.

## Test plan

- [ ] \`cd packages/gazetta && npx vitest run tests/resolver.test.ts\` passes (18 tests; +4 new)
- [ ] \`npx playwright test tests/e2e/editor.test.ts --project=dev --grep "Keyboard shortcuts"\` passes (5 tests)
- [ ] CI passes
- [ ] Reviewer sanity-checks the three operations.md corrections

🤖 Generated with [Claude Code](https://claude.com/claude-code)