### PR TITLE
Contract-test migration: read-only list + site + dependents endpoints

### DIFF
--- a/apps/admin/src/client/api/client.ts
+++ b/apps/admin/src/client/api/client.ts
@@ -129,6 +129,8 @@ import type {
   TargetInfo as TargetInfoShape,
   TargetEnvironment as TargetEnvironmentShape,
   TargetType as TargetTypeShape,
+  SiteManifest as SiteManifestShape,
+  DependentsResponse as DependentsResponseShape,
 } from 'gazetta/admin-api/schemas'
 export type PageSummary = PageSummaryShape
 export type CreatePageRequest = CreatePageRequestShape
@@ -141,11 +143,8 @@ export type FieldSummary = FieldSummaryShape
 export type TargetInfo = TargetInfoShape
 export type TargetEnvironment = TargetEnvironmentShape
 export type TargetType = TargetTypeShape
-export interface SiteManifest {
-  name: string
-  version?: string
-  systemPages?: string[]
-}
+export type SiteManifest = SiteManifestShape
+export type DependentsResponse = DependentsResponseShape
 
 export interface InlineComponent {
   name: string
@@ -229,7 +228,7 @@ export const api = {
     return request<CompareResult>(`/compare${qs}`, options)
   },
   getDependents: (item: string, options?: RequestInit) =>
-    request<{ pages: string[]; fragments: string[] }>(`/dependents?item=${encodeURIComponent(item)}`, options),
+    request<DependentsResponse>(`/dependents?item=${encodeURIComponent(item)}`, options),
   fetchFromTarget: (source: string, items?: string[]) =>
     request<{ success: boolean; copiedFiles: number; items: string[] }>('/fetch', {
       method: 'POST',

--- a/apps/admin/src/client/api/client.ts
+++ b/apps/admin/src/client/api/client.ts
@@ -124,6 +124,11 @@ import type {
   FragmentSummary as FragmentSummaryShape,
   CreateFragmentRequest as CreateFragmentRequestShape,
   CreateFragmentResponse as CreateFragmentResponseShape,
+  TemplateSummary as TemplateSummaryShape,
+  FieldSummary as FieldSummaryShape,
+  TargetInfo as TargetInfoShape,
+  TargetEnvironment as TargetEnvironmentShape,
+  TargetType as TargetTypeShape,
 } from 'gazetta/admin-api/schemas'
 export type PageSummary = PageSummaryShape
 export type CreatePageRequest = CreatePageRequestShape
@@ -131,13 +136,11 @@ export type CreatePageResponse = CreatePageResponseShape
 export type FragmentSummary = FragmentSummaryShape
 export type CreateFragmentRequest = CreateFragmentRequestShape
 export type CreateFragmentResponse = CreateFragmentResponseShape
-export interface TemplateSummary {
-  name: string
-}
-export interface FieldSummary {
-  name: string
-  path: string
-}
+export type TemplateSummary = TemplateSummaryShape
+export type FieldSummary = FieldSummaryShape
+export type TargetInfo = TargetInfoShape
+export type TargetEnvironment = TargetEnvironmentShape
+export type TargetType = TargetTypeShape
 export interface SiteManifest {
   name: string
   version?: string
@@ -162,15 +165,6 @@ export interface FragmentDetail extends FragmentSummary {
   content?: Record<string, unknown>
   components?: ComponentEntry[]
   dir: string
-}
-
-export type TargetEnvironment = 'local' | 'staging' | 'production'
-export type TargetType = 'static' | 'dynamic'
-export interface TargetInfo {
-  name: string
-  environment: TargetEnvironment
-  type: TargetType
-  editable: boolean
 }
 
 export interface PublishResult {

--- a/apps/admin/src/client/composables/api.ts
+++ b/apps/admin/src/client/composables/api.ts
@@ -34,6 +34,7 @@ import {
   type PublishProgress,
   type CompareResult,
   type RevisionSummary,
+  type DependentsResponse,
 } from '../api/client.js'
 
 // ---- Pages -----------------------------------------------------------------
@@ -58,7 +59,7 @@ export interface FragmentsApi {
   createFragment(data: { name: string; template: string }): Promise<{ ok: boolean; name: string }>
   deleteFragment(name: string): Promise<{ ok: boolean }>
   updateFragment(name: string, data: Partial<FragmentDetail>): Promise<{ ok: boolean }>
-  getDependents(item: string, options?: RequestInit): Promise<{ pages: string[]; fragments: string[] }>
+  getDependents(item: string, options?: RequestInit): Promise<DependentsResponse>
 }
 export const FRAGMENTS_API: InjectionKey<FragmentsApi> = Symbol('FragmentsApi')
 export function useFragmentsApi(): FragmentsApi {

--- a/apps/admin/tests/api-contract.test.ts
+++ b/apps/admin/tests/api-contract.test.ts
@@ -25,6 +25,8 @@ import {
   TargetInfoSchema,
   TargetEnvironmentSchema,
   TargetTypeSchema,
+  SiteManifestSchema,
+  DependentsResponseSchema,
 } from 'gazetta/admin-api/schemas'
 import type {
   CreatePageRequest,
@@ -36,6 +38,8 @@ import type {
   TemplateSummary,
   FieldSummary,
   TargetInfo,
+  SiteManifest,
+  DependentsResponse,
 } from 'gazetta/admin-api/schemas'
 
 describe('POST /api/pages contract', () => {
@@ -197,5 +201,57 @@ describe('GET /api/targets contract', () => {
       expect(TargetTypeSchema.safeParse('dynamic').success).toBe(true)
       expect(TargetTypeSchema.safeParse('esi').success).toBe(false)
     })
+  })
+})
+
+describe('GET /api/site contract', () => {
+  it('accepts the minimal manifest the server emits', () => {
+    const manifest: SiteManifest = { name: 'My Site' }
+    expect(SiteManifestSchema.safeParse(manifest).success).toBe(true)
+  })
+
+  it('accepts a fully populated manifest', () => {
+    const manifest: SiteManifest = {
+      name: 'My Site',
+      version: '1.0.0',
+      locale: 'en',
+      baseUrl: 'https://example.com',
+      systemPages: ['404'],
+    }
+    expect(SiteManifestSchema.safeParse(manifest).success).toBe(true)
+  })
+
+  it('accepts the empty-target fallback shape (includes targets:{})', () => {
+    // The /api/site handler returns { name: '(empty)', targets: {} }
+    // when the target has no site.yaml yet. The schema is loose so
+    // the extra field passes through.
+    const r = SiteManifestSchema.safeParse({ name: '(empty)', targets: {} })
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects manifests missing name', () => {
+    expect(SiteManifestSchema.safeParse({ version: '1.0.0' }).success).toBe(false)
+  })
+})
+
+describe('GET /api/dependents contract', () => {
+  it('accepts a well-formed response', () => {
+    const resp: DependentsResponse = { pages: ['home', 'about'], fragments: ['nav'] }
+    expect(DependentsResponseSchema.safeParse(resp).success).toBe(true)
+  })
+
+  it('accepts empty arrays', () => {
+    const resp: DependentsResponse = { pages: [], fragments: [] }
+    expect(DependentsResponseSchema.safeParse(resp).success).toBe(true)
+  })
+
+  it('rejects responses missing required fields', () => {
+    expect(DependentsResponseSchema.safeParse({ pages: [] }).success).toBe(false)
+    expect(DependentsResponseSchema.safeParse({ fragments: [] }).success).toBe(false)
+    expect(DependentsResponseSchema.safeParse({}).success).toBe(false)
+  })
+
+  it('rejects non-string entries', () => {
+    expect(DependentsResponseSchema.safeParse({ pages: [123], fragments: [] }).success).toBe(false)
   })
 })

--- a/apps/admin/tests/api-contract.test.ts
+++ b/apps/admin/tests/api-contract.test.ts
@@ -20,6 +20,11 @@ import {
   CreateFragmentRequestSchema,
   CreateFragmentResponseSchema,
   FragmentSummarySchema,
+  TemplateSummarySchema,
+  FieldSummarySchema,
+  TargetInfoSchema,
+  TargetEnvironmentSchema,
+  TargetTypeSchema,
 } from 'gazetta/admin-api/schemas'
 import type {
   CreatePageRequest,
@@ -28,6 +33,9 @@ import type {
   CreateFragmentRequest,
   CreateFragmentResponse,
   FragmentSummary,
+  TemplateSummary,
+  FieldSummary,
+  TargetInfo,
 } from 'gazetta/admin-api/schemas'
 
 describe('POST /api/pages contract', () => {
@@ -132,6 +140,62 @@ describe('POST /api/fragments contract', () => {
     it('rejects entries missing required fields', () => {
       expect(FragmentSummarySchema.safeParse({ name: 'header' }).success).toBe(false)
       expect(FragmentSummarySchema.safeParse({ template: 'header-layout' }).success).toBe(false)
+    })
+  })
+})
+
+describe('GET /api/templates contract', () => {
+  it('accepts a well-formed summary', () => {
+    const entry: TemplateSummary = { name: 'hero' }
+    expect(TemplateSummarySchema.safeParse(entry).success).toBe(true)
+  })
+
+  it('rejects entries missing name', () => {
+    expect(TemplateSummarySchema.safeParse({}).success).toBe(false)
+  })
+})
+
+describe('GET /api/fields contract', () => {
+  it('accepts a well-formed summary', () => {
+    const entry: FieldSummary = { name: 'brand-color', path: '/abs/path/admin/fields/brand-color.tsx' }
+    expect(FieldSummarySchema.safeParse(entry).success).toBe(true)
+  })
+
+  it('rejects entries missing required fields', () => {
+    expect(FieldSummarySchema.safeParse({ name: 'brand-color' }).success).toBe(false)
+    expect(FieldSummarySchema.safeParse({ path: '/abs/path' }).success).toBe(false)
+  })
+})
+
+describe('GET /api/targets contract', () => {
+  describe('TargetInfo', () => {
+    it('accepts a well-formed entry', () => {
+      const entry: TargetInfo = { name: 'local', environment: 'local', type: 'static', editable: true }
+      expect(TargetInfoSchema.safeParse(entry).success).toBe(true)
+    })
+
+    it('rejects entries missing required fields', () => {
+      expect(TargetInfoSchema.safeParse({ name: 'local', environment: 'local', type: 'static' }).success).toBe(false)
+      expect(TargetInfoSchema.safeParse({ environment: 'local', type: 'static', editable: true }).success).toBe(false)
+    })
+  })
+
+  describe('TargetEnvironment / TargetType enums', () => {
+    it('TargetEnvironment accepts local, staging, production — rejects others', () => {
+      expect(TargetEnvironmentSchema.safeParse('local').success).toBe(true)
+      expect(TargetEnvironmentSchema.safeParse('staging').success).toBe(true)
+      expect(TargetEnvironmentSchema.safeParse('production').success).toBe(true)
+      // No custom environment names — this is a design-decisions.md
+      // property, not a schema accident. If the server ever emits a
+      // custom env value, it must widen the schema first.
+      expect(TargetEnvironmentSchema.safeParse('dev').success).toBe(false)
+      expect(TargetEnvironmentSchema.safeParse('prod').success).toBe(false)
+    })
+
+    it('TargetType accepts static and dynamic only', () => {
+      expect(TargetTypeSchema.safeParse('static').success).toBe(true)
+      expect(TargetTypeSchema.safeParse('dynamic').success).toBe(true)
+      expect(TargetTypeSchema.safeParse('esi').success).toBe(false)
     })
   })
 })

--- a/packages/gazetta/src/admin-api/schemas/dependents.ts
+++ b/packages/gazetta/src/admin-api/schemas/dependents.ts
@@ -1,0 +1,15 @@
+/**
+ * Zod schema for /api/dependents — reverse-dependency lookup for the
+ * publish UI's fragment-blast-radius preview.
+ *
+ * The endpoint always returns two string arrays (pages + fragments
+ * that reference the queried fragment); a 400 on invalid input is
+ * handled separately (not part of the success shape).
+ */
+import { z } from 'zod'
+
+export const DependentsResponseSchema = z.object({
+  pages: z.array(z.string()),
+  fragments: z.array(z.string()),
+})
+export type DependentsResponse = z.infer<typeof DependentsResponseSchema>

--- a/packages/gazetta/src/admin-api/schemas/fields.ts
+++ b/packages/gazetta/src/admin-api/schemas/fields.ts
@@ -1,0 +1,12 @@
+/**
+ * Zod schemas for /api/fields list endpoint.
+ */
+import { z } from 'zod'
+
+/** Summary used in list responses (GET /api/fields). */
+export const FieldSummarySchema = z.object({
+  name: z.string(),
+  /** Absolute filesystem path to the field source file. */
+  path: z.string(),
+})
+export type FieldSummary = z.infer<typeof FieldSummarySchema>

--- a/packages/gazetta/src/admin-api/schemas/index.ts
+++ b/packages/gazetta/src/admin-api/schemas/index.ts
@@ -9,6 +9,8 @@
  *   - GET  /api/templates (list)
  *   - GET  /api/fields (list)
  *   - GET  /api/targets (list)
+ *   - GET  /api/site (manifest)
+ *   - GET  /api/dependents (reverse-dep lookup)
  *
  * Add new endpoint modules here as they move to schema-validated contracts.
  */
@@ -17,3 +19,5 @@ export * from './fragments.js'
 export * from './templates.js'
 export * from './fields.js'
 export * from './targets.js'
+export * from './site.js'
+export * from './dependents.js'

--- a/packages/gazetta/src/admin-api/schemas/index.ts
+++ b/packages/gazetta/src/admin-api/schemas/index.ts
@@ -3,9 +3,17 @@
  * clients. Importing from `gazetta/admin-api/schemas` avoids pulling
  * in Hono + storage-provider code that live under `gazetta/admin-api`.
  *
- * Migrated endpoints so far: POST /api/pages, POST /api/fragments, and
- * their corresponding list-summary shapes. Add new endpoint modules
- * here as they move to schema-validated contracts.
+ * Migrated endpoints so far:
+ *   - POST /api/pages (create + list summary)
+ *   - POST /api/fragments (create + list summary)
+ *   - GET  /api/templates (list)
+ *   - GET  /api/fields (list)
+ *   - GET  /api/targets (list)
+ *
+ * Add new endpoint modules here as they move to schema-validated contracts.
  */
 export * from './pages.js'
 export * from './fragments.js'
+export * from './templates.js'
+export * from './fields.js'
+export * from './targets.js'

--- a/packages/gazetta/src/admin-api/schemas/site.ts
+++ b/packages/gazetta/src/admin-api/schemas/site.ts
@@ -1,0 +1,19 @@
+/**
+ * Zod schemas for /api/site — the site manifest shape as seen by the
+ * admin UI.
+ *
+ * Mirrors what parseSiteManifest() emits plus the empty-target fallback
+ * (which includes an otherwise-absent `targets: {}` field).
+ */
+import { z } from 'zod'
+
+export const SiteManifestSchema = z
+  .object({
+    name: z.string(),
+    version: z.string().optional(),
+    locale: z.string().optional(),
+    baseUrl: z.string().optional(),
+    systemPages: z.array(z.string()).optional(),
+  })
+  .loose()
+export type SiteManifest = z.infer<typeof SiteManifestSchema>

--- a/packages/gazetta/src/admin-api/schemas/targets.ts
+++ b/packages/gazetta/src/admin-api/schemas/targets.ts
@@ -1,0 +1,24 @@
+/**
+ * Zod schemas for /api/targets list endpoint.
+ *
+ * The literal unions mirror `TargetEnvironment` and `TargetType` in
+ * types.ts — keeping them as z.enum here means the wire shape is the
+ * authoritative spec and types.ts just re-exports the inferred types.
+ * Don't duplicate the literals on the client.
+ */
+import { z } from 'zod'
+
+export const TargetEnvironmentSchema = z.enum(['local', 'staging', 'production'])
+export type TargetEnvironment = z.infer<typeof TargetEnvironmentSchema>
+
+export const TargetTypeSchema = z.enum(['static', 'dynamic'])
+export type TargetType = z.infer<typeof TargetTypeSchema>
+
+/** Entry in the list response for GET /api/targets. */
+export const TargetInfoSchema = z.object({
+  name: z.string(),
+  environment: TargetEnvironmentSchema,
+  type: TargetTypeSchema,
+  editable: z.boolean(),
+})
+export type TargetInfo = z.infer<typeof TargetInfoSchema>

--- a/packages/gazetta/src/admin-api/schemas/templates.ts
+++ b/packages/gazetta/src/admin-api/schemas/templates.ts
@@ -1,0 +1,17 @@
+/**
+ * Zod schemas for /api/templates list endpoint.
+ *
+ * Scope note: GET /api/templates/:name/schema returns a spread JSON
+ * Schema with `hasEditor`/`editorUrl`/`fieldsBaseUrl` siblings — that
+ * wire shape is awkward to validate against a static Zod schema
+ * because the JSON Schema payload is arbitrary. Migrating it is a
+ * separate slice that should come with reshaping the response into
+ * a proper `{ jsonSchema, ... }` envelope.
+ */
+import { z } from 'zod'
+
+/** Summary used in list responses (GET /api/templates). */
+export const TemplateSummarySchema = z.object({
+  name: z.string(),
+})
+export type TemplateSummary = z.infer<typeof TemplateSummarySchema>


### PR DESCRIPTION
## Summary
- Read-only endpoints join pages + fragments in the schema-validated family: \`/api/templates\`, \`/api/fields\`, \`/api/targets\`, \`/api/site\`, \`/api/dependents\`
- TargetEnvironment / TargetType are now z.enum literal unions shared with client (no more duplicate literal declarations)
- Client drops 7 local definitions (TemplateSummary, FieldSummary, TargetInfo, TargetEnvironment, TargetType, SiteManifest, and the inline dependents response type); all derive via z.infer
- 16 new contract tests → 33 total

## Out of scope
- \`GET /api/templates/:name/schema\` — current wire shape spreads an arbitrary JSON Schema + sibling fields. Migration should come with reshaping the response into a \`{ jsonSchema, hasEditor, editorUrl?, fieldsBaseUrl }\` envelope, which is a separate refactor.
- Write endpoints (publish, history, etc.) — next slice.

## Test plan
- [x] \`npx vitest run --root apps/admin tests/api-contract.test.ts\` — 33/33 green
- [x] \`npx vitest run --root apps/admin\` — all admin tests green
- [x] \`npm run build -w packages/gazetta\` — clean tsc
- [x] \`cd apps/admin && npx vue-tsc --noEmit\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)