### PR TITLE
Fix missing space between site name and active-target indicator

### DIFF
--- a/apps/admin/src/client/components/CmsToolbar.vue
+++ b/apps/admin/src/client/components/CmsToolbar.vue
@@ -112,7 +112,7 @@ function handleBack() {
 <style scoped>
 .cms-toolbar { border-radius: 0; border-left: 0; border-right: 0; border-top: 0; }
 .cms-logo { font-weight: 700; font-size: 1.125rem; display: flex; align-items: center; gap: 0.5rem; }
-.cms-site-name { margin-left: 1rem; color: var(--color-muted); font-size: 0.875rem; }
+.cms-site-name { margin-left: 1rem; margin-right: 1rem; color: var(--color-muted); font-size: 0.875rem; }
 .cms-btn { margin-left: 0.5rem; }
 .cms-toast { font-size: 0.8125rem; display: flex; align-items: center; gap: 0.375rem; }
 .cms-toast-error { color: var(--color-danger-fg); }


### PR DESCRIPTION
## Summary
The site name (\"Gazetta Starter\") ran into the active-target indicator (\"local\") with no gap in the toolbar. \`.cms-site-name\` had \`margin-left: 1rem\` separating it from the logo but no \`margin-right\` — and PrimeVue Toolbar's start slot doesn't apply a flex gap, so siblings need their own spacing.

Add \`margin-right: 1rem\` mirroring the left margin.

## Before / After
Visible in screenshots: before, \"Starter\" abuts the \"local\" pill. After, comfortable gap on both sides of the site name.

## Test plan
- [x] Visual check in dev (dark mode) — gap visible between site name and target indicator pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)