### PR TITLE
a11y: fix nested-interactive + label in PublishPanel destination group header

### DIFF
--- a/apps/admin/src/client/components/PublishPanel.vue
+++ b/apps/admin/src/client/components/PublishPanel.vue
@@ -373,21 +373,20 @@ function envClass(env: string | undefined): string {
             </label>
             <!-- Group header + indented members (4+ targets, 2+ in env) -->
             <template v-else>
-              <button
-                type="button"
+              <label
                 :class="['destination-group-header', envClass(entry.group.environment)]"
                 :data-testid="`publish-dest-group-${entry.group.environment}`"
-                @click="toggleGroup(entry.group)">
+                :for="`dest-group-${entry.group.environment}`">
                 <Checkbox
                   :modelValue="groupState(entry.group) === 'all'"
                   :indeterminate="groupState(entry.group) === 'some'"
                   :inputId="`dest-group-${entry.group.environment}`"
                   :binary="true"
-                  :tabindex="-1"
+                  @update:modelValue="() => toggleGroup(entry.group)"
                 />
                 <span class="group-label">{{ entry.group.environment }}</span>
                 <span class="group-count">{{ entry.group.members.length }} targets</span>
-              </button>
+              </label>
               <label
                 v-for="t in entry.group.members"
                 :key="t.name"

--- a/tests/e2e/a11y.test.ts
+++ b/tests/e2e/a11y.test.ts
@@ -36,14 +36,6 @@ const BASELINE: Array<{ id: string; reason: string }> = [
     id: 'color-contrast',
     reason: 'tinted state colors (muted labels, env badges) below 4.5:1 in dark mode — needs token-layer pass',
   },
-  {
-    id: 'label',
-    reason: 'several rjsf form inputs render without associated <label> — needs custom field wrapper fix',
-  },
-  {
-    id: 'nested-interactive',
-    reason: 'PrimeVue Checkbox inside a clickable row label; library-level issue with a clean fix via role=group',
-  },
 ]
 
 type Violation = { id: string; impact?: string | null; help: string; helpUrl: string; nodes: unknown[] }


### PR DESCRIPTION
## Summary
The same DOM fix (\`<button>\` → \`<label for="dest-group-{env}">\` in PublishPanel's destination-group-header) resolves **two** BASELINE entries in one change:

1. \`nested-interactive\` — the checkbox \`<input>\` was nested inside an interactive \`<button>\`
2. \`label\` — the same checkbox \`<input>\` had no associated \`<label>\`

Wrapping in \`<label for="dest-group-{env}">\` satisfies both rules: native HTML semantics, label click toggles the input, Checkbox's \`@update:modelValue\` fires \`toggleGroup()\`. Keyboard accessibility preserved through the input itself (Space toggles).

CSS for \`.destination-group-header\` was already non-button-specific (display: flex, cursor: pointer, font-family: inherit, etc.) so no style adjustments needed.

### BASELINE change
Removes both \`nested-interactive\` AND \`label\`. After this and the in-flight #174 (button-name) merge, only **2 entries remain**: \`color-contrast\` and one more for #174's button-name (which removes itself).

Wait — let me re-state: BASELINE goes from 3 entries (color-contrast, button-name, label, nested-interactive) on this branch to 2 (color-contrast, button-name) once this lands. After #174 also lands → 1 (color-contrast).

## Test plan
- [x] \`npx playwright test --project=dev a11y\` — 4/4 (with both label and nested-interactive removed from BASELINE)
- [x] \`npx playwright test --project=dev publish\` — 19/19 (group toggle behavior preserved)
- [x] \`npx playwright test --project=matrix\` — 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)