### PR TITLE
E2E Phase 4 — matrix tests + dev-server settings banner

### DIFF
--- a/.claude/rules/testing-plan.md
+++ b/.claude/rules/testing-plan.md
@@ -498,12 +498,40 @@ Adding these as scenarios too would duplicate existing coverage without closing 
 
 ---
 
-#### ☐ Phase 4 — Matrix tests
+#### ✓ Phase 4 — Matrix tests
 
-- Env × editable for chrome + confirmation
-- Target-type for save-render vs save-fast
+Landed. Two parameterized specs under
+[tests/e2e/matrix/](../../tests/e2e/matrix/) running against a dedicated fixture site
+(`tests/fixtures/sites/target-matrix/`) with 8 targets covering every
+env × editable × type combo that matters:
 
-**Estimate:** ~1 day.
+- **env-chrome.spec.ts** (8 rows) — active-target chrome class + read-only badge track
+  `environment` + `editable` independently of `type`
+- **prod-confirm.spec.ts** (7 rows) — `environment: production` always gates the Publish
+  button with a confirmation banner; non-prod destinations publish in one click,
+  regardless of editable/type combinations
+
+**Infrastructure added:**
+
+- New workspace glob `tests/fixtures/sites/*` in root package.json — a home for test-only
+  fixture sites that shouldn't pollute `examples/` (user-facing samples) or `sites/`
+  (production dogfood)
+- [tests/fixtures/sites/target-matrix/](../../tests/fixtures/sites/target-matrix/) — 8
+  targets (local-edit, local-ro, local-dyn, staging-ro, staging-edit, prod-ro, prod-edit,
+  prod-dyn) each exercising one meaningful axis combination
+- New Playwright project `matrix` in [playwright.config.ts](../../playwright.config.ts) +
+  matching `webServer` entry on port 4005
+
+**Why fixture site over component-level tests:** env × editable × type gate real admin
+UI paths that go through the targets API, not just Vue props. A component test could mount
+with synthetic configs but wouldn't exercise the `/api/targets` serialization or source-
+context resolution. The dedicated fixture site tests the full integration.
+
+**Dev-server settings banner** added as a side effect — startup now prints resolved
+project/site/templates paths, default source target with its env/editable/type, content
+root, and every configured target's props + storage path. Catches fixture misconfig
+(wrong `storage.path`, missing content root) at the first run instead of via empty API
+responses. Opt out with `GAZETTA_QUIET=1`.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
         "apps/*",
         "tools/*",
         "examples/*",
