### PR TITLE
Contract-test migration: /api/compare, /api/publish (+ SSE progress)

### DIFF
--- a/apps/admin/src/client/api/client.ts
+++ b/apps/admin/src/client/api/client.ts
@@ -131,6 +131,9 @@ import type {
   TargetType as TargetTypeShape,
   SiteManifest as SiteManifestShape,
   DependentsResponse as DependentsResponseShape,
+  CompareResult as CompareResultShape,
+  PublishResult as PublishResultShape,
+  PublishProgress as PublishProgressShape,
 } from 'gazetta/admin-api/schemas'
 export type PageSummary = PageSummaryShape
 export type CreatePageRequest = CreatePageRequestShape
@@ -145,6 +148,9 @@ export type TargetEnvironment = TargetEnvironmentShape
 export type TargetType = TargetTypeShape
 export type SiteManifest = SiteManifestShape
 export type DependentsResponse = DependentsResponseShape
+export type CompareResult = CompareResultShape
+export type PublishResult = PublishResultShape
+export type PublishProgress = PublishProgressShape
 
 export interface InlineComponent {
   name: string
@@ -164,29 +170,6 @@ export interface FragmentDetail extends FragmentSummary {
   content?: Record<string, unknown>
   components?: ComponentEntry[]
   dir: string
-}
-
-export interface PublishResult {
-  target: string
-  success: boolean
-  error?: string
-  copiedFiles: number
-}
-export type PublishProgress =
-  | { kind: 'start'; targets: string[]; itemsPerTarget: number }
-  | { kind: 'target-start'; target: string; total: number }
-  | { kind: 'progress'; target: string; current: number; total: number; label: string }
-  | { kind: 'target-result'; result: PublishResult }
-  | { kind: 'done'; results: PublishResult[] }
-  | { kind: 'fatal'; error: string; invalidTemplates?: { name: string; errors: string[] }[] }
-
-export interface CompareResult {
-  added: string[]
-  modified: string[]
-  deleted: string[]
-  unchanged: string[]
-  firstPublish: boolean
-  invalidTemplates: { name: string; errors: string[] }[]
 }
 
 export const api = {

--- a/apps/admin/tests/api-contract.test.ts
+++ b/apps/admin/tests/api-contract.test.ts
@@ -27,6 +27,9 @@ import {
   TargetTypeSchema,
   SiteManifestSchema,
   DependentsResponseSchema,
+  CompareResultSchema,
+  PublishResultSchema,
+  PublishProgressSchema,
 } from 'gazetta/admin-api/schemas'
 import type {
   CreatePageRequest,
@@ -40,6 +43,9 @@ import type {
   TargetInfo,
   SiteManifest,
   DependentsResponse,
+  CompareResult,
+  PublishResult,
+  PublishProgress,
 } from 'gazetta/admin-api/schemas'
 
 describe('POST /api/pages contract', () => {
@@ -253,5 +259,114 @@ describe('GET /api/dependents contract', () => {
 
   it('rejects non-string entries', () => {
     expect(DependentsResponseSchema.safeParse({ pages: [123], fragments: [] }).success).toBe(false)
+  })
+})
+
+describe('GET /api/compare contract', () => {
+  it('accepts a well-formed first-publish result', () => {
+    const r: CompareResult = {
+      added: ['pages/home', 'pages/about'],
+      modified: [],
+      deleted: [],
+      unchanged: [],
+      firstPublish: true,
+      invalidTemplates: [],
+    }
+    expect(CompareResultSchema.safeParse(r).success).toBe(true)
+  })
+
+  it('accepts a mixed diff with invalid-template entries', () => {
+    const r: CompareResult = {
+      added: ['pages/new'],
+      modified: ['pages/home'],
+      deleted: ['pages/old'],
+      unchanged: ['fragments/header'],
+      firstPublish: false,
+      invalidTemplates: [{ name: 'broken', errors: ['syntax error', 'no default export'] }],
+    }
+    expect(CompareResultSchema.safeParse(r).success).toBe(true)
+  })
+
+  it('rejects results missing any required array', () => {
+    expect(
+      CompareResultSchema.safeParse({
+        added: [],
+        modified: [],
+        deleted: [],
+        firstPublish: false,
+        invalidTemplates: [],
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects invalidTemplate entries with wrong shape', () => {
+    expect(
+      CompareResultSchema.safeParse({
+        added: [],
+        modified: [],
+        deleted: [],
+        unchanged: [],
+        firstPublish: false,
+        invalidTemplates: [{ name: 'broken' }],
+      }).success,
+    ).toBe(false)
+  })
+})
+
+describe('POST /api/publish + /api/publish/stream contract', () => {
+  describe('PublishResult', () => {
+    it('accepts a successful per-target result', () => {
+      const r: PublishResult = { target: 'staging', success: true, copiedFiles: 12 }
+      expect(PublishResultSchema.safeParse(r).success).toBe(true)
+    })
+
+    it('accepts a failed per-target result with error message', () => {
+      const r: PublishResult = { target: 'prod', success: false, error: 'network', copiedFiles: 0 }
+      expect(PublishResultSchema.safeParse(r).success).toBe(true)
+    })
+
+    it('rejects missing required fields', () => {
+      expect(PublishResultSchema.safeParse({ target: 'x', success: true }).success).toBe(false)
+      expect(PublishResultSchema.safeParse({ success: true, copiedFiles: 0 }).success).toBe(false)
+    })
+  })
+
+  describe('PublishProgress (SSE event union)', () => {
+    it('accepts each of the six discriminator variants', () => {
+      const events: PublishProgress[] = [
+        { kind: 'start', targets: ['staging', 'prod'], itemsPerTarget: 5 },
+        { kind: 'target-start', target: 'staging', total: 5 },
+        { kind: 'progress', target: 'staging', current: 2, total: 5, label: 'pages/home' },
+        {
+          kind: 'target-result',
+          result: { target: 'staging', success: true, copiedFiles: 5 },
+        },
+        {
+          kind: 'done',
+          results: [{ target: 'staging', success: true, copiedFiles: 5 }],
+        },
+        { kind: 'fatal', error: 'template scan failed', invalidTemplates: [{ name: 'x', errors: ['e'] }] },
+      ]
+      for (const ev of events) {
+        expect(PublishProgressSchema.safeParse(ev).success).toBe(true)
+      }
+    })
+
+    it('accepts fatal without invalidTemplates (field is optional)', () => {
+      expect(PublishProgressSchema.safeParse({ kind: 'fatal', error: 'boom' }).success).toBe(true)
+    })
+
+    it('rejects events with an unknown kind', () => {
+      expect(PublishProgressSchema.safeParse({ kind: 'banana', foo: 1 }).success).toBe(false)
+    })
+
+    it('rejects events with a wrong payload for their kind', () => {
+      // `progress` without `current`
+      expect(PublishProgressSchema.safeParse({ kind: 'progress', target: 'x', total: 5, label: 'y' }).success).toBe(
+        false,
+      )
+      // `target-result` with a non-PublishResult result
+      expect(PublishProgressSchema.safeParse({ kind: 'target-result', result: { target: 'x' } }).success).toBe(false)
+    })
   })
 })

--- a/packages/gazetta/src/admin-api/schemas/compare.ts
+++ b/packages/gazetta/src/admin-api/schemas/compare.ts
@@ -1,0 +1,33 @@
+/**
+ * Zod schema for /api/compare — logical diff between source and target.
+ *
+ * Mirrors the `CompareResult` type that compare.ts returns from
+ * `compareTargets`. The server sends it verbatim via `c.json(result)`,
+ * so the wire shape is identical to the compare function's return
+ * type. Keeping both defined through z.infer means there's a single
+ * source of truth rather than a TS interface *and* a Zod schema that
+ * could drift apart.
+ */
+import { z } from 'zod'
+
+export const InvalidTemplateSchema = z.object({
+  name: z.string(),
+  errors: z.array(z.string()),
+})
+export type InvalidTemplate = z.infer<typeof InvalidTemplateSchema>
+
+export const CompareResultSchema = z.object({
+  /** Items present locally but not on target (no sidecar found) */
+  added: z.array(z.string()),
+  /** Items present on both, hashes differ */
+  modified: z.array(z.string()),
+  /** Items present on target but not locally */
+  deleted: z.array(z.string()),
+  /** Items present on both with matching hashes */
+  unchanged: z.array(z.string()),
+  /** Target has no sidecars at all (never published, or pre-sidecar) */
+  firstPublish: z.boolean(),
+  /** Templates that failed to scan — compare still completes, but hashes for affected pages may be off */
+  invalidTemplates: z.array(InvalidTemplateSchema),
+})
+export type CompareResult = z.infer<typeof CompareResultSchema>

--- a/packages/gazetta/src/admin-api/schemas/index.ts
+++ b/packages/gazetta/src/admin-api/schemas/index.ts
@@ -11,6 +11,8 @@
  *   - GET  /api/targets (list)
  *   - GET  /api/site (manifest)
  *   - GET  /api/dependents (reverse-dep lookup)
+ *   - GET  /api/compare (logical diff result)
+ *   - POST /api/publish + /api/publish/stream (result + SSE progress union)
  *
  * Add new endpoint modules here as they move to schema-validated contracts.
  */
@@ -21,3 +23,5 @@ export * from './fields.js'
 export * from './targets.js'
 export * from './site.js'
 export * from './dependents.js'
+export * from './compare.js'
+export * from './publish.js'

--- a/packages/gazetta/src/admin-api/schemas/publish.ts
+++ b/packages/gazetta/src/admin-api/schemas/publish.ts
@@ -1,0 +1,63 @@
+/**
+ * Zod schemas for /api/publish and /api/publish/stream.
+ *
+ * PublishResult is the per-target terminal outcome. PublishProgress is
+ * the SSE event union streamed from /publish/stream — six discriminated
+ * variants keyed by `kind`. Shared with the client so the stream parser
+ * can derive its event type via z.infer rather than hand-maintaining a
+ * parallel TS union.
+ *
+ * Reuses InvalidTemplate from compare.ts — same shape in both endpoints.
+ */
+import { z } from 'zod'
+import { InvalidTemplateSchema } from './compare.js'
+
+/** Per-target outcome of a publish action. */
+export const PublishResultSchema = z.object({
+  target: z.string(),
+  success: z.boolean(),
+  error: z.string().optional(),
+  copiedFiles: z.number(),
+})
+export type PublishResult = z.infer<typeof PublishResultSchema>
+
+/**
+ * SSE event variants streamed by POST /api/publish/stream. The server
+ * emits events in this order:
+ *   start → (target-start → progress* → target-result)+ → done
+ * or:
+ *   fatal (error anywhere before `done`).
+ */
+export const PublishProgressSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('start'),
+    targets: z.array(z.string()),
+    itemsPerTarget: z.number(),
+  }),
+  z.object({
+    kind: z.literal('target-start'),
+    target: z.string(),
+    total: z.number(),
+  }),
+  z.object({
+    kind: z.literal('progress'),
+    target: z.string(),
+    current: z.number(),
+    total: z.number(),
+    label: z.string(),
+  }),
+  z.object({
+    kind: z.literal('target-result'),
+    result: PublishResultSchema,
+  }),
+  z.object({
+    kind: z.literal('done'),
+    results: z.array(PublishResultSchema),
+  }),
+  z.object({
+    kind: z.literal('fatal'),
+    error: z.string(),
+    invalidTemplates: z.array(InvalidTemplateSchema).optional(),
+  }),
+])
+export type PublishProgress = z.infer<typeof PublishProgressSchema>


### PR DESCRIPTION
## Summary
Continues testing-plan.md Priority 3.2 — the diff + publish surfaces move into the shared Zod schema family.

- \`schemas/compare.ts\` — \`CompareResult\` + \`InvalidTemplate\`. The latter is shared with publish's \`fatal\` event so the shape isn't duplicated.
- \`schemas/publish.ts\` — \`PublishResult\` plus \`PublishProgress\`, a \`z.discriminatedUnion\` over six SSE event kinds (start / target-start / progress / target-result / done / fatal).
- Client drops three local type definitions — \`PublishResult\`, \`PublishProgress\` (a 6-variant union, the biggest drift risk), and \`CompareResult\`.
- 11 new contract tests → 44 total. The \`PublishProgress\` block covers all six discriminator variants plus kind-mismatch rejection, which is where drift would bite.

## Test plan
- [x] \`npx vitest run --root apps/admin tests/api-contract.test.ts\` — 44/44
- [x] \`npx vitest run --root apps/admin\` — 207/207
- [x] \`npx vitest run --root packages/gazetta tests/admin-api.test.ts tests/publish.test.ts\` — 71/71
- [x] \`cd apps/admin && npx vue-tsc --noEmit\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)