### PR TITLE
Contract test pattern via shared Zod schemas (Priority 3.2, first slice)

### DIFF
--- a/.claude/rules/testing-plan.md
+++ b/.claude/rules/testing-plan.md
@@ -228,14 +228,28 @@ this is nightly-only for a reason. When raising `thresholds.break`, do it gradua
 
 ---
 
-#### ☐ 3.2 Contract tests via shared Zod schemas
+#### ◐ 3.2 Contract tests via shared Zod schemas
 
-Admin UI and admin API share no schema source → drift risk. Zod is already in both
-workspaces.
+First slice landed: `POST /api/pages` now has a Zod schema in
+[packages/gazetta/src/admin-api/schemas/pages.ts](../../packages/gazetta/src/admin-api/schemas/pages.ts),
+exposed via a new subpath export `gazetta/admin-api/schemas`. Server validates with
+`safeParse()`, client derives request/response types via `z.infer`.
 
-**Approach:** export Zod schemas from
-[packages/gazetta/src/admin-api/](../../packages/gazetta/src/admin-api/); import on the
-client; validate at the boundary.
+**Pattern established:**
+- Schemas live under `src/admin-api/schemas/{endpoint}.ts`
+- Re-exported from `schemas/index.ts` (barrel)
+- Subpath export keeps Hono + storage providers off the client's type graph
+- Contract test at
+  [apps/admin/tests/api-contract.test.ts](../../apps/admin/tests/api-contract.test.ts)
+  asserts value-level conformance (compile-time drift is already caught by `z.infer`)
+
+**Drift caught while landing:** The client's `createPage` body type was `{ name, template }`
+but the server already accepted an optional `content` field. The schema made this visible
+and the migration widened the client type to match.
+
+**Follow-ups (per-endpoint migration):** The remaining 20+ routes still use hand-rolled
+shape checks. Each migration is mechanical — same pattern, one PR per route group.
+Good starter tickets.
 
 **Skip:** Pact — overkill for single consumer/provider.
 

--- a/apps/admin/src/client/api/client.ts
+++ b/apps/admin/src/client/api/client.ts
@@ -107,7 +107,19 @@ async function publishStream(
   return results
 }
 
-export interface PageSummary { name: string; route: string; template: string }
+// PageSummary / CreatePageRequest / CreatePageResponse come from the
+// shared schema source-of-truth in gazetta/admin-api/schemas. Any
+// drift between these and the server's Zod schema is a compile error
+// at build time — enforced here rather than at runtime.
+import type {
+  PageSummary as PageSummaryShape,
+  CreatePageRequest as CreatePageRequestShape,
+  CreatePageResponse as CreatePageResponseShape,
+} from 'gazetta/admin-api/schemas'
+export type PageSummary = PageSummaryShape
+export type CreatePageRequest = CreatePageRequestShape
+export type CreatePageResponse = CreatePageResponseShape
+
 export interface FragmentSummary { name: string; template: string }
 export interface TemplateSummary { name: string }
 export interface FieldSummary { name: string; path: string }
