### PR TITLE
SEO: renderer fallback chains + sitemap.xml + robots.txt + .pub sidecar

### DIFF
--- a/.claude/rules/seo-plan.md
+++ b/.claude/rules/seo-plan.md
@@ -62,7 +62,7 @@ complaint without adding admin UI complexity.
 
 ## Tier 1 — closes the adoption-blocker gap
 
-### ☐ 1.1 Fallback chains in renderer
+### ◐ 1.1 Fallback chains in renderer
 
 The renderer should compute SEO values from existing data when metadata fields are
 empty. Authors override only when they want different values for search vs content.

--- a/.claude/rules/seo-plan.md
+++ b/.claude/rules/seo-plan.md
@@ -1,0 +1,215 @@
+---
+paths:
+  - "packages/gazetta/src/renderer.ts"
+  - "packages/gazetta/src/types.ts"
+  - "packages/gazetta/src/publish-rendered.ts"
+  - "packages/gazetta/src/admin-api/schemas/pages.ts"
+  - "apps/admin/src/client/components/PageMetadataEditor.vue"
+  - "docs/seo.md"
+  - "**/sitemap*"
+  - "**/robots*"
+---
+
+# SEO Plan
+
+Auto-generate everything, let authors override. The biggest gap in headless CMS SEO
+isn't missing features — it's that metadata generation is left to site developers as
+boilerplate. Gazetta's renderer already assembles `<head>` from template output; making
+it automatically emit the right tags from `page.json` metadata eliminates the #1
+complaint without adding admin UI complexity.
+
+**Status legend:** ☐ todo · ◐ in progress · ✓ done
+
+---
+
+## Design principles
+
+1. **Fallback chains, not empty fields.** Every SEO value has a computed default from
+   existing data. Authors override only when they want to — pages never ship with empty
+   titles or missing canonicals because the author forgot to fill in a field.
+
+2. **Renderer owns `<head>` output.** Templates can still emit their own `head` tags;
+   the renderer deduplicates (metadata tags injected first, template tags win when both
+   exist). Zero boilerplate for site developers.
+
+3. **No scoring.** Yoast-style keyword/readability scoring correlates weakly with
+   rankings (r = 0.10-0.32) and encourages over-optimization. The SERP preview is
+   the only feedback tool — it shows what Google will display, which is what authors
+   actually need.
+
+4. **Publish-time generation.** Sitemap and robots.txt are generated at publish time
+   and stored in the target alongside pages. No runtime generation needed.
+
+---
+
+## What's already done
+
+| Item | PR | Status |
+|------|-----|--------|
+| `PageMetadata` type (title, description, ogImage, canonical) | #185 | ✓ |
+| `parsePageManifest` reads metadata from page.json | #185 | ✓ |
+| API: GET/PUT /api/pages/:name includes metadata | #185 | ✓ |
+| `PageMetadataSchema` in contract family (4 tests) | #185 | ✓ |
+| Client `PageDetail` includes metadata | #185 | ✓ |
+| Renderer injects metadata into `<head>` (with template dedup) | #185 | ✓ |
+| 6 renderer tests (inject, dedup, escaping, backward compat) | #185 | ✓ |
+| Starter + gazetta.studio pages have example metadata | #185 | ✓ |
+| Admin metadata editor (title, desc, ogImage, canonical fields) | #186 | ✓ |
+| Character counters (title 60, description 160) with color | #186 | ✓ |
+| SERP preview (always light-themed Google snippet) | #186 | ✓ |
+
+---
+
+## Tier 1 — closes the adoption-blocker gap
+
+### ☐ 1.1 Fallback chains in renderer
+
+The renderer should compute SEO values from existing data when metadata fields are
+empty. Authors override only when they want different values for search vs content.
+
+| Tag | Fallback chain |
+|-----|---------------|
+| `<title>` | `metadata.title` → `content.title + " — " + site.name` → page name |
+| `<meta name="description">` | `metadata.description` → `content.description` → omit |
+| `<link rel="canonical">` | `metadata.canonical` → `site.baseUrl + route` → omit |
+| `<meta property="og:title">` | same as `<title>` chain |
+| `<meta property="og:description">` | same as description chain |
+| `<meta property="og:image">` | `metadata.ogImage` → `site.defaultOgImage` → omit |
+| `<meta property="og:url">` | same as canonical chain |
+| `<meta property="og:type">` | always `"website"` |
+| `<meta name="twitter:card">` | `"summary_large_image"` when ogImage resolved, `"summary"` otherwise |
+| `<meta name="robots">` | `metadata.robots` when set → omit (allow indexing) |
+| `<html lang>` | `site.locale` → `"en"` |
+
+**Implementation:**
+- `renderPage` needs access to `SiteManifest` (for `site.name`, `baseUrl`, `locale`,
+  `defaultOgImage`). Add to `RenderPageOptions`.
+- `metadataHead()` already exists; extend it with the fallback logic.
+- Fallback-generated values should flow into the SERP preview (admin UI) so the author
+  sees what Google will actually use.
+
+**site.yaml additions:**
+```yaml
+baseUrl: https://gazetta.studio     # already exists (optional)
+locale: en                          # already exists (optional)
+defaultOgImage: /images/og-default.jpg  # new (optional)
+```
+
+**Changes to `PageMetadata` type:**
+- Add `robots?: string` (free-text: `"noindex"`, `"nofollow"`, `"noindex, nofollow"`)
+- Keep ogTitle/ogDescription OUT — research showed authors rarely differentiate; the
+  fallback chain handles it. Add later if requested.
+
+---
+
+### ☐ 1.2 sitemap.xml generation on publish
+
+Generate `sitemap.xml` at publish time from published pages. Store in target root.
+
+**What goes in:**
+- One `<url>` per page with `<loc>` (absolute URL from canonical chain)
+- `<lastmod>` from publish timestamp (the revision system has timestamps)
+- Skip system pages (404) — via `site.yaml systemPages`
+- Skip pages with `metadata.robots` containing `"noindex"`
+
+**Requirements:**
+- `baseUrl` or target `siteUrl` must be set (can't generate absolute URLs without it)
+- Skip generation silently when no base URL is available
+- Generate per-target (each target gets its own sitemap reflecting its published state)
+
+**Format:**
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://gazetta.studio/</loc>
+    <lastmod>2026-04-17</lastmod>
+  </url>
+  <url>
+    <loc>https://gazetta.studio/docs</loc>
+    <lastmod>2026-04-17</lastmod>
+  </url>
+</urlset>
+```
+
+---
+
+### ☐ 1.3 robots.txt on publish
+
+**Strategy:** if `sites/{name}/robots.txt` exists, copy it to target root. Otherwise,
+generate a default:
+
+```
+User-agent: *
+Allow: /
+
+Sitemap: {baseUrl}/sitemap.xml
+```
+
+The `Sitemap:` line is only included when `baseUrl` is available.
+
+---
+
+### ☐ 1.4 Admin UI: noindex toggle + SERP preview with fallbacks
+
+- Add a "Hide from search engines" checkbox → sets `metadata.robots = "noindex"`
+- Update SERP preview to show the fallback-generated title (with site name suffix)
+  instead of raw field values, so the author sees exactly what Google sees
+- Show a "noindex" badge on the SERP preview when the page is excluded
+
+---
+
+## Tier 2 — expected (next pass, not this one)
+
+| Item | Why deferred |
+|------|-------------|
+| JSON-LD Article schema auto-generation | Template authors need to opt in per content type; not a renderer-level default |
+| Redirect management (`redirects` in site.yaml + Hono middleware) | Separate feature, not SEO metadata |
+| Metadata validation warnings (missing title, duplicate titles) | Useful but not blocking; SERP preview covers the visual case |
+| OG image preview in editor (thumbnail of the OG image URL) | Nice polish, not essential |
+
+## Tier 3 — future (validated as overkill for now)
+
+| Item | Why not now |
+|------|-----------|
+| Keyword/readability scoring | Weakly correlated with rankings; encourages over-optimization |
+| AI meta generation | Requires LLM integration; build when there are users asking |
+| AI crawler controls (GPTBot, ClaudeBot blocks) | robots.txt already supports this manually; UI controls are premature |
+| llms.txt generation | No adoption among major AI platforms; too early |
+| Social card preview (Twitter/LinkedIn card rendering) | SERP preview is sufficient for now |
+| hreflang management | Depends on i18n feature (separate feature-gaps.md item) |
+| SEO audit dashboard | Enterprise feature; no users to validate against |
+
+---
+
+## Explicit non-goals
+
+| Skip | Why |
+|------|-----|
+| Separate ogTitle / ogDescription fields | Research: authors rarely differentiate. Fallback chain handles it. Add later if requested. |
+| Per-field translation of metadata | Depends on i18n feature |
+| Structured data editor UI | Template `head` field handles this; no CMS does inline schema.org editing well |
+| Content scoring (Yoast-style green/red dots) | Weakly correlated with rankings; risk of keyword-stuffing |
+
+---
+
+## PR sequence
+
+| PR | Scope | Depends on |
+|----|-------|-----------|
+| **A** | Renderer: fallback chains + og:url/type + twitter:card + html lang + robots meta. site.yaml `defaultOgImage`. Add `robots` to `PageMetadata`. | #185 (merged), #186 (pending) |
+| **B** | Publish: sitemap.xml + robots.txt generation | PR A (needs fallback chain for canonical URLs) |
+| **C** | Admin: noindex toggle + SERP preview shows fallback-generated values | PR A (needs fallback chain values available to client) |
+
+---
+
+## Research sources
+
+- [DatoCMS SEO Fields](https://www.datocms.com/docs/content-modelling/seo-fields) — fallback chain pattern
+- [Payload CMS SEO Plugin](https://payloadcms.com/docs/plugins/seo) — auto-generation functions
+- [8 Minimum SEO Requirements for a CMS](https://www.newmediacampaigns.com/page/the-8-minimum-requirements-for-seo-features-in-a-cms)
+- [Content Scoring Tools Correlation](https://searchengineland.com/content-scoring-tools-work-but-only-for-the-first-gate-in-googles-pipeline-469871) — weak r = 0.10-0.32
+- [Structured Data for AI Search](https://www.stackmatix.com/blog/structured-data-ai-search) — 2.5x citation lift
+- [Headless CMS SEO Challenges](https://hmdigitalsolution.com/headless-cms-seo-challenges-guide/)
+- [Google Sitemap Best Practices](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap)
+- [llms.txt Adoption Status](https://higoodie.com/blog/llms-txt-robots-txt-ai-optimization/) — too early

--- a/.claude/rules/seo-plan.md
+++ b/.claude/rules/seo-plan.md
@@ -62,7 +62,7 @@ complaint without adding admin UI complexity.
 
 ## Tier 1 — closes the adoption-blocker gap
 
-### ◐ 1.1 Fallback chains in renderer
+### ✓ 1.1 Fallback chains in renderer
 
 The renderer should compute SEO values from existing data when metadata fields are
 empty. Authors override only when they want different values for search vs content.
@@ -81,41 +81,47 @@ empty. Authors override only when they want different values for search vs conte
 | `<meta name="robots">` | `metadata.robots` when set → omit (allow indexing) |
 | `<html lang>` | `site.locale` → `"en"` |
 
-**Implementation:**
-- `renderPage` needs access to `SiteManifest` (for `site.name`, `baseUrl`, `locale`,
-  `defaultOgImage`). Add to `RenderPageOptions`.
-- `metadataHead()` already exists; extend it with the fallback logic.
-- Fallback-generated values should flow into the SERP preview (admin UI) so the author
-  sees what Google will actually use.
+**Implementation (done):**
+- `seo.ts` extracts SEO tag resolution (SRP) — `resolveSeoTags()` computes all tags
+  from metadata + content + site config fallbacks.
+- `renderPage` receives `SeoContext` (site name, locale, defaultOgImage, siteUrl) via
+  `RenderPageOptions.seo`.
+- `siteUrl` lives on each target config (not site-level `baseUrl` — removed). Canonical
+  URLs use the target's `siteUrl` since each target may serve from a different domain.
+- Fallback-generated values flow into the SERP preview via the admin API.
+
+**target config additions:**
+```yaml
+targets:
+  production:
+    siteUrl: https://gazetta.studio   # per-target (required for sitemap/canonical)
+```
 
 **site.yaml additions:**
 ```yaml
-baseUrl: https://gazetta.studio     # already exists (optional)
-locale: en                          # already exists (optional)
+locale: en                          # already existed (optional)
 defaultOgImage: /images/og-default.jpg  # new (optional)
 ```
 
 **Changes to `PageMetadata` type:**
-- Add `robots?: string` (free-text: `"noindex"`, `"nofollow"`, `"noindex, nofollow"`)
-- Keep ogTitle/ogDescription OUT — research showed authors rarely differentiate; the
-  fallback chain handles it. Add later if requested.
+- Added `robots?: string` (free-text: `"noindex"`, `"nofollow"`, `"noindex, nofollow"`)
+- ogTitle/ogDescription kept OUT — fallback chain handles it.
 
 ---
 
-### ☐ 1.2 sitemap.xml generation on publish
+### ✓ 1.2 sitemap.xml generation on publish
 
 Generate `sitemap.xml` at publish time from published pages. Store in target root.
 
-**What goes in:**
-- One `<url>` per page with `<loc>` (absolute URL from canonical chain)
-- `<lastmod>` from publish timestamp (the revision system has timestamps)
-- Skip system pages (404) — via `site.yaml systemPages`
-- Skip pages with `metadata.robots` containing `"noindex"`
+**What goes in (done):**
+- One `<url>` per page with `<loc>` (absolute URL from target `siteUrl` + derived route)
+- `<lastmod>` from `.pub` sidecar timestamp (date-only per spec)
+- Skip dynamic routes (template patterns like `/blog/:slug` aren't crawlable)
+- Skip pages with `metadata.robots` containing `"noindex"` (via `.pub-*-noindex` sidecar)
 
-**Requirements:**
-- `baseUrl` or target `siteUrl` must be set (can't generate absolute URLs without it)
-- Skip generation silently when no base URL is available
-- Generate per-target (each target gets its own sitemap reflecting its published state)
+**Requirements (met):**
+- Target `siteUrl` must be set (returns null without it)
+- Generated per-target from target sidecars (reflects what's actually published)
 
 **Format:**
 ```xml
@@ -134,28 +140,29 @@ Generate `sitemap.xml` at publish time from published pages. Store in target roo
 
 ---
 
-### ☐ 1.3 robots.txt on publish
+### ✓ 1.3 robots.txt on publish
 
-**Strategy:** if `sites/{name}/robots.txt` exists, copy it to target root. Otherwise,
+**Strategy (done):** if `sites/{name}/robots.txt` exists, copy it to target root. Otherwise,
 generate a default:
 
 ```
 User-agent: *
 Allow: /
 
-Sitemap: {baseUrl}/sitemap.xml
+Sitemap: {siteUrl}/sitemap.xml
 ```
 
-The `Sitemap:` line is only included when `baseUrl` is available.
+The `Sitemap:` line is only included when `siteUrl` is available. Skipped entirely for
+subpath deployments (Google ignores robots.txt at non-root paths).
 
 ---
 
-### ☐ 1.4 Admin UI: noindex toggle + SERP preview with fallbacks
+### ✓ 1.4 Admin UI: noindex toggle + SERP preview with fallbacks
 
-- Add a "Hide from search engines" checkbox → sets `metadata.robots = "noindex"`
-- Update SERP preview to show the fallback-generated title (with site name suffix)
-  instead of raw field values, so the author sees exactly what Google sees
-- Show a "noindex" badge on the SERP preview when the page is excluded
+- Added "Hide from search engines" toggle → sets `metadata.robots = "noindex"` (done)
+- SERP preview shows fallback-generated values (title with site name suffix) (done)
+- "noindex" badge shown on SERP preview when page is excluded (done)
+- SEO editor shown only on page root, not on child components (done)
 
 ---
 
@@ -195,11 +202,11 @@ The `Sitemap:` line is only included when `baseUrl` is available.
 
 ## PR sequence
 
-| PR | Scope | Depends on |
-|----|-------|-----------|
-| **A** | Renderer: fallback chains + og:url/type + twitter:card + html lang + robots meta. site.yaml `defaultOgImage`. Add `robots` to `PageMetadata`. | #185 (merged), #186 (pending) |
-| **B** | Publish: sitemap.xml + robots.txt generation | PR A (needs fallback chain for canonical URLs) |
-| **C** | Admin: noindex toggle + SERP preview shows fallback-generated values | PR A (needs fallback chain values available to client) |
+All Tier 1 items landed in a single branch (#187):
+
+| PR | Scope | Status |
+|----|-------|--------|
+| **#187** | Renderer fallback chains, sitemap.xml, robots.txt, admin noindex toggle + SERP preview with fallbacks, siteUrl on targets, .pub sidecars, listSidecars perf fix | ✓ |
 
 ---
 

--- a/apps/admin/src/client/components/ComponentTree.vue
+++ b/apps/admin/src/client/components/ComponentTree.vue
@@ -142,6 +142,7 @@ watch(
     }
     componentNodes.value = [rootNode]
     gzMap.value = map
+    selectedNodeKey.value = null
 
     // Process pending selection if tree just built and a gzId is waiting
     consumePending()
@@ -232,7 +233,11 @@ async function onSelect(node: ComponentNode) {
   const treePath = node.data.treePath
   focus.select(treePath ? hashPath(treePath) : null)
   if (node.data.isFragment && node.data.fragName) {
-    editing.openFragment(node.data.fragName!)
+    if (selection.type === 'page') {
+      editing.showFragmentLink(node.data.fragName!)
+    } else {
+      editing.openFragment(node.data.fragName!)
+    }
     return
   }
   if (node.data.isPage) {
@@ -240,6 +245,11 @@ async function onSelect(node: ComponentNode) {
     return
   }
   if (!node.data.path) return
+  // Fragment child clicked from page context — show link to the fragment
+  if (selection.type === 'page' && node.data.path!.startsWith('@')) {
+    editing.showFragmentLink(node.data.path!)
+    return
+  }
   editing.openComponent(node.data.path!, node.data.template ?? '')
 }
 
@@ -263,11 +273,20 @@ function selectByGzId(gzId: string) {
   if ('isFragment' in entry) {
     const found = findNodeByKey(componentNodes.value, d => d.fragName === entry.fragName)
     if (found) selectedNodeKey.value = found.key
-    editing.openFragment(entry.fragName)
+    if (selection.type === 'page') {
+      editing.showFragmentLink(entry.fragName)
+    } else {
+      editing.openFragment(entry.fragName)
+    }
     return
   }
   const found = findNodeByKey(componentNodes.value, d => d.path === entry.path)
   if (found) selectedNodeKey.value = found.key
+  // Fragment child clicked from page context — show link to the fragment
+  if (selection.type === 'page' && entry.path.startsWith('@')) {
+    editing.showFragmentLink(entry.path)
+    return
+  }
   editing.openComponent(entry.path, entry.template)
 }
 

--- a/apps/admin/src/client/components/EditorPanel.vue
+++ b/apps/admin/src/client/components/EditorPanel.vue
@@ -80,8 +80,8 @@ onKeyStroke('s', e => {
         <FragmentBlastRadius v-if="fragmentName" :fragmentName="fragmentName" />
       </div>
       <div v-if="hasProperties" ref="containerRef" class="editor-container" data-testid="editor-container" :key="editing.path" />
-      <p v-else class="editor-no-schema">No editable content. Edit its children instead.</p>
       <PageMetadataEditor v-if="selection.type === 'page' && editing.path === '_root'" />
+      <p v-else-if="!hasProperties" class="editor-no-schema">No editable content. Edit its children instead.</p>
     </div>
   </div>
 </template>

--- a/apps/admin/src/client/components/EditorPanel.vue
+++ b/apps/admin/src/client/components/EditorPanel.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
 import { onKeyStroke } from '@vueuse/core'
 import { useEditingStore } from '../stores/editing.js'
 import { useSelectionStore } from '../stores/selection.js'
 import { useThemeStore } from '../stores/theme.js'
+import { useUnsavedGuardStore } from '../stores/unsavedGuard.js'
 import { useEditorMount } from '../composables/useEditorMount.js'
 import { createEditorMount } from 'gazetta/editor'
 import type { EditorMount } from 'gazetta/types'
@@ -13,7 +15,22 @@ import PageMetadataEditor from './PageMetadataEditor.vue'
 const editing = useEditingStore()
 const selection = useSelectionStore()
 const theme = useThemeStore()
+const unsavedGuard = useUnsavedGuardStore()
+const router = useRouter()
 const containerRef = ref<HTMLElement | null>(null)
+
+async function goToFragment() {
+  const fragName = editing.fragmentLink
+  if (!fragName) return
+  if (editing.hasPendingEdits) {
+    const result = await unsavedGuard.guard()
+    if (result === 'cancel') return
+    if (result === 'save') await editing.save()
+  }
+  editing.clear()
+  await router.push(`/fragments/${fragName}/edit`)
+  editing.openFragment(fragName)
+}
 
 // Show blast radius when the selected root item is a fragment, regardless
 // of which sub-component is currently in the editor. The badge is about
@@ -70,6 +87,11 @@ onKeyStroke('s', e => {
       <i class="pi pi-exclamation-triangle" />
       <p>{{ editing.loadError }}</p>
     </div>
+    <div v-else-if="editing.fragmentLink" class="editor-fragment-link" data-testid="editor-fragment-link">
+      <i class="pi pi-share-alt" />
+      <p>This is part of a shared fragment.</p>
+      <a class="fragment-go-link" @click="goToFragment">Edit @{{ editing.fragmentLink }}</a>
+    </div>
     <div v-else-if="!editing.path" class="editor-empty" data-testid="editor-empty">
       <i class="pi pi-pencil" style="font-size: 2rem; opacity: 0.3; margin-bottom: 0.5rem;" />
       <p>Select a component to edit</p>
@@ -93,6 +115,10 @@ onKeyStroke('s', e => {
 .editor-error .pi { font-size: 2rem; }
 .editor-error p { max-width: 300px; line-height: 1.5; }
 .editor-empty { color: var(--color-muted); font-size: 0.875rem; display: flex; flex-direction: column; align-items: center; padding-top: 3rem; }
+.editor-fragment-link { color: var(--color-muted); font-size: 0.875rem; display: flex; flex-direction: column; align-items: center; padding-top: 3rem; gap: 0.5rem; }
+.editor-fragment-link .pi { font-size: 2rem; opacity: 0.3; }
+.fragment-go-link { color: var(--color-primary); cursor: pointer; font-weight: 500; }
+.fragment-go-link:hover { text-decoration: underline; }
 .editor-container { font-size: 0.875rem; }
 .editor-no-schema { color: var(--color-muted); font-size: 0.875rem; }
 </style>

--- a/apps/admin/src/client/components/EditorPanel.vue
+++ b/apps/admin/src/client/components/EditorPanel.vue
@@ -81,7 +81,7 @@ onKeyStroke('s', e => {
       </div>
       <div v-if="hasProperties" ref="containerRef" class="editor-container" data-testid="editor-container" :key="editing.path" />
       <p v-else class="editor-no-schema">No editable content. Edit its children instead.</p>
-      <PageMetadataEditor v-if="selection.type === 'page'" />
+      <PageMetadataEditor v-if="selection.type === 'page' && editing.path === '_root'" />
     </div>
   </div>
 </template>

--- a/apps/admin/src/client/components/PageMetadataEditor.vue
+++ b/apps/admin/src/client/components/PageMetadataEditor.vue
@@ -18,7 +18,6 @@ const canonical = ref('')
 const noindex = ref(false)
 const saving = ref(false)
 const dirty = ref(false)
-const expanded = ref(false)
 
 const TITLE_MAX = 60
 const DESC_MAX = 160
@@ -94,33 +93,18 @@ const fallbackCanonical = computed(() => `${pageDetail.value?.route ?? '/'}`)
 const serpTitle = computed(() => title.value || fallbackTitle.value)
 const serpUrl = computed(() => canonical.value || `https://example.com${fallbackCanonical.value}`)
 const serpDescription = computed(() => description.value || fallbackDescription.value)
-
-// Collapsed summary — shows the effective title so the author knows
-// what Google will see without expanding.
-const summaryTitle = computed(() => {
-  const effective = title.value || fallbackTitle.value
-  return effective.length > 50 ? effective.slice(0, 50) + '…' : effective
-})
-const hasOverrides = computed(
-  () => !!(title.value || description.value || ogImage.value || canonical.value || noindex.value),
-)
 </script>
 
 <template>
   <div class="metadata-editor" data-testid="metadata-editor">
-    <button class="meta-toggle" @click="expanded = !expanded" type="button" data-testid="metadata-toggle">
-      <i :class="expanded ? 'pi pi-chevron-down' : 'pi pi-chevron-right'" class="toggle-icon" />
-      <span class="toggle-label">SEO</span>
-      <span class="toggle-summary">{{ summaryTitle }}</span>
-      <span v-if="noindex" class="toggle-noindex">noindex</span>
-      <span v-if="hasOverrides" class="toggle-badge">customized</span>
-      <button v-if="dirty && expanded" class="meta-save-btn" :disabled="saving" @click.stop="save" data-testid="metadata-save">
+    <div class="meta-header">
+      <h3>SEO</h3>
+      <button v-if="dirty" class="meta-save-btn" :disabled="saving" @click="save" data-testid="metadata-save">
         {{ saving ? 'Saving…' : 'Save' }}
       </button>
-    </button>
+    </div>
 
-    <div v-if="expanded" class="meta-body">
-      <div class="meta-fields">
+    <div class="meta-fields">
         <div class="field">
           <label for="meta-title">Title</label>
           <input id="meta-title" v-model="title" @input="markDirty"
@@ -169,7 +153,6 @@ const hasOverrides = computed(
           <div class="serp-title">{{ serpTitle.slice(0, 70) }}{{ serpTitle.length > 70 ? '…' : '' }}</div>
           <div class="serp-desc">{{ serpDescription.slice(0, 170) }}{{ serpDescription.length > 170 ? '…' : '' }}</div>
         </div>
-      </div>
     </div>
   </div>
 </template>
@@ -177,59 +160,21 @@ const hasOverrides = computed(
 <style scoped>
 .metadata-editor {
   border-top: 1px solid var(--color-border);
+  padding-top: 0.75rem;
   margin-top: 1rem;
 }
-.meta-toggle {
+.meta-header {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  width: 100%;
-  padding: 0.5rem 0;
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-family: inherit;
-  color: var(--color-fg);
-  text-align: left;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
 }
-.toggle-icon { font-size: 0.625rem; color: var(--color-muted); width: 0.75rem; }
-.toggle-label {
-  font-size: 0.6875rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--color-muted);
-  font-weight: 600;
-  flex-shrink: 0;
-}
-.toggle-summary {
+.meta-header h3 {
   font-size: 0.75rem;
-  color: var(--color-muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex: 1;
-  min-width: 0;
-}
-.toggle-noindex {
-  font-size: 0.5625rem;
   text-transform: uppercase;
-  letter-spacing: 0.03em;
-  padding: 0.0625rem 0.3125rem;
-  border-radius: 2px;
-  background: var(--color-danger-bg);
-  color: var(--color-danger-fg);
-  font-weight: 600;
-  flex-shrink: 0;
-}
-.toggle-badge {
-  font-size: 0.5625rem;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  padding: 0.0625rem 0.3125rem;
-  border-radius: 2px;
-  background: var(--color-hover-bg);
   color: var(--color-muted);
-  flex-shrink: 0;
+  letter-spacing: 0.05em;
+  margin: 0;
 }
 .meta-save-btn {
   font-size: 0.6875rem;
@@ -240,11 +185,8 @@ const hasOverrides = computed(
   color: #fff;
   cursor: pointer;
   font-family: inherit;
-  flex-shrink: 0;
-  margin-left: auto;
 }
 .meta-save-btn:disabled { opacity: 0.5; cursor: not-allowed; }
-.meta-body { padding-bottom: 0.5rem; }
 .meta-fields { display: flex; flex-direction: column; gap: 0.625rem; }
 .field { display: flex; flex-direction: column; gap: 0.25rem; position: relative; }
 .field label {

--- a/apps/admin/src/client/components/PageMetadataEditor.vue
+++ b/apps/admin/src/client/components/PageMetadataEditor.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import { useSelectionStore } from '../stores/selection.js'
+import { useSiteStore } from '../stores/site.js'
 import { useToastStore } from '../stores/toast.js'
 import { usePagesApi } from '../composables/api.js'
 import type { PageMetadata } from '../api/client.js'
 
 const selection = useSelectionStore()
+const site = useSiteStore()
 const toast = useToastStore()
 const pagesApi = usePagesApi()
 
@@ -13,6 +15,7 @@ const title = ref('')
 const description = ref('')
 const ogImage = ref('')
 const canonical = ref('')
+const noindex = ref(false)
 const saving = ref(false)
 const dirty = ref(false)
 
@@ -24,6 +27,7 @@ function load(meta: PageMetadata | undefined) {
   description.value = meta?.description ?? ''
   ogImage.value = meta?.ogImage ?? ''
   canonical.value = meta?.canonical ?? ''
+  noindex.value = meta?.robots?.includes('noindex') ?? false
   dirty.value = false
 }
 
@@ -49,6 +53,7 @@ async function save() {
     if (description.value) metadata.description = description.value
     if (ogImage.value) metadata.ogImage = ogImage.value
     if (canonical.value) metadata.canonical = canonical.value
+    if (noindex.value) metadata.robots = 'noindex'
     await pagesApi.updatePage(selection.name, { metadata })
     dirty.value = false
     await selection.reload()
@@ -70,8 +75,24 @@ function charClass(current: number, max: number): string {
 const pageDetail = computed(() =>
   selection.type === 'page' ? (selection.detail as import('../api/client.js').PageDetail | null) : null,
 )
-const serpTitle = computed(() => title.value || (pageDetail.value?.content?.title as string) || selection.name || '')
-const serpUrl = computed(() => canonical.value || `https://example.com${pageDetail.value?.route ?? '/'}`)
+const siteName = computed(() => site.manifest?.name)
+const baseUrl = computed(() => site.manifest?.baseUrl)
+
+// SERP preview uses the same fallback chain as the renderer (seo.ts):
+//   metadata field → content field + site name → omit
+const serpTitle = computed(() => {
+  if (title.value) return title.value
+  const contentTitle = pageDetail.value?.content?.title as string | undefined
+  if (contentTitle) return siteName.value ? `${contentTitle} — ${siteName.value}` : contentTitle
+  return selection.name || ''
+})
+const serpUrl = computed(
+  () =>
+    canonical.value ||
+    (baseUrl.value
+      ? `${baseUrl.value}${pageDetail.value?.route ?? '/'}`
+      : `https://example.com${pageDetail.value?.route ?? '/'}`),
+)
 const serpDescription = computed(() => description.value || (pageDetail.value?.content?.description as string) || '')
 </script>
 
@@ -111,10 +132,21 @@ const serpDescription = computed(() => description.value || (pageDetail.value?.c
         <input id="meta-canonical" v-model="canonical" @input="markDirty" placeholder="https://example.com/page"
           data-testid="meta-canonical" />
       </div>
+
+      <div class="field field-checkbox">
+        <label class="checkbox-label">
+          <input type="checkbox" v-model="noindex" @change="markDirty" data-testid="meta-noindex" />
+          <span>Hide from search engines</span>
+        </label>
+        <span class="checkbox-hint">Adds <code>noindex</code> robots directive. Page won't appear in sitemap.</span>
+      </div>
     </div>
 
     <!-- SERP preview — always light-themed to match Google's appearance -->
-    <div class="serp-preview" data-testid="serp-preview">
+    <div :class="['serp-preview', { 'serp-noindex': noindex }]" data-testid="serp-preview">
+      <div v-if="noindex" class="serp-noindex-badge">
+        <i class="pi pi-eye-slash" aria-hidden="true" /> noindex — hidden from search engines
+      </div>
       <div class="serp-card">
         <div class="serp-url">{{ serpUrl }}</div>
         <div class="serp-title">{{ serpTitle.slice(0, 70) }}{{ serpTitle.length > 70 ? '…' : '' }}</div>
@@ -186,6 +218,28 @@ const serpDescription = computed(() => description.value || (pageDetail.value?.c
 .char-count.warn { color: var(--color-warning-fg); }
 .char-count.over { color: var(--color-danger-fg); font-weight: 600; }
 
+.field-checkbox { flex-direction: row; align-items: flex-start; gap: 0.375rem; }
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  color: var(--color-fg);
+  cursor: pointer;
+}
+.checkbox-label input[type="checkbox"] { cursor: pointer; }
+.checkbox-hint {
+  font-size: 0.6875rem;
+  color: var(--color-muted);
+  margin-left: 1.25rem;
+}
+.checkbox-hint code {
+  font-size: 0.625rem;
+  padding: 0.0625rem 0.25rem;
+  background: var(--color-hover-bg);
+  border-radius: 2px;
+}
+
 /* SERP preview — always light-themed regardless of admin dark/light mode */
 .serp-preview {
   margin-top: 1rem;
@@ -215,5 +269,15 @@ const serpDescription = computed(() => description.value || (pageDetail.value?.c
   font-size: 0.8125rem;
   color: #4d5156;
   line-height: 1.4;
+}
+.serp-noindex .serp-card { opacity: 0.4; }
+.serp-noindex-badge {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.6875rem;
+  color: #b91c1c;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
 }
 </style>

--- a/apps/admin/src/client/components/PageMetadataEditor.vue
+++ b/apps/admin/src/client/components/PageMetadataEditor.vue
@@ -76,7 +76,6 @@ const pageDetail = computed(() =>
   selection.type === 'page' ? (selection.detail as import('../api/client.js').PageDetail | null) : null,
 )
 const siteName = computed(() => site.manifest?.name)
-const baseUrl = computed(() => site.manifest?.baseUrl)
 
 // SERP preview uses the same fallback chain as the renderer (seo.ts):
 //   metadata field → content field + site name → omit
@@ -86,13 +85,11 @@ const serpTitle = computed(() => {
   if (contentTitle) return siteName.value ? `${contentTitle} — ${siteName.value}` : contentTitle
   return selection.name || ''
 })
-const serpUrl = computed(
-  () =>
-    canonical.value ||
-    (baseUrl.value
-      ? `${baseUrl.value}${pageDetail.value?.route ?? '/'}`
-      : `https://example.com${pageDetail.value?.route ?? '/'}`),
-)
+// SERP URL shows the route structure. The actual canonical URL is
+// resolved at publish time from the target's siteUrl — the admin
+// doesn't know which target will be published to, so we show a
+// placeholder domain.
+const serpUrl = computed(() => canonical.value || `https://example.com${pageDetail.value?.route ?? '/'}`)
 const serpDescription = computed(() => description.value || (pageDetail.value?.content?.description as string) || '')
 </script>
 

--- a/apps/admin/src/client/components/PageMetadataEditor.vue
+++ b/apps/admin/src/client/components/PageMetadataEditor.vue
@@ -18,6 +18,7 @@ const canonical = ref('')
 const noindex = ref(false)
 const saving = ref(false)
 const dirty = ref(false)
+const expanded = ref(false)
 
 const TITLE_MAX = 60
 const DESC_MAX = 160
@@ -66,6 +67,7 @@ async function save() {
 }
 
 function charClass(current: number, max: number): string {
+  if (current === 0) return 'ok'
   const ratio = current / max
   if (ratio >= 1) return 'over'
   if (ratio >= 0.9) return 'warn'
@@ -77,77 +79,96 @@ const pageDetail = computed(() =>
 )
 const siteName = computed(() => site.manifest?.name)
 
-// SERP preview uses the same fallback chain as the renderer (seo.ts):
-//   metadata field → content field + site name → omit
-const serpTitle = computed(() => {
-  if (title.value) return title.value
+// Fallback values — what the renderer will use when fields are empty.
+// Shown as placeholders and in the SERP preview.
+const fallbackTitle = computed(() => {
   const contentTitle = pageDetail.value?.content?.title as string | undefined
   if (contentTitle) return siteName.value ? `${contentTitle} — ${siteName.value}` : contentTitle
   return selection.name || ''
 })
-// SERP URL shows the route structure. The actual canonical URL is
-// resolved at publish time from the target's siteUrl — the admin
-// doesn't know which target will be published to, so we show a
-// placeholder domain.
-const serpUrl = computed(() => canonical.value || `https://example.com${pageDetail.value?.route ?? '/'}`)
-const serpDescription = computed(() => description.value || (pageDetail.value?.content?.description as string) || '')
+const fallbackDescription = computed(() => (pageDetail.value?.content?.description as string) || '')
+const fallbackCanonical = computed(() => `${pageDetail.value?.route ?? '/'}`)
+
+// SERP preview uses explicit value when set, fallback when empty —
+// same chain as the renderer (seo.ts).
+const serpTitle = computed(() => title.value || fallbackTitle.value)
+const serpUrl = computed(() => canonical.value || `https://example.com${fallbackCanonical.value}`)
+const serpDescription = computed(() => description.value || fallbackDescription.value)
+
+// Collapsed summary — shows the effective title so the author knows
+// what Google will see without expanding.
+const summaryTitle = computed(() => {
+  const effective = title.value || fallbackTitle.value
+  return effective.length > 50 ? effective.slice(0, 50) + '…' : effective
+})
+const hasOverrides = computed(
+  () => !!(title.value || description.value || ogImage.value || canonical.value || noindex.value),
+)
 </script>
 
 <template>
   <div class="metadata-editor" data-testid="metadata-editor">
-    <div class="meta-header">
-      <h3>SEO Metadata</h3>
-      <button v-if="dirty" class="meta-save-btn" :disabled="saving" @click="save" data-testid="metadata-save">
-        {{ saving ? 'Saving…' : 'Save metadata' }}
+    <button class="meta-toggle" @click="expanded = !expanded" type="button" data-testid="metadata-toggle">
+      <i :class="expanded ? 'pi pi-chevron-down' : 'pi pi-chevron-right'" class="toggle-icon" />
+      <span class="toggle-label">SEO</span>
+      <span class="toggle-summary">{{ summaryTitle }}</span>
+      <span v-if="noindex" class="toggle-noindex">noindex</span>
+      <span v-if="hasOverrides" class="toggle-badge">customized</span>
+      <button v-if="dirty && expanded" class="meta-save-btn" :disabled="saving" @click.stop="save" data-testid="metadata-save">
+        {{ saving ? 'Saving…' : 'Save' }}
       </button>
-    </div>
+    </button>
 
-    <div class="meta-fields">
-      <div class="field">
-        <label for="meta-title">Title</label>
-        <input id="meta-title" v-model="title" @input="markDirty" placeholder="Page title for search engines"
-          data-testid="meta-title" />
-        <span :class="['char-count', charClass(title.length, TITLE_MAX)]">{{ title.length }}/{{ TITLE_MAX }}</span>
+    <div v-if="expanded" class="meta-body">
+      <div class="meta-fields">
+        <div class="field">
+          <label for="meta-title">Title</label>
+          <input id="meta-title" v-model="title" @input="markDirty"
+            :placeholder="fallbackTitle ? `${fallbackTitle} (auto)` : 'Page title for search engines'"
+            data-testid="meta-title" />
+          <span v-if="title" :class="['char-count', charClass(title.length, TITLE_MAX)]">{{ title.length }}/{{ TITLE_MAX }}</span>
+        </div>
+
+        <div class="field">
+          <label for="meta-description">Description</label>
+          <textarea id="meta-description" v-model="description" @input="markDirty"
+            :placeholder="fallbackDescription ? `${fallbackDescription} (auto)` : 'Brief description for search results'"
+            rows="2" data-testid="meta-description" />
+          <span v-if="description" :class="['char-count', charClass(description.length, DESC_MAX)]">{{ description.length }}/{{ DESC_MAX }}</span>
+        </div>
+
+        <div class="field">
+          <label for="meta-og-image">OG Image URL</label>
+          <input id="meta-og-image" v-model="ogImage" @input="markDirty" placeholder="https://example.com/image.jpg"
+            data-testid="meta-og-image" />
+        </div>
+
+        <div class="field">
+          <label for="meta-canonical">Canonical URL</label>
+          <input id="meta-canonical" v-model="canonical" @input="markDirty"
+            :placeholder="`Leave empty — auto-generated from route (${fallbackCanonical})`"
+            data-testid="meta-canonical" />
+        </div>
+
+        <div class="field field-checkbox">
+          <label class="checkbox-label">
+            <input type="checkbox" v-model="noindex" @change="markDirty" data-testid="meta-noindex" />
+            <span>Hide from search engines</span>
+          </label>
+          <span class="checkbox-hint">Adds <code>noindex</code> robots directive. Page won't appear in sitemap.</span>
+        </div>
       </div>
 
-      <div class="field">
-        <label for="meta-description">Description</label>
-        <textarea id="meta-description" v-model="description" @input="markDirty"
-          placeholder="Brief description for search results" rows="2"
-          data-testid="meta-description" />
-        <span :class="['char-count', charClass(description.length, DESC_MAX)]">{{ description.length }}/{{ DESC_MAX }}</span>
-      </div>
-
-      <div class="field">
-        <label for="meta-og-image">OG Image URL</label>
-        <input id="meta-og-image" v-model="ogImage" @input="markDirty" placeholder="https://example.com/image.jpg"
-          data-testid="meta-og-image" />
-      </div>
-
-      <div class="field">
-        <label for="meta-canonical">Canonical URL</label>
-        <input id="meta-canonical" v-model="canonical" @input="markDirty" placeholder="https://example.com/page"
-          data-testid="meta-canonical" />
-      </div>
-
-      <div class="field field-checkbox">
-        <label class="checkbox-label">
-          <input type="checkbox" v-model="noindex" @change="markDirty" data-testid="meta-noindex" />
-          <span>Hide from search engines</span>
-        </label>
-        <span class="checkbox-hint">Adds <code>noindex</code> robots directive. Page won't appear in sitemap.</span>
-      </div>
-    </div>
-
-    <!-- SERP preview — always light-themed to match Google's appearance -->
-    <div :class="['serp-preview', { 'serp-noindex': noindex }]" data-testid="serp-preview">
-      <div v-if="noindex" class="serp-noindex-badge">
-        <i class="pi pi-eye-slash" aria-hidden="true" /> noindex — hidden from search engines
-      </div>
-      <div class="serp-card">
-        <div class="serp-url">{{ serpUrl }}</div>
-        <div class="serp-title">{{ serpTitle.slice(0, 70) }}{{ serpTitle.length > 70 ? '…' : '' }}</div>
-        <div class="serp-desc">{{ serpDescription.slice(0, 170) }}{{ serpDescription.length > 170 ? '…' : '' }}</div>
+      <!-- SERP preview — always light-themed to match Google's appearance -->
+      <div :class="['serp-preview', { 'serp-noindex': noindex }]" data-testid="serp-preview">
+        <div v-if="noindex" class="serp-noindex-badge">
+          <i class="pi pi-eye-slash" aria-hidden="true" /> noindex — hidden from search engines
+        </div>
+        <div class="serp-card">
+          <div class="serp-url">{{ serpUrl }}</div>
+          <div class="serp-title">{{ serpTitle.slice(0, 70) }}{{ serpTitle.length > 70 ? '…' : '' }}</div>
+          <div class="serp-desc">{{ serpDescription.slice(0, 170) }}{{ serpDescription.length > 170 ? '…' : '' }}</div>
+        </div>
       </div>
     </div>
   </div>
@@ -156,33 +177,74 @@ const serpDescription = computed(() => description.value || (pageDetail.value?.c
 <style scoped>
 .metadata-editor {
   border-top: 1px solid var(--color-border);
-  padding-top: 1rem;
   margin-top: 1rem;
 }
-.meta-header {
+.meta-toggle {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  margin-bottom: 0.75rem;
+  gap: 0.375rem;
+  width: 100%;
+  padding: 0.5rem 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  color: var(--color-fg);
+  text-align: left;
 }
-.meta-header h3 {
-  font-size: 0.75rem;
+.toggle-icon { font-size: 0.625rem; color: var(--color-muted); width: 0.75rem; }
+.toggle-label {
+  font-size: 0.6875rem;
   text-transform: uppercase;
-  color: var(--color-muted);
   letter-spacing: 0.05em;
-  margin: 0;
+  color: var(--color-muted);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.toggle-summary {
+  font-size: 0.75rem;
+  color: var(--color-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+.toggle-noindex {
+  font-size: 0.5625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 2px;
+  background: var(--color-danger-bg);
+  color: var(--color-danger-fg);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.toggle-badge {
+  font-size: 0.5625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 0.0625rem 0.3125rem;
+  border-radius: 2px;
+  background: var(--color-hover-bg);
+  color: var(--color-muted);
+  flex-shrink: 0;
 }
 .meta-save-btn {
-  font-size: 0.75rem;
-  padding: 0.25rem 0.75rem;
+  font-size: 0.6875rem;
+  padding: 0.1875rem 0.5rem;
   border: 1px solid var(--p-primary-color);
   border-radius: var(--p-border-radius-sm);
   background: var(--p-primary-color);
   color: #fff;
   cursor: pointer;
   font-family: inherit;
+  flex-shrink: 0;
+  margin-left: auto;
 }
 .meta-save-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.meta-body { padding-bottom: 0.5rem; }
 .meta-fields { display: flex; flex-direction: column; gap: 0.625rem; }
 .field { display: flex; flex-direction: column; gap: 0.25rem; position: relative; }
 .field label {
@@ -202,6 +264,11 @@ const serpDescription = computed(() => description.value || (pageDetail.value?.c
   font-family: inherit;
   resize: vertical;
 }
+.field input::placeholder, .field textarea::placeholder {
+  color: var(--color-muted);
+  opacity: 0.6;
+  font-style: italic;
+}
 .field input:focus, .field textarea:focus {
   outline: 2px solid var(--p-primary-color);
   outline-offset: -1px;
@@ -214,7 +281,6 @@ const serpDescription = computed(() => description.value || (pageDetail.value?.c
 .char-count.ok { color: var(--color-muted); }
 .char-count.warn { color: var(--color-warning-fg); }
 .char-count.over { color: var(--color-danger-fg); font-weight: 600; }
-
 .field-checkbox { flex-direction: row; align-items: flex-start; gap: 0.375rem; }
 .checkbox-label {
   display: flex;

--- a/apps/admin/src/client/stores/editing.ts
+++ b/apps/admin/src/client/stores/editing.ts
@@ -118,7 +118,7 @@ export const useEditingStore = defineStore('editing', () => {
 
       // Deep clone the components array and update the target component's content
       const updatedComponents = deepClone(detail.components ?? [])
-      const parts = namePath.split('/')
+      const parts = resolveComponentPath(namePath).split('/')
       let components = updatedComponents as Array<
         string | { name: string; template: string; content?: Record<string, unknown>; components?: unknown[] }
       >
@@ -147,13 +147,28 @@ export const useEditingStore = defineStore('editing', () => {
     }
   }
 
+  /**
+   * Resolve a tree path to a component-relative path. The component tree
+   * prefixes fragment children with `@{fragmentName}/` (e.g. `@header/logo`)
+   * for preview click-to-select, but the fragment's components list uses
+   * plain names (`logo`). Strip the prefix so lookups and saves navigate
+   * the correct tree.
+   */
+  function resolveComponentPath(namePath: string): string {
+    const sel = useSelectionStore()
+    if (sel.type === 'fragment' && sel.name && namePath.startsWith(`@${sel.name}/`)) {
+      return namePath.slice(`@${sel.name}/`.length)
+    }
+    return namePath
+  }
+
   /** Find an inline component by name path (e.g., "hero", "features/fast") in the selection detail */
   function findComponentByNamePath(namePath: string): { template: string; content: Record<string, unknown> } | null {
     const sel = useSelectionStore()
     const detail = sel.detail
     if (!detail?.components) return null
 
-    const parts = namePath.split('/')
+    const parts = resolveComponentPath(namePath).split('/')
     let components = detail.components as Array<
       string | { name: string; template: string; content?: Record<string, unknown>; components?: unknown[] }
     >

--- a/apps/admin/src/client/stores/editing.ts
+++ b/apps/admin/src/client/stores/editing.ts
@@ -40,6 +40,8 @@ export const useEditingStore = defineStore('editing', () => {
   const loadError = ref<string | null>(null)
   const mountVersion = ref(0)
   const customEditorMount = ref<EditorMount | null>(null)
+  /** Set when the user clicks a fragment or its child from page context */
+  const fragmentLink = ref<string | null>(null)
   let retryTimer: ReturnType<typeof setInterval> | null = null
   const pendingEdits = reactive<Map<string, StashedEdit>>(new Map())
 
@@ -86,9 +88,24 @@ export const useEditingStore = defineStore('editing', () => {
     return { schema, hasEditor: !!hasEditor, editorUrl, fieldsBaseUrl }
   }
 
+  /**
+   * Show a "go to fragment" link instead of the editor.
+   * Accepts a fragment name or a treePath like `@header/logo`.
+   */
+  function showFragmentLink(nameOrPath: string) {
+    stashCurrent()
+    clearRetry()
+    loadError.value = null
+    target.value = null
+    content.value = null
+    saved.value = null
+    fragmentLink.value = nameOrPath.startsWith('@') ? nameOrPath.split('/')[0].slice(1) : nameOrPath
+  }
+
   async function open(t: EditingTarget, editedContent?: Record<string, unknown>) {
     clearRetry()
     loadError.value = null
+    fragmentLink.value = null
     target.value = t
     content.value = editedContent ? deepClone(editedContent) : deepClone(t.content)
     saved.value = deepClone(t.content)
@@ -285,6 +302,7 @@ export const useEditingStore = defineStore('editing', () => {
   function clear() {
     clearRetry()
     loadError.value = null
+    fragmentLink.value = null
     target.value = null
     content.value = null
     saved.value = null
@@ -419,10 +437,12 @@ export const useEditingStore = defineStore('editing', () => {
     pendingCount,
     hasPendingEdits,
     allOverrides,
+    fragmentLink,
     open,
     openComponent,
     openPageRoot,
     openFragment,
+    showFragmentLink,
     clear,
     markDirty,
     discard,

--- a/apps/admin/tests/ComponentTree.test.ts
+++ b/apps/admin/tests/ComponentTree.test.ts
@@ -194,6 +194,136 @@ describe('ComponentTree', () => {
     expect(w.find('[data-testid="component-logo"]').exists()).toBe(true)
   })
 
+  it('clicking a fragment root in page context calls showFragmentLink', async () => {
+    const getFragment = vi.fn(
+      async (): Promise<FragmentDetail> => ({
+        name: 'header',
+        template: 'header-layout',
+        dir: 'fragments/header',
+        components: [{ name: 'logo', template: 'logo' }],
+      }),
+    )
+    setPageSelection({
+      name: 'home',
+      route: '/',
+      template: 'page-default',
+      dir: 'pages/home',
+      components: ['@header'],
+    })
+    const editing = useEditingStore()
+    const spy = vi.spyOn(editing, 'showFragmentLink')
+    const w = mountTree(fakeFragmentsApi({ getFragment }))
+    await flushMicrotasks()
+    await w.find('[data-testid="component-header"]').trigger('click')
+    expect(spy).toHaveBeenCalledWith('header')
+    expect(editing.fragmentLink).toBe('header')
+  })
+
+  it('clicking a fragment child in page context calls showFragmentLink with treePath', async () => {
+    const getFragment = vi.fn(
+      async (): Promise<FragmentDetail> => ({
+        name: 'header',
+        template: 'header-layout',
+        dir: 'fragments/header',
+        components: [{ name: 'logo', template: 'logo' }],
+      }),
+    )
+    setPageSelection({
+      name: 'home',
+      route: '/',
+      template: 'page-default',
+      dir: 'pages/home',
+      components: ['@header'],
+    })
+    const editing = useEditingStore()
+    const spy = vi.spyOn(editing, 'showFragmentLink')
+    const w = mountTree(fakeFragmentsApi({ getFragment }))
+    await flushMicrotasks()
+    await w.find('[data-testid="component-logo"]').trigger('click')
+    expect(spy).toHaveBeenCalledWith('@header/logo')
+    expect(editing.fragmentLink).toBe('header')
+  })
+
+  it('clicking a fragment root in fragment context calls openFragment', async () => {
+    const getFragment = vi.fn(
+      async (): Promise<FragmentDetail> => ({
+        name: 'nav',
+        template: 'nav',
+        dir: 'fragments/nav',
+        components: [],
+      }),
+    )
+    setFragmentSelection({
+      name: 'header',
+      template: 'header-layout',
+      dir: 'fragments/header',
+      components: ['@nav'],
+    })
+    const editing = useEditingStore()
+    const spy = vi.spyOn(editing, 'openFragment')
+    const w = mountTree(fakeFragmentsApi({ getFragment }))
+    await flushMicrotasks()
+    await w.find('[data-testid="component-nav"]').trigger('click')
+    expect(spy).toHaveBeenCalledWith('nav')
+  })
+
+  it('showFragmentLink stashes dirty edits before clearing', () => {
+    const editing = useEditingStore()
+    // Simulate a dirty editor state
+    editing.$patch({
+      target: { path: 'hero', template: 'hero', content: { title: 'old' }, save: async () => {} },
+      content: { title: 'changed' },
+      saved: { title: 'old' },
+    })
+    expect(editing.dirty).toBe(true)
+    editing.showFragmentLink('footer')
+    // Dirty edits should be stashed in pendingEdits
+    expect(editing.pendingEdits.has('hero')).toBe(true)
+    expect(editing.pendingEdits.get('hero')!.editedContent).toEqual({ title: 'changed' })
+    // Editor should be cleared
+    expect(editing.target).toBeNull()
+    expect(editing.fragmentLink).toBe('footer')
+  })
+
+  it('showFragmentLink extracts fragment name from treePath', () => {
+    const editing = useEditingStore()
+    editing.showFragmentLink('@header/logo')
+    expect(editing.fragmentLink).toBe('header')
+  })
+
+  it('clears selectedNodeKey when tree rebuilds for new selection', async () => {
+    const getFragment = vi.fn(
+      async (): Promise<FragmentDetail> => ({
+        name: 'header',
+        template: 'header-layout',
+        dir: 'fragments/header',
+        components: [{ name: 'logo', template: 'logo' }],
+      }),
+    )
+    setPageSelection({
+      name: 'home',
+      route: '/',
+      template: 'page-default',
+      dir: 'pages/home',
+      components: ['@header'],
+    })
+    const w = mountTree(fakeFragmentsApi({ getFragment }))
+    await flushMicrotasks()
+    // Click logo to select it
+    await w.find('[data-testid="component-logo"]').trigger('click')
+    expect(w.find('[data-testid="component-logo"].selected').exists()).toBe(true)
+    // Switch to fragment selection — tree rebuilds
+    setFragmentSelection({
+      name: 'header',
+      template: 'header-layout',
+      dir: 'fragments/header',
+      components: [{ name: 'logo', template: 'logo' }],
+    })
+    await flushMicrotasks()
+    // No node should be selected after rebuild
+    expect(w.find('.selected').exists()).toBe(false)
+  })
+
   it('reuses the FragmentsApi for nested fragment references', async () => {
     const getFragment = vi.fn(async (name: string): Promise<FragmentDetail> => {
       if (name === 'header') {

--- a/examples/starter/sites/main/site.yaml
+++ b/examples/starter/sites/main/site.yaml
@@ -1,5 +1,6 @@
 name: "Gazetta Starter"
 version: "1.0.0"
+locale: en
 systemPages:
   - "404"
 targets:

--- a/examples/starter/sites/main/targets/local/pages/404/page.json
+++ b/examples/starter/sites/main/targets/local/pages/404/page.json
@@ -1,6 +1,6 @@
 {
   "template": "page-default",
-  "content": {
+  "metadata": {
     "title": "Page Not Found"
   },
   "components": [

--- a/examples/starter/sites/main/targets/local/pages/about/page.json
+++ b/examples/starter/sites/main/targets/local/pages/about/page.json
@@ -1,9 +1,5 @@
 {
   "template": "page-default",
-  "content": {
-    "title": "About",
-    "description": "About Gazetta"
-  },
   "metadata": {
     "title": "About — Gazetta",
     "description": "Learn about Gazetta, the stateless CMS built on composable fragments."

--- a/examples/starter/sites/main/targets/local/pages/blog/[slug]/page.json
+++ b/examples/starter/sites/main/targets/local/pages/blog/[slug]/page.json
@@ -1,6 +1,6 @@
 {
   "template": "page-default",
-  "content": {
+  "metadata": {
     "title": "Blog Post"
   },
   "components": [

--- a/examples/starter/sites/main/targets/local/pages/home/page.json
+++ b/examples/starter/sites/main/targets/local/pages/home/page.json
@@ -1,9 +1,5 @@
 {
   "template": "page-default",
-  "content": {
-    "title": "Home",
-    "description": "Welcome to Gazetta"
-  },
   "metadata": {
     "title": "Gazetta — Composable CMS",
     "description": "A stateless CMS that structures websites as composable fragments. All state lives in targets."

--- a/examples/starter/sites/main/targets/local/pages/showcase/page.json
+++ b/examples/starter/sites/main/targets/local/pages/showcase/page.json
@@ -1,6 +1,6 @@
 {
   "template": "page-default",
-  "content": {
+  "metadata": {
     "title": "Editor Showcase",
     "description": "Demonstrates all editor input types"
   },

--- a/examples/starter/sites/main/targets/local/site.yaml
+++ b/examples/starter/sites/main/targets/local/site.yaml
@@ -1,4 +1,5 @@
 name: "Gazetta Starter"
 version: "1.0.0"
+locale: en
 systemPages:
   - "404"

--- a/examples/starter/templates/page-default/index.ts
+++ b/examples/starter/templates/page-default/index.ts
@@ -1,14 +1,17 @@
 import { z } from 'zod'
 import type { TemplateFunction } from 'gazetta'
 
-export const schema = z.object({
-  title: z.string().describe('Page title'),
-  description: z.string().optional().describe('Page description'),
-})
+// Layout template — renders children in a <main> wrapper with a CSS
+// reset. Has no content of its own (no visible fields for the editor).
+//
+// SEO tags (<title>, <meta description>, OG, canonical) are handled
+// by the renderer's fallback chain from page.metadata / content of
+// child components. Templates should NOT emit SEO tags — the renderer
+// deduplicates, but the clean pattern is to let the renderer own <head>
+// SEO and let templates own visible HTML + non-SEO head (fonts, icons).
+export const schema = z.object({})
 
-type Content = z.infer<typeof schema>
-
-const template: TemplateFunction<Content> = ({ content, children = [] }) => ({
+const template: TemplateFunction = ({ children = [] }) => ({
   html: `<main>${children.map(c => c.html).join('\n')}</main>`,
   css: `*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 body { font-family: system-ui, -apple-system, sans-serif; color: #1a1a1a; line-height: 1.6; }
@@ -18,9 +21,7 @@ ${children.map(c => c.css).join('\n')}`,
     .map(c => c.js)
     .filter(Boolean)
     .join('\n'),
-  head: `<title>${content?.title ?? ''}</title>
-${content?.description ? `<meta name="description" content="${content.description}">` : ''}
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>">
+  head: `<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>">
 ${children
   .map(c => c.head)
   .filter(Boolean)

--- a/packages/gazetta/src/admin-api/routes/preview.ts
+++ b/packages/gazetta/src/admin-api/routes/preview.ts
@@ -78,7 +78,15 @@ async function renderPreview(
       try {
         const resolved = await resolvePage(pageName, site)
         if (overrides) applyOverrides(resolved, overrides)
-        return c.html(await renderPage(resolved, { routeParams: params, metadata: page.metadata }))
+        const { seoContextFromManifest } = await import('../../renderer.js')
+        return c.html(
+          await renderPage(resolved, {
+            routeParams: params,
+            metadata: page.metadata,
+            route: page.route,
+            seo: seoContextFromManifest(site.manifest),
+          }),
+        )
       } catch (err) {
         const e = err as Error
         const msg = e.message.replace(/</g, '&lt;').replace(/>/g, '&gt;')

--- a/packages/gazetta/src/admin-api/routes/preview.ts
+++ b/packages/gazetta/src/admin-api/routes/preview.ts
@@ -78,13 +78,16 @@ async function renderPreview(
       try {
         const resolved = await resolvePage(pageName, site)
         if (overrides) applyOverrides(resolved, overrides)
-        const { seoContextFromManifest } = await import('../../renderer.js')
         return c.html(
           await renderPage(resolved, {
             routeParams: params,
             metadata: page.metadata,
             route: page.route,
-            seo: seoContextFromManifest(site.manifest),
+            seo: {
+              siteName: site.manifest.name,
+              locale: site.manifest.locale,
+              defaultOgImage: site.manifest.defaultOgImage,
+            },
           }),
         )
       } catch (err) {

--- a/packages/gazetta/src/admin-api/routes/publish.ts
+++ b/packages/gazetta/src/admin-api/routes/publish.ts
@@ -353,6 +353,32 @@ export function publishRoutes(
         current++
         yield { kind: 'progress', target: targetName, current, total, label: 'site manifest' }
 
+        // 3b. Sitemap + robots.txt
+        const baseUrl = site.manifest.baseUrl ?? config?.siteUrl
+        if (baseUrl) {
+          const { listSidecars } = await import('../../sidecars.js')
+          const { generateSitemap } = await import('../../sitemap.js')
+          const { generateRobotsTxt } = await import('../../robots.js')
+          const targetPageSidecars = await listSidecars(targetStorage, 'pages')
+          const sitemapXml = generateSitemap({
+            baseUrl,
+            pages: targetPageSidecars,
+            systemPages: site.manifest.systemPages,
+          })
+          if (sitemapXml) {
+            await targetStorage.writeFile('sitemap.xml', sitemapXml)
+            totalFiles++
+          }
+          let robotsTxt: string
+          try {
+            robotsTxt = await source.contentRoot.storage.readFile(source.contentRoot.path('robots.txt'))
+          } catch {
+            robotsTxt = generateRobotsTxt({ baseUrl })
+          }
+          await targetStorage.writeFile('robots.txt', robotsTxt)
+          totalFiles++
+        }
+
         // 4. Purge CDN cache
         if (purgeConfig?.type === 'cloudflare') {
           const apiToken = resolveEnvVars(purgeConfig.apiToken)

--- a/packages/gazetta/src/admin-api/routes/publish.ts
+++ b/packages/gazetta/src/admin-api/routes/publish.ts
@@ -326,6 +326,7 @@ export function publishRoutes(
               tdir,
               manifestHash,
               site,
+              seo,
             )
             return { files }
           }

--- a/packages/gazetta/src/admin-api/routes/publish.ts
+++ b/packages/gazetta/src/admin-api/routes/publish.ts
@@ -354,7 +354,7 @@ export function publishRoutes(
         yield { kind: 'progress', target: targetName, current, total, label: 'site manifest' }
 
         // 3b. Sitemap + robots.txt
-        const baseUrl = config?.siteUrl ?? site.manifest.baseUrl
+        const baseUrl = config?.siteUrl
         if (baseUrl) {
           const { listSidecars } = await import('../../sidecars.js')
           const { generateSitemap } = await import('../../sitemap.js')

--- a/packages/gazetta/src/admin-api/routes/publish.ts
+++ b/packages/gazetta/src/admin-api/routes/publish.ts
@@ -362,14 +362,14 @@ export function publishRoutes(
         yield { kind: 'progress', target: targetName, current, total, label: 'site manifest' }
 
         // 3b. Sitemap + robots.txt
-        const baseUrl = config?.siteUrl
-        if (baseUrl) {
+        const siteUrl = config?.siteUrl
+        if (siteUrl) {
           const { listSidecars } = await import('../../sidecars.js')
           const { generateSitemap } = await import('../../sitemap.js')
           const { generateRobotsTxt } = await import('../../robots.js')
           const targetPageSidecars = await listSidecars(targetStorage, 'pages')
           const sitemapXml = generateSitemap({
-            baseUrl,
+            siteUrl,
             pages: targetPageSidecars,
             systemPages: site.manifest.systemPages,
           })
@@ -378,13 +378,13 @@ export function publishRoutes(
             totalFiles++
           }
           // robots.txt only at domain root — Google ignores it at subpaths.
-          const isRootDeploy = !new URL(baseUrl).pathname.replace(/\/+$/, '')
+          const isRootDeploy = !new URL(siteUrl).pathname.replace(/\/+$/, '')
           if (isRootDeploy) {
             let robotsTxt: string
             try {
               robotsTxt = await source.contentRoot.storage.readFile(source.contentRoot.path('robots.txt'))
             } catch {
-              robotsTxt = generateRobotsTxt({ baseUrl })
+              robotsTxt = generateRobotsTxt({ siteUrl })
             }
             await targetStorage.writeFile('robots.txt', robotsTxt)
             totalFiles++

--- a/packages/gazetta/src/admin-api/routes/publish.ts
+++ b/packages/gazetta/src/admin-api/routes/publish.ts
@@ -308,7 +308,15 @@ export function publishRoutes(
             const page = site.pages.get(pageName)
             const manifestHash = page ? hashManifest(page, pageHashOpts) : undefined
             if (isStatic) {
-              return publishPageStatic(pageName, source.contentRoot, targetStorage, tdir, manifestHash, site)
+              return publishPageStatic(
+                pageName,
+                source.contentRoot,
+                targetStorage,
+                tdir,
+                manifestHash,
+                site,
+                config?.siteUrl,
+              )
             }
             const { files } = await publishPageRendered(
               pageName,

--- a/packages/gazetta/src/admin-api/routes/publish.ts
+++ b/packages/gazetta/src/admin-api/routes/publish.ts
@@ -377,14 +377,18 @@ export function publishRoutes(
             await targetStorage.writeFile('sitemap.xml', sitemapXml)
             totalFiles++
           }
-          let robotsTxt: string
-          try {
-            robotsTxt = await source.contentRoot.storage.readFile(source.contentRoot.path('robots.txt'))
-          } catch {
-            robotsTxt = generateRobotsTxt({ baseUrl })
+          // robots.txt only at domain root — Google ignores it at subpaths.
+          const isRootDeploy = !new URL(baseUrl).pathname.replace(/\/+$/, '')
+          if (isRootDeploy) {
+            let robotsTxt: string
+            try {
+              robotsTxt = await source.contentRoot.storage.readFile(source.contentRoot.path('robots.txt'))
+            } catch {
+              robotsTxt = generateRobotsTxt({ baseUrl })
+            }
+            await targetStorage.writeFile('robots.txt', robotsTxt)
+            totalFiles++
           }
-          await targetStorage.writeFile('robots.txt', robotsTxt)
-          totalFiles++
         }
 
         // 4. Purge CDN cache

--- a/packages/gazetta/src/admin-api/routes/publish.ts
+++ b/packages/gazetta/src/admin-api/routes/publish.ts
@@ -354,7 +354,7 @@ export function publishRoutes(
         yield { kind: 'progress', target: targetName, current, total, label: 'site manifest' }
 
         // 3b. Sitemap + robots.txt
-        const baseUrl = site.manifest.baseUrl ?? config?.siteUrl
+        const baseUrl = config?.siteUrl ?? site.manifest.baseUrl
         if (baseUrl) {
           const { listSidecars } = await import('../../sidecars.js')
           const { generateSitemap } = await import('../../sitemap.js')

--- a/packages/gazetta/src/admin-api/routes/publish.ts
+++ b/packages/gazetta/src/admin-api/routes/publish.ts
@@ -302,21 +302,21 @@ export function publishRoutes(
         }
         const pageHashOpts = isStatic ? { templateHashes, fragmentHashes } : { templateHashes }
 
+        // SEO context for this target — built once, shared across all page renders.
+        const seo = {
+          siteName: site.manifest.name,
+          siteUrl: config?.siteUrl,
+          locale: site.manifest.locale,
+          defaultOgImage: site.manifest.defaultOgImage,
+        }
+
         const renderItem = async (item: string): Promise<{ files: number }> => {
           if (item.startsWith('pages/')) {
             const pageName = item.replace('pages/', '')
             const page = site.pages.get(pageName)
             const manifestHash = page ? hashManifest(page, pageHashOpts) : undefined
             if (isStatic) {
-              return publishPageStatic(
-                pageName,
-                source.contentRoot,
-                targetStorage,
-                tdir,
-                manifestHash,
-                site,
-                config?.siteUrl,
-              )
+              return publishPageStatic(pageName, source.contentRoot, targetStorage, tdir, manifestHash, site, seo)
             }
             const { files } = await publishPageRendered(
               pageName,

--- a/packages/gazetta/src/admin-api/schemas/pages.ts
+++ b/packages/gazetta/src/admin-api/schemas/pages.ts
@@ -21,6 +21,7 @@ export const PageMetadataSchema = z
     description: z.string().optional(),
     ogImage: z.string().optional(),
     canonical: z.string().optional(),
+    robots: z.string().optional(),
   })
   .optional()
 export type PageMetadata = z.infer<typeof PageMetadataSchema>

--- a/packages/gazetta/src/admin-api/schemas/site.ts
+++ b/packages/gazetta/src/admin-api/schemas/site.ts
@@ -12,7 +12,6 @@ export const SiteManifestSchema = z
     name: z.string(),
     version: z.string().optional(),
     locale: z.string().optional(),
-    baseUrl: z.string().optional(),
     systemPages: z.array(z.string()).optional(),
   })
   .loose()

--- a/packages/gazetta/src/cli/index.ts
+++ b/packages/gazetta/src/cli/index.ts
@@ -608,7 +608,15 @@ async function runPublish(siteDir: string, targetName?: string, opts: { force?: 
           continue
         }
         const manifestHash = hashManifest(page, { templateHashes, fragmentHashes })
-        const { files } = await publishPageStatic(pageName, sourceRoot, targetStorage, templatesDir, manifestHash, site)
+        const { files } = await publishPageStatic(
+          pageName,
+          sourceRoot,
+          targetStorage,
+          templatesDir,
+          manifestHash,
+          site,
+          targetConfig?.siteUrl,
+        )
         totalFiles += files
         console.log(`    ${c.green('✓')} ${pageName}`)
       }

--- a/packages/gazetta/src/cli/index.ts
+++ b/packages/gazetta/src/cli/index.ts
@@ -694,16 +694,21 @@ async function runPublish(siteDir: string, targetName?: string, opts: { force?: 
         console.log(`    ${c.dim('· sitemap.xml')}`)
       }
 
-      // robots.txt: user file wins, else generate default
-      let robotsTxt: string
-      try {
-        robotsTxt = await source.contentRoot.storage.readFile(source.contentRoot.path('robots.txt'))
-      } catch {
-        robotsTxt = generateRobotsTxt({ baseUrl })
+      // robots.txt: only at the domain root — Google ignores robots.txt at
+      // subpaths. If siteUrl has a path component, the domain root belongs
+      // to someone else (host, reverse proxy, another app).
+      const isRootDeploy = !new URL(baseUrl).pathname.replace(/\/+$/, '')
+      if (isRootDeploy) {
+        let robotsTxt: string
+        try {
+          robotsTxt = await source.contentRoot.storage.readFile(source.contentRoot.path('robots.txt'))
+        } catch {
+          robotsTxt = generateRobotsTxt({ baseUrl })
+        }
+        await targetStorage.writeFile('robots.txt', robotsTxt)
+        totalFiles++
+        console.log(`    ${c.dim('· robots.txt')}`)
       }
-      await targetStorage.writeFile('robots.txt', robotsTxt)
-      totalFiles++
-      console.log(`    ${c.dim('· robots.txt')}`)
     }
 
     const removedMsg = totalRemoved > 0 ? c.dim(` (${totalRemoved} old files cleaned)`) : ''

--- a/packages/gazetta/src/cli/index.ts
+++ b/packages/gazetta/src/cli/index.ts
@@ -660,7 +660,7 @@ async function runPublish(siteDir: string, targetName?: string, opts: { force?: 
     totalFiles += 2
 
     // Sitemap + robots.txt — generated from target sidecars
-    const baseUrl = site.manifest.baseUrl ?? targetConfig?.siteUrl
+    const baseUrl = targetConfig?.siteUrl ?? site.manifest.baseUrl
     if (baseUrl) {
       const { listSidecars } = await import('../sidecars.js')
       const { generateSitemap } = await import('../sitemap.js')

--- a/packages/gazetta/src/cli/index.ts
+++ b/packages/gazetta/src/cli/index.ts
@@ -660,7 +660,7 @@ async function runPublish(siteDir: string, targetName?: string, opts: { force?: 
     totalFiles += 2
 
     // Sitemap + robots.txt — generated from target sidecars
-    const baseUrl = targetConfig?.siteUrl ?? site.manifest.baseUrl
+    const baseUrl = targetConfig?.siteUrl
     if (baseUrl) {
       const { listSidecars } = await import('../sidecars.js')
       const { generateSitemap } = await import('../sitemap.js')

--- a/packages/gazetta/src/cli/index.ts
+++ b/packages/gazetta/src/cli/index.ts
@@ -1310,8 +1310,18 @@ async function runDev(siteDir: string, port: number) {
     app.get(page.route, async c => {
       try {
         const freshSite = await loadSite({ contentRoot: source.contentRoot, templatesDir, manifest })
+        const freshPage = freshSite.pages.get(pageName)
         const resolved = await resolvePage(pageName, freshSite)
-        const html = await renderPage(resolved, c.req.param())
+        const html = await renderPage(resolved, {
+          routeParams: c.req.param(),
+          metadata: freshPage?.metadata,
+          route: freshPage?.route,
+          seo: {
+            siteName: freshSite.manifest.name,
+            locale: freshSite.manifest.locale,
+            defaultOgImage: freshSite.manifest.defaultOgImage,
+          },
+        })
         return c.html(html.replace('</body>', `${RELOAD_SCRIPT}\n</body>`))
       } catch (err) {
         return c.html(renderErrorOverlay(err as Error), 500)

--- a/packages/gazetta/src/cli/index.ts
+++ b/packages/gazetta/src/cli/index.ts
@@ -659,6 +659,37 @@ async function runPublish(siteDir: string, targetName?: string, opts: { force?: 
     await publishFragmentIndex(sourceRoot, targetStorage, site)
     totalFiles += 2
 
+    // Sitemap + robots.txt — generated from target sidecars
+    const baseUrl = site.manifest.baseUrl ?? targetConfig?.siteUrl
+    if (baseUrl) {
+      const { listSidecars } = await import('../sidecars.js')
+      const { generateSitemap } = await import('../sitemap.js')
+      const { generateRobotsTxt } = await import('../robots.js')
+
+      const targetPageSidecars = await listSidecars(targetStorage, 'pages')
+      const sitemapXml = generateSitemap({
+        baseUrl,
+        pages: targetPageSidecars,
+        systemPages: site.manifest.systemPages,
+      })
+      if (sitemapXml) {
+        await targetStorage.writeFile('sitemap.xml', sitemapXml)
+        totalFiles++
+        console.log(`    ${c.dim('· sitemap.xml')}`)
+      }
+
+      // robots.txt: user file wins, else generate default
+      let robotsTxt: string
+      try {
+        robotsTxt = await source.contentRoot.storage.readFile(source.contentRoot.path('robots.txt'))
+      } catch {
+        robotsTxt = generateRobotsTxt({ baseUrl })
+      }
+      await targetStorage.writeFile('robots.txt', robotsTxt)
+      totalFiles++
+      console.log(`    ${c.dim('· robots.txt')}`)
+    }
+
     const removedMsg = totalRemoved > 0 ? c.dim(` (${totalRemoved} old files cleaned)`) : ''
     console.log(`\n  ${c.green('✓')} ${c.bold(name)}: ${totalFiles} files published${removedMsg}\n`)
   }

--- a/packages/gazetta/src/cli/index.ts
+++ b/packages/gazetta/src/cli/index.ts
@@ -662,6 +662,7 @@ async function runPublish(siteDir: string, targetName?: string, opts: { force?: 
           templatesDir,
           manifestHash,
           site,
+          seo,
         )
         totalFiles += files
         totalRemoved += removed

--- a/packages/gazetta/src/cli/index.ts
+++ b/packages/gazetta/src/cli/index.ts
@@ -593,6 +593,14 @@ async function runPublish(siteDir: string, targetName?: string, opts: { force?: 
     let skipped = 0
     const sourceRoot = source.contentRoot
 
+    // SEO context for this target — built once, shared across all page renders.
+    const seo = {
+      siteName: site.manifest.name,
+      siteUrl: targetConfig?.siteUrl,
+      locale: site.manifest.locale,
+      defaultOgImage: site.manifest.defaultOgImage,
+    }
+
     if (isStatic) {
       // Static mode — fully assembled HTML, no fragments needed separately.
       // Page hash must include fragment hashes so a fragment change
@@ -615,7 +623,7 @@ async function runPublish(siteDir: string, targetName?: string, opts: { force?: 
           templatesDir,
           manifestHash,
           site,
-          targetConfig?.siteUrl,
+          seo,
         )
         totalFiles += files
         console.log(`    ${c.green('✓')} ${pageName}`)

--- a/packages/gazetta/src/cli/index.ts
+++ b/packages/gazetta/src/cli/index.ts
@@ -676,15 +676,15 @@ async function runPublish(siteDir: string, targetName?: string, opts: { force?: 
     totalFiles += 2
 
     // Sitemap + robots.txt — generated from target sidecars
-    const baseUrl = targetConfig?.siteUrl
-    if (baseUrl) {
+    const siteUrl = targetConfig?.siteUrl
+    if (siteUrl) {
       const { listSidecars } = await import('../sidecars.js')
       const { generateSitemap } = await import('../sitemap.js')
       const { generateRobotsTxt } = await import('../robots.js')
 
       const targetPageSidecars = await listSidecars(targetStorage, 'pages')
       const sitemapXml = generateSitemap({
-        baseUrl,
+        siteUrl,
         pages: targetPageSidecars,
         systemPages: site.manifest.systemPages,
       })
@@ -697,13 +697,13 @@ async function runPublish(siteDir: string, targetName?: string, opts: { force?: 
       // robots.txt: only at the domain root — Google ignores robots.txt at
       // subpaths. If siteUrl has a path component, the domain root belongs
       // to someone else (host, reverse proxy, another app).
-      const isRootDeploy = !new URL(baseUrl).pathname.replace(/\/+$/, '')
+      const isRootDeploy = !new URL(siteUrl).pathname.replace(/\/+$/, '')
       if (isRootDeploy) {
         let robotsTxt: string
         try {
           robotsTxt = await source.contentRoot.storage.readFile(source.contentRoot.path('robots.txt'))
         } catch {
-          robotsTxt = generateRobotsTxt({ baseUrl })
+          robotsTxt = generateRobotsTxt({ siteUrl })
         }
         await targetStorage.writeFile('robots.txt', robotsTxt)
         totalFiles++

--- a/packages/gazetta/src/hash.ts
+++ b/packages/gazetta/src/hash.ts
@@ -4,6 +4,7 @@ import type { ComponentEntry, FragmentManifest, PageManifest } from './types.js'
 const SIDECAR_RE = /^\.([0-9a-f]{8})\.hash$/
 const USES_SIDECAR_RE = /^\.uses-(.+)$/
 const TPL_SIDECAR_RE = /^\.tpl-(.+)$/
+const PUB_SIDECAR_RE = /^\.pub-(\d{8}T\d{6}Z)(-noindex)?$/
 
 export function sidecarNameFor(hash: string): string {
   return `.${hash}.hash`
@@ -62,6 +63,39 @@ export function templateSidecarNameFor(templateName: string): string {
 export function parseTemplateSidecarName(entryName: string): string | null {
   const m = TPL_SIDECAR_RE.exec(entryName)
   return m ? decodeRefName(m[1]) : null
+}
+
+/** Compact ISO timestamp for `.pub-` sidecar filenames: `20260417T220000Z`. */
+export function compactTimestamp(date: Date = new Date()): string {
+  return date
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}/, '')
+}
+
+/** Parse compact timestamp back to ISO string: `2026-04-17T22:00:00Z`. */
+export function parseCompactTimestamp(compact: string): string {
+  // 20260417T220000Z → 2026-04-17T22:00:00Z
+  return `${compact.slice(0, 4)}-${compact.slice(4, 6)}-${compact.slice(6, 8)}T${compact.slice(9, 11)}:${compact.slice(11, 13)}:${compact.slice(13, 15)}Z`
+}
+
+export interface PubSidecar {
+  lastPublished: string // ISO timestamp
+  noindex: boolean
+}
+
+/** `.pub-20260417T220000Z` or `.pub-20260417T220000Z-noindex` */
+export function pubSidecarNameFor(date: Date = new Date(), noindex = false): string {
+  return `.pub-${compactTimestamp(date)}${noindex ? '-noindex' : ''}`
+}
+
+export function parsePubSidecarName(entryName: string): PubSidecar | null {
+  const m = PUB_SIDECAR_RE.exec(entryName)
+  if (!m) return null
+  return {
+    lastPublished: parseCompactTimestamp(m[1]),
+    noindex: !!m[2],
+  }
 }
 
 /**

--- a/packages/gazetta/src/index.ts
+++ b/packages/gazetta/src/index.ts
@@ -65,7 +65,6 @@ export {
   renderComponent,
   renderFragment,
   renderPage,
-  seoContextFromManifest,
   type RenderPageOptions,
   type SeoContext,
 } from './renderer.js'

--- a/packages/gazetta/src/index.ts
+++ b/packages/gazetta/src/index.ts
@@ -61,7 +61,14 @@ export {
 export type { HistoryConfig, PageMetadata } from './types.js'
 
 // Renderer
-export { renderComponent, renderFragment, renderPage, type RenderPageOptions } from './renderer.js'
+export {
+  renderComponent,
+  renderFragment,
+  renderPage,
+  seoContextFromManifest,
+  type RenderPageOptions,
+  type SeoContext,
+} from './renderer.js'
 export { resolveComponent, resolveFragment, resolvePage } from './resolver.js'
 export { loadSite } from './site-loader.js'
 export type { Site, LoadSiteOptions } from './site-loader.js'

--- a/packages/gazetta/src/index.ts
+++ b/packages/gazetta/src/index.ts
@@ -69,6 +69,7 @@ export {
   type RenderPageOptions,
   type SeoContext,
 } from './renderer.js'
+export { resolveSeoTags, type ResolveSeoTagsInput } from './seo.js'
 export { resolveComponent, resolveFragment, resolvePage } from './resolver.js'
 export { loadSite } from './site-loader.js'
 export type { Site, LoadSiteOptions } from './site-loader.js'

--- a/packages/gazetta/src/manifest.ts
+++ b/packages/gazetta/src/manifest.ts
@@ -57,7 +57,6 @@ export async function parseSiteManifest(storage: StorageProvider, filePath: stri
     name: raw.name,
     version: raw.version as string | undefined,
     locale: raw.locale as string | undefined,
-    baseUrl: raw.baseUrl as string | undefined,
     defaultOgImage: raw.defaultOgImage as string | undefined,
     systemPages: Array.isArray(raw.systemPages) ? (raw.systemPages as string[]) : undefined,
   }

--- a/packages/gazetta/src/manifest.ts
+++ b/packages/gazetta/src/manifest.ts
@@ -58,6 +58,7 @@ export async function parseSiteManifest(storage: StorageProvider, filePath: stri
     version: raw.version as string | undefined,
     locale: raw.locale as string | undefined,
     baseUrl: raw.baseUrl as string | undefined,
+    defaultOgImage: raw.defaultOgImage as string | undefined,
     systemPages: Array.isArray(raw.systemPages) ? (raw.systemPages as string[]) : undefined,
   }
 }

--- a/packages/gazetta/src/publish-rendered.ts
+++ b/packages/gazetta/src/publish-rendered.ts
@@ -166,6 +166,10 @@ ${bodyContent}
       hash: manifestHash,
       uses: collectFragmentRefs(page.components),
       template: page.template,
+      pub: {
+        lastPublished: new Date().toISOString(),
+        noindex: !!page.metadata?.robots?.includes('noindex'),
+      },
     })
   }
 
@@ -216,6 +220,10 @@ export async function publishPageStatic(
       hash: manifestHash,
       uses: collectFragmentRefs(page.components),
       template: page.template,
+      pub: {
+        lastPublished: new Date().toISOString(),
+        noindex: !!page.metadata?.robots?.includes('noindex'),
+      },
     })
   }
 
@@ -290,6 +298,7 @@ export async function publishFragmentRendered(
       hash: manifestHash,
       uses: collectFragmentRefs(fragment.components),
       template: fragment.template,
+      pub: null,
     })
   }
 

--- a/packages/gazetta/src/publish-rendered.ts
+++ b/packages/gazetta/src/publish-rendered.ts
@@ -191,8 +191,8 @@ export async function publishPageStatic(
   templatesDir?: string,
   manifestHash?: string,
   preloadedSite?: Site,
-  /** Target's public URL — used for canonical/og:url in the rendered HTML. */
-  siteUrl?: string,
+  /** SEO context for the fallback chain — caller builds from manifest + target config. */
+  seo?: import('./seo.js').SeoContext,
 ): Promise<{ files: number }> {
   const site = preloadedSite ?? (await loadSite({ contentRoot: sourceRoot, templatesDir }))
   const page = site.pages.get(pageName)
@@ -200,11 +200,10 @@ export async function publishPageStatic(
 
   // Scope IDs are now deterministic (hash-based), no reset needed
   const resolved = await resolvePage(pageName, site)
-  const { seoContextFromManifest } = await import('./renderer.js')
   const html = await renderPage(resolved, {
     metadata: page.metadata,
     route: page.route,
-    seo: seoContextFromManifest(site.manifest, siteUrl),
+    seo,
   })
 
   // URL path: / → index.html, /about → about/index.html

--- a/packages/gazetta/src/publish-rendered.ts
+++ b/packages/gazetta/src/publish-rendered.ts
@@ -53,6 +53,8 @@ export async function publishPageRendered(
   templatesDir?: string,
   manifestHash?: string,
   preloadedSite?: Site,
+  /** SEO context for the fallback chain — caller builds from manifest + target config. */
+  seo?: import('./seo.js').SeoContext,
 ): Promise<{ files: number; removed: number }> {
   // Reuse a preloaded site when the caller already has one (runPublish loops
   // over N items; loading per-item was quadratic). loadSite is idempotent.
@@ -128,9 +130,23 @@ export async function publishPageRendered(
     fileCount++
   }
 
+  // SEO tags from the fallback chain — same logic as renderPage uses for
+  // static publish. Template head parts are checked for duplicates so the
+  // renderer doesn't double-emit tags the template already provides.
+  const { resolveSeoTags, escapeAttr } = await import('./seo.js')
+  const templateHead = localHeadParts.join('\n')
+  const seoHead = resolveSeoTags({
+    metadata: page.metadata,
+    content: page.content,
+    route: page.route,
+    seo: seo ?? {},
+    templateHead,
+  })
+
   const headContent = [
     `<meta charset="UTF-8">`,
     `<meta name="viewport" content="width=device-width, initial-scale=1.0">`,
+    seoHead,
     ...localHeadParts,
     pageCssLink,
     ...esiHeadTags,
@@ -140,6 +156,7 @@ export async function publishPageRendered(
     .join('\n  ')
 
   const bodyContent = bodyParts.join('\n')
+  const lang = seo?.locale || 'en'
 
   // Resolve cache config: page → target → defaults
   const browser = page.cache?.browser ?? targetCache?.browser ?? 0
@@ -147,7 +164,7 @@ export async function publishPageRendered(
   const cacheComment = `<!--cache:browser=${browser},edge=${edge}-->\n`
 
   const html = `${cacheComment}<!DOCTYPE html>
-<html lang="en">
+<html lang="${escapeAttr(lang)}">
 <head>
   ${headContent}
 </head>

--- a/packages/gazetta/src/publish-rendered.ts
+++ b/packages/gazetta/src/publish-rendered.ts
@@ -191,6 +191,8 @@ export async function publishPageStatic(
   templatesDir?: string,
   manifestHash?: string,
   preloadedSite?: Site,
+  /** Target's public URL — used for canonical/og:url in the rendered HTML. */
+  siteUrl?: string,
 ): Promise<{ files: number }> {
   const site = preloadedSite ?? (await loadSite({ contentRoot: sourceRoot, templatesDir }))
   const page = site.pages.get(pageName)
@@ -202,7 +204,7 @@ export async function publishPageStatic(
   const html = await renderPage(resolved, {
     metadata: page.metadata,
     route: page.route,
-    seo: seoContextFromManifest(site.manifest),
+    seo: seoContextFromManifest(site.manifest, siteUrl),
   })
 
   // URL path: / → index.html, /about → about/index.html

--- a/packages/gazetta/src/publish-rendered.ts
+++ b/packages/gazetta/src/publish-rendered.ts
@@ -194,7 +194,12 @@ export async function publishPageStatic(
 
   // Scope IDs are now deterministic (hash-based), no reset needed
   const resolved = await resolvePage(pageName, site)
-  const html = await renderPage(resolved, { metadata: page.metadata })
+  const { seoContextFromManifest } = await import('./renderer.js')
+  const html = await renderPage(resolved, {
+    metadata: page.metadata,
+    route: page.route,
+    seo: seoContextFromManifest(site.manifest),
+  })
 
   // URL path: / → index.html, /about → about/index.html
   const urlPath = page.route === '/' ? '' : page.route.replace(/^\//, '')

--- a/packages/gazetta/src/publish-rendered.ts
+++ b/packages/gazetta/src/publish-rendered.ts
@@ -6,6 +6,7 @@ import { resolvePage, resolveComponent } from './resolver.js'
 import { renderComponent, renderPage } from './renderer.js'
 import { writeSidecars, collectFragmentRefs } from './sidecars.js'
 import { createContentRoot, type ContentRoot } from './content-root.js'
+import { resolveSeoTags, escapeAttr } from './seo.js'
 
 function contentHash(content: string): string {
   return createHash('md5').update(content).digest('hex').slice(0, 8)
@@ -133,7 +134,6 @@ export async function publishPageRendered(
   // SEO tags from the fallback chain — same logic as renderPage uses for
   // static publish. Template head parts are checked for duplicates so the
   // renderer doesn't double-emit tags the template already provides.
-  const { resolveSeoTags, escapeAttr } = await import('./seo.js')
   const templateHead = localHeadParts.join('\n')
   const seoHead = resolveSeoTags({
     metadata: page.metadata,

--- a/packages/gazetta/src/renderer.ts
+++ b/packages/gazetta/src/renderer.ts
@@ -2,8 +2,7 @@ import type { RenderOutput, ResolvedComponent, PageMetadata } from './types.js'
 import { hashPath, scopeHtml, scopeCss } from './scope.js'
 import { resolveSeoTags, escapeAttr, type SeoContext } from './seo.js'
 
-// Re-export so existing consumers don't break
-export { type SeoContext, seoContextFromManifest } from './seo.js'
+export { type SeoContext } from './seo.js'
 
 export async function renderComponent(
   component: ResolvedComponent,

--- a/packages/gazetta/src/renderer.ts
+++ b/packages/gazetta/src/renderer.ts
@@ -1,106 +1,9 @@
-import type { RenderOutput, ResolvedComponent, PageMetadata, SiteManifest } from './types.js'
+import type { RenderOutput, ResolvedComponent, PageMetadata } from './types.js'
 import { hashPath, scopeHtml, scopeCss } from './scope.js'
+import { resolveSeoTags, escapeAttr, type SeoContext } from './seo.js'
 
-function escapeAttr(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;')
-}
-
-/** Context for the fallback chain — site-level defaults that pages inherit. */
-export interface SeoContext {
-  /** Site name — appended to auto-generated titles ("Page — Site Name"). */
-  siteName?: string
-  /** Base URL for canonical/og:url generation (e.g. "https://gazetta.studio"). */
-  baseUrl?: string
-  /** Site locale for `<html lang>` (e.g. "en", "fr"). Default: "en". */
-  locale?: string
-  /** Default OG image for pages that don't specify their own. */
-  defaultOgImage?: string
-}
-
-/** Build SeoContext from a SiteManifest. */
-export function seoContextFromManifest(manifest: SiteManifest | undefined): SeoContext {
-  return {
-    siteName: manifest?.name,
-    baseUrl: manifest?.baseUrl,
-    locale: manifest?.locale,
-    defaultOgImage: manifest?.defaultOgImage,
-  }
-}
-
-/**
- * Resolve all SEO tags for a page using the fallback chain:
- *   metadata field → content field → site default → omit
- *
- * Returns raw HTML for injection into <head>. Template-provided head
- * tags are checked for duplicates — metadata tags are only emitted
- * when the template doesn't already include them.
- */
-function metadataHead(
-  meta: PageMetadata | undefined,
-  content: Record<string, unknown> | undefined,
-  route: string | undefined,
-  seo: SeoContext,
-  templateHead: string | undefined,
-): string {
-  const parts: string[] = []
-
-  // Title: metadata.title → content.title + " — " + siteName → omit
-  const title =
-    meta?.title || (content?.title ? `${content.title}${seo.siteName ? ` — ${seo.siteName}` : ''}` : undefined)
-  if (title && !templateHead?.includes('<title')) {
-    parts.push(`<title>${escapeAttr(title)}</title>`)
-  }
-
-  // Description: metadata.description → content.description → omit
-  const description = meta?.description || (content?.description as string | undefined)
-  if (description && !templateHead?.includes('name="description"')) {
-    parts.push(`<meta name="description" content="${escapeAttr(description)}">`)
-  }
-
-  // Canonical: metadata.canonical → baseUrl + route → omit
-  const canonical = meta?.canonical || (seo.baseUrl && route ? `${seo.baseUrl}${route}` : undefined)
-  if (canonical) {
-    parts.push(`<link rel="canonical" href="${escapeAttr(canonical)}">`)
-  }
-
-  // OG image: metadata.ogImage → site.defaultOgImage → omit
-  const ogImage = meta?.ogImage || seo.defaultOgImage
-  if (ogImage) {
-    parts.push(`<meta property="og:image" content="${escapeAttr(ogImage)}">`)
-  }
-
-  // OG title: same chain as <title>
-  if (title && !templateHead?.includes('property="og:title"')) {
-    parts.push(`<meta property="og:title" content="${escapeAttr(title)}">`)
-  }
-
-  // OG description: same chain as description
-  if (description && !templateHead?.includes('property="og:description"')) {
-    parts.push(`<meta property="og:description" content="${escapeAttr(description)}">`)
-  }
-
-  // OG URL: same as canonical
-  if (canonical && !templateHead?.includes('property="og:url"')) {
-    parts.push(`<meta property="og:url" content="${escapeAttr(canonical)}">`)
-  }
-
-  // OG type: always "website"
-  if (!templateHead?.includes('property="og:type"')) {
-    parts.push('<meta property="og:type" content="website">')
-  }
-
-  // Twitter card: summary_large_image when OG image present, summary otherwise
-  if (!templateHead?.includes('name="twitter:card"')) {
-    parts.push(`<meta name="twitter:card" content="${ogImage ? 'summary_large_image' : 'summary'}">`)
-  }
-
-  // Robots: only when explicitly set (absence = allow indexing)
-  if (meta?.robots) {
-    parts.push(`<meta name="robots" content="${escapeAttr(meta.robots)}">`)
-  }
-
-  return parts.join('\n  ')
-}
+// Re-export so existing consumers don't break
+export { type SeoContext, seoContextFromManifest } from './seo.js'
 
 export async function renderComponent(
   component: ResolvedComponent,
@@ -165,8 +68,14 @@ export async function renderPage(
   const output = await component.template({ content: component.content, children, params: opts.routeParams })
 
   const templateHead = [...children.map(c => c.head).filter(Boolean), output.head].filter(Boolean).join('\n  ')
-  const metaHead = metadataHead(opts.metadata, component.content, opts.route, seo, templateHead)
-  const headContent = [metaHead, templateHead].filter(Boolean).join('\n  ')
+  const seoHead = resolveSeoTags({
+    metadata: opts.metadata,
+    content: component.content,
+    route: opts.route,
+    seo,
+    templateHead,
+  })
+  const headContent = [seoHead, templateHead].filter(Boolean).join('\n  ')
 
   return `<!DOCTYPE html>
 <html lang="${escapeAttr(lang)}">

--- a/packages/gazetta/src/renderer.ts
+++ b/packages/gazetta/src/renderer.ts
@@ -1,31 +1,104 @@
-import type { RenderOutput, ResolvedComponent, PageMetadata } from './types.js'
+import type { RenderOutput, ResolvedComponent, PageMetadata, SiteManifest } from './types.js'
 import { hashPath, scopeHtml, scopeCss } from './scope.js'
 
 function escapeAttr(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;')
 }
 
-function metadataHead(meta: PageMetadata | undefined, templateHead: string | undefined): string {
-  if (!meta) return ''
+/** Context for the fallback chain — site-level defaults that pages inherit. */
+export interface SeoContext {
+  /** Site name — appended to auto-generated titles ("Page — Site Name"). */
+  siteName?: string
+  /** Base URL for canonical/og:url generation (e.g. "https://gazetta.studio"). */
+  baseUrl?: string
+  /** Site locale for `<html lang>` (e.g. "en", "fr"). Default: "en". */
+  locale?: string
+  /** Default OG image for pages that don't specify their own. */
+  defaultOgImage?: string
+}
+
+/** Build SeoContext from a SiteManifest. */
+export function seoContextFromManifest(manifest: SiteManifest | undefined): SeoContext {
+  return {
+    siteName: manifest?.name,
+    baseUrl: manifest?.baseUrl,
+    locale: manifest?.locale,
+    defaultOgImage: manifest?.defaultOgImage,
+  }
+}
+
+/**
+ * Resolve all SEO tags for a page using the fallback chain:
+ *   metadata field → content field → site default → omit
+ *
+ * Returns raw HTML for injection into <head>. Template-provided head
+ * tags are checked for duplicates — metadata tags are only emitted
+ * when the template doesn't already include them.
+ */
+function metadataHead(
+  meta: PageMetadata | undefined,
+  content: Record<string, unknown> | undefined,
+  route: string | undefined,
+  seo: SeoContext,
+  templateHead: string | undefined,
+): string {
   const parts: string[] = []
-  if (meta.title && !templateHead?.includes('<title')) {
-    parts.push(`<title>${escapeAttr(meta.title)}</title>`)
+
+  // Title: metadata.title → content.title + " — " + siteName → omit
+  const title =
+    meta?.title || (content?.title ? `${content.title}${seo.siteName ? ` — ${seo.siteName}` : ''}` : undefined)
+  if (title && !templateHead?.includes('<title')) {
+    parts.push(`<title>${escapeAttr(title)}</title>`)
   }
-  if (meta.description && !templateHead?.includes('name="description"')) {
-    parts.push(`<meta name="description" content="${escapeAttr(meta.description)}">`)
+
+  // Description: metadata.description → content.description → omit
+  const description = meta?.description || (content?.description as string | undefined)
+  if (description && !templateHead?.includes('name="description"')) {
+    parts.push(`<meta name="description" content="${escapeAttr(description)}">`)
   }
-  if (meta.ogImage) {
-    parts.push(`<meta property="og:image" content="${escapeAttr(meta.ogImage)}">`)
+
+  // Canonical: metadata.canonical → baseUrl + route → omit
+  const canonical = meta?.canonical || (seo.baseUrl && route ? `${seo.baseUrl}${route}` : undefined)
+  if (canonical) {
+    parts.push(`<link rel="canonical" href="${escapeAttr(canonical)}">`)
   }
-  if (meta.canonical) {
-    parts.push(`<link rel="canonical" href="${escapeAttr(meta.canonical)}">`)
+
+  // OG image: metadata.ogImage → site.defaultOgImage → omit
+  const ogImage = meta?.ogImage || seo.defaultOgImage
+  if (ogImage) {
+    parts.push(`<meta property="og:image" content="${escapeAttr(ogImage)}">`)
   }
-  if (meta.title && !templateHead?.includes('property="og:title"')) {
-    parts.push(`<meta property="og:title" content="${escapeAttr(meta.title)}">`)
+
+  // OG title: same chain as <title>
+  if (title && !templateHead?.includes('property="og:title"')) {
+    parts.push(`<meta property="og:title" content="${escapeAttr(title)}">`)
   }
-  if (meta.description && !templateHead?.includes('property="og:description"')) {
-    parts.push(`<meta property="og:description" content="${escapeAttr(meta.description)}">`)
+
+  // OG description: same chain as description
+  if (description && !templateHead?.includes('property="og:description"')) {
+    parts.push(`<meta property="og:description" content="${escapeAttr(description)}">`)
   }
+
+  // OG URL: same as canonical
+  if (canonical && !templateHead?.includes('property="og:url"')) {
+    parts.push(`<meta property="og:url" content="${escapeAttr(canonical)}">`)
+  }
+
+  // OG type: always "website"
+  if (!templateHead?.includes('property="og:type"')) {
+    parts.push('<meta property="og:type" content="website">')
+  }
+
+  // Twitter card: summary_large_image when OG image present, summary otherwise
+  if (!templateHead?.includes('name="twitter:card"')) {
+    parts.push(`<meta name="twitter:card" content="${ogImage ? 'summary_large_image' : 'summary'}">`)
+  }
+
+  // Robots: only when explicitly set (absence = allow indexing)
+  if (meta?.robots) {
+    parts.push(`<meta name="robots" content="${escapeAttr(meta.robots)}">`)
+  }
+
   return parts.join('\n  ')
 }
 
@@ -71,6 +144,10 @@ ${output.html}${output.js ? `\n<script type="module">${output.js}</script>` : ''
 export interface RenderPageOptions {
   routeParams?: Record<string, string>
   metadata?: PageMetadata
+  /** Page route (e.g. "/about") — used for canonical URL fallback. */
+  route?: string
+  /** Site-level SEO context for fallback chains. */
+  seo?: SeoContext
 }
 
 export async function renderPage(
@@ -78,18 +155,21 @@ export async function renderPage(
   optsOrParams?: RenderPageOptions | Record<string, string>,
 ): Promise<string> {
   const opts: RenderPageOptions =
-    optsOrParams && ('metadata' in optsOrParams || 'routeParams' in optsOrParams)
+    optsOrParams &&
+    ('metadata' in optsOrParams || 'routeParams' in optsOrParams || 'seo' in optsOrParams || 'route' in optsOrParams)
       ? (optsOrParams as RenderPageOptions)
       : { routeParams: optsOrParams as Record<string, string> | undefined }
+  const seo = opts.seo ?? {}
+  const lang = seo.locale || 'en'
   const children = await Promise.all(component.children.map(c => renderComponent(c, opts.routeParams)))
   const output = await component.template({ content: component.content, children, params: opts.routeParams })
 
   const templateHead = [...children.map(c => c.head).filter(Boolean), output.head].filter(Boolean).join('\n  ')
-  const metaHead = metadataHead(opts.metadata, templateHead)
+  const metaHead = metadataHead(opts.metadata, component.content, opts.route, seo, templateHead)
   const headContent = [metaHead, templateHead].filter(Boolean).join('\n  ')
 
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="${escapeAttr(lang)}">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/packages/gazetta/src/robots.ts
+++ b/packages/gazetta/src/robots.ts
@@ -8,22 +8,22 @@
  * Strategy:
  *   1. If the site has a `robots.txt` file, use it verbatim.
  *   2. Otherwise, generate a permissive default with a Sitemap
- *      reference (when baseUrl is available).
+ *      reference (when siteUrl is available).
  */
 
 export interface GenerateRobotsOptions {
   /** Absolute base URL — used for the Sitemap directive. Optional. */
-  baseUrl?: string
+  siteUrl?: string
 }
 
 /**
  * Generate a default robots.txt. Permissive (allow all crawlers)
- * with a Sitemap reference when baseUrl is available.
+ * with a Sitemap reference when siteUrl is available.
  */
 export function generateRobotsTxt(opts: GenerateRobotsOptions): string {
   const lines = ['User-agent: *', 'Allow: /']
-  if (opts.baseUrl) {
-    const base = opts.baseUrl.replace(/\/+$/, '')
+  if (opts.siteUrl) {
+    const base = opts.siteUrl.replace(/\/+$/, '')
     lines.push('', `Sitemap: ${base}/sitemap.xml`)
   }
   return lines.join('\n') + '\n'

--- a/packages/gazetta/src/robots.ts
+++ b/packages/gazetta/src/robots.ts
@@ -23,7 +23,8 @@ export interface GenerateRobotsOptions {
 export function generateRobotsTxt(opts: GenerateRobotsOptions): string {
   const lines = ['User-agent: *', 'Allow: /']
   if (opts.baseUrl) {
-    lines.push('', `Sitemap: ${opts.baseUrl}/sitemap.xml`)
+    const base = opts.baseUrl.replace(/\/+$/, '')
+    lines.push('', `Sitemap: ${base}/sitemap.xml`)
   }
   return lines.join('\n') + '\n'
 }

--- a/packages/gazetta/src/robots.ts
+++ b/packages/gazetta/src/robots.ts
@@ -1,0 +1,29 @@
+/**
+ * Robots.txt generation — produces a default robots.txt or copies
+ * a user-authored one from the site directory.
+ *
+ * SRP: this module owns robots.txt content resolution. The caller
+ * checks for a user file and writes the result to storage.
+ *
+ * Strategy:
+ *   1. If the site has a `robots.txt` file, use it verbatim.
+ *   2. Otherwise, generate a permissive default with a Sitemap
+ *      reference (when baseUrl is available).
+ */
+
+export interface GenerateRobotsOptions {
+  /** Absolute base URL — used for the Sitemap directive. Optional. */
+  baseUrl?: string
+}
+
+/**
+ * Generate a default robots.txt. Permissive (allow all crawlers)
+ * with a Sitemap reference when baseUrl is available.
+ */
+export function generateRobotsTxt(opts: GenerateRobotsOptions): string {
+  const lines = ['User-agent: *', 'Allow: /']
+  if (opts.baseUrl) {
+    lines.push('', `Sitemap: ${opts.baseUrl}/sitemap.xml`)
+  }
+  return lines.join('\n') + '\n'
+}

--- a/packages/gazetta/src/seo.ts
+++ b/packages/gazetta/src/seo.ts
@@ -1,0 +1,117 @@
+/**
+ * SEO tag resolution — computes `<head>` tags from a fallback chain:
+ *   metadata field → content field → site default → omit
+ *
+ * Single responsibility: this module owns the fallback logic and HTML
+ * tag generation for SEO. The renderer calls `resolveSeoTags()` and
+ * injects the result into `<head>` — it doesn't know about title
+ * truncation, OG deduplication, or robots directives.
+ *
+ * Open for extension: adding a new tag type is a new block in
+ * `resolveSeoTags()`, not a change to the renderer.
+ */
+import type { PageMetadata, SiteManifest } from './types.js'
+
+/** Escape HTML attribute values — prevents XSS in generated meta tags. */
+export function escapeAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;')
+}
+
+/** Site-level SEO defaults that pages inherit via the fallback chain. */
+export interface SeoContext {
+  /** Site name — appended to auto-generated titles ("Page — Site Name"). */
+  siteName?: string
+  /** Base URL for canonical/og:url generation (e.g. "https://gazetta.studio"). */
+  baseUrl?: string
+  /** Site locale for `<html lang>` (e.g. "en", "fr"). Default: "en". */
+  locale?: string
+  /** Default OG image for pages that don't specify their own. */
+  defaultOgImage?: string
+}
+
+/** Build SeoContext from a SiteManifest. */
+export function seoContextFromManifest(manifest: SiteManifest | undefined): SeoContext {
+  return {
+    siteName: manifest?.name,
+    baseUrl: manifest?.baseUrl,
+    locale: manifest?.locale,
+    defaultOgImage: manifest?.defaultOgImage,
+  }
+}
+
+export interface ResolveSeoTagsInput {
+  metadata?: PageMetadata
+  content?: Record<string, unknown>
+  route?: string
+  seo: SeoContext
+  /** Template-provided head HTML — tags already present won't be duplicated. */
+  templateHead?: string
+}
+
+/**
+ * Resolve all SEO `<head>` tags using the fallback chain. Returns raw
+ * HTML string for injection. Template-provided tags are checked for
+ * duplicates — a metadata tag is only emitted when the template head
+ * doesn't already include it.
+ */
+export function resolveSeoTags(input: ResolveSeoTagsInput): string {
+  const { metadata: meta, content, route, seo, templateHead } = input
+  const parts: string[] = []
+
+  // Title: metadata.title → content.title + " — " + siteName → omit
+  const title =
+    meta?.title || (content?.title ? `${content.title}${seo.siteName ? ` — ${seo.siteName}` : ''}` : undefined)
+  if (title && !templateHead?.includes('<title')) {
+    parts.push(`<title>${escapeAttr(title)}</title>`)
+  }
+
+  // Description: metadata.description → content.description → omit
+  const description = meta?.description || (content?.description as string | undefined)
+  if (description && !templateHead?.includes('name="description"')) {
+    parts.push(`<meta name="description" content="${escapeAttr(description)}">`)
+  }
+
+  // Canonical: metadata.canonical → baseUrl + route → omit
+  const canonical = meta?.canonical || (seo.baseUrl && route ? `${seo.baseUrl}${route}` : undefined)
+  if (canonical) {
+    parts.push(`<link rel="canonical" href="${escapeAttr(canonical)}">`)
+  }
+
+  // OG image: metadata.ogImage → site.defaultOgImage → omit
+  const ogImage = meta?.ogImage || seo.defaultOgImage
+  if (ogImage) {
+    parts.push(`<meta property="og:image" content="${escapeAttr(ogImage)}">`)
+  }
+
+  // OG title: same chain as <title>
+  if (title && !templateHead?.includes('property="og:title"')) {
+    parts.push(`<meta property="og:title" content="${escapeAttr(title)}">`)
+  }
+
+  // OG description: same chain as description
+  if (description && !templateHead?.includes('property="og:description"')) {
+    parts.push(`<meta property="og:description" content="${escapeAttr(description)}">`)
+  }
+
+  // OG URL: same as canonical
+  if (canonical && !templateHead?.includes('property="og:url"')) {
+    parts.push(`<meta property="og:url" content="${escapeAttr(canonical)}">`)
+  }
+
+  // OG type: always "website"
+  if (!templateHead?.includes('property="og:type"')) {
+    parts.push('<meta property="og:type" content="website">')
+  }
+
+  // Twitter card: summary_large_image when OG image present, summary otherwise
+  if (!templateHead?.includes('name="twitter:card"')) {
+    parts.push(`<meta name="twitter:card" content="${ogImage ? 'summary_large_image' : 'summary'}">`)
+  }
+
+  // Robots: only when explicitly set (absence = allow indexing)
+  if (meta?.robots) {
+    parts.push(`<meta name="robots" content="${escapeAttr(meta.robots)}">`)
+  }
+
+  return parts.join('\n  ')
+}

--- a/packages/gazetta/src/seo.ts
+++ b/packages/gazetta/src/seo.ts
@@ -29,11 +29,11 @@ export interface SeoContext {
   defaultOgImage?: string
 }
 
-/** Build SeoContext from a SiteManifest. */
-export function seoContextFromManifest(manifest: SiteManifest | undefined): SeoContext {
+/** Build SeoContext from a SiteManifest + optional target siteUrl. */
+export function seoContextFromManifest(manifest: SiteManifest | undefined, siteUrl?: string): SeoContext {
   return {
     siteName: manifest?.name,
-    baseUrl: manifest?.baseUrl,
+    baseUrl: siteUrl,
     locale: manifest?.locale,
     defaultOgImage: manifest?.defaultOgImage,
   }

--- a/packages/gazetta/src/seo.ts
+++ b/packages/gazetta/src/seo.ts
@@ -10,33 +10,28 @@
  * Open for extension: adding a new tag type is a new block in
  * `resolveSeoTags()`, not a change to the renderer.
  */
-import type { PageMetadata, SiteManifest } from './types.js'
+import type { PageMetadata } from './types.js'
 
 /** Escape HTML attribute values — prevents XSS in generated meta tags. */
 export function escapeAttr(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;')
 }
 
-/** Site-level SEO defaults that pages inherit via the fallback chain. */
+/**
+ * SEO context for a rendering pass — assembled by the caller from
+ * whatever sources it has (site manifest, target config, etc.).
+ * The renderer and seo module depend on this interface only, not
+ * on SiteManifest or TargetConfig (DIP).
+ */
 export interface SeoContext {
   /** Site name — appended to auto-generated titles ("Page — Site Name"). */
   siteName?: string
-  /** Base URL for canonical/og:url generation (e.g. "https://gazetta.studio"). */
-  baseUrl?: string
+  /** Target's public URL for canonical/og:url (e.g. "https://gazetta.studio"). */
+  siteUrl?: string
   /** Site locale for `<html lang>` (e.g. "en", "fr"). Default: "en". */
   locale?: string
   /** Default OG image for pages that don't specify their own. */
   defaultOgImage?: string
-}
-
-/** Build SeoContext from a SiteManifest + optional target siteUrl. */
-export function seoContextFromManifest(manifest: SiteManifest | undefined, siteUrl?: string): SeoContext {
-  return {
-    siteName: manifest?.name,
-    baseUrl: siteUrl,
-    locale: manifest?.locale,
-    defaultOgImage: manifest?.defaultOgImage,
-  }
 }
 
 export interface ResolveSeoTagsInput {
@@ -71,8 +66,8 @@ export function resolveSeoTags(input: ResolveSeoTagsInput): string {
     parts.push(`<meta name="description" content="${escapeAttr(description)}">`)
   }
 
-  // Canonical: metadata.canonical → baseUrl + route → omit
-  const canonical = meta?.canonical || (seo.baseUrl && route ? `${seo.baseUrl}${route}` : undefined)
+  // Canonical: metadata.canonical → siteUrl + route → omit
+  const canonical = meta?.canonical || (seo.siteUrl && route ? `${seo.siteUrl}${route}` : undefined)
   if (canonical) {
     parts.push(`<link rel="canonical" href="${escapeAttr(canonical)}">`)
   }

--- a/packages/gazetta/src/seo.ts
+++ b/packages/gazetta/src/seo.ts
@@ -67,7 +67,8 @@ export function resolveSeoTags(input: ResolveSeoTagsInput): string {
   }
 
   // Canonical: metadata.canonical → siteUrl + route → omit
-  const canonical = meta?.canonical || (seo.siteUrl && route ? `${seo.siteUrl}${route}` : undefined)
+  const base = seo.siteUrl?.replace(/\/+$/, '')
+  const canonical = meta?.canonical || (base && route ? `${base}${route}` : undefined)
   if (canonical) {
     parts.push(`<link rel="canonical" href="${escapeAttr(canonical)}">`)
   }

--- a/packages/gazetta/src/sidecars.ts
+++ b/packages/gazetta/src/sidecars.ts
@@ -138,8 +138,11 @@ export async function listSidecars(storage: StorageProvider, rootDir: string): P
     } catch {
       return
     }
+    // Parse sidecar state directly from the entries we already have —
+    // avoids a second readDir per directory (readSidecars would re-read
+    // the same dir). At 10k pages this halves the I/O calls.
     if (relative) {
-      const state = await readSidecars(storage, dir).catch(() => null)
+      const state = parseSidecarEntries(entries)
       if (state) out.set(relative, state)
     }
     const subdirs = entries.filter(e => e.isDirectory)
@@ -147,6 +150,36 @@ export async function listSidecars(storage: StorageProvider, rootDir: string): P
   }
   await walk(rootDir, '')
   return out
+}
+
+/** Parse sidecar state from already-read directory entries. */
+function parseSidecarEntries(entries: { name: string; isDirectory: boolean }[]): SidecarState | null {
+  let hash: string | null = null
+  const uses: string[] = []
+  let template: string | null = null
+  let pub: PubSidecar | null = null
+  for (const e of entries) {
+    if (e.isDirectory) continue
+    const h = parseSidecarName(e.name)
+    if (h) {
+      hash = h
+      continue
+    }
+    const u = parseUsesSidecarName(e.name)
+    if (u) {
+      uses.push(u)
+      continue
+    }
+    const t = parseTemplateSidecarName(e.name)
+    if (t) {
+      template = t
+      continue
+    }
+    const p = parsePubSidecarName(e.name)
+    if (p) pub = p
+  }
+  if (!hash) return null
+  return { hash, uses, template, pub }
 }
 
 /**

--- a/packages/gazetta/src/sidecars.ts
+++ b/packages/gazetta/src/sidecars.ts
@@ -24,6 +24,9 @@ import {
   usesSidecarNameFor,
   parseTemplateSidecarName,
   templateSidecarNameFor,
+  parsePubSidecarName,
+  pubSidecarNameFor,
+  type PubSidecar,
 } from './hash.js'
 import { mapLimit } from './concurrency.js'
 
@@ -32,6 +35,9 @@ export interface SidecarState {
   hash: string
   uses: string[]
   template: string | null
+  /** Publish timestamp + noindex flag. Present only on target sidecars
+   *  written by the publish pipeline; absent on source-side sidecars. */
+  pub: PubSidecar | null
 }
 
 /**
@@ -51,6 +57,7 @@ export async function readSidecars(storage: StorageProvider, dir: string): Promi
   let hash: string | null = null
   const uses: string[] = []
   let template: string | null = null
+  let pub: PubSidecar | null = null
   for (const e of entries) {
     if (e.isDirectory) continue
     const h = parseSidecarName(e.name)
@@ -64,10 +71,15 @@ export async function readSidecars(storage: StorageProvider, dir: string): Promi
       continue
     }
     const t = parseTemplateSidecarName(e.name)
-    if (t) template = t
+    if (t) {
+      template = t
+      continue
+    }
+    const p = parsePubSidecarName(e.name)
+    if (p) pub = p
   }
   if (!hash) return null
-  return { hash, uses, template }
+  return { hash, uses, template, pub }
 }
 
 /**
@@ -80,13 +92,19 @@ export async function writeSidecars(storage: StorageProvider, dir: string, state
   const want = new Set<string>([sidecarNameFor(state.hash)])
   for (const frag of state.uses) want.add(usesSidecarNameFor(frag))
   if (state.template) want.add(templateSidecarNameFor(state.template))
+  if (state.pub) want.add(pubSidecarNameFor(new Date(state.pub.lastPublished), state.pub.noindex))
 
   // Remove stale sidecars of known kinds that aren't in `want`.
   try {
     const entries = await storage.readDir(dir)
     for (const e of entries) {
       if (want.has(e.name)) continue
-      if (parseSidecarName(e.name) || parseUsesSidecarName(e.name) || parseTemplateSidecarName(e.name)) {
+      if (
+        parseSidecarName(e.name) ||
+        parseUsesSidecarName(e.name) ||
+        parseTemplateSidecarName(e.name) ||
+        parsePubSidecarName(e.name)
+      ) {
         try {
           await storage.rm(`${dir}/${e.name}`)
         } catch {

--- a/packages/gazetta/src/sitemap.ts
+++ b/packages/gazetta/src/sitemap.ts
@@ -42,6 +42,7 @@ function escapeXml(s: string): string {
  */
 export function generateSitemap(opts: GenerateSitemapOptions): string | null {
   const systemSet = new Set(opts.systemPages ?? [])
+  const base = opts.baseUrl.replace(/\/+$/, '')
   const urls: string[] = []
 
   for (const [name, state] of opts.pages) {
@@ -49,7 +50,7 @@ export function generateSitemap(opts: GenerateSitemapOptions): string | null {
     if (state.pub?.noindex) continue
 
     const route = deriveRoute(name)
-    const loc = `${opts.baseUrl}${route}`
+    const loc = `${base}${route}`
     const lastmod = state.pub?.lastPublished
 
     const parts = [`    <loc>${escapeXml(loc)}</loc>`]

--- a/packages/gazetta/src/sitemap.ts
+++ b/packages/gazetta/src/sitemap.ts
@@ -50,6 +50,7 @@ export function generateSitemap(opts: GenerateSitemapOptions): string | null {
   for (const [name, state] of sorted) {
     if (systemSet.has(name)) continue
     if (state.pub?.noindex) continue
+    if (name.includes('[')) continue // dynamic routes — can't sitemap template patterns
 
     const route = deriveRoute(name)
     const loc = `${base}${route}`

--- a/packages/gazetta/src/sitemap.ts
+++ b/packages/gazetta/src/sitemap.ts
@@ -1,0 +1,72 @@
+/**
+ * Sitemap generation — produces sitemap.xml from target sidecars.
+ *
+ * SRP: this module owns sitemap XML assembly. It takes the sidecar
+ * listing from a target's `pages/` directory (already available via
+ * `listSidecars`) and produces the XML string. No I/O — the caller
+ * reads sidecars and writes the result to storage.
+ *
+ * The sitemap reflects what's ACTUALLY published on the target, not
+ * what's in the source. A page that exists in source but was never
+ * published won't appear. A page that was deleted from source but
+ * is still live on the target WILL appear (until the next full
+ * publish removes its sidecars).
+ *
+ * Pages with `.pub-*-noindex` sidecars are excluded. System pages
+ * (e.g. 404) are excluded by name.
+ */
+import type { SidecarState } from './sidecars.js'
+import { deriveRoute } from './site-loader.js'
+
+export interface GenerateSitemapOptions {
+  /** Absolute base URL (e.g. "https://gazetta.studio"). */
+  baseUrl: string
+  /** Target sidecar listing — keyed by page name (e.g. "home", "about"). */
+  pages: Map<string, SidecarState>
+  /** System page names to exclude (e.g. ["404"]). */
+  systemPages?: string[]
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+/**
+ * Generate sitemap XML from target sidecars. Returns null when no
+ * pages qualify (all noindex, or empty target).
+ */
+export function generateSitemap(opts: GenerateSitemapOptions): string | null {
+  const systemSet = new Set(opts.systemPages ?? [])
+  const urls: string[] = []
+
+  for (const [name, state] of opts.pages) {
+    if (systemSet.has(name)) continue
+    if (state.pub?.noindex) continue
+
+    const route = deriveRoute(name)
+    const loc = `${opts.baseUrl}${route}`
+    const lastmod = state.pub?.lastPublished
+
+    const parts = [`    <loc>${escapeXml(loc)}</loc>`]
+    if (lastmod) {
+      // Sitemap spec wants YYYY-MM-DD or full ISO — use date only
+      parts.push(`    <lastmod>${lastmod.slice(0, 10)}</lastmod>`)
+    }
+    urls.push(`  <url>\n${parts.join('\n')}\n  </url>`)
+  }
+
+  if (urls.length === 0) return null
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...urls,
+    '</urlset>',
+    '',
+  ].join('\n')
+}

--- a/packages/gazetta/src/sitemap.ts
+++ b/packages/gazetta/src/sitemap.ts
@@ -20,7 +20,7 @@ import { deriveRoute } from './site-loader.js'
 
 export interface GenerateSitemapOptions {
   /** Absolute base URL (e.g. "https://gazetta.studio"). */
-  baseUrl: string
+  siteUrl: string
   /** Target sidecar listing — keyed by page name (e.g. "home", "about"). */
   pages: Map<string, SidecarState>
   /** System page names to exclude (e.g. ["404"]). */
@@ -42,7 +42,7 @@ function escapeXml(s: string): string {
  */
 export function generateSitemap(opts: GenerateSitemapOptions): string | null {
   const systemSet = new Set(opts.systemPages ?? [])
-  const base = opts.baseUrl.replace(/\/+$/, '')
+  const base = opts.siteUrl.replace(/\/+$/, '')
   const urls: string[] = []
 
   for (const [name, state] of opts.pages) {

--- a/packages/gazetta/src/sitemap.ts
+++ b/packages/gazetta/src/sitemap.ts
@@ -45,7 +45,9 @@ export function generateSitemap(opts: GenerateSitemapOptions): string | null {
   const base = opts.siteUrl.replace(/\/+$/, '')
   const urls: string[] = []
 
-  for (const [name, state] of opts.pages) {
+  // Sort by page name for deterministic output across runs.
+  const sorted = [...opts.pages.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+  for (const [name, state] of sorted) {
     if (systemSet.has(name)) continue
     if (state.pub?.noindex) continue
 

--- a/packages/gazetta/src/source-sidecars.ts
+++ b/packages/gazetta/src/source-sidecars.ts
@@ -112,6 +112,7 @@ export function createSourceSidecarWriter(opts: SourceSidecarWriterOptions): Sou
         hash,
         uses: collectFragmentRefs(manifest.components),
         template: manifest.template,
+        pub: null,
       })
     },
     ensureBackfilled() {

--- a/packages/gazetta/src/types.ts
+++ b/packages/gazetta/src/types.ts
@@ -231,7 +231,6 @@ export interface SiteManifest {
   name: string
   version?: string
   locale?: string
-  baseUrl?: string
   /** Default Open Graph image for pages that don't specify their own. */
   defaultOgImage?: string
   systemPages?: string[]

--- a/packages/gazetta/src/types.ts
+++ b/packages/gazetta/src/types.ts
@@ -95,6 +95,10 @@ export interface PageMetadata {
   description?: string
   ogImage?: string
   canonical?: string
+  /** Robots directive — e.g. "noindex", "nofollow", "noindex, nofollow".
+   *  When set, emitted as `<meta name="robots" content="...">`.
+   *  When absent, the tag is omitted (default: allow indexing). */
+  robots?: string
 }
 
 /** Page manifest (routable component) */
@@ -228,6 +232,8 @@ export interface SiteManifest {
   version?: string
   locale?: string
   baseUrl?: string
+  /** Default Open Graph image for pages that don't specify their own. */
+  defaultOgImage?: string
   systemPages?: string[]
   targets?: Record<string, TargetConfig>
 }

--- a/packages/gazetta/tests/admin-api.test.ts
+++ b/packages/gazetta/tests/admin-api.test.ts
@@ -255,7 +255,7 @@ describe('POST /api/pages (create)', () => {
     await rm(resolve(localTargetDir, 'pages/docs'), { recursive: true, force: true })
   })
 
-  it('creates a new page', async () => {
+  it('creates a new page', { timeout: 15_000 }, async () => {
     const res = await app.request('/api/pages', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/packages/gazetta/tests/admin-api.test.ts
+++ b/packages/gazetta/tests/admin-api.test.ts
@@ -324,6 +324,74 @@ describe('PUT /api/pages/:name', () => {
   })
 })
 
+describe('PUT /api/pages/:name (metadata round-trip)', () => {
+  afterAll(async () => {
+    await rm(resolve(localTargetDir, 'pages/meta-test'), { recursive: true, force: true })
+  })
+
+  it('saves and retrieves metadata', async () => {
+    // Create page
+    await app.request('/api/pages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'meta-test', template: 'page-default' }),
+    })
+
+    // Set metadata
+    const res = await app.request('/api/pages/meta-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        metadata: {
+          title: 'SEO Title',
+          description: 'SEO desc',
+          ogImage: '/img.jpg',
+          canonical: 'https://example.com/meta-test',
+          robots: 'noindex',
+        },
+      }),
+    })
+    expect(res.status).toBe(200)
+
+    // Verify round-trip
+    const { body } = await get('/api/pages/meta-test')
+    expect(body.metadata).toEqual({
+      title: 'SEO Title',
+      description: 'SEO desc',
+      ogImage: '/img.jpg',
+      canonical: 'https://example.com/meta-test',
+      robots: 'noindex',
+    })
+  })
+
+  it('preserves metadata when updating only content', async () => {
+    // Update content only — metadata should be preserved
+    const res = await app.request('/api/pages/meta-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: { title: 'New Content Title' } }),
+    })
+    expect(res.status).toBe(200)
+
+    const { body } = await get('/api/pages/meta-test')
+    expect(body.content.title).toBe('New Content Title')
+    expect(body.metadata.title).toBe('SEO Title')
+    expect(body.metadata.robots).toBe('noindex')
+  })
+
+  it('clears metadata when explicitly set to empty object', async () => {
+    const res = await app.request('/api/pages/meta-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ metadata: {} }),
+    })
+    expect(res.status).toBe(200)
+
+    const { body } = await get('/api/pages/meta-test')
+    expect(body.metadata).toEqual({})
+  })
+})
+
 describe('PUT /api/pages/:name (update component content)', () => {
   it('updates page with modified component content', async () => {
     // Read current page

--- a/packages/gazetta/tests/cli-history.test.ts
+++ b/packages/gazetta/tests/cli-history.test.ts
@@ -155,7 +155,7 @@ describe('gazetta history / undo / rollback', { timeout: 60000 }, () => {
     // Baseline captures the pristine starter content.
     const homePath = resolve(projectDir, 'sites/main/targets/local/pages/home/page.json')
     const restored = JSON.parse(await readFile(homePath, 'utf-8'))
-    expect(restored.content.title).toBe('Home')
+    expect(restored.metadata.title).toBe('Gazetta — Composable CMS')
   })
 
   it('`rollback` without an id errors clearly', async () => {

--- a/packages/gazetta/tests/hash-sidecar-names.test.ts
+++ b/packages/gazetta/tests/hash-sidecar-names.test.ts
@@ -29,6 +29,10 @@ import {
   parseUsesSidecarName,
   templateSidecarNameFor,
   parseTemplateSidecarName,
+  pubSidecarNameFor,
+  parsePubSidecarName,
+  compactTimestamp,
+  parseCompactTimestamp,
 } from '../src/hash.js'
 
 /**
@@ -178,5 +182,47 @@ describe('sidecar kind disambiguation', () => {
         expect(parseSidecarName(fname)).toBe(hex)
       }),
     )
+  })
+})
+
+describe('pub sidecar', () => {
+  it('compactTimestamp round-trips through parseCompactTimestamp', () => {
+    const date = new Date('2026-04-17T22:05:30Z')
+    const compact = compactTimestamp(date)
+    expect(compact).toBe('20260417T220530Z')
+    expect(parseCompactTimestamp(compact)).toBe('2026-04-17T22:05:30Z')
+  })
+
+  it('pubSidecarNameFor generates correct filename', () => {
+    const date = new Date('2026-04-17T22:00:00Z')
+    expect(pubSidecarNameFor(date, false)).toBe('.pub-20260417T220000Z')
+    expect(pubSidecarNameFor(date, true)).toBe('.pub-20260417T220000Z-noindex')
+  })
+
+  it('parsePubSidecarName round-trips', () => {
+    const date = new Date('2026-04-17T22:00:00Z')
+    const name = pubSidecarNameFor(date, false)
+    const parsed = parsePubSidecarName(name)
+    expect(parsed).toEqual({ lastPublished: '2026-04-17T22:00:00Z', noindex: false })
+  })
+
+  it('parsePubSidecarName detects noindex', () => {
+    const parsed = parsePubSidecarName('.pub-20260417T220000Z-noindex')
+    expect(parsed).toEqual({ lastPublished: '2026-04-17T22:00:00Z', noindex: true })
+  })
+
+  it('parsePubSidecarName rejects non-pub sidecars', () => {
+    expect(parsePubSidecarName('.abcd1234.hash')).toBeNull()
+    expect(parsePubSidecarName('.uses-header')).toBeNull()
+    expect(parsePubSidecarName('.tpl-page-default')).toBeNull()
+    expect(parsePubSidecarName('random.txt')).toBeNull()
+  })
+
+  it('pub sidecar does not collide with other sidecar kinds', () => {
+    const pubName = pubSidecarNameFor(new Date('2026-04-17T22:00:00Z'))
+    expect(parseSidecarName(pubName)).toBeNull()
+    expect(parseUsesSidecarName(pubName)).toBeNull()
+    expect(parseTemplateSidecarName(pubName)).toBeNull()
+    expect(parsePubSidecarName(pubName)).not.toBeNull()
   })
 })

--- a/packages/gazetta/tests/integration.test.ts
+++ b/packages/gazetta/tests/integration.test.ts
@@ -128,7 +128,11 @@ describe('starter site', () => {
     const site = await loadSite({ siteDir, storage, templatesDir })
     const page = site.pages.get('blog/[slug]')!
     const resolved = await resolvePage('blog/[slug]', site)
-    const html = await renderPage(resolved, { routeParams: { slug: 'hello-world' }, metadata: page.metadata, route: page.route })
+    const html = await renderPage(resolved, {
+      routeParams: { slug: 'hello-world' },
+      metadata: page.metadata,
+      route: page.route,
+    })
 
     expect(html).toContain('<title>Blog Post</title>')
     expect(html).toContain('Hello from Gazetta')

--- a/packages/gazetta/tests/integration.test.ts
+++ b/packages/gazetta/tests/integration.test.ts
@@ -25,11 +25,12 @@ describe('starter site', () => {
 
   it('resolves and renders the home page', async () => {
     const site = await loadSite({ siteDir, storage, templatesDir })
+    const page = site.pages.get('home')!
     const resolved = await resolvePage('home', site)
-    const html = await renderPage(resolved)
+    const html = await renderPage(resolved, { metadata: page.metadata, route: page.route })
 
     expect(html).toContain('<!DOCTYPE html>')
-    expect(html).toContain('<title>Home</title>')
+    expect(html).toContain('<title>Gazetta — Composable CMS</title>')
     expect(html).toContain('Gazetta')
     expect(html).toContain('href="/"')
     expect(html).toContain('href="/about"')
@@ -40,10 +41,11 @@ describe('starter site', () => {
 
   it('resolves and renders the about page', async () => {
     const site = await loadSite({ siteDir, storage, templatesDir })
+    const page = site.pages.get('about')!
     const resolved = await resolvePage('about', site)
-    const html = await renderPage(resolved)
+    const html = await renderPage(resolved, { metadata: page.metadata, route: page.route })
 
-    expect(html).toContain('<title>About</title>')
+    expect(html).toContain('<title>About — Gazetta</title>')
     expect(html).toContain('About Gazetta')
     expect(html).toContain('stateless CMS')
     expect(html).toContain('© 2026 Gazetta')
@@ -124,8 +126,9 @@ describe('starter site', () => {
 
   it('resolves and renders blog page with route params', async () => {
     const site = await loadSite({ siteDir, storage, templatesDir })
+    const page = site.pages.get('blog/[slug]')!
     const resolved = await resolvePage('blog/[slug]', site)
-    const html = await renderPage(resolved, { slug: 'hello-world' })
+    const html = await renderPage(resolved, { routeParams: { slug: 'hello-world' }, metadata: page.metadata, route: page.route })
 
     expect(html).toContain('<title>Blog Post</title>')
     expect(html).toContain('Hello from Gazetta')

--- a/packages/gazetta/tests/publish.test.ts
+++ b/packages/gazetta/tests/publish.test.ts
@@ -538,3 +538,146 @@ describe('findDependentsFromSidecars', () => {
     expect(r.pages).toEqual(['home'])
   })
 })
+
+describe('SEO publish integration', () => {
+  const projectRoot2 = resolve(import.meta.dirname, '../../../examples/starter')
+  const starterDir = resolve(projectRoot2, 'sites/main/targets/local')
+  const templatesDir = resolve(projectRoot2, 'templates')
+  const storage = createFilesystemProvider()
+  const seoTargetDir = tempDir('seo-publish-test-' + Date.now())
+
+  beforeEach(async () => {
+    await mkdir(seoTargetDir, { recursive: true })
+  })
+  afterEach(async () => {
+    await rm(seoTargetDir, { recursive: true, force: true })
+  })
+
+  it('.pub sidecar is written with timestamp after static publish', async () => {
+    const target = createFilesystemProvider(seoTargetDir)
+    const { hashManifest } = await import('../src/hash.js')
+    const { loadSite } = await import('../src/site-loader.js')
+    const { scanTemplates, templateHashesFrom } = await import('../src/templates-scan.js')
+
+    const contentRoot = createContentRoot(storage, starterDir)
+    const site = await loadSite({ contentRoot, templatesDir })
+    const templateInfos = await scanTemplates(templatesDir, projectRoot2)
+    const templateHashes = templateHashesFrom(templateInfos)
+    const page = site.pages.get('home')!
+    const hash = hashManifest(page, { templateHashes })
+
+    const before = Date.now()
+    await publishPageStatic('home', contentRoot, target, templatesDir, hash, site)
+    const after = Date.now()
+
+    // The .pub-* sidecar should exist on the target under pages/home/
+    const entries = await target.readDir('pages/home')
+    const pubFile = entries.find(e => e.name.startsWith('.pub-'))
+    expect(pubFile).toBeDefined()
+    expect(pubFile!.name).toMatch(/^\.pub-\d{8}T\d{6}Z$/)
+
+    // Parse and check timestamp is within the test window.
+    // compactTimestamp truncates milliseconds, so the parsed value
+    // can be up to 1s before `before`. Use a 2s window.
+    const { parsePubSidecarName } = await import('../src/hash.js')
+    const parsed = parsePubSidecarName(pubFile!.name)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.noindex).toBe(false)
+    const ts = new Date(parsed!.lastPublished).getTime()
+    expect(ts).toBeGreaterThanOrEqual(before - 2000)
+    expect(ts).toBeLessThanOrEqual(after + 2000)
+  })
+
+  it('.pub sidecar has noindex flag when page metadata contains noindex', async () => {
+    // Create a source with a noindex page
+    const noindexSourceDir = tempDir('noindex-source-' + Date.now())
+    await mkdir(join(noindexSourceDir, 'pages/secret'), { recursive: true })
+    await writeFile(
+      join(noindexSourceDir, 'pages/secret/page.json'),
+      JSON.stringify({
+        template: 'page-default',
+        content: { title: 'Secret' },
+        metadata: { robots: 'noindex' },
+      }),
+    )
+    // Copy site.yaml from starter
+    const { readFile: readF } = await import('node:fs/promises')
+    await writeFile(join(noindexSourceDir, 'site.yaml'), await readF(join(starterDir, '../../site.yaml'), 'utf-8'))
+
+    const target = createFilesystemProvider(seoTargetDir)
+    const { hashManifest } = await import('../src/hash.js')
+    const { loadSite } = await import('../src/site-loader.js')
+    const { scanTemplates, templateHashesFrom } = await import('../src/templates-scan.js')
+
+    const contentRoot = createContentRoot(createFilesystemProvider(), noindexSourceDir)
+    const site = await loadSite({ contentRoot, templatesDir })
+    const templateInfos = await scanTemplates(templatesDir, projectRoot2)
+    const templateHashes = templateHashesFrom(templateInfos)
+    const page = site.pages.get('secret')!
+    const hash = hashManifest(page, { templateHashes })
+
+    await publishPageStatic('secret', contentRoot, target, templatesDir, hash, site)
+
+    const entries = await target.readDir('pages/secret')
+    const pubFile = entries.find(e => e.name.startsWith('.pub-'))
+    expect(pubFile).toBeDefined()
+    expect(pubFile!.name).toMatch(/-noindex$/)
+
+    const { parsePubSidecarName } = await import('../src/hash.js')
+    const parsed = parsePubSidecarName(pubFile!.name)
+    expect(parsed!.noindex).toBe(true)
+
+    await rm(noindexSourceDir, { recursive: true, force: true })
+  })
+
+  it('sitemap.xml is generated from target sidecars after publish', async () => {
+    const target = createFilesystemProvider(seoTargetDir)
+    const { hashManifest } = await import('../src/hash.js')
+    const { loadSite } = await import('../src/site-loader.js')
+    const { scanTemplates, templateHashesFrom } = await import('../src/templates-scan.js')
+    const { listSidecars } = await import('../src/sidecars.js')
+    const { generateSitemap } = await import('../src/sitemap.js')
+
+    const contentRoot = createContentRoot(storage, starterDir)
+    const site = await loadSite({ contentRoot, templatesDir })
+    const templateInfos = await scanTemplates(templatesDir, projectRoot2)
+    const templateHashes = templateHashesFrom(templateInfos)
+
+    // Publish home + about
+    for (const name of ['home', 'about']) {
+      const page = site.pages.get(name)!
+      const hash = hashManifest(page, { templateHashes })
+      await publishPageStatic(name, contentRoot, target, templatesDir, hash, site)
+    }
+
+    // Generate sitemap from target sidecars
+    const sidecars = await listSidecars(target, 'pages')
+    expect(sidecars.size).toBe(2)
+
+    const xml = generateSitemap({
+      baseUrl: 'https://example.com',
+      pages: sidecars,
+    })
+    expect(xml).not.toBeNull()
+    expect(xml).toContain('<loc>https://example.com/</loc>')
+    expect(xml).toContain('<loc>https://example.com/about</loc>')
+    expect(xml).toContain('<lastmod>')
+
+    // Write and verify it's readable
+    await target.writeFile('sitemap.xml', xml!)
+    const stored = await target.readFile('sitemap.xml')
+    expect(stored).toBe(xml)
+  })
+
+  it('robots.txt is generated with sitemap reference', async () => {
+    const { generateRobotsTxt } = await import('../src/robots.js')
+    const target = createFilesystemProvider(seoTargetDir)
+
+    const txt = generateRobotsTxt({ baseUrl: 'https://example.com' })
+    await target.writeFile('robots.txt', txt)
+
+    const stored = await target.readFile('robots.txt')
+    expect(stored).toContain('User-agent: *')
+    expect(stored).toContain('Sitemap: https://example.com/sitemap.xml')
+  })
+})

--- a/packages/gazetta/tests/publish.test.ts
+++ b/packages/gazetta/tests/publish.test.ts
@@ -655,7 +655,7 @@ describe('SEO publish integration', () => {
     expect(sidecars.size).toBe(2)
 
     const xml = generateSitemap({
-      baseUrl: 'https://example.com',
+      siteUrl: 'https://example.com',
       pages: sidecars,
     })
     expect(xml).not.toBeNull()
@@ -673,7 +673,7 @@ describe('SEO publish integration', () => {
     const { generateRobotsTxt } = await import('../src/robots.js')
     const target = createFilesystemProvider(seoTargetDir)
 
-    const txt = generateRobotsTxt({ baseUrl: 'https://example.com' })
+    const txt = generateRobotsTxt({ siteUrl: 'https://example.com' })
     await target.writeFile('robots.txt', txt)
 
     const stored = await target.readFile('robots.txt')

--- a/packages/gazetta/tests/publish.test.ts
+++ b/packages/gazetta/tests/publish.test.ts
@@ -72,7 +72,7 @@ describe('publishItems', () => {
   })
 
   it('preserves file content', async () => {
-    const content = JSON.stringify({ template: 'page-default', content: { title: 'Home' } })
+    const content = JSON.stringify({ template: 'page-default', metadata: { title: 'Home' } })
     await writeTestFile(sourceDir, 'pages/home/page.json', content)
     await writeTestFile(sourceDir, 'site.yaml', 'name: Test')
 
@@ -261,7 +261,11 @@ describe('publishRendered', () => {
     expect(html).toContain('<!DOCTYPE html>')
     expect(html).toContain('<!--esi:/fragments/header/index.html-->')
     expect(html).toContain('Welcome to Gazetta')
-    expect(html).toContain('<title>Home</title>')
+    // Note: ESI publish path assembles <head> from per-component output,
+    // not via renderPage. SEO fallback chain doesn't run here — <title>
+    // must come from template head or be added to the ESI assembly.
+    // Template no longer emits <title> (renderer owns it), so ESI pages
+    // currently lack it. This is a known gap to fix separately.
 
     // Check hashed CSS exists
     const entries = await target.readDir('pages/home')
@@ -384,7 +388,9 @@ describe('publishPageStatic', () => {
     const html = await target.readFile('index.html')
     expect(html).toContain('<!DOCTYPE html>')
     expect(html).toContain('Welcome to Gazetta')
-    expect(html).toContain('<title>Home</title>') // from page content
+    // Static publish uses renderPage which runs the SEO fallback chain.
+    // metadata.title wins over content.title.
+    expect(html).toContain('<title>Gazetta — Composable CMS</title>')
     // Fragments baked in
     expect(html).toContain('Gazetta') // from header
     expect(html).toContain('© 2026') // from footer

--- a/packages/gazetta/tests/publish.test.ts
+++ b/packages/gazetta/tests/publish.test.ts
@@ -261,11 +261,9 @@ describe('publishRendered', () => {
     expect(html).toContain('<!DOCTYPE html>')
     expect(html).toContain('<!--esi:/fragments/header/index.html-->')
     expect(html).toContain('Welcome to Gazetta')
-    // Note: ESI publish path assembles <head> from per-component output,
-    // not via renderPage. SEO fallback chain doesn't run here — <title>
-    // must come from template head or be added to the ESI assembly.
-    // Template no longer emits <title> (renderer owns it), so ESI pages
-    // currently lack it. This is a known gap to fix separately.
+    // ESI publish path now runs resolveSeoTags for <head> SEO injection.
+    // metadata.title wins via the fallback chain.
+    expect(html).toContain('<title>Gazetta — Composable CMS</title>')
 
     // Check hashed CSS exists
     const entries = await target.readDir('pages/home')

--- a/packages/gazetta/tests/publish.test.ts
+++ b/packages/gazetta/tests/publish.test.ts
@@ -557,7 +557,7 @@ describe('SEO publish integration', () => {
     await rm(seoTargetDir, { recursive: true, force: true })
   })
 
-  it('.pub sidecar is written with timestamp after static publish', async () => {
+  it('.pub sidecar is written with timestamp after static publish', { timeout: 15_000 }, async () => {
     const target = createFilesystemProvider(seoTargetDir)
     const { hashManifest } = await import('../src/hash.js')
     const { loadSite } = await import('../src/site-loader.js')

--- a/packages/gazetta/tests/renderer.test.ts
+++ b/packages/gazetta/tests/renderer.test.ts
@@ -384,4 +384,147 @@ describe('renderPage', () => {
     expect(html).toContain('A &amp; B &lt;script>')
     expect(html).toContain('content="He said &quot;hello&quot;"')
   })
+
+  // --- Fallback chain tests ---
+
+  it('title falls back to content.title + site name when metadata.title is empty', async () => {
+    const page: ResolvedComponent = {
+      template: () => ({ html: '<p>body</p>', css: '', js: '' }),
+      children: [],
+      treePath: 'page',
+      content: { title: 'About Us' },
+    }
+    const html = await renderPage(page, { seo: { siteName: 'Gazetta' } })
+    expect(html).toContain('<title>About Us — Gazetta</title>')
+    expect(html).toContain('property="og:title" content="About Us — Gazetta"')
+  })
+
+  it('title falls back to content.title without suffix when siteName is absent', async () => {
+    const page: ResolvedComponent = {
+      template: () => ({ html: '<p>body</p>', css: '', js: '' }),
+      children: [],
+      treePath: 'page',
+      content: { title: 'About Us' },
+    }
+    const html = await renderPage(page, { seo: {} })
+    expect(html).toContain('<title>About Us</title>')
+  })
+
+  it('description falls back to content.description', async () => {
+    const page: ResolvedComponent = {
+      template: () => ({ html: '<p>body</p>', css: '', js: '' }),
+      children: [],
+      treePath: 'page',
+      content: { description: 'A page about us' },
+    }
+    const html = await renderPage(page, { seo: {} })
+    expect(html).toContain('name="description" content="A page about us"')
+    expect(html).toContain('property="og:description" content="A page about us"')
+  })
+
+  it('canonical falls back to baseUrl + route', async () => {
+    const page = leaf('<p>body</p>', '', '', 'page')
+    const html = await renderPage(page, { route: '/about', seo: { baseUrl: 'https://example.com' } })
+    expect(html).toContain('href="https://example.com/about"')
+    expect(html).toContain('property="og:url" content="https://example.com/about"')
+  })
+
+  it('og:image falls back to site defaultOgImage', async () => {
+    const page = leaf('<p>body</p>', '', '', 'page')
+    const html = await renderPage(page, { seo: { defaultOgImage: '/images/default.jpg' } })
+    expect(html).toContain('property="og:image" content="/images/default.jpg"')
+  })
+
+  it('metadata.ogImage overrides site defaultOgImage', async () => {
+    const page = leaf('<p>body</p>', '', '', 'page')
+    const html = await renderPage(page, {
+      metadata: { ogImage: '/images/page.jpg' },
+      seo: { defaultOgImage: '/images/default.jpg' },
+    })
+    expect(html).toContain('property="og:image" content="/images/page.jpg"')
+    expect(html).not.toContain('default.jpg')
+  })
+
+  it('emits og:type=website and twitter:card', async () => {
+    const page = leaf('<p>body</p>', '', '', 'page')
+    const html = await renderPage(page, { seo: {} })
+    expect(html).toContain('property="og:type" content="website"')
+    expect(html).toContain('name="twitter:card" content="summary"')
+  })
+
+  it('twitter:card is summary_large_image when og:image is resolved', async () => {
+    const page = leaf('<p>body</p>', '', '', 'page')
+    const html = await renderPage(page, { metadata: { ogImage: '/img.jpg' } })
+    expect(html).toContain('name="twitter:card" content="summary_large_image"')
+  })
+
+  it('emits robots meta when metadata.robots is set', async () => {
+    const page = leaf('<p>body</p>', '', '', 'page')
+    const html = await renderPage(page, { metadata: { robots: 'noindex, nofollow' } })
+    expect(html).toContain('name="robots" content="noindex, nofollow"')
+  })
+
+  it('omits robots meta when metadata.robots is absent', async () => {
+    const page = leaf('<p>body</p>', '', '', 'page')
+    const html = await renderPage(page, { metadata: {} })
+    expect(html).not.toContain('name="robots"')
+  })
+
+  it('uses site locale for <html lang>', async () => {
+    const page = leaf('<p>body</p>', '', '', 'page')
+    const html = await renderPage(page, { seo: { locale: 'fr' } })
+    expect(html).toContain('<html lang="fr">')
+  })
+
+  it('defaults <html lang> to en when locale is absent', async () => {
+    const page = leaf('<p>body</p>', '', '', 'page')
+    const html = await renderPage(page, { seo: {} })
+    expect(html).toContain('<html lang="en">')
+  })
+
+  it('metadata.title wins over content.title fallback', async () => {
+    const page: ResolvedComponent = {
+      template: () => ({ html: '<p>body</p>', css: '', js: '' }),
+      children: [],
+      treePath: 'page',
+      content: { title: 'Content Title' },
+    }
+    const html = await renderPage(page, {
+      metadata: { title: 'SEO Title' },
+      seo: { siteName: 'Site' },
+    })
+    expect(html).toContain('<title>SEO Title</title>')
+    expect(html).not.toContain('Content Title')
+  })
+
+  it('full fallback chain with all values populated', async () => {
+    const page: ResolvedComponent = {
+      template: () => ({ html: '<p>body</p>', css: '', js: '' }),
+      children: [],
+      treePath: 'page',
+      content: { title: 'Fallback', description: 'Fallback desc' },
+    }
+    const html = await renderPage(page, {
+      metadata: {
+        title: 'SEO Title',
+        description: 'SEO desc',
+        ogImage: '/seo.jpg',
+        canonical: 'https://example.com/page',
+        robots: 'noindex',
+      },
+      route: '/page',
+      seo: { siteName: 'MySite', baseUrl: 'https://example.com', locale: 'de', defaultOgImage: '/default.jpg' },
+    })
+    expect(html).toContain('<html lang="de">')
+    expect(html).toContain('<title>SEO Title</title>')
+    expect(html).toContain('name="description" content="SEO desc"')
+    expect(html).toContain('href="https://example.com/page"')
+    expect(html).toContain('property="og:image" content="/seo.jpg"')
+    expect(html).toContain('property="og:url" content="https://example.com/page"')
+    expect(html).toContain('property="og:type" content="website"')
+    expect(html).toContain('name="twitter:card" content="summary_large_image"')
+    expect(html).toContain('name="robots" content="noindex"')
+    expect(html).not.toContain('Fallback')
+    expect(html).not.toContain('default.jpg')
+  })
 })

--- a/packages/gazetta/tests/renderer.test.ts
+++ b/packages/gazetta/tests/renderer.test.ts
@@ -429,6 +429,13 @@ describe('renderPage', () => {
     expect(html).toContain('property="og:url" content="https://example.com/about"')
   })
 
+  it('strips trailing slash from siteUrl before appending route', async () => {
+    const page = leaf('<p>body</p>', '', '', 'page')
+    const html = await renderPage(page, { route: '/about', seo: { siteUrl: 'https://example.com/blog/' } })
+    expect(html).toContain('href="https://example.com/blog/about"')
+    expect(html).not.toContain('blog//about')
+  })
+
   it('og:image falls back to site defaultOgImage', async () => {
     const page = leaf('<p>body</p>', '', '', 'page')
     const html = await renderPage(page, { seo: { defaultOgImage: '/images/default.jpg' } })

--- a/packages/gazetta/tests/renderer.test.ts
+++ b/packages/gazetta/tests/renderer.test.ts
@@ -422,9 +422,9 @@ describe('renderPage', () => {
     expect(html).toContain('property="og:description" content="A page about us"')
   })
 
-  it('canonical falls back to baseUrl + route', async () => {
+  it('canonical falls back to siteUrl + route', async () => {
     const page = leaf('<p>body</p>', '', '', 'page')
-    const html = await renderPage(page, { route: '/about', seo: { baseUrl: 'https://example.com' } })
+    const html = await renderPage(page, { route: '/about', seo: { siteUrl: 'https://example.com' } })
     expect(html).toContain('href="https://example.com/about"')
     expect(html).toContain('property="og:url" content="https://example.com/about"')
   })
@@ -513,7 +513,7 @@ describe('renderPage', () => {
         robots: 'noindex',
       },
       route: '/page',
-      seo: { siteName: 'MySite', baseUrl: 'https://example.com', locale: 'de', defaultOgImage: '/default.jpg' },
+      seo: { siteName: 'MySite', siteUrl: 'https://example.com', locale: 'de', defaultOgImage: '/default.jpg' },
     })
     expect(html).toContain('<html lang="de">')
     expect(html).toContain('<title>SEO Title</title>')

--- a/packages/gazetta/tests/robots.test.ts
+++ b/packages/gazetta/tests/robots.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { generateRobotsTxt } from '../src/robots.js'
+
+describe('generateRobotsTxt', () => {
+  it('generates permissive default with Sitemap when baseUrl is set', () => {
+    const txt = generateRobotsTxt({ baseUrl: 'https://example.com' })
+    expect(txt).toContain('User-agent: *')
+    expect(txt).toContain('Allow: /')
+    expect(txt).toContain('Sitemap: https://example.com/sitemap.xml')
+  })
+
+  it('omits Sitemap line when baseUrl is absent', () => {
+    const txt = generateRobotsTxt({})
+    expect(txt).toContain('User-agent: *')
+    expect(txt).toContain('Allow: /')
+    expect(txt).not.toContain('Sitemap')
+  })
+
+  it('ends with a newline', () => {
+    const txt = generateRobotsTxt({})
+    expect(txt.endsWith('\n')).toBe(true)
+  })
+})

--- a/packages/gazetta/tests/robots.test.ts
+++ b/packages/gazetta/tests/robots.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect } from 'vitest'
 import { generateRobotsTxt } from '../src/robots.js'
 
 describe('generateRobotsTxt', () => {
-  it('generates permissive default with Sitemap when baseUrl is set', () => {
-    const txt = generateRobotsTxt({ baseUrl: 'https://example.com' })
+  it('generates permissive default with Sitemap when siteUrl is set', () => {
+    const txt = generateRobotsTxt({ siteUrl: 'https://example.com' })
     expect(txt).toContain('User-agent: *')
     expect(txt).toContain('Allow: /')
     expect(txt).toContain('Sitemap: https://example.com/sitemap.xml')
   })
 
-  it('omits Sitemap line when baseUrl is absent', () => {
+  it('omits Sitemap line when siteUrl is absent', () => {
     const txt = generateRobotsTxt({})
     expect(txt).toContain('User-agent: *')
     expect(txt).toContain('Allow: /')

--- a/packages/gazetta/tests/sidecars.test.ts
+++ b/packages/gazetta/tests/sidecars.test.ts
@@ -90,6 +90,7 @@ describe('readSidecars', () => {
       hash: 'abcd1234',
       uses: [],
       template: null,
+      pub: null,
     })
   })
 
@@ -118,6 +119,7 @@ describe('readSidecars', () => {
       hash: 'abcd1234',
       uses: [],
       template: null,
+      pub: null,
     })
   })
 
@@ -143,6 +145,7 @@ describe('writeSidecars', () => {
       hash: 'deadbeef',
       uses: ['header', 'footer'],
       template: 'page-default',
+      pub: null,
     }
     await writeSidecars(storage, 'pages/home', state)
     const files = [...storage.dump().keys()].filter(p => p.startsWith('pages/home/'))
@@ -153,14 +156,14 @@ describe('writeSidecars', () => {
   })
 
   it('skips tpl-* when template is null', async () => {
-    await writeSidecars(storage, 'pages/home', { hash: 'deadbeef', uses: [], template: null })
+    await writeSidecars(storage, 'pages/home', { hash: 'deadbeef', uses: [], template: null, pub: null })
     const files = [...storage.dump().keys()].filter(p => p.startsWith('pages/home/'))
     expect(files).toContain('pages/home/.deadbeef.hash')
     expect(files.some(f => f.includes('.tpl-'))).toBe(false)
   })
 
   it('is idempotent — writing the same state twice leaves the same files', async () => {
-    const state: SidecarState = { hash: 'aa11bb22', uses: ['nav'], template: 'layout' }
+    const state: SidecarState = { hash: 'aa11bb22', uses: ['nav'], template: 'layout', pub: null }
     await writeSidecars(storage, 'pages/home', state)
     const snap1 = new Set([...storage.dump().keys()])
     await writeSidecars(storage, 'pages/home', state)
@@ -174,12 +177,14 @@ describe('writeSidecars', () => {
       hash: '11111111',
       uses: ['header', 'footer'],
       template: 'old-layout',
+      pub: null,
     })
     // New state: only header, different template, different hash
     await writeSidecars(storage, 'pages/home', {
       hash: '22222222',
       uses: ['header'],
       template: 'new-layout',
+      pub: null,
     })
     const files = [...storage.dump().keys()].filter(p => p.startsWith('pages/home/'))
     expect(files).toContain('pages/home/.22222222.hash')
@@ -197,7 +202,7 @@ describe('writeSidecars', () => {
       'pages/home/index.html': '<html>',
       'pages/home/.01234567.hash': '', // an old sidecar — this SHOULD be removed
     })
-    await writeSidecars(storage, 'pages/home', { hash: 'abcdef01', uses: [], template: null })
+    await writeSidecars(storage, 'pages/home', { hash: 'abcdef01', uses: [], template: null, pub: null })
     const files = [...storage.dump().keys()].filter(p => p.startsWith('pages/home/'))
     expect(files).toContain('pages/home/page.json')
     expect(files).toContain('pages/home/index.html')

--- a/packages/gazetta/tests/sitemap.test.ts
+++ b/packages/gazetta/tests/sitemap.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { generateSitemap } from '../src/sitemap.js'
+import type { SidecarState } from '../src/sidecars.js'
+
+function page(name: string, lastPublished?: string, noindex = false): [string, SidecarState] {
+  return [
+    name,
+    {
+      hash: '00000000',
+      uses: [],
+      template: null,
+      pub: lastPublished ? { lastPublished, noindex } : null,
+    },
+  ]
+}
+
+describe('generateSitemap', () => {
+  it('generates XML with loc for each page', () => {
+    const pages = new Map([page('home'), page('about'), page('blog/hello')])
+    const xml = generateSitemap({ baseUrl: 'https://example.com', pages })!
+    expect(xml).toContain('<loc>https://example.com/</loc>')
+    expect(xml).toContain('<loc>https://example.com/about</loc>')
+    expect(xml).toContain('<loc>https://example.com/blog/hello</loc>')
+    expect(xml).toContain('<?xml version="1.0"')
+    expect(xml).toContain('<urlset')
+  })
+
+  it('includes lastmod from pub sidecar timestamp', () => {
+    const pages = new Map([page('about', '2026-04-17T22:00:00Z')])
+    const xml = generateSitemap({ baseUrl: 'https://example.com', pages })!
+    expect(xml).toContain('<lastmod>2026-04-17</lastmod>')
+  })
+
+  it('omits lastmod when pub sidecar has no timestamp', () => {
+    const pages = new Map([page('about')])
+    const xml = generateSitemap({ baseUrl: 'https://example.com', pages })!
+    expect(xml).not.toContain('<lastmod>')
+  })
+
+  it('skips pages with noindex pub sidecar', () => {
+    const pages = new Map([page('home'), page('secret', '2026-04-17T22:00:00Z', true)])
+    const xml = generateSitemap({ baseUrl: 'https://example.com', pages })!
+    expect(xml).toContain('<loc>https://example.com/</loc>')
+    expect(xml).not.toContain('secret')
+  })
+
+  it('skips system pages', () => {
+    const pages = new Map([page('home'), page('404')])
+    const xml = generateSitemap({ baseUrl: 'https://example.com', pages, systemPages: ['404'] })!
+    expect(xml).toContain('<loc>https://example.com/</loc>')
+    expect(xml).not.toContain('404')
+  })
+
+  it('returns null when no pages qualify', () => {
+    const pages = new Map([page('404')])
+    expect(generateSitemap({ baseUrl: 'https://example.com', pages, systemPages: ['404'] })).toBeNull()
+  })
+
+  it('returns null for empty target', () => {
+    expect(generateSitemap({ baseUrl: 'https://example.com', pages: new Map() })).toBeNull()
+  })
+
+  it('escapes special characters in URLs', () => {
+    const pages = new Map([page('search&filter')])
+    const xml = generateSitemap({ baseUrl: 'https://example.com', pages })!
+    expect(xml).toContain('search&amp;filter')
+  })
+})

--- a/packages/gazetta/tests/sitemap.test.ts
+++ b/packages/gazetta/tests/sitemap.test.ts
@@ -65,4 +65,13 @@ describe('generateSitemap', () => {
     const xml = generateSitemap({ siteUrl: 'https://example.com', pages })!
     expect(xml).toContain('search&amp;filter')
   })
+
+  it('skips dynamic route pages (template patterns are not crawlable)', () => {
+    const pages = new Map([page('home'), page('blog/[slug]'), page('docs/[...path]')])
+    const xml = generateSitemap({ siteUrl: 'https://example.com', pages })!
+    expect(xml).toContain('<loc>https://example.com/</loc>')
+    expect(xml).not.toContain(':slug')
+    expect(xml).not.toContain('[slug]')
+    expect(xml).not.toContain('[...path]')
+  })
 })

--- a/packages/gazetta/tests/sitemap.test.ts
+++ b/packages/gazetta/tests/sitemap.test.ts
@@ -66,6 +66,19 @@ describe('generateSitemap', () => {
     expect(xml).toContain('search&amp;filter')
   })
 
+  it('strips trailing slash from siteUrl', () => {
+    const pages = new Map([page('about')])
+    const xml = generateSitemap({ siteUrl: 'https://example.com/', pages })!
+    expect(xml).toContain('<loc>https://example.com/about</loc>')
+    expect(xml).not.toContain('//about')
+  })
+
+  it('handles siteUrl with subpath and trailing slash', () => {
+    const pages = new Map([page('about')])
+    const xml = generateSitemap({ siteUrl: 'https://example.com/blog/', pages })!
+    expect(xml).toContain('<loc>https://example.com/blog/about</loc>')
+  })
+
   it('skips dynamic route pages (template patterns are not crawlable)', () => {
     const pages = new Map([page('home'), page('blog/[slug]'), page('docs/[...path]')])
     const xml = generateSitemap({ siteUrl: 'https://example.com', pages })!

--- a/packages/gazetta/tests/sitemap.test.ts
+++ b/packages/gazetta/tests/sitemap.test.ts
@@ -17,7 +17,7 @@ function page(name: string, lastPublished?: string, noindex = false): [string, S
 describe('generateSitemap', () => {
   it('generates XML with loc for each page', () => {
     const pages = new Map([page('home'), page('about'), page('blog/hello')])
-    const xml = generateSitemap({ baseUrl: 'https://example.com', pages })!
+    const xml = generateSitemap({ siteUrl: 'https://example.com', pages })!
     expect(xml).toContain('<loc>https://example.com/</loc>')
     expect(xml).toContain('<loc>https://example.com/about</loc>')
     expect(xml).toContain('<loc>https://example.com/blog/hello</loc>')
@@ -27,42 +27,42 @@ describe('generateSitemap', () => {
 
   it('includes lastmod from pub sidecar timestamp', () => {
     const pages = new Map([page('about', '2026-04-17T22:00:00Z')])
-    const xml = generateSitemap({ baseUrl: 'https://example.com', pages })!
+    const xml = generateSitemap({ siteUrl: 'https://example.com', pages })!
     expect(xml).toContain('<lastmod>2026-04-17</lastmod>')
   })
 
   it('omits lastmod when pub sidecar has no timestamp', () => {
     const pages = new Map([page('about')])
-    const xml = generateSitemap({ baseUrl: 'https://example.com', pages })!
+    const xml = generateSitemap({ siteUrl: 'https://example.com', pages })!
     expect(xml).not.toContain('<lastmod>')
   })
 
   it('skips pages with noindex pub sidecar', () => {
     const pages = new Map([page('home'), page('secret', '2026-04-17T22:00:00Z', true)])
-    const xml = generateSitemap({ baseUrl: 'https://example.com', pages })!
+    const xml = generateSitemap({ siteUrl: 'https://example.com', pages })!
     expect(xml).toContain('<loc>https://example.com/</loc>')
     expect(xml).not.toContain('secret')
   })
 
   it('skips system pages', () => {
     const pages = new Map([page('home'), page('404')])
-    const xml = generateSitemap({ baseUrl: 'https://example.com', pages, systemPages: ['404'] })!
+    const xml = generateSitemap({ siteUrl: 'https://example.com', pages, systemPages: ['404'] })!
     expect(xml).toContain('<loc>https://example.com/</loc>')
     expect(xml).not.toContain('404')
   })
 
   it('returns null when no pages qualify', () => {
     const pages = new Map([page('404')])
-    expect(generateSitemap({ baseUrl: 'https://example.com', pages, systemPages: ['404'] })).toBeNull()
+    expect(generateSitemap({ siteUrl: 'https://example.com', pages, systemPages: ['404'] })).toBeNull()
   })
 
   it('returns null for empty target', () => {
-    expect(generateSitemap({ baseUrl: 'https://example.com', pages: new Map() })).toBeNull()
+    expect(generateSitemap({ siteUrl: 'https://example.com', pages: new Map() })).toBeNull()
   })
 
   it('escapes special characters in URLs', () => {
     const pages = new Map([page('search&filter')])
-    const xml = generateSitemap({ baseUrl: 'https://example.com', pages })!
+    const xml = generateSitemap({ siteUrl: 'https://example.com', pages })!
     expect(xml).toContain('search&amp;filter')
   })
 })

--- a/scripts/bench-publish-10k.ts
+++ b/scripts/bench-publish-10k.ts
@@ -1,0 +1,265 @@
+#!/usr/bin/env npx tsx
+/**
+ * Benchmark: full publish pipeline at 10k pages.
+ *
+ * Measures per-phase timings to identify bottlenecks in the publish
+ * workflow at scale. Runs against both Azurite (Azure Blob) and
+ * MinIO (S3) via the existing docker-compose.yml.
+ *
+ * Usage:
+ *   npx tsx scripts/bench-publish-10k.ts [--pages=10000] [--provider=azurite|minio|filesystem]
+ *
+ * Requires Docker running for azurite/minio providers.
+ */
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const PAGE_COUNT = Number(process.argv.find(a => a.startsWith('--pages='))?.split('=')[1] ?? 10_000)
+const PROVIDER = process.argv.find(a => a.startsWith('--provider='))?.split('=')[1] ?? 'filesystem'
+
+// --- Timing helpers ---
+function timer() {
+  const start = performance.now()
+  return () => ((performance.now() - start) / 1000).toFixed(2) + 's'
+}
+
+function log(label: string, elapsed: string, detail?: string) {
+  const pad = label.padEnd(20)
+  console.log(`  ${pad} ${elapsed}${detail ? `  (${detail})` : ''}`)
+}
+
+// --- Seed page manifests ---
+async function seedPages(dir: string, count: number): Promise<void> {
+  const t = timer()
+  const pagesDir = join(dir, 'pages')
+
+  // Write in parallel batches to avoid fd exhaustion
+  const batchSize = 500
+  for (let i = 0; i < count; i += batchSize) {
+    const batch = []
+    for (let j = i; j < Math.min(i + batchSize, count); j++) {
+      const name = `page-${String(j).padStart(5, '0')}`
+      const pageDir = join(pagesDir, name)
+      batch.push(
+        mkdir(pageDir, { recursive: true }).then(() =>
+          writeFile(
+            join(pageDir, 'page.json'),
+            JSON.stringify({
+              template: 'bench',
+              content: { title: `Page ${j}`, description: `Description for page ${j}` },
+              metadata:
+                j % 100 === 0 ? { robots: 'noindex' } : { title: `SEO Title ${j}`, description: `SEO desc ${j}` },
+            }),
+          ),
+        ),
+      )
+    }
+    await Promise.all(batch)
+  }
+
+  // Site yaml
+  await writeFile(
+    join(dir, 'site.yaml'),
+    `name: Bench Site
+baseUrl: https://bench.example.com
+locale: en
+systemPages: []
+targets:
+  bench:
+    storage:
+      type: filesystem
+      path: ./dist/bench
+`,
+  )
+
+  // Stub template
+  const tplDir = join(dir, 'templates', 'bench')
+  await mkdir(tplDir, { recursive: true })
+  await writeFile(
+    join(tplDir, 'index.ts'),
+    `export const schema = { _def: { typeName: 'ZodObject' }, shape: { title: {}, description: {} } }
+export default ({ content }) => ({
+  html: '<h1>' + (content?.title ?? '') + '</h1><p>' + (content?.description ?? '') + '</p>',
+  css: 'h1 { color: navy; }',
+  js: '',
+})
+`,
+  )
+
+  // package.json for templates workspace
+  await writeFile(join(dir, 'templates', 'package.json'), JSON.stringify({ name: 'templates', private: true }))
+
+  log('Seed', t(), `${count} pages`)
+}
+
+// --- Create storage provider ---
+async function createProvider(
+  provider: string,
+  projectDir: string,
+): Promise<{ storage: import('../packages/gazetta/src/types.js').StorageProvider; cleanup: () => Promise<void> }> {
+  if (provider === 'filesystem') {
+    const { createFilesystemProvider } = await import('../packages/gazetta/src/providers/filesystem.js')
+    const distDir = join(projectDir, 'dist', 'bench')
+    await mkdir(distDir, { recursive: true })
+    return { storage: createFilesystemProvider(distDir), cleanup: async () => {} }
+  }
+
+  if (provider === 'azurite') {
+    const { DockerComposeEnvironment } = await import('testcontainers')
+    const env = await new DockerComposeEnvironment('.', 'docker-compose.yml').withStartupTimeout(60_000).up(['azurite'])
+    const container = env.getContainer('azurite-1')
+    const port = container.getMappedPort(10000)
+    const connStr = `DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:${port}/devstoreaccount1;`
+    const { createAzureBlobProvider } = await import('../packages/gazetta/src/providers/azure-blob.js')
+    const storage = await createAzureBlobProvider({ connectionString: connStr, container: 'bench-10k' })
+    return { storage, cleanup: () => env.down() }
+  }
+
+  if (provider === 'minio') {
+    const { DockerComposeEnvironment } = await import('testcontainers')
+    const env = await new DockerComposeEnvironment('.', 'docker-compose.yml').withStartupTimeout(60_000).up(['minio'])
+    const container = env.getContainer('minio-1')
+    const port = container.getMappedPort(9000)
+    const { createS3Provider } = await import('../packages/gazetta/src/providers/s3.js')
+    const storage = await createS3Provider({
+      endpoint: `http://127.0.0.1:${port}`,
+      bucket: 'bench-10k',
+      region: 'us-east-1',
+      accessKeyId: 'minioadmin',
+      secretAccessKey: 'minioadmin',
+      forcePathStyle: true,
+    })
+    return { storage, cleanup: () => env.down() }
+  }
+
+  throw new Error(`Unknown provider: ${provider}`)
+}
+
+// --- Main ---
+async function main() {
+  console.log(`\n=== Publish benchmark: ${PAGE_COUNT} pages on ${PROVIDER} ===\n`)
+
+  // 1. Seed
+  const projectDir = await mkdtemp(join(tmpdir(), 'gazetta-bench-'))
+  try {
+    await seedPages(projectDir, PAGE_COUNT)
+
+    // 2. Create provider
+    const tSetup = timer()
+    const { storage: targetStorage, cleanup } = await createProvider(PROVIDER, projectDir)
+    log('Provider setup', tSetup())
+
+    try {
+      // 3. Load site
+      const tLoad = timer()
+      const { loadSite } = await import('../packages/gazetta/src/site-loader.js')
+      const { createContentRoot } = await import('../packages/gazetta/src/content-root.js')
+      const { createFilesystemProvider } = await import('../packages/gazetta/src/providers/filesystem.js')
+      const sourceStorage = createFilesystemProvider(projectDir)
+      const contentRoot = createContentRoot(sourceStorage)
+      const site = await loadSite({ contentRoot, templatesDir: join(projectDir, 'templates') })
+      log('Load site', tLoad(), `${site.pages.size} pages`)
+
+      // 4. Template scan
+      const tScan = timer()
+      const { scanTemplates, templateHashesFrom } = await import('../packages/gazetta/src/templates-scan.js')
+      const templateInfos = await scanTemplates(join(projectDir, 'templates'), projectDir)
+      const templateHashes = templateHashesFrom(templateInfos)
+      log('Template scan', tScan(), `${templateInfos.length} templates`)
+
+      // 5. Compare (first publish — empty target)
+      const tCompare = timer()
+      const { compareTargets } = await import('../packages/gazetta/src/compare.js')
+      const cmp = await compareTargets({
+        sourceRoot: contentRoot,
+        target: targetStorage,
+        templatesDir: join(projectDir, 'templates'),
+        projectRoot: projectDir,
+        type: 'static',
+        scanTemplates: async () => templateInfos,
+      })
+      log('Compare', tCompare(), `${cmp.added.length} added, ${cmp.unchanged.length} unchanged`)
+
+      // 6. Render + upload
+      const tPublish = timer()
+      const { publishPageStatic } = await import('../packages/gazetta/src/publish-rendered.js')
+      const { hashManifest } = await import('../packages/gazetta/src/hash.js')
+      let published = 0
+      // Batch to avoid memory pressure
+      const pageNames = [...site.pages.keys()]
+      const batchSize = 100
+      for (let i = 0; i < pageNames.length; i += batchSize) {
+        const batch = pageNames.slice(i, i + batchSize)
+        await Promise.all(
+          batch.map(async name => {
+            const page = site.pages.get(name)!
+            const hash = hashManifest(page, { templateHashes })
+            await publishPageStatic(name, contentRoot, targetStorage, join(projectDir, 'templates'), hash, site)
+            published++
+          }),
+        )
+        if (published % 1000 === 0) process.stdout.write(`    ${published}/${PAGE_COUNT}\r`)
+      }
+      log('Render + upload', tPublish(), `${published} pages`)
+
+      // 7. Sitemap
+      const tSitemap = timer()
+      const { listSidecars } = await import('../packages/gazetta/src/sidecars.js')
+      const { generateSitemap } = await import('../packages/gazetta/src/sitemap.js')
+      const targetSidecars = await listSidecars(targetStorage, 'pages')
+      const sitemapXml = generateSitemap({
+        baseUrl: 'https://bench.example.com',
+        pages: targetSidecars,
+        systemPages: [],
+      })
+      if (sitemapXml) {
+        await targetStorage.writeFile('sitemap.xml', sitemapXml)
+      }
+      log(
+        'Sitemap',
+        tSitemap(),
+        `${targetSidecars.size} entries, ${sitemapXml ? Math.round(sitemapXml.length / 1024) + 'KB' : 'null'}`,
+      )
+
+      // 8. Robots
+      const tRobots = timer()
+      const { generateRobotsTxt } = await import('../packages/gazetta/src/robots.js')
+      await targetStorage.writeFile('robots.txt', generateRobotsTxt({ baseUrl: 'https://bench.example.com' }))
+      log('robots.txt', tRobots())
+
+      // 9. Total
+      console.log()
+
+      // === Incremental publish (0 changes) ===
+      console.log(`=== Incremental publish (0 changes) ===\n`)
+
+      const tIncCompare = timer()
+      const cmp2 = await compareTargets({
+        sourceRoot: contentRoot,
+        target: targetStorage,
+        templatesDir: join(projectDir, 'templates'),
+        projectRoot: projectDir,
+        type: 'static',
+        scanTemplates: async () => templateInfos,
+      })
+      log('Compare', tIncCompare(), `${cmp2.added.length} added, ${cmp2.unchanged.length} unchanged`)
+
+      const tIncSitemap = timer()
+      const sidecars2 = await listSidecars(targetStorage, 'pages')
+      generateSitemap({ baseUrl: 'https://bench.example.com', pages: sidecars2 })
+      log('Sitemap', tIncSitemap(), `${sidecars2.size} entries`)
+
+      console.log()
+    } finally {
+      await cleanup()
+    }
+  } finally {
+    await rm(projectDir, { recursive: true, force: true })
+  }
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/sites/gazetta.studio/site.yaml
+++ b/sites/gazetta.studio/site.yaml
@@ -1,4 +1,5 @@
 name: "Gazetta Studio"
+locale: en
 targets:
   local:
     storage:

--- a/sites/gazetta.studio/targets/local/pages/blog/page.json
+++ b/sites/gazetta.studio/targets/local/pages/blog/page.json
@@ -1,6 +1,6 @@
 {
   "template": "site-layout",
-  "content": {
+  "metadata": {
     "title": "Blog — Gazetta",
     "description": "News, tutorials, and updates from the Gazetta team."
   },

--- a/sites/gazetta.studio/targets/local/pages/blog/page.json
+++ b/sites/gazetta.studio/targets/local/pages/blog/page.json
@@ -4,11 +4,6 @@
     "title": "Blog — Gazetta",
     "description": "News, tutorials, and updates from the Gazetta team."
   },
-  "metadata": {
-    "title": "Blog — Gazetta",
-    "description": "News, tutorials, and updates from the Gazetta team.",
-    "canonical": "https://gazetta.studio/blog"
-  },
   "components": [
     "@header",
     {

--- a/sites/gazetta.studio/targets/local/pages/docs/page.json
+++ b/sites/gazetta.studio/targets/local/pages/docs/page.json
@@ -1,11 +1,8 @@
 {
   "template": "site-layout",
-  "content": {
-    "title": "Documentation — Gazetta",
-    "description": "Learn how to build composable websites with Gazetta."
-  },
   "metadata": {
-    "description": "Learn how to build composable websites with Gazetta. Templates, fragments, pages, targets, and CLI reference."
+    "description": "Learn how to build composable websites with Gazetta. Templates, fragments, pages, targets, and CLI reference.",
+    "title": "Documentation — Gazetta"
   },
   "components": [
     "@header",

--- a/sites/gazetta.studio/targets/local/pages/docs/page.json
+++ b/sites/gazetta.studio/targets/local/pages/docs/page.json
@@ -5,9 +5,7 @@
     "description": "Learn how to build composable websites with Gazetta."
   },
   "metadata": {
-    "title": "Documentation — Gazetta",
-    "description": "Learn how to build composable websites with Gazetta. Templates, fragments, pages, targets, and CLI reference.",
-    "canonical": "https://gazetta.studio/docs"
+    "description": "Learn how to build composable websites with Gazetta. Templates, fragments, pages, targets, and CLI reference."
   },
   "components": [
     "@header",

--- a/sites/gazetta.studio/targets/local/pages/home/page.json
+++ b/sites/gazetta.studio/targets/local/pages/home/page.json
@@ -4,11 +4,6 @@
     "title": "Gazetta — Stateless CMS for Composable Websites",
     "description": "No database. No build step. Pages composed from reusable components at serve time."
   },
-  "metadata": {
-    "title": "Gazetta — Stateless CMS for Composable Websites",
-    "description": "No database. No build step. Pages composed from reusable components at serve time.",
-    "canonical": "https://gazetta.studio/"
-  },
   "components": [
     "@header",
     {

--- a/sites/gazetta.studio/targets/local/pages/home/page.json
+++ b/sites/gazetta.studio/targets/local/pages/home/page.json
@@ -1,6 +1,6 @@
 {
   "template": "site-layout",
-  "content": {
+  "metadata": {
     "title": "Gazetta — Stateless CMS for Composable Websites",
     "description": "No database. No build step. Pages composed from reusable components at serve time."
   },

--- a/sites/gazetta.studio/targets/local/site.yaml
+++ b/sites/gazetta.studio/targets/local/site.yaml
@@ -1,1 +1,2 @@
 name: "Gazetta Studio"
+locale: en

--- a/sites/gazetta.studio/templates/site-layout/index.ts
+++ b/sites/gazetta.studio/templates/site-layout/index.ts
@@ -1,14 +1,11 @@
 import { z } from 'zod'
 import type { TemplateFunction } from 'gazetta'
 
-export const schema = z.object({
-  title: z.string().describe('Page title'),
-  description: z.string().optional().describe('Page description'),
-})
+// Layout template — dark theme with Inter font. No content of its own.
+// SEO tags are handled by the renderer's fallback chain from page.metadata.
+export const schema = z.object({})
 
-type Content = z.infer<typeof schema>
-
-const template: TemplateFunction<Content> = ({ content, children = [] }) => ({
+const template: TemplateFunction = ({ children = [] }) => ({
   html: `<div class="site">${children.map(c => c.html).join('\n')}</div>`,
   css: `*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 body { font-family: 'Inter', system-ui, -apple-system, sans-serif; color: #e4e4e7; background: #09090b; line-height: 1.6; }
@@ -20,9 +17,7 @@ ${children.map(c => c.css).join('\n')}`,
     .map(c => c.js)
     .filter(Boolean)
     .join('\n'),
-  head: `<title>${content?.title ?? ''}</title>
-${content?.description ? `<meta name="description" content="${content.description}">` : ''}
-<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%238b5cf6'/%3E%3Crect x='7' y='7' width='8' height='8' rx='2' fill='white'/%3E%3Crect x='17' y='7' width='8' height='8' rx='2' fill='white' opacity='.6'/%3E%3Crect x='7' y='17' width='8' height='8' rx='2' fill='white' opacity='.6'/%3E%3Crect x='17' y='17' width='8' height='8' rx='2' fill='white' opacity='.3'/%3E%3C/svg%3E">
+  head: `<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%238b5cf6'/%3E%3Crect x='7' y='7' width='8' height='8' rx='2' fill='white'/%3E%3Crect x='17' y='7' width='8' height='8' rx='2' fill='white' opacity='.6'/%3E%3Crect x='7' y='17' width='8' height='8' rx='2' fill='white' opacity='.6'/%3E%3Crect x='17' y='17' width='8' height='8' rx='2' fill='white' opacity='.3'/%3E%3C/svg%3E">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
SEO plan items 1.1–1.3. Covers the full Tier 1 renderer + publish pipeline work:

### 1. Renderer fallback chains (seo.ts)
Every SEO tag has a computed default from existing data — pages never ship with empty metadata:

| Tag | Fallback chain |
|-----|---------------|
| `<title>` | `metadata.title` → `content.title + " — " + site.name` → omit |
| `<meta name="description">` | `metadata.description` → `content.description` → omit |
| `<link rel="canonical">` | `metadata.canonical` → `site.baseUrl + route` → omit |
| `og:image` | `metadata.ogImage` → `site.defaultOgImage` → omit |
| `og:title/description/url` | same chains |
| `og:type` | always `"website"` |
| `twitter:card` | `summary_large_image` when ogImage, else `summary` |
| `<meta name="robots">` | `metadata.robots` when set → omit |
| `<html lang>` | `site.locale` → `"en"` |

Extracted into `seo.ts` (SRP) — renderer stays focused on HTML assembly.

### 2. .pub sidecar
New sidecar kind: `.pub-{compact-timestamp}` with optional `-noindex` suffix. Written per-page at publish time. Encodes when the page was last published and whether it's noindex. Parsed alongside existing .hash/.uses-*/.tpl-* kinds via readDir (zero extra I/O — filename IS the data).

### 3. sitemap.xml generation
Generated at publish time from **target sidecars** (not source) — reflects what's actually published. Uses `deriveRoute(name)` for `<loc>`, `.pub` timestamp for `<lastmod>` (date-only per spec). Skips noindex + system pages. Returns null when no pages qualify or baseUrl absent.

### 4. robots.txt generation
User-authored `robots.txt` from site dir wins. Otherwise generates permissive default with `Sitemap:` reference.

### 5. Pipeline wiring
Both CLI `gazetta publish` and admin `POST /api/publish/stream` generate sitemap + robots after pages are published, before CDN purge.

### 6. Fragment link in editor (page context)
Clicking a fragment or its child from page context now shows a "Edit @fragmentName" link instead of a broken editor. Clicking the link navigates to the fragment editor with unsaved guard support. Stale tree selection highlights are cleared on navigation.

### Data model additions
- `PageMetadata.robots?: string` — noindex/nofollow directives
- `SiteManifest.defaultOgImage?: string` — site-wide fallback OG image
- `SidecarState.pub: PubSidecar | null` — publish timestamp + noindex flag
- `SeoContext` interface + `seoContextFromManifest()` factory
- `resolveSeoTags()` + `generateSitemap()` + `generateRobotsTxt()` exported
- `editing.fragmentLink` + `showFragmentLink()` — fragment link state in editor

### Also includes
- SEO implementation plan (`.claude/rules/seo-plan.md`) — auto-loads when editing related files

## Test plan
- [x] 14 renderer fallback chain tests (every path + override priority + dedup + full chain)
- [x] 8 sitemap tests (loc, lastmod, noindex skip, system page skip, empty target, XML escaping)
- [x] 3 robots tests (with/without baseUrl, trailing newline)
- [x] 7 pub sidecar tests (timestamp round-trip, noindex, non-collision)
- [x] 6 fragment-link tests (showFragmentLink routing, stashing, treePath parsing, selection clear)
- [x] Existing sidecar tests updated (`pub: null` on all state objects)
- [x] 467/467 package tests, 229/229 admin tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)