### PR TITLE
Storage provider conformance — Azure CRUD parity (Priority 2.1)

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@hono/vite-dev-server": "^0.25.1",
-    "@testcontainers/azurite": "^11.13.0",
     "@types/js-yaml": "^4.0.0",
     "@types/node": "^25.6.0",
     "@vitejs/plugin-vue": "^6.0.6",

--- a/apps/admin/tests/_helpers/provider-conformance.ts
+++ b/apps/admin/tests/_helpers/provider-conformance.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared storage-provider conformance suite — the canonical "does this
+ * provider satisfy StorageProvider?" test battery, extracted so every
+ * provider (filesystem, S3, Azure Blob, R2) runs the same assertions.
+ *
+ * Closes testing-plan.md Priority 2.1: Azure had only 3 publish-level
+ * tests, S3 had 8 direct CRUD tests. Parity now enforced by running
+ * the same function against both.
+ *
+ * SRP: this module owns the conformance contract, nothing else. New
+ * providers opt in by calling `runProviderConformance(...)` from their
+ * docker.test.ts describe block with a factory that returns an
+ * initialized StorageProvider.
+ *
+ * Why a factory rather than a plain instance: providers need different
+ * buckets/containers per test batch (to keep parallel test runs from
+ * colliding), so the caller supplies a "give me a provider named X"
+ * callback. The helper calls it once at suite start.
+ */
+import { beforeAll, describe, it, expect } from 'vitest'
+import type { StorageProvider } from 'gazetta'
+
+export interface ProviderFactory {
+  /** Human-readable name, used in the describe() label. */
+  name: string
+  /**
+   * Create an initialized provider bound to a unique namespace (bucket /
+   * container / dir). Caller decides the naming scheme; helper only
+   * requires that successive calls with different names don't collide.
+   */
+  make(namespace: string): Promise<StorageProvider>
+}
+
+/**
+ * Register the storage-provider conformance battery under its own
+ * describe() block. Call once per provider from docker.test.ts.
+ *
+ * Each test uses fresh keys so ordering doesn't matter, but the test
+ * suite itself shares one provider (one bucket/container) because
+ * per-test provision would triple Azurite/MinIO setup time.
+ */
+export function runProviderConformance(factory: ProviderFactory): void {
+  describe(`${factory.name} — StorageProvider conformance`, () => {
+    let provider: StorageProvider
+
+    beforeAll(async () => {
+      // A stable namespace per provider; tests use unique file paths
+      // within it so state doesn't leak between tests.
+      provider = await factory.make('conformance')
+    })
+
+    it('writes and reads a file', async () => {
+      await provider.writeFile('rw/hello.txt', 'hello world')
+      expect(await provider.readFile('rw/hello.txt')).toBe('hello world')
+    })
+
+    it('exists returns true for a written file and false for a missing one', async () => {
+      await provider.writeFile('exists/yes.txt', 'yes')
+      expect(await provider.exists('exists/yes.txt')).toBe(true)
+      expect(await provider.exists('exists/nope.txt')).toBe(false)
+    })
+
+    it('reads a directory and distinguishes files vs subdirectories', async () => {
+      await provider.writeFile('readdir/a.txt', 'a')
+      await provider.writeFile('readdir/b.txt', 'b')
+      await provider.writeFile('readdir/sub/c.txt', 'c')
+
+      const entries = await provider.readDir('readdir')
+      const names = entries.map(e => e.name)
+      expect(names).toContain('a.txt')
+      expect(names).toContain('b.txt')
+      expect(names).toContain('sub')
+      expect(entries.find(e => e.name === 'sub')?.isDirectory).toBe(true)
+      expect(entries.find(e => e.name === 'a.txt')?.isDirectory).toBe(false)
+    })
+
+    it('exists on a directory prefix returns true, on a missing prefix returns false', async () => {
+      await provider.writeFile('existsdir/file.txt', 'content')
+      expect(await provider.exists('existsdir')).toBe(true)
+      expect(await provider.exists('existsdir-missing')).toBe(false)
+    })
+
+    it('readFile throws on a missing file', async () => {
+      await expect(provider.readFile('never/written.txt')).rejects.toThrow()
+    })
+
+    it('rm deletes a single file', async () => {
+      await provider.writeFile('rm-file/bye.txt', 'bye')
+      await provider.rm('rm-file/bye.txt')
+      expect(await provider.exists('rm-file/bye.txt')).toBe(false)
+    })
+
+    it('rm deletes a directory recursively', async () => {
+      await provider.writeFile('rm-dir/a.txt', 'a')
+      await provider.writeFile('rm-dir/b.txt', 'b')
+      await provider.writeFile('rm-dir/sub/c.txt', 'c')
+      await provider.rm('rm-dir')
+      expect(await provider.exists('rm-dir/a.txt')).toBe(false)
+      expect(await provider.exists('rm-dir/b.txt')).toBe(false)
+      expect(await provider.exists('rm-dir/sub/c.txt')).toBe(false)
+    })
+
+    it('mkdir is safe to call (no-op on object stores, creates on fs)', async () => {
+      // No assertion beyond "doesn't throw" — object stores have no
+      // real directories, filesystem does but we don't need to verify
+      // that here (filesystem-provider.test.ts covers the fs-specific
+      // behavior). The contract is: mkdir must be idempotent and safe.
+      await provider.mkdir('mkdir-safe/a/b/c')
+      await provider.mkdir('mkdir-safe/a/b/c')  // second call, same path
+    })
+  })
+}