@@ -168,7 +180,7 @@ export const api = {
   getPages: (opts?: { target?: string }) =>
     request<PageSummary[]>(opts?.target ? `/pages?target=${encodeURIComponent(opts.target)}` : '/pages'),
   getPage: (name: string, options?: RequestInit) => request<PageDetail>(`/pages/${name}`, options),
-  createPage: (data: { name: string; template: string }) => request<{ ok: boolean; name: string }>('/pages', { method: 'POST', body: JSON.stringify(data) }),
+  createPage: (data: CreatePageRequest) => request<CreatePageResponse>('/pages', { method: 'POST', body: JSON.stringify(data) }),
   deletePage: (name: string) => request<{ ok: boolean }>(`/pages/${name}`, { method: 'DELETE' }),
   updatePage: (name: string, data: Partial<PageDetail>) => request<{ ok: boolean }>(`/pages/${name}`, { method: 'PUT', body: JSON.stringify(data) }),
   /** List fragments. See getPages for the `target` option. */

--- a/apps/admin/tests/api-contract.test.ts
+++ b/apps/admin/tests/api-contract.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Contract tests — assert that the client's request/response types agree
+ * with the server's Zod schemas at runtime.
+ *
+ * TypeScript already catches compile-time drift (the client's types come
+ * from the same schema file via z.infer). This file catches value-level
+ * drift: if a test fixture or a real request ever passes through with
+ * a field TypeScript happens to allow (e.g. via `as any` or through an
+ * un-typed intermediate), safeParse surfaces it here.
+ *
+ * Coverage is deliberately narrow — only the endpoints that have been
+ * migrated to schema-validated contracts. Follow-ups extend the coverage
+ * as each endpoint moves to the new pattern (testing-plan.md Priority 3.2).
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  CreatePageRequestSchema,
+  CreatePageResponseSchema,
+  PageSummarySchema,
+} from 'gazetta/admin-api/schemas'
+import type { CreatePageRequest, CreatePageResponse, PageSummary } from 'gazetta/admin-api/schemas'
+
+describe('POST /api/pages contract', () => {
+  describe('CreatePageRequest', () => {
+    it('accepts the minimal shape the client uses', () => {
+      const body: CreatePageRequest = { name: 'home', template: 'page-default' }
+      expect(CreatePageRequestSchema.safeParse(body).success).toBe(true)
+    })
+
+    it('accepts an optional content field', () => {
+      const body: CreatePageRequest = {
+        name: 'home',
+        template: 'page-default',
+        content: { title: 'Home' },
+      }
+      expect(CreatePageRequestSchema.safeParse(body).success).toBe(true)
+    })
+
+    it('rejects empty name', () => {
+      const r = CreatePageRequestSchema.safeParse({ name: '', template: 'page-default' })
+      expect(r.success).toBe(false)
+    })
+
+    it('rejects empty template', () => {
+      const r = CreatePageRequestSchema.safeParse({ name: 'home', template: '' })
+      expect(r.success).toBe(false)
+    })
+
+    it('rejects missing required fields', () => {
+      expect(CreatePageRequestSchema.safeParse({ name: 'home' }).success).toBe(false)
+      expect(CreatePageRequestSchema.safeParse({ template: 'page-default' }).success).toBe(false)
+      expect(CreatePageRequestSchema.safeParse({}).success).toBe(false)
+    })
+  })
+
+  describe('CreatePageResponse', () => {
+    it('accepts the response shape the server emits', () => {
+      const resp: CreatePageResponse = { ok: true, name: 'home' }
+      expect(CreatePageResponseSchema.safeParse(resp).success).toBe(true)
+    })
+
+    it('rejects responses missing required fields', () => {
+      expect(CreatePageResponseSchema.safeParse({ ok: true }).success).toBe(false)
+      expect(CreatePageResponseSchema.safeParse({ name: 'home' }).success).toBe(false)
+    })
+  })
+
+  describe('PageSummary (GET /api/pages list shape)', () => {
+    it('accepts a well-formed entry', () => {
+      const entry: PageSummary = { name: 'home', route: '/', template: 'page-default' }
+      expect(PageSummarySchema.safeParse(entry).success).toBe(true)
+    })
+
+    it('rejects entries missing required fields', () => {
+      expect(PageSummarySchema.safeParse({ name: 'home', route: '/' }).success).toBe(false)
+    })
+  })
+})

--- a/packages/gazetta/package.json
+++ b/packages/gazetta/package.json
@@ -38,6 +38,10 @@
       "types": "./dist/admin-api/index.d.ts",
       "import": "./dist/admin-api/index.js"
     },
