### PR TITLE
Contract-test migration: /api/history* + /api/fetch

### DIFF
--- a/apps/admin/src/client/api/client.ts
+++ b/apps/admin/src/client/api/client.ts
@@ -134,6 +134,11 @@ import type {
   CompareResult as CompareResultShape,
   PublishResult as PublishResultShape,
   PublishProgress as PublishProgressShape,
+  RevisionSummary as RevisionSummaryShape,
+  RevisionOperation as RevisionOperationShape,
+  ListHistoryResponse as ListHistoryResponseShape,
+  RestoreRevisionResponse as RestoreRevisionResponseShape,
+  FetchResponse as FetchResponseShape,
 } from 'gazetta/admin-api/schemas'
 export type PageSummary = PageSummaryShape
 export type CreatePageRequest = CreatePageRequestShape
@@ -151,6 +156,11 @@ export type DependentsResponse = DependentsResponseShape
 export type CompareResult = CompareResultShape
 export type PublishResult = PublishResultShape
 export type PublishProgress = PublishProgressShape
+export type RevisionSummary = RevisionSummaryShape
+export type RevisionOperation = RevisionOperationShape
+export type ListHistoryResponse = ListHistoryResponseShape
+export type RestoreRevisionResponse = RestoreRevisionResponseShape
+export type FetchResponse = FetchResponseShape
 
 export interface InlineComponent {
   name: string
@@ -213,35 +223,23 @@ export const api = {
   getDependents: (item: string, options?: RequestInit) =>
     request<DependentsResponse>(`/dependents?item=${encodeURIComponent(item)}`, options),
   fetchFromTarget: (source: string, items?: string[]) =>
-    request<{ success: boolean; copiedFiles: number; items: string[] }>('/fetch', {
+    request<FetchResponse>('/fetch', {
       method: 'POST',
       body: JSON.stringify({ source, items }),
     }),
   /** List revisions on a target, newest first. */
   listHistory: (target: string, limit = 50) =>
-    request<{ revisions: RevisionSummary[] }>(`/history?target=${encodeURIComponent(target)}&limit=${limit}`),
+    request<ListHistoryResponse>(`/history?target=${encodeURIComponent(target)}&limit=${limit}`),
   /** Undo the most recent write on a target — restores the previous
    *  revision as a forward 'rollback'. 409 when there's nothing to undo. */
   undoLastWrite: (target: string) =>
-    request<{ revision: RevisionSummary; restoredFrom: string }>(`/history/undo?target=${encodeURIComponent(target)}`, {
+    request<RestoreRevisionResponse>(`/history/undo?target=${encodeURIComponent(target)}`, {
       method: 'POST',
     }),
   /** Restore an arbitrary revision on a target. 404 when the id doesn't exist. */
   restoreRevision: (target: string, revisionId: string) =>
-    request<{ revision: RevisionSummary; restoredFrom: string }>(
+    request<RestoreRevisionResponse>(
       `/history/restore?target=${encodeURIComponent(target)}&id=${encodeURIComponent(revisionId)}`,
       { method: 'POST' },
     ),
-}
-
-/** Summary shape returned by history endpoints (no snapshot). */
-export interface RevisionSummary {
-  id: string
-  timestamp: string
-  operation: 'save' | 'publish' | 'rollback'
-  author?: string
-  source?: string
-  items: string[]
-  message?: string
-  restoredFrom?: string
 }

--- a/apps/admin/tests/api-contract.test.ts
+++ b/apps/admin/tests/api-contract.test.ts
@@ -30,6 +30,10 @@ import {
   CompareResultSchema,
   PublishResultSchema,
   PublishProgressSchema,
+  RevisionSummarySchema,
+  ListHistoryResponseSchema,
+  RestoreRevisionResponseSchema,
+  FetchResponseSchema,
 } from 'gazetta/admin-api/schemas'
 import type {
   CreatePageRequest,
@@ -46,6 +50,10 @@ import type {
   CompareResult,
   PublishResult,
   PublishProgress,
+  RevisionSummary,
+  ListHistoryResponse,
+  RestoreRevisionResponse,
+  FetchResponse,
 } from 'gazetta/admin-api/schemas'
 
 describe('POST /api/pages contract', () => {
@@ -368,5 +376,117 @@ describe('POST /api/publish + /api/publish/stream contract', () => {
       // `target-result` with a non-PublishResult result
       expect(PublishProgressSchema.safeParse({ kind: 'target-result', result: { target: 'x' } }).success).toBe(false)
     })
+  })
+})
+
+describe('GET /api/history + POST /api/history/{undo,restore} contract', () => {
+  describe('RevisionSummary', () => {
+    it('accepts a minimal save revision', () => {
+      const rev: RevisionSummary = {
+        id: 'rev-1713295810000',
+        timestamp: '2026-04-16T20:00:00.000Z',
+        operation: 'save',
+        items: ['pages/home'],
+      }
+      expect(RevisionSummarySchema.safeParse(rev).success).toBe(true)
+    })
+
+    it('accepts a rollback revision with all optional fields set', () => {
+      const rev: RevisionSummary = {
+        id: 'rev-1713295900000',
+        timestamp: '2026-04-16T20:10:00.000Z',
+        operation: 'rollback',
+        author: 'alice',
+        source: 'staging',
+        items: ['pages/home', 'fragments/header'],
+        message: 'Rollback to rev-1713295810000',
+        restoredFrom: 'rev-1713295810000',
+      }
+      expect(RevisionSummarySchema.safeParse(rev).success).toBe(true)
+    })
+
+    it('rejects unknown operation values', () => {
+      expect(
+        RevisionSummarySchema.safeParse({
+          id: 'rev-1',
+          timestamp: '2026-04-16T20:00:00.000Z',
+          operation: 'delete',
+          items: [],
+        }).success,
+      ).toBe(false)
+    })
+
+    it('rejects missing required fields', () => {
+      expect(
+        RevisionSummarySchema.safeParse({
+          id: 'rev-1',
+          timestamp: '2026-04-16T20:00:00.000Z',
+          operation: 'save',
+          // items missing
+        }).success,
+      ).toBe(false)
+    })
+  })
+
+  describe('ListHistoryResponse', () => {
+    it('accepts an empty history', () => {
+      const r: ListHistoryResponse = { revisions: [] }
+      expect(ListHistoryResponseSchema.safeParse(r).success).toBe(true)
+    })
+
+    it('accepts a populated history', () => {
+      const r: ListHistoryResponse = {
+        revisions: [
+          { id: 'rev-2', timestamp: '2026-04-16T20:10:00.000Z', operation: 'save', items: [] },
+          { id: 'rev-1', timestamp: '2026-04-16T20:00:00.000Z', operation: 'publish', items: ['x'] },
+        ],
+      }
+      expect(ListHistoryResponseSchema.safeParse(r).success).toBe(true)
+    })
+
+    it('rejects responses missing the revisions field', () => {
+      expect(ListHistoryResponseSchema.safeParse({}).success).toBe(false)
+    })
+  })
+
+  describe('RestoreRevisionResponse (shared by /undo and /restore)', () => {
+    it('accepts a well-formed response', () => {
+      const r: RestoreRevisionResponse = {
+        revision: {
+          id: 'rev-3',
+          timestamp: '2026-04-16T20:20:00.000Z',
+          operation: 'rollback',
+          items: [],
+          restoredFrom: 'rev-1',
+        },
+        restoredFrom: 'rev-1',
+      }
+      expect(RestoreRevisionResponseSchema.safeParse(r).success).toBe(true)
+    })
+
+    it('rejects responses missing restoredFrom', () => {
+      expect(
+        RestoreRevisionResponseSchema.safeParse({
+          revision: { id: 'rev-3', timestamp: 't', operation: 'rollback', items: [] },
+        }).success,
+      ).toBe(false)
+    })
+  })
+})
+
+describe('POST /api/fetch contract', () => {
+  it('accepts a well-formed response', () => {
+    const r: FetchResponse = { success: true, copiedFiles: 3, items: ['pages/home', 'fragments/header'] }
+    expect(FetchResponseSchema.safeParse(r).success).toBe(true)
+  })
+
+  it('accepts a zero-copy response', () => {
+    const r: FetchResponse = { success: true, copiedFiles: 0, items: [] }
+    expect(FetchResponseSchema.safeParse(r).success).toBe(true)
+  })
+
+  it('rejects responses missing required fields', () => {
+    expect(FetchResponseSchema.safeParse({ success: true, copiedFiles: 0 }).success).toBe(false)
+    expect(FetchResponseSchema.safeParse({ copiedFiles: 0, items: [] }).success).toBe(false)
   })
 })

--- a/packages/gazetta/src/admin-api/schemas/fetch.ts
+++ b/packages/gazetta/src/admin-api/schemas/fetch.ts
@@ -1,0 +1,12 @@
+/**
+ * Zod schema for POST /api/fetch — pull content from another target
+ * into the source target (the cross-target admin copy operation).
+ */
+import { z } from 'zod'
+
+export const FetchResponseSchema = z.object({
+  success: z.boolean(),
+  copiedFiles: z.number(),
+  items: z.array(z.string()),
+})
+export type FetchResponse = z.infer<typeof FetchResponseSchema>

--- a/packages/gazetta/src/admin-api/schemas/history.ts
+++ b/packages/gazetta/src/admin-api/schemas/history.ts
@@ -1,0 +1,42 @@
+/**
+ * Zod schemas for /api/history* endpoints.
+ *
+ * Revision mirrors the `Revision` interface in history.ts (metadata
+ * only — snapshot is server-internal and stripped from the wire).
+ * ListHistoryResponse wraps it in `{ revisions }`; RestoreResponse
+ * is the shared shape for both /undo and /restore.
+ */
+import { z } from 'zod'
+
+export const RevisionOperationSchema = z.enum(['save', 'publish', 'rollback'])
+export type RevisionOperation = z.infer<typeof RevisionOperationSchema>
+
+/** Summary of a single revision — server emits this from /history. */
+export const RevisionSummarySchema = z.object({
+  id: z.string(),
+  timestamp: z.string(),
+  operation: RevisionOperationSchema,
+  author: z.string().optional(),
+  source: z.string().optional(),
+  items: z.array(z.string()),
+  message: z.string().optional(),
+  restoredFrom: z.string().optional(),
+})
+export type RevisionSummary = z.infer<typeof RevisionSummarySchema>
+
+/** Response body for GET /api/history. */
+export const ListHistoryResponseSchema = z.object({
+  revisions: z.array(RevisionSummarySchema),
+})
+export type ListHistoryResponse = z.infer<typeof ListHistoryResponseSchema>
+
+/**
+ * Response body for both POST /api/history/undo and
+ * POST /api/history/restore. `restoredFrom` is the revision id the
+ * new revision rolled back to.
+ */
+export const RestoreRevisionResponseSchema = z.object({
+  revision: RevisionSummarySchema,
+  restoredFrom: z.string(),
+})
+export type RestoreRevisionResponse = z.infer<typeof RestoreRevisionResponseSchema>

--- a/packages/gazetta/src/admin-api/schemas/index.ts
+++ b/packages/gazetta/src/admin-api/schemas/index.ts
@@ -13,6 +13,8 @@
  *   - GET  /api/dependents (reverse-dep lookup)
  *   - GET  /api/compare (logical diff result)
  *   - POST /api/publish + /api/publish/stream (result + SSE progress union)
+ *   - GET  /api/history + POST /api/history/{undo,restore} (revisions + restore)
+ *   - POST /api/fetch (cross-target copy)
  *
  * Add new endpoint modules here as they move to schema-validated contracts.
  */
@@ -25,3 +27,5 @@ export * from './site.js'
 export * from './dependents.js'
 export * from './compare.js'
 export * from './publish.js'
+export * from './history.js'
+export * from './fetch.js'


### PR DESCRIPTION
## Summary
Continues testing-plan.md Priority 3.2 — the remaining write/read admin endpoints join the Zod schema family.

- \`schemas/history.ts\` — \`RevisionSummary\` (wire shape, metadata only), \`ListHistoryResponse\` (\`{ revisions }\`), and \`RestoreRevisionResponse\` (shared by \`/undo\` and \`/restore\`: both emit \`{ revision, restoredFrom }\`). Operation enum pinned to \`save | publish | rollback\` via \`z.enum\`.
- \`schemas/fetch.ts\` — \`FetchResponse\` for POST /api/fetch.
- Client drops the \`RevisionSummary\` interface and three inline response types on \`listHistory\` / \`undoLastWrite\` / \`restoreRevision\` / \`fetchFromTarget\`.
- 12 new contract tests → 56 total.

## Remaining endpoints (complete 3.2 picture)
- \`GET /api/preview\` — JSON configured-preview-data lookup (not used by the admin SPA; low-priority migration)
- \`GET /api/templates/:name/schema\` — spreads an arbitrary JSON Schema + sibling fields. Migration blocked on reshaping the wire format into a \`{ jsonSchema, ... }\` envelope; deferred to a separate refactor.

## Test plan
- [x] \`npx vitest run --root apps/admin tests/api-contract.test.ts\` — 56/56
- [x] \`npx vitest run --root apps/admin\` — 219/219
- [x] \`npm run build -w packages/gazetta\` — clean tsc
- [x] \`cd apps/admin && npx vue-tsc --noEmit\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)