-        "sites/*"
+        "sites/*",
+        "tests/fixtures/sites/*"
       ],
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",
@@ -2495,6 +2496,10 @@
     },
     "node_modules/@gazetta/admin": {
       "resolved": "apps/admin",
+      "link": true
+    },
+    "node_modules/@gazetta/fixture-target-matrix": {
+      "resolved": "tests/fixtures/sites/target-matrix",
       "link": true
     },
     "node_modules/@gazetta/mcp-dev": {
@@ -7253,7 +7258,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -12165,6 +12169,14 @@
         "gazetta": "*",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "tsx": "^4.21.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "tests/fixtures/sites/target-matrix": {
+      "name": "@gazetta/fixture-target-matrix",
+      "devDependencies": {
+        "gazetta": "*",
         "tsx": "^4.21.0",
         "zod": "^4.3.6"
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "apps/*",
     "tools/*",
     "examples/*",
-    "sites/*"
+    "sites/*",
+    "tests/fixtures/sites/*"
   ],
   "scripts": {
     "build": "npm run build -w packages/gazetta",

--- a/packages/gazetta/src/cli/index.ts
+++ b/packages/gazetta/src/cli/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { resolve, join, dirname } from 'node:path'
+import { resolve, join, dirname, relative } from 'node:path'
 import { watch, existsSync, readFileSync } from 'node:fs'
 import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
@@ -14,6 +14,7 @@ import { createFilesystemProvider } from '../providers/filesystem.js'
 import { invalidateTemplate, invalidateAllTemplates } from '../template-loader.js'
 // createTargetRegistry is used lazily by admin-api publish routes
 import type { SiteManifest } from '../types.js'
+import { getEnvironment, getType, isEditable } from '../types.js'
 import { createAdminApp } from '../admin-api/index.js'
 
 // ANSI color helpers — no dependency, suppressed when NO_COLOR or CI
@@ -1190,6 +1191,40 @@ async function runDev(siteDir: string, port: number) {
     console.log()
     console.log(`  ${c.dim('┃')} Pages    ${[...site.pages.entries()].map(([n, p]) => `${c.dim(p.route)} ${c.dim('→')} ${n}`).join(c.dim(', '))}`)
     console.log(`  ${c.dim('┃')} Frags    ${c.dim([...site.fragments.keys()].join(', ') || '(none)')}`)
+
+    // ---- Settings banner ----
+    // Prints resolved configuration at startup so path / target / site
+    // issues are diagnosed immediately instead of via empty API responses.
+    // Opt-in via GAZETTA_QUIET=1 for scripted callers that don't want it.
+    if (!process.env.GAZETTA_QUIET) {
+      const relProject = relative(process.cwd(), projectRoot) || '.'
+      const relSite = relative(projectRoot, siteDir) || '.'
+      const relTemplates = relative(projectRoot, templatesDir) || '.'
+      const sourceName = source.targetName ?? '(none)'
+      const sourceCfg = targetConfigs[sourceName]
+      const sourceEnv = sourceCfg ? getEnvironment(sourceCfg) : 'unknown'
+      const sourceType = sourceCfg ? getType(sourceCfg) : 'unknown'
+      const sourceEditable = sourceCfg ? isEditable(sourceCfg) : false
+      const sourceRoot = source.contentRoot.rootPath || '.'
+      const targetsCount = Object.keys(targetConfigs).length
+      console.log()
+      console.log(`  ${c.dim('┃')} ${c.bold('Settings')}`)
+      console.log(`  ${c.dim('┃')}   Project      ${c.dim(relProject)}`)
+      console.log(`  ${c.dim('┃')}   Site         ${c.dim(relSite)}`)
+      console.log(`  ${c.dim('┃')}   Templates    ${c.dim(relTemplates)}`)
+      console.log(`  ${c.dim('┃')}   Source       ${sourceName} ${c.dim(`(${sourceEnv}, ${sourceEditable ? 'editable' : 'read-only'}, ${sourceType})`)}`)
+      console.log(`  ${c.dim('┃')}   Content root ${c.dim(sourceRoot)}`)
+      console.log(`  ${c.dim('┃')}   Targets (${targetsCount})`)
+      for (const [name, cfg] of Object.entries(targetConfigs)) {
+        const env = getEnvironment(cfg)
+        const type = getType(cfg)
+        const ed = isEditable(cfg) ? 'editable ' : 'read-only'
+        const storagePath = cfg.storage?.type === 'filesystem'
+          ? (cfg.storage.path ?? `targets/${name}`)
+          : `${cfg.storage?.type ?? '?'}`
+        console.log(`  ${c.dim('┃')}     ${c.dim('•')} ${name.padEnd(14)} ${c.dim(env.padEnd(11))} ${c.dim(ed)} ${c.dim(type.padEnd(8))} ${c.dim('→ ' + storagePath)}`)
+      }
+    }
 
     if (isDevMode && cmsWebDir) {
       // While Vite is spinning up (compiling, scanning deps, attaching

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,12 +24,14 @@ export default defineConfig({
       // Feature suites use `.spec.ts` (see the Phase 1 restructure that
       // split the old editor.test.ts). a11y.test.ts predates the rename
       // and stays on `.test.ts`. Production runs against pre-built admins
-      // on fixed ports in their own projects — exclude them here.
+      // on fixed ports in their own projects — exclude them here. Matrix
+      // runs against its own fixture site (tests/fixtures/sites/target-
+      // matrix) so `matrix/**` is excluded too.
       // testIgnore applies to basenames consistently; a negative-lookahead
       // on testMatch would match the full path and wouldn't catch
       // `tests/e2e/production-esi.test.ts`.
       testMatch: ['**/*.test.ts', '**/*.spec.ts'],
-      testIgnore: ['**/production.test.ts', '**/production-*.test.ts'],
+      testIgnore: ['**/production.test.ts', '**/production-*.test.ts', '**/matrix/**'],
       // baseURL is set per-worker by the testSite fixture in tests/e2e/fixtures.ts
     },
     {
@@ -46,6 +48,16 @@ export default defineConfig({
       name: 'prod-esi',
       testMatch: 'production-esi.test.ts',
       use: { baseURL: 'http://localhost:4004' },
+    },
+    {
+      name: 'matrix',
+      // Parameterized env × editable × type tests against the target-matrix
+      // fixture site. The site under tests/fixtures/sites/target-matrix/
+      // ships 8 targets — one per meaningful axis-value combination — so
+      // matrix tests assert on admin UI chrome reactions to those props
+      // without spinning up a per-row dev server.
+      testMatch: ['**/matrix/**/*.spec.ts'],
+      use: { baseURL: 'http://localhost:4005' },
     },
   ],
   webServer: [
@@ -66,6 +78,15 @@ export default defineConfig({
     {
       command: 'cd examples/starter && npx tsx ../../packages/gazetta/src/cli/index.ts publish esi-test sites/main && node ../../packages/gazetta/dist/cli/index.js serve esi-test sites/main -p 4004',
       url: 'http://localhost:4004/health',
+      reuseExistingServer: !process.env.CI,
+      timeout: 60000,
+    },
+    {
+      // Matrix fixture site — 8 targets covering env × editable × type.
+      // Runs as a dev server (not a prod serve) because matrix tests
+      // exercise the admin UI, not the rendered site.
+      command: 'cd tests/fixtures/sites/target-matrix && npx tsx ../../../../packages/gazetta/src/cli/index.ts dev sites/main --port 4005',
+      url: 'http://localhost:4005/admin',
       reuseExistingServer: !process.env.CI,
       timeout: 60000,
     },

--- a/tests/e2e/matrix/env-chrome.spec.ts
+++ b/tests/e2e/matrix/env-chrome.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Matrix test — environment chrome + read-only badge across all 8
+ * target-matrix axis combinations. Runs against the target-matrix
+ * fixture site (tests/fixtures/sites/target-matrix/) so each row
+ * tests a real live target, not a mocked one.
+ *
+ * Axis coverage (see site.yaml):
+ *   environment: local | staging | production
+ *   editable:    true  | false
+ *   type:        static | dynamic
+ *
+ * What this proves:
+ *   - env-{local,staging,production} class flows from target.environment
+ *     through to the active-target-indicator regardless of editable/type
+ *   - read-only badge shown iff target.editable === false
+ *   - The switcher menu lists every target and chrome follows on switch
+ */
+import { test, expect } from '@playwright/test'
+
+/**
+ * One row per target in tests/fixtures/sites/target-matrix/site.yaml.
+ * Kept deliberately exhaustive so a new axis-behavior becomes a single
+ * data-table entry, not a new test.
+ */
+const matrix = [
+  { name: 'local-edit',   env: 'local',      editable: true,  chromeClass: 'env-local',      readOnly: false },
+  { name: 'local-ro',     env: 'local',      editable: false, chromeClass: 'env-local',      readOnly: true  },
+  { name: 'local-dyn',    env: 'local',      editable: true,  chromeClass: 'env-local',      readOnly: false },
+  { name: 'staging-ro',   env: 'staging',    editable: false, chromeClass: 'env-staging',    readOnly: true  },
+  { name: 'staging-edit', env: 'staging',    editable: true,  chromeClass: 'env-staging',    readOnly: false },
+  { name: 'prod-ro',      env: 'production', editable: false, chromeClass: 'env-production', readOnly: true  },
+  { name: 'prod-edit',    env: 'production', editable: true,  chromeClass: 'env-production', readOnly: false },
+  { name: 'prod-dyn',     env: 'production', editable: false, chromeClass: 'env-production', readOnly: true  },
+] as const
+
+test.describe('Active-target chrome matrix', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin')
+    await expect(page.locator('[data-testid="active-target-indicator"]')).toBeVisible()
+  })
+
+  for (const row of matrix) {
+    test(`${row.name} → chrome=${row.chromeClass} readOnly=${row.readOnly}`, async ({ page }) => {
+      const indicator = page.locator('[data-testid="active-target-indicator"]')
+
+      // Open the switcher and select the target under test. Every run
+      // starts from whatever was active last; the menu always lists all
+      // targets so this is stable regardless of order.
+      await indicator.click()
+      const menu = page.locator('[data-testid="active-target-menu"]')
+      await expect(menu).toBeVisible()
+      await menu.getByRole('menuitem', { name: row.name, exact: true }).click()
+
+      // Assert chrome class + indicator content.
+      await expect(indicator).toContainText(row.name)
+      await expect(indicator).toHaveClass(new RegExp(row.chromeClass))
+
+      // Read-only badge: shown iff editable === false.
+      const badge = indicator.locator('.readonly-badge')
+      if (row.readOnly) {
+        await expect(badge).toBeVisible()
+        await expect(badge).toContainText('read-only')
+      } else {
+        await expect(badge).toHaveCount(0)
+      }
+    })
+  }
+})

--- a/tests/e2e/matrix/prod-confirm.spec.ts
+++ b/tests/e2e/matrix/prod-confirm.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Matrix test — production destinations gate the Publish button with
+ * an explicit confirmation banner, regardless of editable/type axes.
+ *
+ * Non-production destinations publish in one click, even when they're
+ * read-only or dynamic. The prod-confirm gate is specifically tied to
+ * `environment === 'production'` and must not be bypassed by type or
+ * editable combinations.
+ *
+ * Runs against tests/fixtures/sites/target-matrix/. The matrix site's
+ * first target (local-edit) is the active source by default; each row
+ * here picks a different destination and asserts on the confirmation
+ * behavior.
+ */
+import { test, expect } from '@playwright/test'
+
+/**
+ * Destinations grouped by whether they should trigger the prod-confirm
+ * banner. The gating contract: production → banner; staging/local →
+ * immediate publish. editable and type don't affect this.
+ */
+const destinations = [
+  { name: 'local-ro',     env: 'local',      editable: false, type: 'static',  requiresConfirm: false },
+  { name: 'local-dyn',    env: 'local',      editable: true,  type: 'dynamic', requiresConfirm: false },
+  { name: 'staging-ro',   env: 'staging',    editable: false, type: 'static',  requiresConfirm: false },
+  { name: 'staging-edit', env: 'staging',    editable: true,  type: 'static',  requiresConfirm: false },
+  { name: 'prod-ro',      env: 'production', editable: false, type: 'static',  requiresConfirm: true  },
+  { name: 'prod-edit',    env: 'production', editable: true,  type: 'static',  requiresConfirm: true  },
+  { name: 'prod-dyn',     env: 'production', editable: false, type: 'dynamic', requiresConfirm: true  },
+] as const
+
+test.describe('Publish confirmation matrix', () => {
+  for (const row of destinations) {
+    test(`dest=${row.name} (env=${row.env}) → requiresConfirm=${row.requiresConfirm}`, async ({ page }) => {
+      await page.goto('/admin')
+      await page.locator('[data-testid="publish-btn"]').click()
+      await expect(page.locator('[data-testid="publish-panel"]')).toBeVisible()
+
+      // Pick this row's destination. Because local-edit is the default
+      // active/source, it won't appear in the destinations list — that's
+      // fine, the matrix only enumerates non-local-edit rows.
+      await page.locator(`[data-testid="publish-dest-${row.name}"]`).click()
+
+      // Wait for the item list to populate (compare runs after destination
+      // changes). Matrix fixture has just one page (home), so its row is
+      // the strong signal that the panel is ready.
+      await expect(page.locator('[data-testid="publish-item-pages/home"]')).toBeVisible({ timeout: 10000 })
+
+      // Click Publish. Prod destinations should reveal the confirm banner
+      // without dispatching; non-prod should proceed to the stream/result.
+      await page.locator('[data-testid="publish-panel-confirm"]').click()
+
+      if (row.requiresConfirm) {
+        await expect(page.locator('[data-testid="publish-confirm-banner"]')).toBeVisible()
+        await expect(page.locator('[data-testid="publish-panel-confirm-prod"]')).toBeVisible()
+        // Step back to reset state for the next test in the same worker.
+        await page.locator('button', { hasText: 'Back' }).click()
+        await page.locator('[data-testid="publish-panel-cancel"]').click()
+      } else {
+        // Banner must NOT appear — either the Done button lands (fast
+        // publish) or the progress block is in flight.
+        await expect(page.locator('[data-testid="publish-confirm-banner"]')).toHaveCount(0)
+        // Wait for the stream to complete before moving on.
+        await expect(page.locator('[data-testid="publish-panel-done"]')).toBeVisible({ timeout: 15000 })
+        await page.locator('[data-testid="publish-panel-done"]').click()
+      }
+    })
+  }
+})

--- a/tests/fixtures/sites/target-matrix/package.json
+++ b/tests/fixtures/sites/target-matrix/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@gazetta/fixture-target-matrix",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx ../../../../packages/gazetta/src/cli/index.ts dev sites/main"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0",
+    "zod": "^4.3.6",
+    "gazetta": "*"
+  }
+}

--- a/tests/fixtures/sites/target-matrix/sites/main/site.yaml
+++ b/tests/fixtures/sites/target-matrix/sites/main/site.yaml
@@ -1,0 +1,71 @@
+name: "Target Matrix Fixture"
+version: "1.0.0"
+targets:
+  # Axis coverage (environment × editable × type). Each target exists
+  # to prove the admin UI reacts correctly to one combination. Minimal
+  # storage — filesystem — because matrix tests don't exercise publish
+  # execution, only the UI that reacts to target properties.
+
+  # --- local environment ---
+  local-edit:
+    storage:
+      type: filesystem
+    # path defaults to ./targets/local-edit — where the source content
+    # lives. environment: local, editable: true, type: static (all defaults).
+
+  local-ro:
+    storage:
+      type: filesystem
+      path: ./dist/local-ro
+    editable: false
+    # Local target that's NOT editable — an override of the default.
+    # Proves the editable flag is respected even against env defaults.
+
+  local-dyn:
+    storage:
+      type: filesystem
+      path: ./dist/local-dyn
+    type: dynamic
+    # Editable dynamic local — proves the type flag flows independently
+    # of environment.
+
+  # --- staging environment ---
+  staging-ro:
+    storage:
+      type: filesystem
+      path: ./dist/staging-ro
+    environment: staging
+    # editable: false is the env default for staging
+
+  staging-edit:
+    storage:
+      type: filesystem
+      path: ./dist/staging-edit
+    environment: staging
+    editable: true
+    # Editable staging — overrides the env default for draft-editing
+    # workflows on staging.
+
+  # --- production environment ---
+  prod-ro:
+    storage:
+      type: filesystem
+      path: ./dist/prod-ro
+    environment: production
+
+  prod-edit:
+    storage:
+      type: filesystem
+      path: ./dist/prod-edit
+    environment: production
+    editable: true
+    # Hotfix-accepting production — unblocks the deferred Phase 3 scenario
+    # (source=prod → local). Without editable:true the source dropdown
+    # doesn't show prod.
+
+  prod-dyn:
+    storage:
+      type: filesystem
+      path: ./dist/prod-dyn
+    environment: production
+    type: dynamic

--- a/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/fragments/footer/fragment.json
+++ b/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/fragments/footer/fragment.json
@@ -1,0 +1,12 @@
+{
+  "template": "footer-layout",
+  "components": [
+    {
+      "name": "copyright",
+      "template": "copyright",
+      "content": {
+        "text": "© 2026 Gazetta. Built with composable components."
+      }
+    }
+  ]
+}

--- a/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/fragments/header/fragment.json
+++ b/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/fragments/header/fragment.json
@@ -1,0 +1,33 @@
+{
+  "template": "header-layout",
+  "components": [
+    {
+      "name": "logo",
+      "template": "logo",
+      "content": {
+        "text": "Gazetta",
+        "href": "/"
+      }
+    },
+    {
+      "name": "nav",
+      "template": "nav",
+      "content": {
+        "links": [
+          {
+            "label": "Home",
+            "href": "/"
+          },
+          {
+            "label": "About",
+            "href": "/about"
+          },
+          {
+            "label": "Blog",
+            "href": "/blog/hello-world"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/pages/404/page.json
+++ b/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/pages/404/page.json
@@ -1,0 +1,17 @@
+{
+  "template": "page-default",
+  "content": {
+    "title": "Page Not Found"
+  },
+  "components": [
+    "@header",
+    {
+      "name": "message",
+      "template": "text-block",
+      "content": {
+        "body": "<p>The page you're looking for doesn't exist. <a href='/'>Go home</a>.</p>"
+      }
+    },
+    "@footer"
+  ]
+}

--- a/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/pages/about/page.json
+++ b/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/pages/about/page.json
@@ -1,0 +1,28 @@
+{
+  "template": "page-default",
+  "content": {
+    "title": "About",
+    "description": "About Gazetta"
+  },
+  "components": [
+    "@header",
+    {
+      "name": "about-text",
+      "template": "text-block",
+      "content": {
+        "heading": "About Gazetta",
+        "body": "Gazetta is a stateless CMS that structures websites as composable components. No database, no build step — just templates, fragments, and pages composed at serve time."
+      }
+    },
+    {
+      "name": "testimonial",
+      "template": "quote-card",
+      "content": {
+        "quote": "Gazetta lets us update shared components once and every page reflects it instantly. No more rebuilding the entire site.",
+        "author": "Site Developer",
+        "role": "Vue SSR template example"
+      }
+    },
+    "@footer"
+  ]
+}

--- a/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/pages/blog/[slug]/page.json
+++ b/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/pages/blog/[slug]/page.json
@@ -1,0 +1,17 @@
+{
+  "template": "page-default",
+  "content": {
+    "title": "Blog Post"
+  },
+  "components": [
+    "@header",
+    {
+      "name": "article",
+      "template": "markdown",
+      "content": {
+        "body": "# Hello from Gazetta\n\n*By The Gazetta Team*\n\nThis is a blog post written in **markdown**. The slug from the URL is available to templates via route params.\n\n## Features\n\n- **Bold** and *italic* text\n- [Links](https://gazetta.studio)\n- Code blocks with `inline code`\n- Lists, tables, blockquotes\n\n> Gazetta converts markdown to HTML automatically when you use `format.markdown()` in your Zod schema.\n\n```ts\nexport const schema = z.object({\n  body: z.string().meta(format.markdown()),\n})\n```\n\nThat's it. The CMS editor shows a markdown textarea, and the renderer converts it to HTML before your template receives it.\n"
+      }
+    },
+    "@footer"
+  ]
+}

--- a/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/pages/home/page.json
+++ b/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/pages/home/page.json
@@ -1,0 +1,82 @@
+{
+  "template": "page-default",
+  "content": {
+    "title": "Home",
+    "description": "Welcome to Gazetta"
+  },
+  "components": [
+    "@header",
+    {
+      "name": "hero",
+      "template": "hero",
+      "content": {
+        "title": "Welcome to Gazetta",
+        "subtitle": "A stateless CMS that composes pages from reusable components"
+      }
+    },
+    {
+      "name": "features",
+      "template": "features-grid",
+      "content": {
+        "heading": "Why Gazetta?"
+      },
+      "components": [
+        {
+          "name": "fast",
+          "template": "feature-card",
+          "content": {
+            "icon": "⚡",
+            "title": "Fast",
+            "description": "Edge composition at request time. No full rebuilds."
+          }
+        },
+        {
+          "name": "composable",
+          "template": "feature-card",
+          "content": {
+            "icon": "🧩",
+            "title": "Composable",
+            "description": "Build pages from reusable fragments. Recursive composition."
+          }
+        },
+        {
+          "name": "open-source",
+          "template": "feature-card",
+          "content": {
+            "icon": "🔓",
+            "title": "Open Source",
+            "description": "No vendor lock-in. Use any framework for templates."
+          }
+        }
+      ]
+    },
+    {
+      "name": "demo",
+      "template": "counter",
+      "content": {
+        "label": "Clicks",
+        "start": 0
+      }
+    },
+    {
+      "name": "vue-demo",
+      "template": "vue-test",
+      "content": {
+        "heading": "Vue SSR Works",
+        "body": "This component is rendered with Vue 3 SSR"
+      }
+    },
+    {
+      "name": "banner",
+      "template": "banner",
+      "content": {
+        "heading": "Get Started Today",
+        "text": "Build beautiful sites with composable fragments",
+        "buttonText": "Learn More",
+        "buttonUrl": "/about",
+        "background": "#667eea"
+      }
+    },
+    "@footer"
+  ]
+}

--- a/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/pages/showcase/page.json
+++ b/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/pages/showcase/page.json
@@ -1,0 +1,25 @@
+{
+  "template": "page-default",
+  "content": {
+    "title": "Editor Showcase",
+    "description": "Demonstrates all editor input types"
+  },
+  "components": [
+    "@header",
+    {
+      "name": "showcase-demo",
+      "template": "showcase",
+      "content": {
+        "body": "<p>This is a <strong>rich text</strong> field with <em>formatting</em> support.</p>",
+        "image": "https://images.unsplash.com/photo-1517694712202-14dd9538aa97?w=800",
+        "website": "https://gazetta.studio",
+        "slug": "editor-showcase",
+        "snippet": "<div class=\"hero\">\n  <h1>Hello World</h1>\n</div>",
+        "metadata": "{ \"version\": 1, \"draft\": true }",
+        "accentColor": "#667eea",
+        "layout": "centered"
+      }
+    },
+    "@footer"
+  ]
+}

--- a/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/site.yaml
+++ b/tests/fixtures/sites/target-matrix/sites/main/targets/local-edit/site.yaml
@@ -1,0 +1,2 @@
+name: "Target Matrix Fixture"
+version: "1.0.0"

--- a/tests/fixtures/sites/target-matrix/templates/article/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/article/index.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  title: z.string().describe('Article title'),
+  author: z.string().optional().describe('Author name'),
+  body: z.string().describe('Article body'),
+})
+
+const template: TemplateFunction = ({ content = {}, params = {} }) => ({
+  html: `<article class="article">
+  <h1>${content.title ?? params.slug ?? ''}</h1>
+  <p class="article-meta">By ${content.author ?? 'Unknown'}</p>
+  <div class="article-body">${content.body ?? ''}</div>
+</article>`,
+  css: `.article { padding: 3rem 2rem; max-width: 48rem; margin: 0 auto; }
+.article h1 { font-size: 2rem; margin-bottom: 0.5rem; }
+.article-meta { color: #888; margin-bottom: 2rem; }
+.article-body { line-height: 1.8; }`,
+  js: '',
+})
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/banner/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/banner/index.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+import { format } from 'gazetta'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  heading: z.string().describe('Banner heading'),
+  text: z.string().optional().describe('Supporting text'),
+  buttonText: z.string().optional().describe('Button label'),
+  buttonUrl: z.string().optional().describe('Button link URL'),
+  background: z.string().meta(format.field('brand-color')).optional().describe('Background color (default: #667eea)'),
+})
+
+type Content = z.infer<typeof schema>
+
+const template: TemplateFunction<Content> = ({ content }) => {
+  const bg = content?.background ?? 'linear-gradient(135deg, #667eea, #764ba2)'
+  return {
+    html: `<section class="banner" style="background:${bg}">
+  <h2 class="banner-heading">${content?.heading ?? ''}</h2>
+  ${content?.text ? `<p class="banner-text">${content.text}</p>` : ''}
+  ${content?.buttonText ? `<a class="banner-btn" href="${content.buttonUrl ?? '#'}">${content.buttonText}</a>` : ''}
+</section>`,
+    css: `.banner { padding: 4rem 2rem; text-align: center; color: #fff; border-radius: 12px; margin: 2rem auto; max-width: 72rem; }
+.banner-heading { font-size: 2rem; font-weight: 700; margin-bottom: 0.75rem; }
+.banner-text { font-size: 1.125rem; opacity: 0.9; margin-bottom: 1.5rem; max-width: 36rem; margin-left: auto; margin-right: auto; }
+.banner-btn { display: inline-block; padding: 0.75rem 2rem; background: #fff; color: #1a1a1a; border-radius: 8px; font-weight: 600; text-decoration: none; font-size: 0.9375rem; }
+.banner-btn:hover { opacity: 0.9; }`,
+    js: '',
+  }
+}
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/blog-post/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/blog-post/index.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod'
+import { format, type TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  title: z.string().describe('Post title'),
+  date: z.string().optional().describe('Publication date'),
+  author: z.string().optional().describe('Author name'),
+  tags: z.array(z.string()).optional().describe('Tags'),
+  body: z.string().meta(format.markdown()).describe('Post body (markdown)'),
+})
+
+type Content = z.infer<typeof schema>
+
+const template: TemplateFunction<Content> = ({ content }) => {
+  const tags = content?.tags ?? []
+  return {
+    html: `<article class="blog-post">
+  <header class="blog-post-header">
+    <h1 class="blog-post-title">${content?.title ?? ''}</h1>
+    <div class="blog-post-meta">
+      ${content?.author ? `<span class="blog-post-author">By ${content.author}</span>` : ''}
+      ${content?.date ? `<time class="blog-post-date">${content.date}</time>` : ''}
+    </div>
+    ${tags.length ? `<div class="blog-post-tags">${tags.map(t => `<span class="blog-post-tag">${t}</span>`).join('')}</div>` : ''}
+  </header>
+  <div class="blog-post-body">${content?.body ?? ''}</div>
+</article>`,
+    css: `.blog-post { max-width: 42rem; margin: 0 auto; padding: 2rem 0; }
+.blog-post-header { margin-bottom: 2rem; }
+.blog-post-title { font-size: 2.25rem; font-weight: 700; line-height: 1.2; margin-bottom: 0.75rem; }
+.blog-post-meta { display: flex; gap: 1rem; font-size: 0.875rem; color: #6b7280; margin-bottom: 0.75rem; }
+.blog-post-author { font-weight: 500; }
+.blog-post-tags { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+.blog-post-tag { padding: 0.25rem 0.75rem; background: #f3f4f6; border-radius: 999px; font-size: 0.75rem; color: #4b5563; }
+.blog-post-body { line-height: 1.8; }
+.blog-post-body h2 { font-size: 1.5rem; margin-top: 2rem; margin-bottom: 0.5rem; }
+.blog-post-body h3 { font-size: 1.25rem; margin-top: 1.5rem; margin-bottom: 0.5rem; }
+.blog-post-body p { margin-bottom: 1rem; }
+.blog-post-body a { color: #667eea; }
+.blog-post-body code { background: #f0f0f0; padding: 0.125rem 0.375rem; border-radius: 3px; font-size: 0.875rem; }
+.blog-post-body pre { background: #1e1e2e; color: #e0e0e0; padding: 1rem; border-radius: 8px; overflow-x: auto; margin-bottom: 1rem; }
+.blog-post-body pre code { background: none; padding: 0; }
+.blog-post-body blockquote { border-left: 3px solid #667eea; padding-left: 1rem; color: #666; margin-bottom: 1rem; }
+.blog-post-body ul, .blog-post-body ol { margin-bottom: 1rem; padding-left: 1.5rem; }
+.blog-post-body img { max-width: 100%; border-radius: 8px; }`,
+    js: '',
+  }
+}
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/card-grid/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/card-grid/index.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  heading: z.string().optional().describe('Section heading'),
+  columns: z.number().optional().describe('Minimum column width in px (default: 280)'),
+})
+
+type Content = z.infer<typeof schema>
+
+const template: TemplateFunction<Content> = ({ content, children = [] }) => {
+  const minWidth = content?.columns ?? 280
+  return {
+    html: `<section class="card-grid">
+  ${content?.heading ? `<h2 class="card-grid-heading">${content.heading}</h2>` : ''}
+  <div class="card-grid-items">${children.map(c => c.html).join('\n')}</div>
+</section>`,
+    css: `.card-grid { padding: 3rem 2rem; max-width: 72rem; margin: 0 auto; }
+.card-grid-heading { font-size: 1.75rem; text-align: center; margin-bottom: 2rem; }
+.card-grid-items { display: grid; grid-template-columns: repeat(auto-fit, minmax(${minWidth}px, 1fr)); gap: 1.5rem; }
+${children.map(c => c.css).join('\n')}`,
+    js: children.map(c => c.js).filter(Boolean).join('\n'),
+    head: children.map(c => c.head).filter(Boolean).join('\n'),
+  }
+}
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/card/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/card/index.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  title: z.string().describe('Card title'),
+  body: z.string().describe('Card body text'),
+  link: z.string().optional().describe('Link URL'),
+  linkText: z.string().optional().describe('Link text'),
+})
+
+type Content = z.infer<typeof schema>
+
+const template: TemplateFunction<Content> = ({ content }) => ({
+  html: `<div class="card">
+  <h3 class="card-title">${content?.title ?? ''}</h3>
+  <p class="card-body">${content?.body ?? ''}</p>
+  ${content?.link ? `<a class="card-link" href="${content.link}">${content.linkText ?? 'Read more'}</a>` : ''}
+</div>`,
+  css: `.card { padding: 1.5rem; border: 1px solid #e5e7eb; border-radius: 8px; background: #fff; }
+.card-title { font-size: 1.125rem; font-weight: 600; margin-bottom: 0.5rem; }
+.card-body { color: #6b7280; font-size: 0.875rem; line-height: 1.6; margin-bottom: 0.75rem; }
+.card-link { color: #667eea; font-size: 0.875rem; font-weight: 500; text-decoration: none; }
+.card-link:hover { text-decoration: underline; }`,
+  js: '',
+})
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/copyright/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/copyright/index.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  text: z.string().describe('Copyright text'),
+})
+
+const template: TemplateFunction = ({ content = {} }) => ({
+  html: `<p class="copyright">${content.text ?? ''}</p>`,
+  css: `.copyright { color: #888; font-size: 0.875rem; }`,
+  js: '',
+})
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/counter/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/counter/index.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  label: z.string().describe('Button label'),
+  start: z.number().optional().describe('Starting count'),
+})
+
+type Content = z.infer<typeof schema>
+
+const template: TemplateFunction<Content> = ({ content }) => {
+  const { label = 'Count', start = 0 } = content ?? {}
+  // Use a unique ID so multiple counters on one page don't collide
+  const id = `counter-${Math.random().toString(36).slice(2, 8)}`
+  return {
+    html: `<div class="counter" id="${id}">
+  <span class="counter-value">${start}</span>
+  <button class="counter-btn" data-action="decrement">−</button>
+  <button class="counter-btn" data-action="increment">+</button>
+  <span class="counter-label">${label}</span>
+</div>`,
+    css: `.counter { display: inline-flex; align-items: center; gap: 0.5rem; padding: 1rem 1.5rem; border: 1px solid #e5e7eb; border-radius: 8px; background: #fff; }
+.counter-value { font-size: 2rem; font-weight: 700; min-width: 3rem; text-align: center; }
+.counter-btn { width: 2.5rem; height: 2.5rem; border: 1px solid #d1d5db; border-radius: 6px; background: #f9fafb; font-size: 1.25rem; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+.counter-btn:hover { background: #e5e7eb; }
+.counter-btn:active { background: #d1d5db; }
+.counter-label { font-size: 0.875rem; color: #6b7280; }`,
+    js: `{
+  const el = document.getElementById('${id}')
+  const display = el.querySelector('.counter-value')
+  let count = ${start}
+  el.querySelector('[data-action="increment"]').addEventListener('click', () => {
+    display.textContent = ++count
+  })
+  el.querySelector('[data-action="decrement"]').addEventListener('click', () => {
+    display.textContent = --count
+  })
+}`,
+  }
+}
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/feature-card/index.tsx
+++ b/tests/fixtures/sites/target-matrix/templates/feature-card/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  icon: z.string().describe('Emoji icon'),
+  title: z.string().describe('Card title'),
+  description: z.string().describe('Card description'),
+})
+
+type Content = z.infer<typeof schema>
+
+function FeatureCard({ icon, title, description }: Content) {
+  return (
+    <div className="feature-card">
+      <span className="feature-icon">{icon}</span>
+      <h3>{title}</h3>
+      <p>{description}</p>
+    </div>
+  )
+}
+
+const template: TemplateFunction<Content> = ({ content }) => {
+  const { icon = '', title = '', description = '' } = content ?? {}
+  return {
+    html: renderToStaticMarkup(<FeatureCard icon={icon} title={title} description={description} />),
+  css: `.feature-card { padding: 1.5rem; border: 1px solid #eee; border-radius: 8px; text-align: center; }
+.feature-icon { font-size: 2rem; display: block; margin-bottom: 0.5rem; }
+.feature-card h3 { font-size: 1.125rem; margin-bottom: 0.5rem; }
+.feature-card p { color: #666; font-size: 0.875rem; }`,
+  js: '',
+  }
+}
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/features-grid/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/features-grid/index.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  heading: z.string().describe('Section heading'),
+})
+
+const template: TemplateFunction = ({ content = {}, children = [] }) => ({
+  html: `<section class="features">
+  <h2>${content.heading ?? ''}</h2>
+  <div class="features-grid">${children.map(c => c.html).join('\n')}</div>
+</section>`,
+  css: `.features { padding: 3rem 2rem; }
+.features h2 { text-align: center; font-size: 1.75rem; margin-bottom: 2rem; }
+.features-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.5rem; max-width: 60rem; margin: 0 auto; }
+${children.map(c => c.css).join('\n')}`,
+  js: children.map(c => c.js).filter(Boolean).join('\n'),
+})
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/footer-layout/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/footer-layout/index.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({})
+
+const template: TemplateFunction = ({ children = [] }) => ({
+  html: `<footer class="site-footer">${children.map(c => c.html).join('\n')}</footer>`,
+  css: `.site-footer { padding: 2rem; text-align: center; background: #f5f5f5; border-top: 1px solid #eee; margin-top: auto; }
+${children.map(c => c.css).join('\n')}`,
+  js: children.map(c => c.js).filter(Boolean).join('\n'),
+})
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/header-layout/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/header-layout/index.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({})
+
+const template: TemplateFunction = ({ children = [] }) => ({
+  html: `<header class="site-header">${children.map(c => c.html).join('\n')}</header>`,
+  css: `.site-header { display: flex; align-items: center; justify-content: space-between; padding: 1rem 2rem; background: #fff; border-bottom: 1px solid #eee; }
+${children.map(c => c.css).join('\n')}`,
+  js: children.map(c => c.js).filter(Boolean).join('\n'),
+})
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/hero/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/hero/index.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  title: z.string().describe('Title'),
+  subtitle: z.string().optional().describe('Subtitle'),
+})
+
+const template: TemplateFunction = ({ content = {} }) => ({
+  html: `<section class="hero">
+  <h1>${content.title ?? ''}</h1>
+  <p>${content.subtitle ?? ''}</p>
+</section>`,
+  css: `.hero { padding: 4rem 2rem; text-align: center; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; }
+.hero h1 { font-size: 2.5rem; margin-bottom: 1rem; }
+.hero p { font-size: 1.25rem; opacity: 0.9; }`,
+  js: '',
+})
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/logo/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/logo/index.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  text: z.string().describe('Logo text'),
+  href: z.string().optional().describe('Link URL'),
+})
+
+const template: TemplateFunction = ({ content = {} }) => ({
+  html: content.href
+    ? `<a class="site-logo" href="${content.href}">${content.text ?? ''}</a>`
+    : `<span class="site-logo">${content.text ?? ''}</span>`,
+  css: `.site-logo { font-size: 1.25rem; font-weight: 700; text-decoration: none; color: #1a1a1a; }`,
+  js: '',
+})
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/markdown/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/markdown/index.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+import { format, type TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  body: z.string().meta(format.markdown()).describe('Content (markdown)'),
+})
+
+type Content = z.infer<typeof schema>
+
+const template: TemplateFunction<Content> = ({ content }) => ({
+  html: `<article class="markdown">${content?.body ?? ''}</article>`,
+  css: `.markdown { max-width: 42rem; margin: 0 auto; padding: 2rem 0; line-height: 1.8; }
+.markdown h1 { font-size: 2rem; margin-bottom: 0.5rem; }
+.markdown h2 { font-size: 1.5rem; margin-top: 2rem; margin-bottom: 0.5rem; }
+.markdown h3 { font-size: 1.25rem; margin-top: 1.5rem; margin-bottom: 0.5rem; }
+.markdown p { margin-bottom: 1rem; }
+.markdown a { color: #667eea; }
+.markdown code { background: #f0f0f0; padding: 0.125rem 0.375rem; border-radius: 3px; font-size: 0.875rem; }
+.markdown pre { background: #1e1e2e; color: #e0e0e0; padding: 1rem; border-radius: 8px; overflow-x: auto; margin-bottom: 1rem; }
+.markdown pre code { background: none; padding: 0; }
+.markdown blockquote { border-left: 3px solid #667eea; padding-left: 1rem; color: #666; margin-bottom: 1rem; }
+.markdown ul, .markdown ol { margin-bottom: 1rem; padding-left: 1.5rem; }
+.markdown li { margin-bottom: 0.25rem; }
+.markdown table { width: 100%; border-collapse: collapse; margin-bottom: 1rem; }
+.markdown th, .markdown td { padding: 0.5rem; border: 1px solid #ddd; text-align: left; }
+.markdown th { background: #f8f8f8; font-weight: 600; }
+.markdown hr { border: none; border-top: 1px solid #eee; margin: 2rem 0; }
+.markdown img { max-width: 100%; border-radius: 8px; }`,
+  js: '',
+})
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/nav/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/nav/index.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  links: z.array(z.object({
+    label: z.string().describe('Link text'),
+    href: z.string().describe('URL'),
+  })).describe('Navigation links'),
+})
+
+const template: TemplateFunction = ({ content = {} }) => {
+  const links = (content.links ?? []) as Array<{ label: string; href: string }>
+  return {
+    html: `<nav class="site-nav">${links.map(l => `<a href="${l.href}">${l.label}</a>`).join('\n')}</nav>`,
+    css: `.site-nav { display: flex; gap: 1.5rem; }
+.site-nav a { text-decoration: none; color: #333; font-weight: 500; }
+.site-nav a:hover { color: #667eea; }`,
+    js: '',
+  }
+}
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/page-default/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/page-default/index.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  title: z.string().describe('Page title'),
+  description: z.string().optional().describe('Page description'),
+})
+
+type Content = z.infer<typeof schema>
+
+const template: TemplateFunction<Content> = ({ content, children = [] }) => ({
+  html: `<main>${children.map(c => c.html).join('\n')}</main>`,
+  css: `*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: system-ui, -apple-system, sans-serif; color: #1a1a1a; line-height: 1.6; }
+main { min-height: 100vh; display: flex; flex-direction: column; }
+${children.map(c => c.css).join('\n')}`,
+  js: children.map(c => c.js).filter(Boolean).join('\n'),
+  head: `<title>${content?.title ?? ''}</title>
+${content?.description ? `<meta name="description" content="${content.description}">` : ''}
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>">
+${children.map(c => c.head).filter(Boolean).join('\n')}`,
+})
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/quote-card/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/quote-card/index.ts
@@ -1,0 +1,34 @@
+import { createSSRApp, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  quote: z.string().describe('Quote text'),
+  author: z.string().describe('Author name'),
+  role: z.string().optional().describe('Author role or title'),
+})
+
+type Content = z.infer<typeof schema>
+
+const QuoteCard = (props: Content) => h('blockquote', { class: 'quote-card' }, [
+  h('p', { class: 'quote-text' }, `"${props.quote}"`),
+  h('footer', { class: 'quote-footer' }, [
+    h('strong', props.author),
+    props.role ? h('span', ` — ${props.role}`) : null,
+  ]),
+])
+
+const template: TemplateFunction<Content> = async ({ content }) => {
+  const app = createSSRApp(QuoteCard, content ?? {})
+  const html = await renderToString(app)
+  return {
+    html,
+    css: `.quote-card { padding: 1.5rem 2rem; border-left: 3px solid #667eea; background: #f8f9fa; border-radius: 0 8px 8px 0; margin: 1rem 0; }
+.quote-text { font-style: italic; font-size: 1.125rem; margin-bottom: 0.75rem; color: #333; }
+.quote-footer { font-size: 0.875rem; color: #666; }`,
+    js: '',
+  }
+}
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/showcase/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/showcase/index.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod'
+import { format } from 'gazetta'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  // Rich text (Tiptap editor)
+  body: z.string().meta(format.richtext()).describe('Rich text content'),
+
+  // Image with preview
+  image: z.string().meta(format.image()).optional().describe('Hero image URL'),
+
+  // Link input
+  website: z.string().meta(format.link()).optional().describe('Website URL'),
+
+  // Slug
+  slug: z.string().meta(format.slug()).optional().describe('URL slug'),
+
+  // Code editor
+  snippet: z.string().meta(format.code({ language: 'html' })).optional().describe('HTML snippet'),
+
+  // JSON editor
+  metadata: z.string().meta(format.json()).optional().describe('Custom metadata (JSON)'),
+
+  // Color picker (explicit format)
+  accentColor: z.string().meta(format.color()).optional().describe('Accent color'),
+
+  // Select (enum)
+  layout: z.enum(['centered', 'wide', 'full']).optional().describe('Layout style'),
+})
+
+type Content = z.infer<typeof schema>
+
+const template: TemplateFunction<Content> = ({ content }) => {
+  const accent = content?.accentColor ?? '#667eea'
+  return {
+    html: `<section class="showcase" style="--accent: ${accent}">
+  ${content?.image ? `<img class="showcase-img" src="${content.image}" alt="" />` : ''}
+  <div class="showcase-body ${content?.layout ?? 'centered'}">${content?.body ?? ''}</div>
+  ${content?.website ? `<a class="showcase-link" href="${content.website}">Visit website</a>` : ''}
+  ${content?.snippet ? `<div class="showcase-snippet">${content.snippet}</div>` : ''}
+  ${content?.slug ? `<div class="showcase-slug">/${content.slug}</div>` : ''}
+</section>`,
+    css: `.showcase { padding: 2rem; max-width: 72rem; margin: 0 auto; }
+.showcase-img { max-width: 100%; border-radius: 8px; margin-bottom: 1.5rem; }
+.showcase-body { line-height: 1.7; }
+.showcase-body.wide { max-width: 48rem; }
+.showcase-body.centered { max-width: 36rem; margin: 0 auto; text-align: center; }
+.showcase-body.full { max-width: none; }
+.showcase-link { display: inline-block; margin-top: 1rem; color: var(--accent); text-decoration: none; font-weight: 600; }
+.showcase-link:hover { text-decoration: underline; }
+.showcase-snippet { margin-top: 1.5rem; padding: 1rem; background: #f3f4f6; border-radius: 8px; font-family: monospace; font-size: 0.875rem; white-space: pre-wrap; }
+.showcase-slug { margin-top: 0.5rem; color: #9ca3af; font-size: 0.875rem; font-family: monospace; }`,
+    js: '',
+  }
+}
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/text-block/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/text-block/index.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  heading: z.string().describe('Heading'),
+  body: z.string().describe('Body text'),
+})
+
+const template: TemplateFunction = ({ content = {} }) => ({
+  html: `<section class="text-block">
+  <h2>${content.heading ?? ''}</h2>
+  <p>${content.body ?? ''}</p>
+</section>`,
+  css: `.text-block { padding: 3rem 2rem; max-width: 48rem; margin: 0 auto; }
+.text-block h2 { font-size: 1.75rem; margin-bottom: 1rem; }
+.text-block p { color: #555; }`,
+  js: '',
+})
+
+export default template