+    "./admin-api/schemas": {
+      "types": "./dist/admin-api/schemas/index.d.ts",
+      "import": "./dist/admin-api/schemas/index.js"
+    },
     "./workers/cloudflare-r2": {
       "types": "./dist/workers/cloudflare-r2.d.ts",
       "import": "./dist/workers/cloudflare-r2.js"

--- a/packages/gazetta/src/admin-api/routes/pages.ts
+++ b/packages/gazetta/src/admin-api/routes/pages.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { loadSite } from '../../site-loader.js'
 import { recordWrite } from '../../history-recorder.js'
 import type { SourceContextResolver } from '../source-context.js'
+import { CreatePageRequestSchema } from '../schemas/pages.js'
 
 export function pageRoutes(resolve: SourceContextResolver) {
   const app = new Hono()
@@ -34,10 +35,19 @@ export function pageRoutes(resolve: SourceContextResolver) {
   app.post('/api/pages', async (c) => {
     const source = await resolve(c.req.query('target'))
     const { storage, sidecarWriter } = source
-    const body = await c.req.json() as { name: string; template: string; content?: Record<string, unknown> }
-    if (!body.name || !body.template) {
-      return c.json({ error: 'Missing required fields: name, template' }, 400)
+    // Schema-validate the body so drift between client and server
+    // can't silently accept malformed requests. The Zod schema is the
+    // single source of truth, shared with the client via
+    // `gazetta/admin-api/schemas` (see testing-plan.md Priority 3.2).
+    const raw = await c.req.json()
+    const parsed = CreatePageRequestSchema.safeParse(raw)
+    if (!parsed.success) {
+      return c.json({
+        error: 'Invalid request body',
+        issues: parsed.error.issues.map(i => ({ path: i.path.join('.'), message: i.message })),
+      }, 400)
     }
+    const body = parsed.data
 
     const pageDir = source.contentRoot.path('pages', body.name)
     const manifestPath = join(pageDir, 'page.json')

--- a/packages/gazetta/src/admin-api/schemas/index.ts
+++ b/packages/gazetta/src/admin-api/schemas/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Barrel for Zod schemas shared between the admin API server and its
+ * clients. Importing from `gazetta/admin-api/schemas` avoids pulling
+ * in Hono + storage-provider code that live under `gazetta/admin-api`.
+ *
+ * First slice covers only POST /api/pages. Add new endpoint modules
+ * here as they migrate to schema-validated contracts.
+ */
+export * from './pages.js'

--- a/packages/gazetta/src/admin-api/schemas/pages.ts
+++ b/packages/gazetta/src/admin-api/schemas/pages.ts
@@ -1,0 +1,41 @@
+/**
+ * Zod schemas for /api/pages routes — the single source of truth for
+ * request/response shapes on that endpoint.
+ *
+ * Shared across server (routes/pages.ts uses .parse() to validate
+ * incoming bodies) and client (apps/admin/src/client/api/client.ts
+ * derives types via z.infer) so drift between them is impossible:
+ * either one of them fails to compile, or the contract test in
+ * apps/admin/tests/api-contract.test.ts surfaces the mismatch.
+ *
+ * First slice — POST /api/pages only. The rest of the endpoints still
+ * use hand-rolled shape checks; migrating them is mechanical and
+ * tracked as a follow-up to testing-plan.md Priority 3.2.
+ */
+import { z } from 'zod'
+
+/** Summary used in list responses (GET /api/pages). */
+export const PageSummarySchema = z.object({
+  name: z.string(),
+  route: z.string(),
+  template: z.string(),
+})
+export type PageSummary = z.infer<typeof PageSummarySchema>
+
+/** Body for POST /api/pages (create). */
+export const CreatePageRequestSchema = z.object({
+  /** Page name — used as the directory name and identity. Must be non-empty. */
+  name: z.string().min(1),
+  /** Template name to bind. Must be non-empty. */
+  template: z.string().min(1),
+  /** Optional initial content; defaults to `{ title: name }` server-side. */
+  content: z.record(z.string(), z.unknown()).optional(),
+})
+export type CreatePageRequest = z.infer<typeof CreatePageRequestSchema>
+
+/** Response for POST /api/pages (create). */
+export const CreatePageResponseSchema = z.object({
+  ok: z.boolean(),
+  name: z.string(),
+})
+export type CreatePageResponse = z.infer<typeof CreatePageResponseSchema>


### PR DESCRIPTION
## Summary

Lands the canonical pattern for admin-API contracts. First slice: \`POST /api/pages\`. Remaining 20+ routes follow the same recipe as mechanical follow-ups.

## The drift I found while landing

**Server** parsed bodies as \`{ name, template, content? }\` — accepted \`content\` as an optional init field.
**Client** declared \`createPage\` with \`{ name, template }\` — missing \`content\` entirely.

TypeScript alone wouldn't have caught this — each side typed its local view correctly. The shared Zod schema makes this exact kind of drift a compile error going forward.

## Shape

- **\`packages/gazetta/src/admin-api/schemas/\`** — Zod schemas, one file per endpoint
- **New subpath export** \`gazetta/admin-api/schemas\` — keeps Hono + storage providers off the client's type graph (the \`gazetta/admin-api\` export still includes them; this one doesn't)
- **Server:** \`CreatePageRequestSchema.safeParse(body)\` — returns structured 400 with issues on failure
- **Client:** \`z.infer\` via re-export; hand-declared interfaces deleted
- **Contract test** ([apps/admin/tests/api-contract.test.ts](apps/admin/tests/api-contract.test.ts)) — 9 tests covering valid shapes, missing fields, empty fields, response shape

## SOLID

- **SRP:** schemas module owns the contract, nothing else
- **DIP:** both server and client depend on the same abstraction (the schema), not on each other
- **Package boundary (ISP):** subpath export isolates schema consumers from the Hono runtime

## Pattern for follow-ups

Each of the remaining ~20 routes migrates the same way:

1. Schema under \`src/admin-api/schemas/{endpoint}.ts\`
2. Route's \`as { ... }\` → \`schema.safeParse\`
3. Client hand-type → \`z.infer\` re-export
4. Extend [api-contract.test.ts](apps/admin/tests/api-contract.test.ts)

These are good starter tickets — mechanical work with clear pattern.

## Tests

- 406 in \`packages/gazetta\` — unchanged
- 172 in \`apps/admin\` (was 163; +9 new)
- Typecheck + build green

## Test plan

- [ ] \`npm run build\` at repo root passes
- [ ] \`cd apps/admin && npx vitest run tests/api-contract.test.ts\` — 9 tests pass
- [ ] \`cd packages/gazetta && npx vitest run tests/admin-api.test.ts\` — 34 tests pass (server integration)
- [ ] CI passes
- [ ] Reviewer sanity-checks the subpath export is a clean boundary (no \`gazetta/admin-api\` imports leaking Hono into the client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)