### PR TITLE
Update testing-plan 2.3 with a11y BASELINE burndown progress

### DIFF
--- a/.claude/rules/testing-plan.md
+++ b/.claude/rules/testing-plan.md
@@ -152,17 +152,23 @@ three real claims:
 Landed via `@axe-core/playwright` in [tests/e2e/a11y.test.ts](../../tests/e2e/a11y.test.ts).
 Four surfaces scanned (site tree, editor view, Publish panel, active-target switcher).
 
-**Baseline allowlist pattern:** 5 known violations tracked in the test file's `BASELINE`
+**Baseline allowlist pattern:** known violations tracked in the test file's `BASELINE`
 array — each entry names a rule id + the reason it's deferred. New violations not in the
-allowlist fail CI; fixes remove entries. Known debt at introduction (2026-04-16):
+allowlist fail CI; fixes remove entries.
 
-- `color-contrast` — tinted state colors below 4.5:1 in dark mode
-- `button-name` — icon-only buttons need aria-label audit
-- `label` — rjsf inputs rendering without labels
-- `frame-title` — preview iframe missing dynamic title
-- `nested-interactive` — PrimeVue Checkbox inside clickable row
+**BASELINE burndown (2026-04-16):**
 
-**Remaining work:** burn down the BASELINE entries as fixes land.
+| Rule id | Status | Resolution |
+|---------|--------|------------|
+| `button-name` | ✓ landed in #174 | Added `title` + `aria-label` to icon-only Buttons in CmsToolbar (back-to-browse, theme-toggle), SiteTree (delete-{page,fragment}-{name}), and ComponentTree (move-up / move-down / remove). Toolbar buttons get `title` (doubles as tooltip); row-scoped buttons get `aria-label` only (tooltips on every row would be noisy). |
+| `frame-title` | ✓ landed in #175 | Added a `previewTitle` computed to PreviewPanel.vue's `<iframe>` — composes route + active-target name (e.g. "Preview of /home on staging"). |
+| `nested-interactive` + `label` | ✓ landed in #176 | One DOM fix resolved both: PublishPanel's destination-group-header `<button>` containing a Checkbox `<input>` became a `<label for="dest-group-{env}">`. Native HTML semantics — label click toggles the input via `@update:modelValue` → `toggleGroup()`. |
+| `color-contrast` | ◐ deferred | Tinted state colors (muted labels, env badges) below 4.5:1 in dark mode. Needs a token-layer pass per [css-theming.md](./css-theming.md). |
+
+**Remaining:** `color-contrast` only. The deferral is principled — it requires
+design tradeoffs across the entire `--color-*` semantic token layer, and
+`css-theming.md` calls it out as the in-flight token work that supersedes
+piecemeal fixes.
 
 **Skipped:** Vitest-level a11y via `@chialab/vitest-axe` — e2e coverage is sufficient.
 
@@ -567,7 +573,7 @@ responses. Opt out with `GAZETTA_QUIET=1`.
 | 1 | ✓ Priority 1.1-1.3 (Vue tests, sidecars, PBT) | ✓ Phase 1 (file moves, no-risk) |
 | 2 | ✓ Priority 1.4 (fault injection) | ◐ Phase 2 (POMs — two landed, more follow) |
 | 3 | ✓ Priority 2.1 (Azure CRUD parity) | ◐ Phase 3 (scenarios — 3 landed, 1 deferred) |
-| 4 | ✓ Priority 2.2 · ◐ Priority 2.3 (a11y BASELINE burndown) | ✓ Phase 4 (matrices) |
+| 4 | ✓ Priority 2.2 · ◐ Priority 2.3 (4 of 5 BASELINE entries cleared; color-contrast deferred to css-theming token pass) | ✓ Phase 4 (matrices) |
 | Later | Priority 3 (✓ 3.1 mutation nightly · ✓ 3.2 contract-test endpoint burndown) | Cross-surface scenario #4 (hotfix source=prod) when dev-server target-registry reload lands |
 
 Estimates are predictions. Real pace depends on what you hit.


### PR DESCRIPTION
## Summary
4 of 5 BASELINE entries cleared across the in-flight a11y PRs:
- #174 — button-name (icon-only Buttons in CmsToolbar / SiteTree / ComponentTree)
- #175 — frame-title (preview iframe \`previewTitle\` computed)
- #176 — nested-interactive + label (one DOM fix: PublishPanel destination-group-header \`<button>\` → \`<label>\`)

Only color-contrast remains and is principled-deferred to the css-theming token-layer pass.

## Why ◐ stays (not ✓)
color-contrast is genuine remaining work, even though it's explicitly deferred. Flipping the parent flag to ✓ would misrepresent the residual. The new reality table makes the split explicit so future readers see done-vs-deferred at a glance.

## Test plan
No code changes — plan is auto-loaded context. The four PRs (#174, #175, #176) plus this audit reflect the matching code state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)