--- a/tests/fixtures/sites/target-matrix/templates/two-column/index.ts
+++ b/tests/fixtures/sites/target-matrix/templates/two-column/index.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+import type { TemplateFunction } from 'gazetta'
+
+export const schema = z.object({
+  sidebarWidth: z.string().optional().describe('Sidebar width (default: 280px)'),
+  reverse: z.boolean().optional().describe('Put sidebar on the right'),
+})
+
+type Content = z.infer<typeof schema>
+
+const template: TemplateFunction<Content> = ({ content, children = [] }) => {
+  const sidebar = children[0]
+  const main = children.slice(1)
+  const width = content?.sidebarWidth ?? '280px'
+  const direction = content?.reverse ? 'row-reverse' : 'row'
+  return {
+    html: `<div class="two-col" style="flex-direction:${direction}">
+  <aside class="two-col-sidebar">${sidebar?.html ?? ''}</aside>
+  <div class="two-col-main">${main.map(c => c.html).join('\n')}</div>
+</div>`,
+    css: `.two-col { display: flex; gap: 2rem; max-width: 72rem; margin: 0 auto; padding: 2rem; }
+.two-col-sidebar { flex: 0 0 ${width}; }
+.two-col-main { flex: 1; min-width: 0; }
+@media (max-width: 768px) { .two-col { flex-direction: column !important; } .two-col-sidebar { flex: none; } }
+${children.map(c => c.css).join('\n')}`,
+    js: children.map(c => c.js).filter(Boolean).join('\n'),
+    head: children.map(c => c.head).filter(Boolean).join('\n'),
+  }
+}
+
+export default template

