### PR TITLE
Add page-level SEO metadata (data model + API + renderer)

### DIFF
--- a/apps/admin/src/client/api/client.ts
+++ b/apps/admin/src/client/api/client.ts
@@ -121,6 +121,7 @@ import type {
   PageSummary as PageSummaryShape,
   CreatePageRequest as CreatePageRequestShape,
   CreatePageResponse as CreatePageResponseShape,
+  PageMetadata as PageMetadataShape,
   FragmentSummary as FragmentSummaryShape,
   CreateFragmentRequest as CreateFragmentRequestShape,
   CreateFragmentResponse as CreateFragmentResponseShape,
@@ -143,6 +144,7 @@ import type {
 export type PageSummary = PageSummaryShape
 export type CreatePageRequest = CreatePageRequestShape
 export type CreatePageResponse = CreatePageResponseShape
+export type PageMetadata = PageMetadataShape
 export type FragmentSummary = FragmentSummaryShape
 export type CreateFragmentRequest = CreateFragmentRequestShape
 export type CreateFragmentResponse = CreateFragmentResponseShape
@@ -173,6 +175,7 @@ export type ComponentEntry = string | InlineComponent
 export interface PageDetail extends PageSummary {
   content?: Record<string, unknown>
   components?: ComponentEntry[]
+  metadata?: PageMetadata
   dir: string
 }
 

--- a/apps/admin/tests/api-contract.test.ts
+++ b/apps/admin/tests/api-contract.test.ts
@@ -17,6 +17,7 @@ import {
   CreatePageRequestSchema,
   CreatePageResponseSchema,
   PageSummarySchema,
+  PageMetadataSchema,
   CreateFragmentRequestSchema,
   CreateFragmentResponseSchema,
   FragmentSummarySchema,
@@ -39,6 +40,7 @@ import type {
   CreatePageRequest,
   CreatePageResponse,
   PageSummary,
+  PageMetadata,
   CreateFragmentRequest,
   CreateFragmentResponse,
   FragmentSummary,
@@ -109,6 +111,30 @@ describe('POST /api/pages contract', () => {
 
     it('rejects entries missing required fields', () => {
       expect(PageSummarySchema.safeParse({ name: 'home', route: '/' }).success).toBe(false)
+    })
+  })
+
+  describe('PageMetadata (optional SEO metadata on pages)', () => {
+    it('accepts a fully populated metadata object', () => {
+      const meta: PageMetadata = {
+        title: 'My Page',
+        description: 'A description',
+        ogImage: 'https://example.com/img.jpg',
+        canonical: 'https://example.com/my-page',
+      }
+      expect(PageMetadataSchema.safeParse(meta)?.success).toBe(true)
+    })
+
+    it('accepts undefined (metadata is optional on pages)', () => {
+      expect(PageMetadataSchema.safeParse(undefined)?.success).toBe(true)
+    })
+
+    it('accepts an empty object (all fields optional)', () => {
+      expect(PageMetadataSchema.safeParse({})?.success).toBe(true)
+    })
+
+    it('accepts partial metadata', () => {
+      expect(PageMetadataSchema.safeParse({ title: 'Just a title' })?.success).toBe(true)
     })
   })
 })

--- a/examples/starter/sites/main/targets/local/pages/about/page.json
+++ b/examples/starter/sites/main/targets/local/pages/about/page.json
@@ -4,6 +4,10 @@
     "title": "About",
     "description": "About Gazetta"
   },
+  "metadata": {
+    "title": "About — Gazetta",
+    "description": "Learn about Gazetta, the stateless CMS built on composable fragments."
+  },
   "components": [
     "@header",
     {

--- a/examples/starter/sites/main/targets/local/pages/home/page.json
+++ b/examples/starter/sites/main/targets/local/pages/home/page.json
@@ -4,6 +4,10 @@
     "title": "Home",
     "description": "Welcome to Gazetta"
   },
+  "metadata": {
+    "title": "Gazetta — Composable CMS",
+    "description": "A stateless CMS that structures websites as composable fragments. All state lives in targets."
+  },
   "components": [
     "@header",
     {

--- a/packages/gazetta/src/admin-api/routes/pages.ts
+++ b/packages/gazetta/src/admin-api/routes/pages.ts
@@ -82,6 +82,7 @@ export function pageRoutes(resolve: SourceContextResolver) {
       template: page.template,
       content: page.content,
       components: page.components,
+      metadata: page.metadata,
       dir: page.dir,
     })
   })
@@ -95,11 +96,13 @@ export function pageRoutes(resolve: SourceContextResolver) {
     if (!page) return c.json({ error: `Page "${name}" not found` }, 404)
 
     const body = await c.req.json()
-    const manifest = {
+    const manifest: Record<string, unknown> = {
       template: body.template ?? page.template,
       content: body.content ?? page.content,
       components: body.components ?? page.components,
     }
+    if (body.metadata !== undefined) manifest.metadata = body.metadata
+    else if (page.metadata) manifest.metadata = page.metadata
 
     const manifestPath = join(page.dir, 'page.json')
     const serialized = JSON.stringify(manifest, null, 2) + '\n'

--- a/packages/gazetta/src/admin-api/routes/preview.ts
+++ b/packages/gazetta/src/admin-api/routes/preview.ts
@@ -78,7 +78,7 @@ async function renderPreview(
       try {
         const resolved = await resolvePage(pageName, site)
         if (overrides) applyOverrides(resolved, overrides)
-        return c.html(await renderPage(resolved, params))
+        return c.html(await renderPage(resolved, { routeParams: params, metadata: page.metadata }))
       } catch (err) {
         const e = err as Error
         const msg = e.message.replace(/</g, '&lt;').replace(/>/g, '&gt;')

--- a/packages/gazetta/src/admin-api/schemas/pages.ts
+++ b/packages/gazetta/src/admin-api/schemas/pages.ts
@@ -14,6 +14,17 @@
  */
 import { z } from 'zod'
 
+/** SEO metadata for a page — surfaced in <head> and used by sitemap generation. */
+export const PageMetadataSchema = z
+  .object({
+    title: z.string().optional(),
+    description: z.string().optional(),
+    ogImage: z.string().optional(),
+    canonical: z.string().optional(),
+  })
+  .optional()
+export type PageMetadata = z.infer<typeof PageMetadataSchema>
+
 /** Summary used in list responses (GET /api/pages). */
 export const PageSummarySchema = z.object({
   name: z.string(),

--- a/packages/gazetta/src/index.ts
+++ b/packages/gazetta/src/index.ts
@@ -58,10 +58,10 @@ export {
   getHistoryRetention,
   DEFAULT_HISTORY_RETENTION,
 } from './types.js'
-export type { HistoryConfig } from './types.js'
+export type { HistoryConfig, PageMetadata } from './types.js'
 
 // Renderer
-export { renderComponent, renderFragment, renderPage } from './renderer.js'
+export { renderComponent, renderFragment, renderPage, type RenderPageOptions } from './renderer.js'
 export { resolveComponent, resolveFragment, resolvePage } from './resolver.js'
 export { loadSite } from './site-loader.js'
 export type { Site, LoadSiteOptions } from './site-loader.js'

--- a/packages/gazetta/src/manifest.ts
+++ b/packages/gazetta/src/manifest.ts
@@ -72,6 +72,7 @@ export async function parsePageManifest(storage: StorageProvider, filePath: stri
     template: raw.template as string,
     content: raw.content as Record<string, unknown> | undefined,
     components: parseComponents(raw.components),
+    metadata: raw.metadata as import('./types.js').PageMetadata | undefined,
     cache: raw.cache as import('./types.js').CacheConfig | undefined,
   }
 }

--- a/packages/gazetta/src/publish-rendered.ts
+++ b/packages/gazetta/src/publish-rendered.ts
@@ -194,7 +194,7 @@ export async function publishPageStatic(
 
   // Scope IDs are now deterministic (hash-based), no reset needed
   const resolved = await resolvePage(pageName, site)
-  const html = await renderPage(resolved)
+  const html = await renderPage(resolved, { metadata: page.metadata })
 
   // URL path: / → index.html, /about → about/index.html
   const urlPath = page.route === '/' ? '' : page.route.replace(/^\//, '')

--- a/packages/gazetta/src/renderer.ts
+++ b/packages/gazetta/src/renderer.ts
@@ -1,5 +1,33 @@
-import type { RenderOutput, ResolvedComponent } from './types.js'
+import type { RenderOutput, ResolvedComponent, PageMetadata } from './types.js'
 import { hashPath, scopeHtml, scopeCss } from './scope.js'
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;')
+}
+
+function metadataHead(meta: PageMetadata | undefined, templateHead: string | undefined): string {
+  if (!meta) return ''
+  const parts: string[] = []
+  if (meta.title && !templateHead?.includes('<title')) {
+    parts.push(`<title>${escapeAttr(meta.title)}</title>`)
+  }
+  if (meta.description && !templateHead?.includes('name="description"')) {
+    parts.push(`<meta name="description" content="${escapeAttr(meta.description)}">`)
+  }
+  if (meta.ogImage) {
+    parts.push(`<meta property="og:image" content="${escapeAttr(meta.ogImage)}">`)
+  }
+  if (meta.canonical) {
+    parts.push(`<link rel="canonical" href="${escapeAttr(meta.canonical)}">`)
+  }
+  if (meta.title && !templateHead?.includes('property="og:title"')) {
+    parts.push(`<meta property="og:title" content="${escapeAttr(meta.title)}">`)
+  }
+  if (meta.description && !templateHead?.includes('property="og:description"')) {
+    parts.push(`<meta property="og:description" content="${escapeAttr(meta.description)}">`)
+  }
+  return parts.join('\n  ')
+}
 
 export async function renderComponent(
   component: ResolvedComponent,
@@ -40,11 +68,25 @@ ${output.html}${output.js ? `\n<script type="module">${output.js}</script>` : ''
 </html>`
 }
 
-export async function renderPage(component: ResolvedComponent, routeParams?: Record<string, string>): Promise<string> {
-  const children = await Promise.all(component.children.map(c => renderComponent(c, routeParams)))
-  const output = await component.template({ content: component.content, children, params: routeParams })
+export interface RenderPageOptions {
+  routeParams?: Record<string, string>
+  metadata?: PageMetadata
+}
 
-  const headContent = [...children.map(c => c.head).filter(Boolean), output.head].filter(Boolean).join('\n  ')
+export async function renderPage(
+  component: ResolvedComponent,
+  optsOrParams?: RenderPageOptions | Record<string, string>,
+): Promise<string> {
+  const opts: RenderPageOptions =
+    optsOrParams && ('metadata' in optsOrParams || 'routeParams' in optsOrParams)
+      ? (optsOrParams as RenderPageOptions)
+      : { routeParams: optsOrParams as Record<string, string> | undefined }
+  const children = await Promise.all(component.children.map(c => renderComponent(c, opts.routeParams)))
+  const output = await component.template({ content: component.content, children, params: opts.routeParams })
+
+  const templateHead = [...children.map(c => c.head).filter(Boolean), output.head].filter(Boolean).join('\n  ')
+  const metaHead = metadataHead(opts.metadata, templateHead)
+  const headContent = [metaHead, templateHead].filter(Boolean).join('\n  ')
 
   return `<!DOCTYPE html>
 <html lang="en">

--- a/packages/gazetta/src/types.ts
+++ b/packages/gazetta/src/types.ts
@@ -89,9 +89,18 @@ export interface CacheConfig {
   purge?: PurgeConfig
 }
 
+/** SEO metadata for a page — surfaced in <head> and used by sitemap generation. */
+export interface PageMetadata {
+  title?: string
+  description?: string
+  ogImage?: string
+  canonical?: string
+}
+
 /** Page manifest (routable component) */
 export interface PageManifest extends ComponentManifest {
   route: string
+  metadata?: PageMetadata
   cache?: CacheConfig
 }
 

--- a/packages/gazetta/tests/renderer.test.ts
+++ b/packages/gazetta/tests/renderer.test.ts
@@ -312,4 +312,76 @@ describe('renderPage', () => {
     expect(html1).toContain(`data-gz="${id}"`)
     expect(html2).toContain(`data-gz="${id}"`)
   })
+
+  it('injects metadata title and description into <head> when template omits them', async () => {
+    const page = leaf('<p>body</p>', '', '', 'page')
+    const html = await renderPage(page, {
+      metadata: { title: 'My Page', description: 'A test page' },
+    })
+    expect(html).toContain('<title>My Page</title>')
+    expect(html).toContain('<meta name="description" content="A test page">')
+    expect(html).toContain('<meta property="og:title" content="My Page">')
+    expect(html).toContain('<meta property="og:description" content="A test page">')
+  })
+
+  it('injects og:image and canonical link when provided', async () => {
+    const page = leaf('<p>body</p>', '', '', 'page')
+    const html = await renderPage(page, {
+      metadata: { ogImage: 'https://example.com/img.jpg', canonical: 'https://example.com/' },
+    })
+    expect(html).toContain('<meta property="og:image" content="https://example.com/img.jpg">')
+    expect(html).toContain('<link rel="canonical" href="https://example.com/">')
+  })
+
+  it('does not duplicate title when template already provides one', async () => {
+    const page: ResolvedComponent = {
+      template: () => ({ html: '<p>body</p>', css: '', js: '', head: '<title>Template Title</title>' }),
+      children: [],
+      treePath: 'page',
+    }
+    const html = await renderPage(page, {
+      metadata: { title: 'Meta Title', description: 'desc' },
+    })
+    expect(html).toContain('<title>Template Title</title>')
+    expect(html).not.toContain('<title>Meta Title</title>')
+    // description should still appear since template didn't provide one
+    expect(html).toContain('<meta name="description" content="desc">')
+  })
+
+  it('does not duplicate description when template already provides one', async () => {
+    const page: ResolvedComponent = {
+      template: () => ({
+        html: '<p>body</p>',
+        css: '',
+        js: '',
+        head: '<meta name="description" content="from template">',
+      }),
+      children: [],
+      treePath: 'page',
+    }
+    const html = await renderPage(page, {
+      metadata: { description: 'from metadata' },
+    })
+    expect(html).toContain('name="description" content="from template"')
+    // metadata's name="description" should NOT be injected (template provided one)
+    expect(html).not.toContain('name="description" content="from metadata"')
+    // og:description should still be injected since template didn't provide that
+    expect(html).toContain('property="og:description" content="from metadata"')
+  })
+
+  it('renders without metadata (backward compatible)', async () => {
+    const page = leaf('<p>body</p>', '', '', 'page')
+    const html = await renderPage(page)
+    expect(html).toContain('<p>body</p>')
+    expect(html).not.toContain('og:title')
+  })
+
+  it('escapes special characters in metadata values', async () => {
+    const page = leaf('<p>body</p>', '', '', 'page')
+    const html = await renderPage(page, {
+      metadata: { title: 'A & B <script>', description: 'He said "hello"' },
+    })
+    expect(html).toContain('A &amp; B &lt;script>')
+    expect(html).toContain('content="He said &quot;hello&quot;"')
+  })
 })

--- a/sites/gazetta.studio/targets/local/pages/blog/page.json
+++ b/sites/gazetta.studio/targets/local/pages/blog/page.json
@@ -4,6 +4,11 @@
     "title": "Blog — Gazetta",
     "description": "News, tutorials, and updates from the Gazetta team."
   },
+  "metadata": {
+    "title": "Blog — Gazetta",
+    "description": "News, tutorials, and updates from the Gazetta team.",
+    "canonical": "https://gazetta.studio/blog"
+  },
   "components": [
     "@header",
     {

--- a/sites/gazetta.studio/targets/local/pages/docs/page.json
+++ b/sites/gazetta.studio/targets/local/pages/docs/page.json
@@ -4,6 +4,11 @@
     "title": "Documentation — Gazetta",
     "description": "Learn how to build composable websites with Gazetta."
   },
+  "metadata": {
+    "title": "Documentation — Gazetta",
+    "description": "Learn how to build composable websites with Gazetta. Templates, fragments, pages, targets, and CLI reference.",
+    "canonical": "https://gazetta.studio/docs"
+  },
   "components": [
     "@header",
     {

--- a/sites/gazetta.studio/targets/local/pages/home/page.json
+++ b/sites/gazetta.studio/targets/local/pages/home/page.json
@@ -4,6 +4,11 @@
     "title": "Gazetta — Stateless CMS for Composable Websites",
     "description": "No database. No build step. Pages composed from reusable components at serve time."
   },
+  "metadata": {
+    "title": "Gazetta — Stateless CMS for Composable Websites",
+    "description": "No database. No build step. Pages composed from reusable components at serve time.",
+    "canonical": "https://gazetta.studio/"
+  },
   "components": [
     "@header",
     {


### PR DESCRIPTION
## Summary
First slice of the SEO metadata feature ([feature-gaps.md](docs/feature-gaps.md) table-stakes section). Adds a \`metadata\` field to pages that the renderer injects into \`<head>\`.

### What's in this PR
- **Data model**: \`PageMetadata\` type (title, description, ogImage, canonical — all optional) on \`PageManifest\`
- **API**: GET returns metadata; PUT accepts it with merge-on-partial-update semantics
- **Renderer**: \`metadataHead()\` injects tags only when the template's own \`head\` output doesn't already include them — prevents duplicate \`<title>\` or description when templates explicitly handle SEO
- **Tags injected**: \`<title>\`, \`<meta name="description">\`, \`<meta property="og:title">\`, \`<meta property="og:description">\`, \`<meta property="og:image">\`, \`<link rel="canonical">\`
- **Schema**: \`PageMetadataSchema\` in the contract family (4 tests)
- **Starter**: home + about pages get example metadata
- **Backward compatible**: pages without metadata render exactly as before

### What's NOT in this PR (next slice)
- Admin UI editor for metadata fields (character counters, SERP preview)
- Sitemap.xml generation on publish

## Test plan
- [x] 6 renderer tests: inject, dedup title when template provides one, dedup description, escaping, og:image + canonical, backward compat
- [x] 4 contract tests: fully populated, undefined, empty object, partial
- [x] \`npm test\` — 223/223 admin tests
- [x] \`npx vitest run --root packages/gazetta\` — 429/429 package tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)