--- a/apps/admin/tests/docker.test.ts
+++ b/apps/admin/tests/docker.test.ts
@@ -13,6 +13,7 @@ import {
   publishSiteManifest,
   publishFragmentIndex,
 } from 'gazetta'
+import { runProviderConformance } from './_helpers/provider-conformance.js'
 
 const projectRoot = resolve(import.meta.dirname, '../../../examples/starter')
 // Content lives under the local target (post-transformation layout).
@@ -66,67 +67,30 @@ function s3(bucket: string) {
   return provider
 }
 
-// ---- S3 Storage Provider ----
+// ---- StorageProvider conformance (shared battery) ----
+// S3 (MinIO) and Azure Blob (Azurite) both satisfy the StorageProvider
+// contract — same 8-test CRUD battery runs against both, so parity gaps
+// get caught at test time, not in production.
 
-describe('S3 storage provider (MinIO)', () => {
-  let provider: ReturnType<typeof createS3Provider>
+runProviderConformance({
+  name: 'S3 (MinIO)',
+  make: async () => {
+    const p = s3('conformance-s3')
+    await p.init()
+    return p
+  },
+})
 
-  beforeAll(async () => {
-    provider = s3('s3-provider-test')
-    await provider.init()
-  })
-
-  it('writes and reads a file', async () => {
-    await provider.writeFile('test.txt', 'hello world')
-    expect(await provider.readFile('test.txt')).toBe('hello world')
-  })
-
-  it('checks file exists', async () => {
-    await provider.writeFile('exists.txt', 'yes')
-    expect(await provider.exists('exists.txt')).toBe(true)
-    expect(await provider.exists('nope.txt')).toBe(false)
-  })
-
-  it('reads directory entries', async () => {
-    await provider.writeFile('dir/a.txt', 'a')
-    await provider.writeFile('dir/b.txt', 'b')
-    await provider.writeFile('dir/sub/c.txt', 'c')
-
-    const entries = await provider.readDir('dir')
-    const names = entries.map(e => e.name)
-    expect(names).toContain('a.txt')
-    expect(names).toContain('b.txt')
-    expect(names).toContain('sub')
-    expect(entries.find(e => e.name === 'sub')?.isDirectory).toBe(true)
-    expect(entries.find(e => e.name === 'a.txt')?.isDirectory).toBe(false)
-  })
-
-  it('checks directory exists', async () => {
-    await provider.writeFile('mydir/file.txt', 'content')
-    expect(await provider.exists('mydir')).toBe(true)
-    expect(await provider.exists('nonexistent-dir')).toBe(false)
-  })
-
-  it('throws on reading nonexistent file', async () => {
-    await expect(provider.readFile('missing.txt')).rejects.toThrow()
-  })
-
-  it('deletes files', async () => {
-    await provider.writeFile('to-delete.txt', 'bye')
-    await provider.rm('to-delete.txt')
-    expect(await provider.exists('to-delete.txt')).toBe(false)
-  })
-
-  it('deletes directory recursively', async () => {
-    await provider.writeFile('rmdir/a.txt', 'a')
-    await provider.writeFile('rmdir/b.txt', 'b')
-    await provider.rm('rmdir')
-    expect(await provider.exists('rmdir/a.txt')).toBe(false)
-  })
-
-  it('mkdir is a no-op', async () => {
-    await provider.mkdir('some/nested/dir')
-  })
+runProviderConformance({
+  name: 'Azure Blob (Azurite)',
+  make: async () => {
+    const p = createAzureBlobProvider({
+      connectionString: azuriteConnectionString,
+      container: 'conformance-azure',
+    })
+    await p.init()
+    return p
+  },
 })
 
 // ---- Azure Blob (Azurite) ----

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
       },
       "devDependencies": {
         "@hono/vite-dev-server": "^0.25.1",
-        "@testcontainers/azurite": "^11.13.0",
         "@types/js-yaml": "^4.0.0",
         "@types/node": "^25.6.0",
         "@vitejs/plugin-vue": "^6.0.6",
@@ -3766,16 +3765,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@testcontainers/azurite": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@testcontainers/azurite/-/azurite-11.14.0.tgz",
-      "integrity": "sha512-J/1yBoR1X06Aoemcl3kHeQnkbNi2mc8FmMYOBQoHRX65xLfQuRVmvTTxz/OZf8OFJHJQYKxJ+bMcukGPY8YFeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "testcontainers": "^11.14.0"
-      }
     },
     "node_modules/@tiptap/core": {
       "version": "3.22.3",


### PR DESCRIPTION
## Summary

Re-opened after base-branch deletion auto-closed #155.

Closes Priority 2.1 from [testing-plan.md](.claude/rules/testing-plan.md). S3 had 8 direct CRUD tests; Azure had 3 publish-level tests only — parity gap in StorageProvider contract coverage. After: both providers run the same 8-test battery via a shared \`runProviderConformance\` helper.

## SOLID

- **SRP:** [tests/_helpers/provider-conformance.ts](apps/admin/tests/_helpers/provider-conformance.ts) owns the contract
- **OCP:** new providers opt in via one call with a factory

## Cleanup

Removed dead \`@testcontainers/azurite\` dep from [apps/admin/package.json](apps/admin/package.json) — installed but never imported.

## Tests

- 163 tests in apps/admin (was 155; +8 from the new Azure conformance)
- S3's existing battery runs under the shared description, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)