### PR TITLE
Add SEO metadata editor with SERP preview

### DIFF
--- a/apps/admin/src/client/components/EditorPanel.vue
+++ b/apps/admin/src/client/components/EditorPanel.vue
@@ -8,6 +8,7 @@ import { useEditorMount } from '../composables/useEditorMount.js'
 import { createEditorMount } from 'gazetta/editor'
 import type { EditorMount } from 'gazetta/types'
 import FragmentBlastRadius from './FragmentBlastRadius.vue'
+import PageMetadataEditor from './PageMetadataEditor.vue'
 
 const editing = useEditingStore()
 const selection = useSelectionStore()
@@ -73,13 +74,14 @@ onKeyStroke('s', e => {
       <i class="pi pi-pencil" style="font-size: 2rem; opacity: 0.3; margin-bottom: 0.5rem;" />
       <p>Select a component to edit</p>
     </div>
-    <div v-else>
+    <div v-else class="editor-active">
       <div class="editor-header">
         <h3>{{ editing.template }}</h3>
         <FragmentBlastRadius v-if="fragmentName" :fragmentName="fragmentName" />
       </div>
       <div v-if="hasProperties" ref="containerRef" class="editor-container" data-testid="editor-container" :key="editing.path" />
       <p v-else class="editor-no-schema">No editable content. Edit its children instead.</p>
+      <PageMetadataEditor v-if="selection.type === 'page'" />
     </div>
   </div>
 </template>

--- a/apps/admin/src/client/components/PageMetadataEditor.vue
+++ b/apps/admin/src/client/components/PageMetadataEditor.vue
@@ -1,0 +1,219 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { useSelectionStore } from '../stores/selection.js'
+import { useToastStore } from '../stores/toast.js'
+import { usePagesApi } from '../composables/api.js'
+import type { PageMetadata } from '../api/client.js'
+
+const selection = useSelectionStore()
+const toast = useToastStore()
+const pagesApi = usePagesApi()
+
+const title = ref('')
+const description = ref('')
+const ogImage = ref('')
+const canonical = ref('')
+const saving = ref(false)
+const dirty = ref(false)
+
+const TITLE_MAX = 60
+const DESC_MAX = 160
+
+function load(meta: PageMetadata | undefined) {
+  title.value = meta?.title ?? ''
+  description.value = meta?.description ?? ''
+  ogImage.value = meta?.ogImage ?? ''
+  canonical.value = meta?.canonical ?? ''
+  dirty.value = false
+}
+
+watch(
+  () => selection.detail,
+  d => {
+    if (d && 'metadata' in d) load(d.metadata as PageMetadata | undefined)
+    else load(undefined)
+  },
+  { immediate: true },
+)
+
+function markDirty() {
+  dirty.value = true
+}
+
+async function save() {
+  if (!selection.name || selection.type !== 'page') return
+  saving.value = true
+  try {
+    const metadata: PageMetadata = {}
+    if (title.value) metadata.title = title.value
+    if (description.value) metadata.description = description.value
+    if (ogImage.value) metadata.ogImage = ogImage.value
+    if (canonical.value) metadata.canonical = canonical.value
+    await pagesApi.updatePage(selection.name, { metadata })
+    dirty.value = false
+    await selection.reload()
+    toast.show('Metadata saved')
+  } catch (err) {
+    toast.showError(err, 'Failed to save metadata')
+  } finally {
+    saving.value = false
+  }
+}
+
+function charClass(current: number, max: number): string {
+  const ratio = current / max
+  if (ratio >= 1) return 'over'
+  if (ratio >= 0.9) return 'warn'
+  return 'ok'
+}
+
+const pageDetail = computed(() =>
+  selection.type === 'page' ? (selection.detail as import('../api/client.js').PageDetail | null) : null,
+)
+const serpTitle = computed(() => title.value || (pageDetail.value?.content?.title as string) || selection.name || '')
+const serpUrl = computed(() => canonical.value || `https://example.com${pageDetail.value?.route ?? '/'}`)
+const serpDescription = computed(() => description.value || (pageDetail.value?.content?.description as string) || '')
+</script>
+
+<template>
+  <div class="metadata-editor" data-testid="metadata-editor">
+    <div class="meta-header">
+      <h3>SEO Metadata</h3>
+      <button v-if="dirty" class="meta-save-btn" :disabled="saving" @click="save" data-testid="metadata-save">
+        {{ saving ? 'Saving…' : 'Save metadata' }}
+      </button>
+    </div>
+
+    <div class="meta-fields">
+      <div class="field">
+        <label for="meta-title">Title</label>
+        <input id="meta-title" v-model="title" @input="markDirty" placeholder="Page title for search engines"
+          data-testid="meta-title" />
+        <span :class="['char-count', charClass(title.length, TITLE_MAX)]">{{ title.length }}/{{ TITLE_MAX }}</span>
+      </div>
+
+      <div class="field">
+        <label for="meta-description">Description</label>
+        <textarea id="meta-description" v-model="description" @input="markDirty"
+          placeholder="Brief description for search results" rows="2"
+          data-testid="meta-description" />
+        <span :class="['char-count', charClass(description.length, DESC_MAX)]">{{ description.length }}/{{ DESC_MAX }}</span>
+      </div>
+
+      <div class="field">
+        <label for="meta-og-image">OG Image URL</label>
+        <input id="meta-og-image" v-model="ogImage" @input="markDirty" placeholder="https://example.com/image.jpg"
+          data-testid="meta-og-image" />
+      </div>
+
+      <div class="field">
+        <label for="meta-canonical">Canonical URL</label>
+        <input id="meta-canonical" v-model="canonical" @input="markDirty" placeholder="https://example.com/page"
+          data-testid="meta-canonical" />
+      </div>
+    </div>
+
+    <!-- SERP preview — always light-themed to match Google's appearance -->
+    <div class="serp-preview" data-testid="serp-preview">
+      <div class="serp-card">
+        <div class="serp-url">{{ serpUrl }}</div>
+        <div class="serp-title">{{ serpTitle.slice(0, 70) }}{{ serpTitle.length > 70 ? '…' : '' }}</div>
+        <div class="serp-desc">{{ serpDescription.slice(0, 170) }}{{ serpDescription.length > 170 ? '…' : '' }}</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.metadata-editor {
+  border-top: 1px solid var(--color-border);
+  padding-top: 1rem;
+  margin-top: 1rem;
+}
+.meta-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+.meta-header h3 {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+.meta-save-btn {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--p-primary-color);
+  border-radius: var(--p-border-radius-sm);
+  background: var(--p-primary-color);
+  color: #fff;
+  cursor: pointer;
+  font-family: inherit;
+}
+.meta-save-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.meta-fields { display: flex; flex-direction: column; gap: 0.625rem; }
+.field { display: flex; flex-direction: column; gap: 0.25rem; position: relative; }
+.field label {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-muted);
+  font-weight: 500;
+}
+.field input, .field textarea {
+  font-size: 0.8125rem;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--color-input-border);
+  border-radius: var(--p-border-radius-sm);
+  background: var(--color-input-bg);
+  color: var(--color-fg);
+  font-family: inherit;
+  resize: vertical;
+}
+.field input:focus, .field textarea:focus {
+  outline: 2px solid var(--p-primary-color);
+  outline-offset: -1px;
+}
+.char-count {
+  font-size: 0.625rem;
+  align-self: flex-end;
+  font-variant-numeric: tabular-nums;
+}
+.char-count.ok { color: var(--color-muted); }
+.char-count.warn { color: var(--color-warning-fg); }
+.char-count.over { color: var(--color-danger-fg); font-weight: 600; }
+
+/* SERP preview — always light-themed regardless of admin dark/light mode */
+.serp-preview {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  background: #fff;
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+}
+.serp-card { font-family: Arial, sans-serif; }
+.serp-url {
+  font-size: 0.75rem;
+  color: #202124;
+  margin-bottom: 0.125rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.serp-title {
+  font-size: 1.125rem;
+  color: #1a0dab;
+  line-height: 1.3;
+  margin-bottom: 0.25rem;
+  cursor: pointer;
+}
+.serp-title:hover { text-decoration: underline; }
+.serp-desc {
+  font-size: 0.8125rem;
+  color: #4d5156;
+  line-height: 1.4;
+}
+</style>


### PR DESCRIPTION
## Summary
Second slice of the SEO metadata feature (PR #185 landed the data model + API + renderer). Adds an inline metadata editor to the admin's editor panel with a live Google SERP preview.

### PageMetadataEditor.vue
- **Fields**: title (60-char counter), description (160-char counter), OG image URL, canonical URL
- **Char counters**: muted when OK, amber at 90%, red when over limit
- **SERP preview**: always light-themed (white card, blue title link, gray description) — matches how the page actually looks in Google regardless of the admin's dark/light mode
- **Fallback values**: SERP preview shows \`content.title\` / \`content.description\` when metadata fields are empty, so the author sees what Google would use by default
- **Independent save**: saves via \`api.updatePage(name, { metadata })\` with its own dirty tracking and "Save metadata" button (only appears when dirty)

### Mounting
- Visible in \`EditorPanel.vue\` whenever \`selection.type === 'page'\` — works on page root AND child components so the author can tweak SEO while editing any component
- Hidden for fragments (fragments don't have page-level metadata)

## Visual verification
Tested in browser — dark mode, light mode, fragment editing (hidden), page root + child component editing (visible). Screenshots in conversation.

## Test plan
- [x] \`npx vue-tsc --noEmit\` — clean
- [x] \`npx vitest run --root apps/admin\` — 223/223
- [x] Visual: dark mode fields + light SERP card
- [x] Visual: light mode fields + light SERP card
- [x] Visual: fragment editing — metadata section absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)