### PR TITLE
E2E Phase 2 follow-up — SiteTreePom + 7-file migration

### DIFF
--- a/.claude/rules/testing-plan.md
+++ b/.claude/rules/testing-plan.md
@@ -410,21 +410,27 @@ files stay on `.test.ts` and are excluded via `testIgnore`.
 
 #### ◐ Phase 2 — Page Objects
 
-First POM landed: [PublishPanelPom](../../tests/e2e/pages/PublishPanel.ts). Covers the
-full Publish-panel surface — opening, source/destinations, items, publish action (with
-prod confirmation variant), status surfaces (confirm banner, invalid-templates, progress,
-per-target results). Migrated the full `Publish panel` describe in
-[publish.spec.ts](../../tests/e2e/publish.spec.ts) — 14 tests, test count unchanged,
-pass rate unchanged.
+Two POMs landed:
+
+**[PublishPanelPom](../../tests/e2e/pages/PublishPanel.ts)** — full Publish-panel surface:
+opening, source/destinations, items, publish action (with prod confirmation variant),
+status surfaces (confirm banner, invalid-templates, progress, per-target results).
+Migrated the `Publish panel` describe in [publish.spec.ts](../../tests/e2e/publish.spec.ts)
+(14 tests).
+
+**[SiteTreePom](../../tests/e2e/pages/SiteTree.ts)** — site tree sidebar: page/fragment
+rows, dirty dots, delete buttons, new-page/new-fragment creation buttons, selected-state
+helpers (`selectedPage` / `selectedFragment`) for the `.selected` class. Migrated 27
+selectors across 7 spec files (smoke, site-tree, editor, deep-linking, publish,
+target-switch, unsaved-guard).
 
 **Pattern:** POMs live under `tests/e2e/pages/`, one file per surface. Composition, no
 inheritance — each POM takes a `page` in the constructor. Methods expose user-level
