### PR TITLE
a11y: give preview iframe an accessible title (removes frame-title BASELINE)

### DIFF
--- a/apps/admin/src/client/components/PreviewPanel.vue
+++ b/apps/admin/src/client/components/PreviewPanel.vue
@@ -70,6 +70,22 @@ const fragmentScopeGzId = computed(() => {
   return hashPath(`@${selection.name}`)
 })
 
+/**
+ * Accessible name for the preview iframe. Axe's frame-title rule
+ * requires a non-empty title; screen readers announce it when users
+ * enter the frame. Compose target + route so the title updates as
+ * either changes (e.g., switching active target or selecting a
+ * different page). Falls back to a static label when nothing is
+ * selected yet — the iframe is briefly present before first load.
+ */
+const previewTitle = computed(() => {
+  const target = activeTarget.activeTargetName
+  const route = previewRoute.value
+  if (target && route) return `Preview of ${route} on ${target}`
+  if (route) return `Preview of ${route}`
+  return 'Site preview'
+})
+
 // Device presets
 const devicePresets = [
   { label: 'Desktop', width: '100%', icon: 'pi pi-desktop' },
@@ -568,6 +584,7 @@ watchDebounced(
       </div>
       <div class="preview-frame-wrapper">
         <iframe ref="iframeRef" class="preview-iframe" data-testid="preview-iframe"
+          :title="previewTitle"
           :style="{ width: previewWidth, maxWidth: '100%' }" />
       </div>
     </template>

--- a/tests/e2e/a11y.test.ts
+++ b/tests/e2e/a11y.test.ts
@@ -42,11 +42,6 @@ const BASELINE: Array<{ id: string; reason: string }> = [
     reason: 'several rjsf form inputs render without associated <label> — needs custom field wrapper fix',
   },
   {
-    id: 'frame-title',
-    reason:
-      "preview <iframe> lacks title attr — trivial add but requires tying into ActiveTargetIndicator's dynamic label",
-  },
-  {
     id: 'nested-interactive',
     reason: 'PrimeVue Checkbox inside a clickable row label; library-level issue with a clean fix via role=group',
   },


### PR DESCRIPTION
## Summary
Second BASELINE burndown (after #174). Axe's \`frame-title\` rule requires \`<iframe>\` elements to carry a \`title\` — screen readers announce it when users enter the frame.

### Fix
Bind a computed \`previewTitle\` to the preview iframe in \`PreviewPanel.vue\`. Composes the route + active target name so the title updates dynamically:

- \`"Preview of /home on staging"\` — target + route both known
- \`"Preview of /home"\` — route known, no target
- \`"Site preview"\` — pre-first-selection fallback

Both pieces are already in scope: \`previewRoute\` from the selection store, \`activeTarget.activeTargetName\` from the activeTarget store. No new deps.

### BASELINE change
Removed the \`frame-title\` entry from [tests/e2e/a11y.test.ts](tests/e2e/a11y.test.ts). Four entries remain:
- \`color-contrast\` — CSS token work
- \`label\` — rjsf internals
- \`button-name\` — waiting on #174 to merge
- \`nested-interactive\` — PrimeVue semantics

## Test plan
- [x] \`npx playwright test --project=dev a11y\` — 4/4 green
- [x] \`npx playwright test --project=dev target-switch smoke\` — 5/5 (preview-iframe selector still resolves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)