### PR TITLE
a11y: add accessible names to icon-only buttons (removes button-name BASELINE)

### DIFF
--- a/apps/admin/src/client/components/CmsToolbar.vue
+++ b/apps/admin/src/client/components/CmsToolbar.vue
@@ -72,8 +72,10 @@ function handleBack() {
   <Toolbar class="cms-toolbar">
     <template #start>
       <Button v-if="uiMode.mode === 'edit' && !isDevPage" icon="pi pi-arrow-left" text rounded
+        title="Back to browse" aria-label="Back to browse"
         data-testid="back-to-browse" @click="handleBack" size="small" class="cms-btn" />
       <Button v-if="isDevPage" icon="pi pi-arrow-left" text rounded
+        title="Back to editor" aria-label="Back to editor"
         data-testid="back-to-editor" @click="router.back()" size="small" class="cms-btn" />
       <span class="cms-logo">
         <i class="pi pi-objects-column" />
@@ -94,6 +96,8 @@ function handleBack() {
       <Button v-if="!isDevPage" icon="pi pi-code" text rounded title="Dev Playground"
         data-testid="dev-playground-link" @click="router.push('/dev')" size="small" class="cms-btn" />
       <Button :icon="theme.dark ? 'pi pi-sun' : 'pi pi-moon'" text rounded
+        :title="theme.dark ? 'Switch to light mode' : 'Switch to dark mode'"
+        :aria-label="theme.dark ? 'Switch to light mode' : 'Switch to dark mode'"
         data-testid="theme-toggle" @click="theme.toggle()" size="small" class="cms-btn" />
       <Button v-if="uiMode.mode === 'edit'" :label="saveLabel" icon="pi pi-save" :severity="saveSeverity" :loading="editing.saving"
         data-testid="save-btn" :title="saveTitle" :disabled="!editing.hasPendingEdits" @click="editing.save()" size="small" class="cms-btn" />

--- a/apps/admin/src/client/components/ComponentTree.vue
+++ b/apps/admin/src/client/components/ComponentTree.vue
@@ -335,14 +335,17 @@ async function addComponent(name: string, template: string) {
         <span v-if="node.data?.isTopLevel && depth !== -1" class="node-actions">
           <Button icon="pi pi-arrow-up" text rounded size="small"
             :data-testid="`move-up-${node.label}`"
+            :aria-label="`Move ${node.label} up`"
             :disabled="(node.data.index as number) === 0"
             @click.stop="moveComponent(node.data.index as number, -1)" />
           <Button icon="pi pi-arrow-down" text rounded size="small"
             :data-testid="`move-down-${node.label}`"
+            :aria-label="`Move ${node.label} down`"
             :disabled="(node.data.index as number) === componentCount - 1"
             @click.stop="moveComponent(node.data.index as number, 1)" />
           <Button icon="pi pi-trash" text rounded size="small" severity="danger"
             :data-testid="`remove-${node.label}`"
+            :aria-label="`Remove ${node.label}`"
             @click.stop="removeComponent(node.data.index as number)" />
         </span>
       </div>

--- a/apps/admin/src/client/components/SiteTree.vue
+++ b/apps/admin/src/client/components/SiteTree.vue
@@ -122,6 +122,7 @@ async function handleDelete(node: SiteNode, e: Event) {
         :data-testid="`dirty-${node.type}-${node.name}`" />
       <Button icon="pi pi-trash" text rounded size="small" severity="danger"
         class="node-delete" :data-testid="`delete-${node.type}-${node.name}`"
+        :aria-label="`Delete ${node.type} ${node.name}`"
         @click="handleDelete(node, $event)" />
     </div>
 
@@ -138,6 +139,7 @@ async function handleDelete(node: SiteNode, e: Event) {
           :data-testid="`dirty-${node.type}-${node.name}`" />
         <Button icon="pi pi-trash" text rounded size="small" severity="danger"
           class="node-delete" :data-testid="`delete-${node.type}-${node.name}`"
+          :aria-label="`Delete ${node.type} ${node.name}`"
           @click="handleDelete(node, $event)" />
       </div>
     </template>
@@ -155,6 +157,7 @@ async function handleDelete(node: SiteNode, e: Event) {
         :data-testid="`dirty-${node.type}-${node.name}`" />
       <Button icon="pi pi-trash" text rounded size="small" severity="danger"
         class="node-delete" :data-testid="`delete-${node.type}-${node.name}`"
+        :aria-label="`Delete ${node.type} ${node.name}`"
         @click="handleDelete(node, $event)" />
     </div>
 

--- a/tests/e2e/a11y.test.ts
+++ b/tests/e2e/a11y.test.ts
@@ -36,7 +36,6 @@ const BASELINE: Array<{ id: string; reason: string }> = [
     id: 'color-contrast',
     reason: 'tinted state colors (muted labels, env badges) below 4.5:1 in dark mode — needs token-layer pass',
   },
-  { id: 'button-name', reason: 'icon-only PrimeVue buttons (tree chevrons, dialog close) need title/aria-label audit' },
   {
     id: 'label',
     reason: 'several rjsf form inputs render without associated <label> — needs custom field wrapper fix',


### PR DESCRIPTION
## Summary
First burndown of a testing-plan.md Priority 2.3 BASELINE entry. The \`button-name\` rule (icon-only buttons missing an accessible name) failed across all four a11y scan surfaces; this PR fixes every offender and removes the allowlist entry.

### Fixes
- **CmsToolbar**: \`back-to-browse\`, \`back-to-editor\`, \`theme-toggle\` → \`title\` + \`aria-label\` (theme-toggle's label flips with the current mode)
- **SiteTree**: \`delete-{page,fragment}-{name}\` (3 Button sites) → \`aria-label\` \`"Delete {type} {name}"\` (hover-reveal; no \`title\` to keep tooltips from spamming every row)
- **ComponentTree**: \`move-up\`, \`move-down\`, \`remove\` → \`aria-label\` \`"Move {label} {up|down}"\` / \`"Remove {label}"\` (same hover-reveal rationale)

### Why this split of \`title\` vs \`aria-label\`
Axe's \`button-name\` rule accepts either. Toolbar buttons are persistent — a \`title\` tooltip is useful. Row-scoped delete/move/remove buttons appear on every list item; \`title\` tooltips there would clutter hover UX, so \`aria-label\` only.

### BASELINE change
Removed the \`button-name\` entry from [tests/e2e/a11y.test.ts](tests/e2e/a11y.test.ts). The four remaining entries (\`color-contrast\`, \`label\`, \`frame-title\`, \`nested-interactive\`) stay — each needs its own investigation.

## Test plan
- [x] \`npx playwright test --project=dev a11y\` — 4/4 green (previously failed with button-name removed)
- [x] \`npx playwright test --project=dev unsaved-guard keyboard smoke\` — 14/14 (no selector regressions from the new attrs)
- [x] \`npx vitest run --root apps/admin\` — 207/207
- [x] \`cd apps/admin && npx vue-tsc --noEmit\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)