### PR TITLE
E2E Phase 2 — PublishPanelPom + publish.spec.ts migration

### DIFF
--- a/.claude/rules/testing-plan.md
+++ b/.claude/rules/testing-plan.md
@@ -408,12 +408,23 @@ files stay on `.test.ts` and are excluded via `testIgnore`.
 
 ---
 
-#### ☐ Phase 2 — Page Objects
+#### ◐ Phase 2 — Page Objects
 
-- Build `PublishPanel`, `SiteTree`, `ComponentTree` POMs
-- Adopt in heaviest tests first; iterate — don't big-bang
+First POM landed: [PublishPanelPom](../../tests/e2e/pages/PublishPanel.ts). Covers the
+full Publish-panel surface — opening, source/destinations, items, publish action (with
+prod confirmation variant), status surfaces (confirm banner, invalid-templates, progress,
+per-target results). Migrated the full `Publish panel` describe in
+[publish.spec.ts](../../tests/e2e/publish.spec.ts) — 14 tests, test count unchanged,
+pass rate unchanged.
 
-**Estimate:** ~1 day.
+**Pattern:** POMs live under `tests/e2e/pages/`, one file per surface. Composition, no
+inheritance — each POM takes a `page` in the constructor. Methods expose user-level
+actions; getters expose locators; assertions stay in the tests. Matches
+[Playwright POM docs](https://playwright.dev/docs/pom).
+
+**Follow-ups:** SiteTreePom + ComponentTreePom — deferred to PRs that actually migrate
+tests using them. Building POMs without consumers is dead code; adding a POM with its
+first migration keeps the API honest.
 
 ---
 

--- a/tests/e2e/pages/PublishPanel.ts
+++ b/tests/e2e/pages/PublishPanel.ts
@@ -1,0 +1,153 @@
+/**
+ * Page Object for the unified Publish panel.
+ *
+ * Wraps the `[data-testid="publish-panel"]` surface so tests depend on
+ * user-level actions ("open", "pick destination", "click publish")
+ * instead of raw selectors. When a testid renames or the DOM shifts,
+ * only this file changes.
+ *
+ * Conventions (per Playwright POM docs + team-preferences rule #3):
+ * - Locators returned, no assertions — tests own `expect()`
+ * - `page` injected in the constructor; no inheritance
+ * - Method names match what the user does, not the DOM: `publish()`
+ *   clicks the button; `publishWithProdConfirm()` handles the
+ *   two-click dance for production targets.
+ */
+import type { Locator, Page } from '@playwright/test'
+
+export class PublishPanelPom {
+  constructor(private readonly page: Page) {}
+
+  // ---- Opening ---------------------------------------------------------
+
+  /** Open the panel from the toolbar button. Panel is not scoped to a
+   *  selected item — it's a cross-target operation. */
+  async open(): Promise<void> {
+    await this.page.goto('/admin')
+    await this.page.locator('[data-testid="publish-btn"]').click()
+  }
+
+  /** Root of the panel — for visibility assertions at the top of tests. */
+  get root(): Locator {
+    return this.page.locator('[data-testid="publish-panel"]')
+  }
+
+  // ---- Source ----------------------------------------------------------
+
+  /** Fixed source chip (shown when only one editable target exists). */
+  get sourceFixed(): Locator {
+    return this.page.locator('[data-testid="publish-source-fixed"]')
+  }
+
+  // ---- Destinations ----------------------------------------------------
+
+  /** Destination row (single). */
+  destination(name: string): Locator {
+    return this.page.locator(`[data-testid="publish-dest-${name}"]`)
+  }
+
+  /** Group header row (e.g. `production` when 2+ prod targets exist). */
+  destinationGroup(env: string): Locator {
+    return this.page.locator(`[data-testid="publish-dest-group-${env}"]`)
+  }
+
+  /** Click a destination to toggle its selection. */
+  async pickDestination(name: string): Promise<void> {
+    await this.destination(name).click()
+  }
+
+  /** Click a group header — selects/deselects every member at once. */
+  async toggleGroup(env: string): Promise<void> {
+    await this.destinationGroup(env).click()
+  }
+
+  /** Whether a destination's row-level PrimeVue checkbox is checked. */
+  isDestinationChecked(name: string): Locator {
+    return this.page.locator(`[data-testid="publish-dest-${name}"] .p-checkbox-checked`)
+  }
+
+  // ---- Items -----------------------------------------------------------
+
+  /** Item row by path (e.g. `pages/home`, `fragments/header`). */
+  item(path: string): Locator {
+    return this.page.locator(`[data-testid="publish-item-${path}"]`)
+  }
+
+  /** Summary line showing added/modified/deleted counts. */
+  get itemsSummary(): Locator {
+    return this.page.locator('[data-testid="publish-items-summary"]')
+  }
+
+  /** Inline compare-error block (shown when the compare API fails). */
+  get itemsError(): Locator {
+    return this.page.locator('[data-testid="publish-items-error"]')
+  }
+
+  /** Click Select-all above the items list. */
+  async selectAllItems(): Promise<void> {
+    await this.page.locator('[data-testid="publish-select-all"]').click()
+  }
+
+  /** Click Select-none above the items list. */
+  async selectNoItems(): Promise<void> {
+    await this.page.locator('[data-testid="publish-select-none"]').click()
+  }
+
+  // ---- Action buttons --------------------------------------------------
+
+  /** The main Publish button (enabled when source + destinations + items
+   *  are all set). Non-prod destinations: one click runs the publish.
+   *  Prod destinations: first click reveals the confirm banner. */
+  get publishButton(): Locator {
+    return this.page.locator('[data-testid="publish-panel-confirm"]')
+  }
+
+  /** The danger-styled second-click button that appears only after a
+   *  production destination triggers the confirm flow. */
+  get publishProdConfirmButton(): Locator {
+    return this.page.locator('[data-testid="publish-panel-confirm-prod"]')
+  }
+
+  /** The Done button that replaces Publish/Cancel after a successful run. */
+  get doneButton(): Locator {
+    return this.page.locator('[data-testid="publish-panel-done"]')
+  }
+
+  /** Click Publish (single-click). For non-prod destinations only. */
+  async publish(): Promise<void> {
+    await this.publishButton.click()
+  }
+
+  /** Click Publish, then the prod-specific second-click confirm. */
+  async publishWithProdConfirm(): Promise<void> {
+    await this.publishButton.click()
+    await this.publishProdConfirmButton.click()
+  }
+
+  /** Back button (appears only in the confirm-banner state). */
+  async clickBack(): Promise<void> {
+    await this.page.locator('button', { hasText: 'Back' }).click()
+  }
+
+  // ---- Status surfaces -------------------------------------------------
+
+  /** Production confirmation banner. */
+  get confirmBanner(): Locator {
+    return this.page.locator('[data-testid="publish-confirm-banner"]')
+  }
+
+  /** Invalid-templates fatal banner (rendered on SSE fatal event). */
+  get invalidTemplatesBanner(): Locator {
+    return this.page.locator('[data-testid="publish-invalid-templates"]')
+  }
+
+  /** Streaming-progress block — visible between publish-start and publish-done. */
+  get progressBlock(): Locator {
+    return this.page.locator('[data-testid="publish-progress"]')
+  }
+
+  /** Per-destination result row (success or error). */
+  result(target: string): Locator {
+    return this.page.locator(`[data-testid="publish-result-${target}"]`)
+  }
+}

--- a/tests/e2e/publish.spec.ts
+++ b/tests/e2e/publish.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from './fixtures'
 import { openEditor } from './helpers'
+import { PublishPanelPom } from './pages/PublishPanel'
 import { mkdir, writeFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 
@@ -16,36 +17,25 @@ test.describe('Publish panel', () => {
     await rm(stagingDir(projectDir), { recursive: true, force: true })
   }
 
-  /** Open the unified Publish panel from the toolbar. Panel is not scoped
-   *  to a selected item — it's a cross-target operation. */
-  async function openPublish(page: import('@playwright/test').Page) {
-    await page.goto('/admin')
-    await page.locator('[data-testid="publish-btn"]').click()
-    await expect(page.locator('[data-testid="publish-panel"]')).toBeVisible()
-  }
-
-  /** Check the destination by clicking its row. Source defaults to the
-   *  active target (local in starter). */
-  async function pickDestination(page: import('@playwright/test').Page, name: string) {
-    await page.locator(`[data-testid="publish-dest-${name}"]`).click()
-  }
-
   test('opens with local as source and destinations listed', async ({ page, testSite: _ }) => {
-    await openPublish(page)
+    const panel = new PublishPanelPom(page)
+    await panel.open()
+    await expect(panel.root).toBeVisible()
     // Single editable target in starter (local) — source renders as a fixed chip
-    await expect(page.locator('[data-testid="publish-source-fixed"]')).toContainText('local')
+    await expect(panel.sourceFixed).toContainText('local')
     // Every non-source target appears as a destination row
-    await expect(page.locator('[data-testid="publish-dest-staging"]')).toBeVisible()
-    await expect(page.locator('[data-testid="publish-dest-esi-test"]')).toBeVisible()
-    await expect(page.locator('[data-testid="publish-dest-production"]')).toBeVisible()
+    await expect(panel.destination('staging')).toBeVisible()
+    await expect(panel.destination('esi-test')).toBeVisible()
+    await expect(panel.destination('production')).toBeVisible()
   })
 
   test('first-publish destination shows all items as added', async ({ page, testSite }) => {
     await wipe(testSite.projectDir)
-    await openPublish(page)
-    await pickDestination(page, 'staging')
+    const panel = new PublishPanelPom(page)
+    await panel.open()
+    await panel.pickDestination('staging')
     // Every local page becomes an 'added' row against the empty staging target
-    const homeRow = page.locator('[data-testid="publish-item-pages/home"]')
+    const homeRow = panel.item('pages/home')
     await expect(homeRow).toBeVisible()
     await expect(homeRow.locator('.marker-added')).toHaveText('+')
   })
@@ -58,9 +48,10 @@ test.describe('Publish panel', () => {
     await seedSidecar(join(stagingDir(testSite.projectDir), 'pages/home'), '00000000')
     await seedSidecar(join(stagingDir(testSite.projectDir), 'pages/about'), 'aaaaaaaa')
 
-    await openPublish(page)
-    await pickDestination(page, 'staging')
-    const row = page.locator('[data-testid="publish-item-pages/home"]')
+    const panel = new PublishPanelPom(page)
+    await panel.open()
+    await panel.pickDestination('staging')
+    const row = panel.item('pages/home')
     await expect(row).toBeVisible()
     await expect(row.locator('.marker-modified')).toHaveText('●')
     await expect(row.locator('.dest-state-modified')).toContainText('modified')
@@ -72,9 +63,10 @@ test.describe('Publish panel', () => {
     // staging but not on the source, so compare classifies it 'deleted'.
     await seedSidecar(join(stagingDir(testSite.projectDir), 'pages/old-contact'), '11111111')
 
-    await openPublish(page)
-    await pickDestination(page, 'staging')
-    const deletedRow = page.locator('[data-testid="publish-item-pages/old-contact"]')
+    const panel = new PublishPanelPom(page)
+    await panel.open()
+    await panel.pickDestination('staging')
+    const deletedRow = panel.item('pages/old-contact')
     await expect(deletedRow).toBeVisible()
     await expect(deletedRow).toHaveClass(/item-deleted/)
     // Deleted rows get a spacer instead of a checkbox
@@ -89,13 +81,13 @@ test.describe('Publish panel', () => {
     await seedSidecar(join(stagingDir(testSite.projectDir), 'pages/old-contact'), '11111111')
     // Other local pages (about/blog/showcase/404) become 'added' rows.
 
-    await openPublish(page)
-    await pickDestination(page, 'staging')
-    const summary = page.locator('[data-testid="publish-items-summary"]')
-    await expect(summary).toBeVisible()
-    await expect(summary).toContainText('modified')
-    await expect(summary).toContainText('added')
-    await expect(summary).toContainText('deleted')
+    const panel = new PublishPanelPom(page)
+    await panel.open()
+    await panel.pickDestination('staging')
+    await expect(panel.itemsSummary).toBeVisible()
+    await expect(panel.itemsSummary).toContainText('modified')
+    await expect(panel.itemsSummary).toContainText('added')
+    await expect(panel.itemsSummary).toContainText('deleted')
   })
 
   test('fragment row shows blast-radius badge', async ({ page, testSite }) => {
@@ -105,9 +97,10 @@ test.describe('Publish panel', () => {
     const esiDir = join(testSite.projectDir, 'sites/main/dist/esi-test')
     await rm(esiDir, { recursive: true, force: true })
 
-    await openPublish(page)
-    await pickDestination(page, 'esi-test')
-    const headerRow = page.locator('[data-testid="publish-item-fragments/header"]')
+    const panel = new PublishPanelPom(page)
+    await panel.open()
+    await panel.pickDestination('esi-test')
+    const headerRow = panel.item('fragments/header')
     await expect(headerRow).toBeVisible()
     // Fragment rows mount a FragmentBlastRadius component (pulled in via
     // api.getDependents) — the badge shows the count of pages that reference it.
@@ -122,55 +115,57 @@ test.describe('Publish panel', () => {
       status: 500, contentType: 'application/json',
       body: JSON.stringify({ error: 'Storage unreachable' }),
     }))
-    await openPublish(page)
-    await pickDestination(page, 'staging')
-    const err = page.locator('[data-testid="publish-items-error"]')
-    await expect(err).toBeVisible()
-    await expect(err).toContainText('Storage unreachable')
+    const panel = new PublishPanelPom(page)
+    await panel.open()
+    await panel.pickDestination('staging')
+    await expect(panel.itemsError).toBeVisible()
+    await expect(panel.itemsError).toContainText('Storage unreachable')
   })
 
   test('production destination requires confirmation before publishing', async ({ page, testSite }) => {
     await wipe(testSite.projectDir)
     // Fixture swaps the azure-blob production target for a filesystem one
     // with environment:production so this test doesn't need Azurite.
-    await openPublish(page)
-    await pickDestination(page, 'production')
+    const panel = new PublishPanelPom(page)
+    await panel.open()
+    await panel.pickDestination('production')
     // First click on Publish reveals the confirmation banner; the button
     // changes to a danger-styled "Yes, publish to production" variant.
-    await page.locator('[data-testid="publish-panel-confirm"]').click()
-    await expect(page.locator('[data-testid="publish-confirm-banner"]')).toBeVisible()
-    await expect(page.locator('[data-testid="publish-panel-confirm-prod"]')).toBeVisible()
-    await page.locator('button', { hasText: 'Back' }).click()
-    await expect(page.locator('[data-testid="publish-confirm-banner"]')).toHaveCount(0)
+    await panel.publish()
+    await expect(panel.confirmBanner).toBeVisible()
+    await expect(panel.publishProdConfirmButton).toBeVisible()
+    await panel.clickBack()
+    await expect(panel.confirmBanner).toHaveCount(0)
   })
 
   test('non-production destination publishes without confirmation', async ({ page, testSite }) => {
     await wipe(testSite.projectDir)
-    await openPublish(page)
-    await pickDestination(page, 'staging')
+    const panel = new PublishPanelPom(page)
+    await panel.open()
+    await panel.pickDestination('staging')
     // Staging has environment:staging — no confirmation gate.
     // Clicking Publish goes straight to the streaming action.
-    await page.locator('[data-testid="publish-panel-confirm"]').click()
-    await expect(page.locator('[data-testid="publish-confirm-banner"]')).toHaveCount(0)
+    await panel.publish()
+    await expect(panel.confirmBanner).toHaveCount(0)
     // Wait for completion — the Done button replaces Cancel/Publish on success.
-    await expect(page.locator('[data-testid="publish-panel-done"]')).toBeVisible({ timeout: 10000 })
+    await expect(panel.doneButton).toBeVisible({ timeout: 10000 })
   })
 
   test('publish streams per-destination progress and lands on results', async ({ page, testSite }) => {
     await wipe(testSite.projectDir)
-    await openPublish(page)
-    await pickDestination(page, 'staging')
-    await page.locator('[data-testid="publish-panel-confirm"]').click()
+    const panel = new PublishPanelPom(page)
+    await panel.open()
+    await panel.pickDestination('staging')
+    await panel.publish()
     // Either we catch the progress block mid-stream, or the publish is fast
     // enough to land straight on results — both are valid. What matters is
     // the per-destination result row.
-    const progressBlock = page.locator('[data-testid="publish-progress"]')
     await Promise.race([
-      progressBlock.waitFor({ timeout: 2000 }).catch(() => null),
-      page.locator('[data-testid="publish-result-staging"]').waitFor({ timeout: 5000 }),
+      panel.progressBlock.waitFor({ timeout: 2000 }).catch(() => null),
+      panel.result('staging').waitFor({ timeout: 5000 }),
     ])
-    await expect(page.locator('[data-testid="publish-result-staging"]')).toBeVisible({ timeout: 10000 })
-    await expect(page.locator('[data-testid="publish-result-staging"]')).toHaveClass(/success/)
+    await expect(panel.result('staging')).toBeVisible({ timeout: 10000 })
+    await expect(panel.result('staging')).toHaveClass(/success/)
   })
 
   test('invalid templates surface as fatal error on publish', async ({ page, testSite }) => {
@@ -186,12 +181,12 @@ test.describe('Publish panel', () => {
     const orig = await readFile(tpl, 'utf-8')
     await writeFile(tpl, 'this is not valid ts!!!')
     try {
-      await openPublish(page)
-      await pickDestination(page, 'staging')
-      await page.locator('[data-testid="publish-panel-confirm"]').click()
-      const banner = page.locator('[data-testid="publish-invalid-templates"]')
-      await expect(banner).toBeVisible({ timeout: 10000 })
-      await expect(banner).toContainText('hero')
+      const panel = new PublishPanelPom(page)
+      await panel.open()
+      await panel.pickDestination('staging')
+      await panel.publish()
+      await expect(panel.invalidTemplatesBanner).toBeVisible({ timeout: 10000 })
+      await expect(panel.invalidTemplatesBanner).toContainText('hero')
     } finally {
       await writeFile(tpl, orig)
     }
@@ -204,46 +199,45 @@ test.describe('Publish panel', () => {
     if ((await html.getAttribute('class'))?.includes('dark')) {
       await page.locator('[data-testid="theme-toggle"]').click()
     }
+    const panel = new PublishPanelPom(page)
     await page.locator('[data-testid="publish-btn"]').click()
-    await expect(page.locator('[data-testid="publish-panel"]')).toBeVisible()
-    await pickDestination(page, 'staging')
-    await expect(page.locator('[data-testid="publish-item-pages/home"]')).toBeVisible()
+    await expect(panel.root).toBeVisible()
+    await panel.pickDestination('staging')
+    await expect(panel.item('pages/home')).toBeVisible()
     await expect(html).not.toHaveClass(/dark/)
   })
 
   test('environment group header selects all members in the group', async ({ page, testSite }) => {
     await wipe(testSite.projectDir)
-    await openPublish(page)
+    const panel = new PublishPanelPom(page)
+    await panel.open()
     // Starter has two staging-env targets: staging + esi-test. The group
     // header appears when a group has 2+ members; single-member groups
     // (local when source, production) render flat.
-    const groupHeader = page.locator('[data-testid="publish-dest-group-staging"]')
-    await expect(groupHeader).toBeVisible()
+    await expect(panel.destinationGroup('staging')).toBeVisible()
     // Neither member selected initially → clicking the header selects both.
     // PrimeVue Checkbox exposes state via the .p-checkbox-checked class on
     // the wrapper rather than the native `checked` attribute.
-    await groupHeader.click()
-    await expect(page.locator('[data-testid="publish-dest-staging"] .p-checkbox-checked')).toHaveCount(1)
-    await expect(page.locator('[data-testid="publish-dest-esi-test"] .p-checkbox-checked')).toHaveCount(1)
+    await panel.toggleGroup('staging')
+    await expect(panel.isDestinationChecked('staging')).toHaveCount(1)
+    await expect(panel.isDestinationChecked('esi-test')).toHaveCount(1)
     // Clicking again deselects both.
-    await groupHeader.click()
-    await expect(page.locator('[data-testid="publish-dest-staging"] .p-checkbox-checked')).toHaveCount(0)
-    await expect(page.locator('[data-testid="publish-dest-esi-test"] .p-checkbox-checked')).toHaveCount(0)
+    await panel.toggleGroup('staging')
+    await expect(panel.isDestinationChecked('staging')).toHaveCount(0)
+    await expect(panel.isDestinationChecked('esi-test')).toHaveCount(0)
   })
 
   test('select-all and select-none toggle every selectable item', async ({ page, testSite }) => {
     await wipe(testSite.projectDir)
-    await openPublish(page)
-    await pickDestination(page, 'staging')
-    const selectAll = page.locator('[data-testid="publish-select-all"]')
-    const selectNone = page.locator('[data-testid="publish-select-none"]')
-    await expect(selectAll).toBeVisible()
-    // Starts with every item checked (default). Click Select none → button
-    // stays but Publish should become disabled (no items selected).
-    await selectNone.click()
-    await expect(page.locator('[data-testid="publish-panel-confirm"]')).toBeDisabled()
-    await selectAll.click()
-    await expect(page.locator('[data-testid="publish-panel-confirm"]')).toBeEnabled()
+    const panel = new PublishPanelPom(page)
+    await panel.open()
+    await panel.pickDestination('staging')
+    // Starts with every item checked (default). Click Select none → Publish
+    // should become disabled (no items selected).
+    await panel.selectNoItems()
+    await expect(panel.publishButton).toBeDisabled()
+    await panel.selectAllItems()
+    await expect(panel.publishButton).toBeEnabled()
   })
 })
 


### PR DESCRIPTION
## Summary

Closes Phase 2 (first slice) of the e2e restructure plan. Lands the first Page Object and migrates the \`Publish panel\` describe block in \`publish.spec.ts\` to use it.

## POM shape

[tests/e2e/pages/PublishPanel.ts](tests/e2e/pages/PublishPanel.ts) — wraps the unified Publish panel:

- **Opening:** \`open()\`, \`root\`
- **Source:** \`sourceFixed\`
- **Destinations:** \`destination(name)\`, \`destinationGroup(env)\`, \`pickDestination\`, \`toggleGroup\`, \`isDestinationChecked\`
- **Items:** \`item(path)\`, \`itemsSummary\`, \`itemsError\`, \`selectAllItems\`, \`selectNoItems\`
- **Action:** \`publishButton\`, \`publishProdConfirmButton\`, \`doneButton\`, \`publish()\`, \`publishWithProdConfirm()\`, \`clickBack()\`
- **Status:** \`confirmBanner\`, \`invalidTemplatesBanner\`, \`progressBlock\`, \`result(target)\`

**Design:** composition, no inheritance (per user preference). \`page\` injected in the constructor. Methods expose user-level actions; locators returned via getters; assertions stay in the tests — matches the [Playwright POM docs](https://playwright.dev/docs/pom).

## Migration scope

\`publish.spec.ts\` — the \`Publish panel\` describe (14 tests) now instantiates \`PublishPanelPom\` instead of using raw selectors. The three other describes in the file (\`Fragment blast radius\`, \`Save button labeling\`, \`Sync indicator grouping\`) don't use the publish panel — they stay selector-based, unchanged.

Local \`openPublish()\` + \`pickDestination()\` helpers inside the describe block were absorbed into the POM; deleted from \`publish.spec.ts\`.

## Test parity

17/17 pass locally. Same count as before the migration.

## Why only PublishPanelPom in this PR

Deliberate. The other two POMs (SiteTree, ComponentTree) would be dead code without migrations — the heaviest selector user is this one. Follow-up PRs add them alongside their first consumers. Building APIs without consumers is guesswork; building them with a migration keeps the API honest.

## Stacking

Targets \`e2e-restructure-phase-1\` (#161), not main.

## Test plan

- [ ] \`npx playwright test tests/e2e/publish.spec.ts --project=dev\` passes (17 tests)
- [ ] CI passes
- [ ] Reviewer sanity-checks the POM API surface — anything missing from the public shape?

🤖 Generated with [Claude Code](https://claude.com/claude-code)