-actions; getters expose locators; assertions stay in the tests. Matches
+actions; getters/methods return locators; assertions stay in the tests. Matches
 [Playwright POM docs](https://playwright.dev/docs/pom).
 
-**Follow-ups:** SiteTreePom + ComponentTreePom — deferred to PRs that actually migrate
-tests using them. Building POMs without consumers is dead code; adding a POM with its
-first migration keeps the API honest.
+**Follow-ups:** ComponentTreePom — deferred to PR that migrates component-ops.spec and
+similar. Each POM with its first consumer keeps the API honest (avoids dead-code POMs).
 
 ---
 

--- a/tests/e2e/deep-linking.spec.ts
+++ b/tests/e2e/deep-linking.spec.ts
@@ -1,9 +1,11 @@
 import { test, expect } from './fixtures'
+import { SiteTreePom } from './pages/SiteTree'
 
 test.describe('Deep linking', () => {
   test('direct URL to page selects it in browse mode', async ({ page }) => {
     await page.goto('/admin/pages/about')
-    await expect(page.locator('[data-testid="site-page-about"].selected')).toBeVisible({ timeout: 10000 })
+    const tree = new SiteTreePom(page)
+    await expect(tree.selectedPage('about')).toBeVisible({ timeout: 10000 })
     // Preview should show about page
     const iframe = page.frameLocator('[data-testid="preview-iframe"]')
     await iframe.locator('[data-gz]').first().waitFor({ timeout: 10000 })
@@ -17,12 +19,14 @@ test.describe('Deep linking', () => {
 
   test('direct URL to fragment selects it', async ({ page }) => {
     await page.goto('/admin/fragments/header')
-    await expect(page.locator('[data-testid="site-fragment-header"].selected')).toBeVisible({ timeout: 10000 })
+    const tree = new SiteTreePom(page)
+    await expect(tree.selectedFragment('header')).toBeVisible({ timeout: 10000 })
   })
 
   test('back button navigates from edit to browse', async ({ page }) => {
     await page.goto('/admin/pages/home')
-    await page.locator('[data-testid="site-page-home"].selected').waitFor({ timeout: 10000 })
+    const tree = new SiteTreePom(page)
+    await tree.selectedPage('home').waitFor({ timeout: 10000 })
 
     // Enter edit mode via preview click
     const iframe = page.frameLocator('[data-testid="preview-iframe"]')
@@ -36,16 +40,17 @@ test.describe('Deep linking', () => {
     // Browser back should return to browse mode
     await page.goBack()
     await expect(page).toHaveURL(/\/pages\/home$/)
-    await expect(page.locator('[data-testid="site-page-home"]')).toBeVisible()
+    await expect(tree.pageRow('home')).toBeVisible()
   })
 
   test('URL updates when switching pages', async ({ page }) => {
     await page.goto('/admin/pages/home')
-    await page.locator('[data-testid="site-page-home"].selected').waitFor({ timeout: 10000 })
+    const tree = new SiteTreePom(page)
+    await tree.selectedPage('home').waitFor({ timeout: 10000 })
 
-    await page.click('[data-testid="site-page-about"]')
+    await tree.openPage('about')
     await expect(page).toHaveURL(/\/pages\/about/)
-    await expect(page.locator('[data-testid="site-page-about"].selected')).toBeVisible()
+    await expect(tree.selectedPage('about')).toBeVisible()
   })
 })
 

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from './fixtures'
 import { openEditor } from './helpers'
+import { SiteTreePom } from './pages/SiteTree'
 
 test.describe('Default editor', () => {
   test('loads @rjsf form for template without custom editor', async ({ page }) => {
@@ -76,18 +77,21 @@ test.describe('Custom field', () => {
 test.describe('Rapid selection', () => {
   test('last click wins when rapidly switching pages', async ({ page }) => {
     await page.goto('/admin')
-    await expect(page.locator('[data-testid="site-page-home"]')).toBeVisible()
+    const tree = new SiteTreePom(page)
+    await expect(tree.pageRow('home')).toBeVisible()
 
-    // Click two pages rapidly without waiting for the first to load
-    page.click('[data-testid="site-page-home"]')
-    await page.click('[data-testid="site-page-about"]')
+    // Click two pages rapidly without waiting for the first to load.
+    // Intentionally omit `await` on the first click so the two commands
+    // race — we're testing the "last click wins" invariant.
+    void tree.pageRow('home').click()
+    await tree.openPage('about')
 
     // Wait for preview to settle — the about page should win
     const iframe = page.frameLocator('[data-testid="preview-iframe"]')
     await iframe.locator('[data-gz]').first().waitFor({ timeout: 10000 })
 
     // The selected item in the tree should be about, not home
-    await expect(page.locator('[data-testid="site-page-about"].selected')).toBeVisible()
-    await expect(page.locator('[data-testid="site-page-home"].selected')).not.toBeVisible()
+    await expect(tree.selectedPage('about')).toBeVisible()
+    await expect(tree.selectedPage('home')).not.toBeVisible()
   })
 })

--- a/tests/e2e/pages/SiteTree.ts
+++ b/tests/e2e/pages/SiteTree.ts
@@ -1,0 +1,105 @@
+/**
+ * Page Object for the site tree in the admin sidebar.
+ *
+ * Wraps the selector shapes `[data-testid="site-{type}-{name}"]`,
+ * `[data-testid="dirty-{type}-{name}"]`, `[data-testid="delete-{type}-
+ * {name}"]`, and the "new page / new fragment" buttons so tests work in
+ * user-level terms ("open the home page", "the header fragment is dirty")
+ * instead of string-formatted data-testid lookups.
+ *
+ * Conventions match PublishPanelPom:
+ * - `page` injected in the constructor; no inheritance
+ * - Methods = user actions; getters return locators; assertions stay
+ *   in the tests
+ * - Encodes the {type: 'page' | 'fragment'} distinction once, here
+ */
+import type { Locator, Page } from '@playwright/test'
+
+export type NodeKind = 'page' | 'fragment'
+
+export class SiteTreePom {
+  constructor(private readonly page: Page) {}
+
+  // ---- Rows ------------------------------------------------------------
+
+  /** Tree row for a page by name (e.g. 'home', 'about'). */
+  pageRow(name: string): Locator {
+    return this.page.locator(`[data-testid="site-page-${name}"]`)
+  }
+
+  /** Tree row for a fragment by name (e.g. 'header', 'footer'). */
+  fragmentRow(name: string): Locator {
+    return this.page.locator(`[data-testid="site-fragment-${name}"]`)
+  }
+
+  /** Generic accessor — useful when tests iterate both types. */
+  node(kind: NodeKind, name: string): Locator {
+    return this.page.locator(`[data-testid="site-${kind}-${name}"]`)
+  }
+
+  // ---- Dirty indicators -----------------------------------------------
+
+  /** Dirty dot on a page row (appears when the page differs from the
+   *  reference target's sidecar hash). */
+  dirtyDotPage(name: string): Locator {
+    return this.page.locator(`[data-testid="dirty-page-${name}"]`)
+  }
+
+  /** Dirty dot on a fragment row. */
+  dirtyDotFragment(name: string): Locator {
+    return this.page.locator(`[data-testid="dirty-fragment-${name}"]`)
+  }
+
+  // ---- Delete buttons --------------------------------------------------
+
+  /** Delete action for a page (visible on hover in the UI). */
+  deletePageButton(name: string): Locator {
+    return this.page.locator(`[data-testid="delete-page-${name}"]`)
+  }
+
+  /** Delete action for a fragment. */
+  deleteFragmentButton(name: string): Locator {
+    return this.page.locator(`[data-testid="delete-fragment-${name}"]`)
+  }
+
+  // ---- Creation -------------------------------------------------------
+
+  /** Button that opens the "new page" dialog. */
+  get newPageButton(): Locator {
+    return this.page.locator('[data-testid="new-page"]')
+  }
+
+  /** Button that opens the "new fragment" dialog. */
+  get newFragmentButton(): Locator {
+    return this.page.locator('[data-testid="new-fragment"]')
+  }
+
+  // ---- Actions ---------------------------------------------------------
+
+  /** Click a page row → admin navigates to /admin/pages/{name}. */
+  async openPage(name: string): Promise<void> {
+    await this.pageRow(name).click()
+  }
+
+  /** Click a fragment row → admin navigates to /admin/fragments/{name}. */
+  async openFragment(name: string): Promise<void> {
+    await this.fragmentRow(name).click()
+  }
+
+  // ---- State queries ---------------------------------------------------
+
+  /**
+   * Selected-state accessor for a page row. The admin adds `.selected`
+   * to the active row; this helper composes the selector so tests can
+   * `expect(tree.selectedPage('home')).toBeVisible()` without fiddling
+   * with class names.
+   */
+  selectedPage(name: string): Locator {
+    return this.page.locator(`[data-testid="site-page-${name}"].selected`)
+  }
+
+  /** Selected-state for a fragment row. */
+  selectedFragment(name: string): Locator {
+    return this.page.locator(`[data-testid="site-fragment-${name}"].selected`)
+  }
+}

--- a/tests/e2e/publish.spec.ts
+++ b/tests/e2e/publish.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from './fixtures'
 import { openEditor } from './helpers'
 import { PublishPanelPom } from './pages/PublishPanel'
+import { SiteTreePom } from './pages/SiteTree'
 import { mkdir, writeFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 
@@ -250,7 +251,8 @@ test.describe('Fragment blast radius', () => {
     // an empty index and the badge would render count=0. This test
     // covers both the UI layer and that invariant.
     await page.goto('/admin')
-    const row = page.locator('[data-testid="site-fragment-header"]')
+    const tree = new SiteTreePom(page)
+    const row = tree.fragmentRow('header')
     await row.waitFor({ timeout: 10000 })
     const badge = row.locator('[data-testid="fragment-blast-radius"]')
     await badge.waitFor({ timeout: 5000 })

--- a/tests/e2e/site-tree.spec.ts
+++ b/tests/e2e/site-tree.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from './fixtures'
+import { SiteTreePom } from './pages/SiteTree'
 import { mkdir, writeFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 
@@ -20,14 +21,15 @@ test.describe('SiteTree dirty indicators', () => {
     // simpler: just leave as wrong hash → modified. Both home and about will show dots.
 
     await page.goto('/admin')
+    const tree = new SiteTreePom(page)
     // Wait for compare cycle
     // Long timeout — on CI the picker tries production first (azurite refused,
     // ~10s timeout) before falling back to staging, so first dots take longer.
-    await page.locator('[data-testid="dirty-page-home"]').waitFor({ timeout: 30000 })
-    await expect(page.locator('[data-testid="dirty-page-home"]')).toBeVisible()
-    await expect(page.locator('[data-testid="dirty-page-about"]')).toBeVisible()
+    await tree.dirtyDotPage('home').waitFor({ timeout: 30000 })
+    await expect(tree.dirtyDotPage('home')).toBeVisible()
+    await expect(tree.dirtyDotPage('about')).toBeVisible()
     // showcase has no sidecar → added → dirty
-    await expect(page.locator('[data-testid="dirty-page-showcase"]')).toBeVisible()
+    await expect(tree.dirtyDotPage('showcase')).toBeVisible()
   })
 
   test('no dots when filesystem target is fully in sync', async ({ page, testSite }) => {
@@ -39,12 +41,13 @@ test.describe('SiteTree dirty indicators', () => {
     const stagingDir = join(testSite.projectDir, 'sites/main/dist/staging')
     await rm(stagingDir, { recursive: true, force: true })
     await page.goto('/admin')
+    const tree = new SiteTreePom(page)
     // First-publish path → every page dirty
     // Long timeout — on CI the picker tries production first (azurite refused,
     // ~10s timeout) before falling back to staging, so first dots take longer.
-    await page.locator('[data-testid="dirty-page-home"]').waitFor({ timeout: 30000 })
-    await expect(page.locator('[data-testid="dirty-page-home"]')).toBeVisible()
-    await expect(page.locator('[data-testid="dirty-page-about"]')).toBeVisible()
-    await expect(page.locator('[data-testid="dirty-page-showcase"]')).toBeVisible()
+    await tree.dirtyDotPage('home').waitFor({ timeout: 30000 })
+    await expect(tree.dirtyDotPage('home')).toBeVisible()
+    await expect(tree.dirtyDotPage('about')).toBeVisible()
+    await expect(tree.dirtyDotPage('showcase')).toBeVisible()
   })
 })

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,12 +1,14 @@
 import { test, expect } from './fixtures'
+import { SiteTreePom } from './pages/SiteTree'
 
 test.describe('Admin loads', () => {
   test('site tree shows pages and fragments', async ({ page }) => {
     await page.goto('/admin')
-    await expect(page.locator('[data-testid="site-page-home"]')).toBeVisible()
-    await expect(page.locator('[data-testid="site-page-about"]')).toBeVisible()
-    await expect(page.locator('[data-testid="site-fragment-header"]')).toBeVisible()
-    await expect(page.locator('[data-testid="site-fragment-footer"]')).toBeVisible()
+    const tree = new SiteTreePom(page)
+    await expect(tree.pageRow('home')).toBeVisible()
+    await expect(tree.pageRow('about')).toBeVisible()
+    await expect(tree.fragmentRow('header')).toBeVisible()
+    await expect(tree.fragmentRow('footer')).toBeVisible()
   })
 })
 

--- a/tests/e2e/target-switch.spec.ts
+++ b/tests/e2e/target-switch.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from './fixtures'
 import { openEditor } from './helpers'
+import { SiteTreePom } from './pages/SiteTree'
 import { rm } from 'node:fs/promises'
 import { join } from 'node:path'
 
@@ -82,7 +83,8 @@ test.describe('Target switch with missing item', () => {
     await wipeStaging(testSite.projectDir)
     // Select home on local.
     await page.goto('/admin/pages/home')
-    await page.waitForSelector('[data-testid="site-page-home"]', { timeout: 10000 })
+    const tree = new SiteTreePom(page)
+    await tree.pageRow('home').waitFor({ timeout: 10000 })
     // Switch to staging — home doesn't exist there.
     await page.locator('[data-testid="active-target-indicator"]').click()
     await page.locator('[data-testid="active-target-menu"]').getByRole('menuitem', { name: 'staging' }).click()

--- a/tests/e2e/unsaved-guard.spec.ts
+++ b/tests/e2e/unsaved-guard.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from './fixtures'
 import { openEditor } from './helpers'
+import { SiteTreePom } from './pages/SiteTree'
 
 test.describe('Unsaved changes dialog', () => {
   test('shows styled dialog with Save/Discard/Cancel when leaving with unsaved changes', async ({ page }) => {
@@ -62,7 +63,8 @@ test.describe('Unsaved changes dialog', () => {
 
     // Dialog closes, back to browse mode (SiteTree visible)
     await expect(page.locator('.p-dialog')).not.toBeVisible()
-    await expect(page.locator('[data-testid="site-page-home"]')).toBeVisible()
+    const tree = new SiteTreePom(page)
+    await expect(tree.pageRow('home')).toBeVisible()
   })
 })
 


### PR DESCRIPTION
## Summary

Follow-up to Phase 2 (PublishPanelPom). Lands [SiteTreePom](tests/e2e/pages/SiteTree.ts) and migrates every raw \`site-*\` and \`dirty-*\` data-testid across the dev project's spec files.

27 raw selectors → POM calls. Zero test-count change, zero pass-rate change.

## POM shape

[tests/e2e/pages/SiteTree.ts](tests/e2e/pages/SiteTree.ts):

- **Rows:** \`pageRow(name)\`, \`fragmentRow(name)\`, \`node(kind, name)\`
- **Dirty dots:** \`dirtyDotPage(name)\`, \`dirtyDotFragment(name)\`
- **Delete buttons:** \`deletePageButton\` / \`deleteFragmentButton\`
- **Creation:** \`newPageButton\` / \`newFragmentButton\`
- **Actions:** \`openPage(name)\`, \`openFragment(name)\`
- **State queries:** \`selectedPage(name)\`, \`selectedFragment(name)\` — \`.selected\` composed into the selector so tests don't manually chain class names

Same conventions as [PublishPanelPom](tests/e2e/pages/PublishPanel.ts): composition, \`page\` in constructor, methods = user actions, locators returned, assertions stay in tests.

## Files migrated

- \`smoke.spec.ts\` — site tree presence checks
- \`site-tree.spec.ts\` — all 8 dirty-dot assertions (densest consumer)
- \`editor.spec.ts\` — rapid-selection test
- \`deep-linking.spec.ts\` — 7 selectors including \`.selected\` state
- \`publish.spec.ts\` — Fragment blast radius
- \`target-switch.spec.ts\` — missing-item test
- \`unsaved-guard.spec.ts\` — post-discard site tree check

Not migrated:
- \`a11y.test.ts\` — uses \`site-fragment-header\` as a "wait for tree rendered" probe; the POM abstraction would obscure the intent
- \`production.test.ts\` — different Playwright project, separate scope

## Tests

- **24/24** pass across smoke + deep-linking + editor + unsaved-guard + site-tree
- **20/20** pass in publish + target-switch
- Typecheck clean

## Why now

#162 established the POM pattern. Without a second POM the pattern's value is untested. SiteTreePom covers a surface touched by 7 specs — the highest selector-reuse reduction available without further refactoring.

## Test plan

- [ ] CI passes on all e2e shards
- [ ] Reviewer spot-checks 1-2 migrated files for parity with pre-POM behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)