--- a/tests/fixtures/sites/target-matrix/tsconfig.json
+++ b/tests/fixtures/sites/target-matrix/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["templates/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Closes Phase 4 of the e2e restructure plan. Lands parameterized env × editable × type matrix tests running against a dedicated fixture site, plus a startup settings banner on \`gazetta dev\` that prints resolved config (which caught a fixture misconfig mid-PR, proving its value).

## Matrix tests (15 parameterized rows)

- [tests/e2e/matrix/env-chrome.spec.ts](tests/e2e/matrix/env-chrome.spec.ts) — 8 rows proving the active-target chrome class + read-only badge flow from (environment, editable) independently of type
- [tests/e2e/matrix/prod-confirm.spec.ts](tests/e2e/matrix/prod-confirm.spec.ts) — 7 rows proving the Publish confirmation banner is gated by \`environment: production\` ONLY; editable and type don't affect it

## Fixture site

[tests/fixtures/sites/target-matrix/](tests/fixtures/sites/target-matrix/) — 8 targets, one per meaningful axis combination: \`local-edit\`, \`local-ro\`, \`local-dyn\`, \`staging-ro\`, \`staging-edit\`, \`prod-ro\`, \`prod-edit\`, \`prod-dyn\`.

Minimal site (inherits starter's templates for completeness — admin-api walks templates at startup). Matrix tests exercise admin UI chrome + publish panel behavior, not page rendering.

## Workspace + CI wiring

- **Root package.json:** added \`tests/fixtures/sites/*\` to \`workspaces\` glob. Future test-only fixture sites (e.g. hotfix scenario, i18n, perf) drop into the same directory without polluting \`examples/\` (user-facing) or \`sites/\` (production dogfood).
- **playwright.config.ts:** new \`matrix\` project with \`testMatch: **/matrix/**/*.spec.ts\` and \`baseURL: http://localhost:4005\`. The \`dev\` project excludes the matrix directory so tests don't double-run.
- **webServer:** new entry spawns \`gazetta dev\` against the fixture site on port 4005.

## Dev-server settings banner

[packages/gazetta/src/cli/index.ts](packages/gazetta/src/cli/index.ts) — the \`gazetta dev\` startup banner now prints:

\`\`\`
  ┃ Settings
  ┃   Project      .
  ┃   Site         sites/main
  ┃   Templates    templates
  ┃   Source       local-edit (local, editable, static)
  ┃   Content root targets/local-edit
  ┃   Targets (8)
  ┃     • local-edit     local       editable  static   → targets/local-edit
  ┃     • local-ro       local       read-only static   → ./dist/local-ro
  ┃     • local-dyn      local       editable  dynamic  → ./dist/local-dyn
  ┃     • staging-ro     staging     read-only static   → ./dist/staging-ro
  ┃     ...
\`\`\`

Opt out with \`GAZETTA_QUIET=1\` for scripted callers.

**Caught a real fixture misconfig mid-PR** — I'd set \`local-edit: storage: { path: ./dist/local-edit }\` which made the dev server look for pages in \`./dist/local-edit/pages/\` not \`./targets/local-edit/pages/\`. Without the banner this showed as an empty \`/api/pages\` with no obvious cause.

## Plan progress after this PR

| # | Task | Status |
|---|------|--------|
| 1.1-1.4, 2.1-2.3, 3.1-3.2 | Priorities 1-3 | ✓ |
| Phase 1 | E2E reorganize | ✓ |
| Phase 2 | POMs | ◐ (first slice) |
| Phase 3 | Scenarios | ◐ (3 of 4, hotfix deferred) |
| Phase 4 | Matrix tests | ✓ |

The hotfix scenario (Phase 3 deferral) is now unblocked — \`prod-edit\` in the matrix fixture is an editable production target. Small follow-up.

## Tests

- 15/15 matrix tests pass
- 68/68 dev project tests pass (no regressions)
- Typecheck + build clean

## Test plan

- [ ] CI passes on all projects (dev, matrix, prod-*)
- [ ] Reviewer sanity-checks: does the Settings banner match the format you'd want? Opt-out via env var acceptable?
- [ ] Confirm the fixture workspace doesn't cause ripple issues with \`npm install\` / \`npm test\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)