### PR TITLE
AI integration v1.5 — alt-text generation (in progress)

### DIFF
--- a/.claude/rules/design-ai-implementation.md
+++ b/.claude/rules/design-ai-implementation.md
@@ -14,15 +14,15 @@ Branch: `ai-alt-v1.5` off `main`. Commits ordered low-risk-first per [team-prefe
 
 | # | Commit | Status | Risk | Validates |
 |---|---|---|---|---|
-| 1 | AI infrastructure: refusal + vision-prep + prompt policies | ☐ | Low | Pure functions; no external dependencies |
-| 2 | AltTextAdapter + null adapter + AltSuggester contract | ☐ | Low-medium | The seam everything else hangs off |
-| 3 | Anthropic adapter + msw tests | ☐ | Medium-high | First real provider integration; proves adapter contract |
-| 4 | OpenAI adapter + msw tests | ☐ | Low | Substitution proof; second provider |
-| 5 | Ollama adapter + msw tests | ☐ | Low | Self-hosted parity; third provider |
-| 6 | Site/target config types + `ai:` block schema + resolvers + factory | ☐ | Medium | Config layering correctness |
-| 7 | `POST /api/assets/:name/suggest-alt` route + `/api/targets` capability | ☐ | Medium | Admin API integration |
-| 8 | UI: upload-list auto-fill + detail-pane "✨ Suggest" | ☐ | Medium | The visible feature |
-| 9 | Docs (`docs/content-assets.md` AI alt section + `site.yaml` examples) + plan update | ☐ | Low | User-facing documentation |
+| 1 | AI infrastructure: refusal + vision-prep + prompt policies | ✓ | Low | Pure functions; no external dependencies |
+| 2 | AltTextAdapter + null adapter + AltSuggester contract | ✓ | Low-medium | The seam everything else hangs off |
+| 3 | Anthropic adapter + msw tests | ✓ | Medium-high | First real provider integration; proves adapter contract |
+| 4 | OpenAI adapter + msw tests | ✓ | Low | Substitution proof; second provider |
+| 5 | Ollama adapter + msw tests | ✓ | Low | Self-hosted parity; third provider |
+| 6 | Site/target config types + `ai:` block schema + resolvers + factory | ✓ | Medium | Config layering correctness |
+| 7 | `POST /api/assets/:name/suggest-alt` route + `/api/targets` capability | ✓ | Medium | Admin API integration |
+| 8 | UI: upload-list auto-fill + detail-pane "✨ Suggest" | ✓ | Medium | The visible feature |
+| 9 | Docs (`docs/content-assets.md` AI alt section + `site.yaml` examples) + plan update | ✓ | Low | User-facing documentation |
 
 ### Per-commit scope
 

--- a/.claude/rules/design-ai-implementation.md
+++ b/.claude/rules/design-ai-implementation.md
@@ -1,0 +1,303 @@
+# AI Integration — Implementation
+
+Companion to [design-ai.md](design-ai.md). This doc covers what we're doing with the design: v1.5 commit sequence with risk ordering, scope per commit, deferred items, open implementation questions, and migration considerations.
+
+See [design-ai.md](design-ai.md) for the design itself.
+
+## v1.5 commit sequence
+
+**Status legend**: ✓ shipped · ◐ in progress · ☐ pending
+
+Branch: `ai-alt-v1.5` off `main`. Commits ordered low-risk-first per [team-preferences.md rule 17](team-preferences.md): "Build and validate, don't spike. Each commit must produce real code that stays if the approach works, be independently rollback-able, validate the riskiest assumptions early."
+
+### Commit sequence
+
+| # | Commit | Status | Risk | Validates |
+|---|---|---|---|---|
+| 1 | AI infrastructure: refusal + vision-prep + prompt policies | ☐ | Low | Pure functions; no external dependencies |
+| 2 | AltTextAdapter + null adapter + AltSuggester contract | ☐ | Low-medium | The seam everything else hangs off |
+| 3 | Anthropic adapter + msw tests | ☐ | Medium-high | First real provider integration; proves adapter contract |
+| 4 | OpenAI adapter + msw tests | ☐ | Low | Substitution proof; second provider |
+| 5 | Ollama adapter + msw tests | ☐ | Low | Self-hosted parity; third provider |
+| 6 | Site/target config types + `ai:` block schema + resolvers + factory | ☐ | Medium | Config layering correctness |
+| 7 | `POST /api/assets/:name/suggest-alt` route + `/api/targets` capability | ☐ | Medium | Admin API integration |
+| 8 | UI: upload-list auto-fill + detail-pane "✨ Suggest" | ☐ | Medium | The visible feature |
+| 9 | Docs (`docs/content-assets.md` AI alt section + `site.yaml` examples) + plan update | ☐ | Low | User-facing documentation |
+
+### Per-commit scope
+
+#### Commit 1: AI infrastructure
+
+**Files added:**
+- `packages/gazetta/src/ai/refusal.ts` — `detectRefusal(text, adapterMarkers)` + shared marker list
+- `packages/gazetta/src/ai/vision-prep.ts` — `prepareForVision(input)` with sharp resize-to-768
+- `packages/gazetta/src/ai/prompt-policies.ts` — five policy functions (taskFraming, styleGuidance, length, locale, outputDiscipline)
+- `packages/gazetta/src/ai/compose-prompt.ts` — `composePrompt(req, policies)`
+- `packages/gazetta/src/ai/provider.ts` — `AIProvider` type
+- `packages/gazetta/src/ai/errors.ts` — `AltAdapterError` + variants
+- Test files for each
+
+**Tests:**
+- `tests/ai-refusal.test.ts` — shared markers + adapter-specific markers + empty-response case
+- `tests/ai-vision-prep.test.ts` — JPEG/PNG/SVG paths + skip-if-small + animated poster
+- `tests/ai-compose-prompt.test.ts` — default policies + custom policy injection + empty-string drop-out
+- `tests/ai-prompt-policies.test.ts` — each policy in isolation + locale ≠ 'en' branch
+
+**No consumers yet.** Pure utility ship.
+
+**Why first:** Lowest blast radius. If the design of any of these is wrong, only the file being wrong reverts. No upstream coupling.
+
+#### Commit 2: AltTextAdapter + null adapter + AltSuggester contract
+
+**Files added:**
+- `packages/gazetta/src/alt/adapter.ts` — `AltTextAdapter` interface, `AltSuggestion`, `AltGenerateInput`, `AltRequest`, `AltStyle`
+- `packages/gazetta/src/alt/null-adapter.ts` — `nullAltAdapter` with `supports()` always false
+- `packages/gazetta/src/alt/suggester.ts` — `AltSuggester` interface + `createAltSuggester({ adapter })`
+
+**Tests:**
+- `tests/alt-suggester.test.ts` — orchestration: AbortSignal forwarding, error → null + event, refusal pass-through, vision-prep called once, prompt composed once
+- `tests/alt-null-adapter.test.ts` — supports always false; LSP check
+
+**Why second:** Defines the seam. With three providers landing in commits 3-5, the contract has to be right first. Null adapter is the LSP test seam — proves substitution works before any real adapter ships.
+
+**Risk:** the contract may need to flex when commit 3 hits a real SDK. If that happens, amend commit 2 before pushing 3 (or land a 2.5 if 2 is already on the remote).
+
+#### Commit 3: Anthropic adapter
+
+**Files added:**
+- `packages/gazetta/src/alt/anthropic.ts` — `createAnthropicAltAdapter({ apiKey, model })` using `@anthropic-ai/sdk`
+- `package.json` — add `@anthropic-ai/sdk` dependency
+- Anthropic-specific refusal markers in the adapter file
+
+**Tests:**
+- `tests/alt-anthropic.test.ts` — msw-mocked happy path, refusal detection, error → typed error, AbortSignal cancellation, model parameter usage, image base64 encoding correctness
+
+**Why now:** First real integration. If the SDK's request/response shape doesn't fit `AltGenerateInput`/`AltSuggestion`, this is where we find out. With only the contract layer above us (commits 1-2), revert is cheap.
+
+**Risk:** highest in the sequence. Anthropic SDK quirks (rate limit error shapes, vision content format edge cases) surface here.
+
+#### Commit 4: OpenAI adapter
+
+**Files added:**
+- `packages/gazetta/src/alt/openai.ts` — `createOpenAIAltAdapter({ apiKey, model })` using `openai` SDK
+- `package.json` — add `openai` dependency
+- OpenAI-specific refusal markers
+
+**Tests:**
+- `tests/alt-openai.test.ts` — same shape as Anthropic tests; provider-specific request/response shape
+
+**Why now:** Substitution proof. The interface from commit 2 has been validated against one provider; this confirms it generalizes. If the interface needs adjustment to fit OpenAI, that's evidence the design from commit 2 was wrong — fix at commit 2 (or 2.5).
+
+#### Commit 5: Ollama adapter
+
+**Files added:**
+- `packages/gazetta/src/alt/ollama.ts` — `createOllamaAltAdapter({ baseUrl, model })` using fetch (no SDK)
+- Ollama-specific refusal markers
+
+**Tests:**
+- `tests/alt-ollama.test.ts` — msw-mocked happy path, refusal detection, connection-refused error, AbortSignal, base64 encoding
+
+**Why now:** Self-hosted path. Different from the SaaS adapters in that it's HTTP-against-localhost without an SDK. If the interface fits Ollama too, the abstraction is solid across the v1.5 set.
+
+**No SDK dependency.** Ollama's JS SDK exists but adds little value over `fetch` for our use case (single endpoint, no auth, no streaming).
+
+#### Commit 6: Site/target config + resolvers + factory
+
+**Files added/modified:**
+- `packages/gazetta/src/types.ts` — `AIConfig`, `AltTextConfig` (site + target), `SiteConfig.ai`, `SiteConfig.altText`, `TargetConfig.altText`
+- `packages/gazetta/src/ai/provider.ts` — extend with `ResolvedAIBase` + `resolveAIBase(site)`
+- `packages/gazetta/src/alt/config.ts` — `ResolvedAltConfig` + `resolveAltConfig(site, target, base)`
+- `packages/gazetta/src/alt/index.ts` — `buildAltAdapter(target)` factory + `isAltAdapterConfigured(target)`
+
+**Tests:**
+- `tests/alt-config-resolver.test.ts` — inheritance (target > site > base > hardcoded default) + provider must come from somewhere + null-when-nothing-configured
+- `tests/alt-factory.test.ts` — provider selection + missing API key → throws + null factory output when unconfigured + each provider construction path
+
+**Why now:** Adapters exist; config now wires them up. Factory is the single seam between config layers and adapters. No HTTP yet.
+
+**Validates:** the three-layer config decomposition (env / site `ai:` / per-task) actually composes correctly.
+
+#### Commit 7: Admin API integration
+
+**Files added/modified:**
+- `packages/gazetta/src/admin-api/routes/suggest-alt.ts` — the route
+- `packages/gazetta/src/admin-api/routes/targets.ts` — extend with `altText: { available, auto }` per target
+- `packages/gazetta/src/admin-api/schemas/assets.ts` — `SuggestAltResponseSchema`
+- `packages/gazetta/src/admin-api/schemas/targets.ts` — extend `TargetInfoSchema` with `altText`
+- `packages/gazetta/src/admin-api/error-response.ts` — handle `AltAdapterError` variants
+- Wire route into the admin-api `Hono` app
+
+**Tests:**
+- `tests/admin-api-suggest-alt.test.ts` — happy path, refusal pass-through, 503 unavailable, 502 adapter-failed, 404 missing asset, locale parameter, target parameter
+- `tests/admin-api-targets-alttext.test.ts` — capability flag presence, available true/false based on env
+
+**Why now:** Server-side feature is complete after this commit — a manual `curl` proves end-to-end works without any UI.
+
+#### Commit 8: UI integration
+
+**Files modified:**
+- `apps/admin/src/client/api/assets.ts` — add `suggestAlt(name, target, locale)` API call
+- `apps/admin/src/client/components/AssetUploadZone.vue` — auto-fire on upload when `auto: true`; AbortSignal on user typing
+- `apps/admin/src/client/components/AssetAltEditor.vue` — "✨ Suggest" button visible when `available`
+- Loading indicator during in-flight suggest; refusal toast component
+- `apps/admin/src/client/stores/activeTarget.ts` — expose `altText` capability
+
+**Tests:**
+- `apps/admin/tests/AssetUploadZone.test.ts` — auto-fire on `auto: true`, no fire on `auto: false`, abort on user typing, refusal shown as toast
+- `apps/admin/tests/AssetAltEditor.test.ts` — button hidden when `available: false`, click triggers suggest, refusal shown inline
+
+**Why last:** Visible feature. Full-stack working before authors see it. If any layer is wrong, lower commits revert without UI thrash.
+
+#### Commit 9: Docs + plan
+
+**Files added/modified:**
+- `docs/content-assets.md` — new "AI alt text" section: configuration, provider choice, privacy considerations, refusal handling, manual override
+- `docs/transform-adapters.md` — cross-link to AI integration
+- `examples/starter/sites/main/site.yaml` — add commented-out `ai:` and `altText:` examples
+- `.claude/rules/design-media-implementation.md` — mark "AI alt-text adapter" row ✓ in v1.5 capabilities table
+- `.claude/rules/design-ai-implementation.md` — mark commits ✓ as they land
+
+## Branch and PR posture
+
+- Branch: `ai-alt-v1.5` off `main`
+- PR opens after commit 5 (abstraction proven by three providers); later commits push to the same PR
+- Merge with `gh pr merge --rebase` per [team-preferences.md rule 16](team-preferences.md)
+- CI runs on every push; broken intermediate commits fail PR checks but never main
+
+## What's deferred from v1.5
+
+### Tracked for v1.6+
+
+| Item | Trigger to revisit |
+|---|---|
+| Per-target adapter override | Concrete operator request: "I need different providers per target" |
+| `CachedAltSuggester` decorator | Operational measurement: cache hit would be > 30% in real workflows |
+| Distributed cache (Redis-backed) | Multi-replica admin operators report duplicate-billing pain |
+| Translation pipeline (`translateFrom: 'en'`) | Ollama users report bad non-English alt quality |
+| Bulk-suggest CLI (`gazetta assets suggest-alt --all`) | Operators ask for backfill; design-media.md already lists this |
+| Cost monitoring / budget caps | Site reports unexpected provider bills |
+| Confidence field (real, not stub) | A provider exposes calibrated confidence for vision-description tasks |
+| Custom prompt policies per site | Editorial style guides differ enough that the WCAG-grounded default doesn't fit |
+| Image generation task | New blocks `imageGeneration:` and `packages/gazetta/src/imagegen/` directory |
+| Tag suggestion task | Same shape as alt-text but different output structure |
+| Summarization task | Text input not bytes; first text-task forces a `text-prep.ts` peer to `vision-prep.ts` |
+
+### Translation as the canonical second consumer
+
+Translation is the most likely v1.6 task. Its arrival validates the v1.5 architecture:
+- `ai/refusal.ts` — reused; translation refusals look like alt refusals
+- `ai/compose-prompt.ts` — reused; translation has its own policies
+- `ai/prompt-policies.ts` — extends with translation-specific policies (preserve technical terms, formality, etc.)
+- `ai/vision-prep.ts` — not used (text task)
+- `ai/provider.ts` — `ResolvedAIBase` reused; `resolveTranslationConfig` peers `resolveAltConfig`
+- `site.yaml` — adds `translation:` block; `ai:` block unchanged
+- `TargetInfo` — adds `translation: { available, configuredFor: ['fr', 'ar'] }` peer to `altText`
+
+If translation lands cleanly with no `ai/` modifications, the v1.5 architecture passed. If `ai/` needs significant changes, the abstraction was wrong and gets restructured then — with two real consumers as evidence.
+
+## Open implementation questions
+
+1. **Anthropic SDK vision content format.** The SDK accepts image content as `{ type: 'image', source: { type: 'base64', media_type, data } }`. Verify: does the SDK accept `Uint8Array` directly, or do we need to convert to base64 string? Affects adapter performance for large bytes.
+
+2. **OpenAI base64 data URL size limit.** OpenAI accepts `image_url` with `data:image/...;base64,...` URLs. Verify: is there a documented size cap for the data URL (i.e., post-base64 size ~33% larger than raw bytes)? At 768×768 JPEG quality 85, prep output is ~80 KB raw → ~107 KB base64 — well under typical request body limits, but verify.
+
+3. **Ollama vision request shape.** Ollama's `/api/generate` accepts `images: [<base64>]`. Verify: which endpoint to use (`generate` vs `chat`) for best alt-text output? Test against `llama3.2-vision` 11b in particular.
+
+4. **AbortSignal across SDK versions.** `@anthropic-ai/sdk` and `openai` both support AbortSignal in recent versions. Verify exact minimum versions; pin appropriately.
+
+5. **Refusal marker maintenance.** Provider safety messaging drifts as models update. The marker list will need updates. Plan: review markers per major model version bump (e.g., when defaultModel changes from `claude-haiku-4-5` to `claude-haiku-5-0`); document maintenance expectation in `ai/refusal.ts` header comment.
+
+6. **`auto: true` on bulk uploads.** A 50-asset upload with `auto: true` fires 50 parallel suggest calls. Each provider has its own rate limit (Anthropic 50 req/min on standard tier, OpenAI similar, Ollama unlimited but CPU-bound). Decision: rely on provider SDK retries (they handle 429s with backoff) for v1.5; admin-side throttling lands if measurement shows real pain. Document the trade in `docs/content-assets.md`.
+
+7. **Locale fallback for unsupported locales.** Active locale is `pt-BR`; provider doesn't reliably write Brazilian Portuguese. Behavior: trust the model — modern vision models handle BCP-47 locale codes reasonably. If real use shows quality issues, the locale resolution chain (per design-media.md) gets honored: `pt-BR → pt → default-locale`. Document as a known limitation with workaround.
+
+## Migration
+
+### Existing sites
+
+`site.yaml` files without `ai:` or `altText:` blocks continue to work — schema validation treats both as optional. AI features stay off until configured.
+
+### Pre-existing assets
+
+Manual backfill via the detail-pane "✨ Suggest" button. No bulk-suggest CLI in v1.5 (deferred). Authors who want to backfill 100 existing assets click 100 times — acceptable for v1.5; CLI lands when scale demands it.
+
+### Provider switching
+
+Operator changes `ai.provider`:
+1. Updates `.env.local` to provide new credentials
+2. Restarts admin process (env read at boot; config read at first use)
+3. Existing alt text is unchanged (alt is on assets, not in any provider-coupled cache)
+4. New suggestions come from new provider
+
+No data migration. Provider switch is config-only.
+
+### Disabling AI
+
+Operator removes `altText:` block (or sets per-target overrides as needed):
+1. `isAltAdapterConfigured(target)` returns false
+2. `/api/targets` reports `altText.available: false`
+3. UI hides affordances on next load (SSE reload triggers refresh)
+4. Existing alt text stays on assets; no destructive change
+
+## Test infrastructure
+
+### msw for HTTP mocking
+
+All three adapters use `msw` (Mock Service Worker) for HTTP mocking in unit tests. This is new infrastructure for the codebase — adopted in commit 1 alongside the first adapter test.
+
+**Why msw:** standard Node HTTP mocking; intercepts at the fetch/XHR layer (works with any SDK); fixture-friendly (canned response files). No real provider calls in CI; no real model in CI; deterministic.
+
+**Pattern:**
+```ts
+// tests/alt-anthropic.test.ts (sketch)
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+
+const server = setupServer(
+  http.post('https://api.anthropic.com/v1/messages', () => {
+    return HttpResponse.json({
+      content: [{ type: 'text', text: 'Mountain at sunset' }],
+    })
+  }),
+)
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+```
+
+### No real-model CI tests in v1.5
+
+Per the grilling decisions: real Ollama in CI requires 8 GB model download per run (disk + network); real SaaS calls cost money + are non-deterministic. msw tests prove the adapter speaks each provider's protocol correctly — that's what CI gates on.
+
+**Future nightly real-model run** (Ollama only; SaaS is rate-limited + costly): runs once a week, asserts non-empty response, posts to workflow output for human review. Not gating. Lands when there's a documented drift incident; not v1.5.
+
+## Estimates
+
+Wall-clock for solo dev:
+
+| Commit | Estimate |
+|---|---|
+| 1 (AI infrastructure) | 1 day |
+| 2 (Adapter contract + null + suggester) | 1 day |
+| 3 (Anthropic) | 1.5 days |
+| 4 (OpenAI) | 0.5 day (after Anthropic-as-template) |
+| 5 (Ollama) | 0.5 day |
+| 6 (Config + factory) | 1 day |
+| 7 (Admin route + capability) | 1 day |
+| 8 (UI: upload-list + detail-pane) | 1.5 days |
+| 9 (Docs + plan) | 0.5 day |
+
+**Total: ~8.5 days.** With CI iteration + review feedback + the typical "first integration is harder than expected," budget ~2 weeks.
+
+## SOLID checks per commit
+
+Each commit's SOLID posture, validated at design time:
+
+- **Commit 1**: SRP per module (refusal, vision-prep, prompt). OCP via composable policies + adapter-specific markers. No interfaces yet — pure utilities.
+- **Commit 2**: ISP via narrow `AltTextAdapter` (just `supports` + `generate`). LSP validated by null adapter. DIP via `AltSuggester` depending on adapter abstraction.
+- **Commits 3-5**: LSP across three real implementations. SRP — each adapter owns provider mechanics, nothing else (no UI, no config, no caching).
+- **Commit 6**: SRP at config layer (each layer's resolver owns its layer). DIP via factory — adapters take literal config, never read env or YAML directly.
+- **Commit 7**: SRP — route handler owns one concern (suggest-alt). DIP via suggester (route depends on abstraction, not on Anthropic/OpenAI/Ollama).
+- **Commit 8**: ISP — UI components depend on `TargetInfo.altText` capability shape, not on adapter details. Provider-agnostic UI.
+
+Any commit failing SOLID review at PR time is a structural correction (per [team-preferences.md rule 18](team-preferences.md)), not a patch — amend before merge if not yet pushed; new commit with clear "structural correction" message if already on the remote.

--- a/.claude/rules/design-ai.md
+++ b/.claude/rules/design-ai.md
@@ -1,0 +1,492 @@
+# AI Integration
+
+How the CMS integrates AI capabilities — alt-text generation in v1.5, with translation, summarization, and tag suggestion as anticipated future tasks. Designed as a layered abstraction so each new task adds to a shared infrastructure rather than reimplementing it.
+
+**This doc covers the design:** layered architecture, configuration model, alt-text task in detail, refusal handling, image preprocessing, prompt composition, runtime model, security, and distinctive choices.
+
+**Companion docs:**
+- [design-ai-implementation.md](design-ai-implementation.md) — v1.5 commit sequence, scope, deferred items, migration path.
+
+## Scope
+
+**In v1.5:**
+- Alt-text generation as the first AI task
+- Three providers: Anthropic Claude, OpenAI gpt-4o, Ollama llama3.2-vision (self-hosted)
+- Per-task config blocks under `site.yaml` (`altText:`)
+- Cross-task `ai:` block for shared concerns (`provider`, `defaultModel`)
+- Process-level credentials via `.env.local` (no per-target API keys)
+- Auto-fill on upload (default) + on-demand from detail pane
+- Structured refusal detection (provider says no → don't auto-fill, show reason)
+- Direct multilingual generation (model writes in target locale; no separate translation pass)
+- Per-target overrides for behavior (`auto`, etc.); never for credentials/provider
+
+**Out of v1.5 (explicit):**
+- Translation task (designed for; not implemented)
+- Tag suggestion, summarization, image generation
+- Per-target adapter override (process-level adapter only in v1.5)
+- Distributed cache for suggestions (suggester is stateless; multi-replica correct)
+- Confidence scoring (the field doesn't exist on the contract)
+- Cost monitoring / budget caps
+- Admin-side rate-limit throttling (provider SDKs handle their own backoff)
+- AI safety/content moderation (provider's own policies apply; we surface refusals structurally)
+
+**Non-goals:**
+- Replacing author judgment. AI alt is a suggestion the author can accept, edit, or clear. The author is always the final word.
+- Provider-specific quality optimization. We ship neutral prompts that work across Claude, gpt-4o, and llama3.2-vision. Operators tune `model` per task if they want a specific provider's strengths.
+
+## Architecture: three orthogonal layers
+
+AI in Gazetta is **three concerns at three lifetimes**, each with its own home:
+
+| Layer | What it owns | Where it lives | Lifetime |
+|---|---|---|---|
+| **Provider account** | API keys, base URLs | `.env.local` | Process |
+| **Task configuration** | Per-task model, behavior flags, sizing | `site.yaml` (per-task blocks, `ai:` for shared) | Site lifetime |
+| **Cross-task infrastructure** | Refusal detection, prompt composition, vision preprocessing | Code modules under `packages/gazetta/src/ai/` | Code, not config |
+
+These layers don't bleed into each other. Credentials never appear in `site.yaml`. Cross-task code never reads config directly — it operates on resolved literal arguments. Per-task config never references env vars; the factory wires the layers together.
+
+### Why three layers, not one big config block
+
+Earlier drafts of this design merged all AI config into one `ai:` block. That bundled cross-task concerns (provider) with task-specific concerns (`maxImageEdge` only applies to vision tasks; `auto` only applies to alt-text). Splitting at the right SOLID seams:
+
+- **Cross-task fields** in `ai:` — fields that ALL AI tasks legitimately use (provider, default model)
+- **Task-specific fields** in per-task blocks — fields that only one task uses (`auto` for alt; future `translateOnPublish` for translation)
+- **Vision-specific fields** stay on vision-using task blocks — `maxImageEdge` is on `altText:`, would also be on a future tag-suggestion task that processes images, never on `translation:`
+
+This avoids inventing a "vision tasks" sub-grouping (ISP violation — would mean some tasks implement an interface they don't fully use).
+
+## Configuration model
+
+### Env (`.env.local`)
+
+Process-level credentials only. Gitignored. Never in `site.yaml`.
+
+```
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+# OLLAMA_BASE_URL=http://localhost:11434  (optional; default shown)
+```
+
+If a provider's adapter is selected but its key is missing, `isAltAdapterConfigured(target)` returns false, the UI hides AI affordances, and any direct route call returns `503 alt_adapter_unavailable` with a structured error. No throw at admin boot — process starts always; per-task features fail at first invocation, where the failure is in context.
+
+### Site-level (`site.yaml` top-level)
+
+Two blocks: `ai:` for cross-task, `altText:` for the v1.5 task.
+
+```yaml
+name: main
+defaultLocale: en
+
+ai:
+  provider: anthropic              # one of: anthropic, openai, ollama
+  defaultModel: claude-haiku-4-5   # falls back to per-provider sensible default if unset
+
+altText:
+  # provider: <inherits ai.provider>
+  # model: <inherits ai.defaultModel>
+  auto: true                       # default; auto-fire suggest on upload
+  maxImageEdge: 768                # default; vision-call sizing
+
+# Future:
+# translation:
+#   model: claude-sonnet-4-5       # override defaultModel for translation quality
+#   translateOnPublish: false
+```
+
+**Field inheritance:** task block resolves left-to-right against `target → site task block → site ai block → hardcoded default`. First defined wins. The `resolveAltConfig(site, target, base)` function is the single source of truth for the merge.
+
+**Provider can be overridden per task** (e.g., `altText.provider: ollama` while `ai.provider: anthropic`). v1.5 doesn't expose this in any UI, but the config model accepts it — when a future operator needs Anthropic for translation and Ollama for alt-text in one site, no schema migration is required.
+
+### Target-level (`site.yaml` per target)
+
+Per-task **behavior** overrides only. Never provider, never credentials.
+
+```yaml
+targets:
+  local:
+    storage: { type: filesystem }
+    # inherits everything from site
+  production:
+    storage: { type: r2, ... }
+    altText:
+      auto: false                  # review-first on prod
+```
+
+**Why behavior-only at target level:** provider/credentials are operationally global. An operator with one Anthropic account uses it for staging and prod alike. Per-target provider-switching is theoretically possible (the schema permits it for forward-compatibility) but not a v1.5 feature.
+
+### The capability flag the UI sees
+
+The `/api/targets` endpoint returns `TargetInfo.altText: { available, auto }` per target. The UI renders affordances based on this resolved capability — not on raw config.
+
+```ts
+interface AltTextCapability {
+  available: boolean    // resolved adapter exists + credentials present
+  auto: boolean         // resolved auto flag (post-merge)
+}
+
+interface TargetInfo {
+  // ... existing fields
+  altText: AltTextCapability
+}
+```
+
+`available` is a process-global truth in v1.5 (one adapter for the admin). It varies per-target only when target-level provider override lands in a future version. The shape is right for now; expansion is additive.
+
+## Code organization
+
+```
+packages/gazetta/src/
+  ai/                              # cross-task infrastructure
+    refusal.ts                     # refusal detection — provider patterns
+    compose-prompt.ts              # prompt assembly from typed AltRequest
+    prompt-policies.ts             # per-dimension prompt-policy modules
+    vision-prep.ts                 # sharp-based resize-to-768 for vision calls
+    provider.ts                    # AIProvider type + ResolvedAIBase + resolveAIBase
+    errors.ts                      # AI-specific error taxonomy
+  alt/                             # alt-text task
+    adapter.ts                     # AltTextAdapter interface + AltSuggestion type
+    suggester.ts                   # AltSuggester orchestration (cancellation, errors, events)
+    null-adapter.ts                # safe default; supports() = false everywhere
+    anthropic.ts                   # provider impl
+    openai.ts
+    ollama.ts
+    config.ts                      # ResolvedAltConfig + resolveAltConfig
+    index.ts                       # buildAltAdapter factory
+```
+
+**`ai/` is a code library, not an inheritance hierarchy.** Tasks compose `ai/` utilities; they don't extend a base class. `alt/` imports `ai/refusal.ts`, `ai/compose-prompt.ts`, `ai/vision-prep.ts`. A future `translate/` directory will import `ai/refusal.ts`, `ai/compose-prompt.ts` (different policies, same composer), and contribute its own task-specific code.
+
+This is composition over inheritance from the start, per [team-preferences.md](team-preferences.md): "Prefer composition over inheritance — use static helpers or injected services, not base classes."
+
+## Alt-text task
+
+### The contract
+
+```ts
+// alt/adapter.ts
+export interface AltTextAdapter {
+  readonly name: string
+  /** True when the adapter can describe this MIME (images-only in v1.5). */
+  supports(mime: string): boolean
+  /** Returns suggestion + structured refusal info; throws on transport / API failure. */
+  generate(input: AltGenerateInput, signal?: AbortSignal): Promise<AltSuggestion>
+}
+
+export interface AltGenerateInput {
+  bytes: Uint8Array
+  mime: string
+  request: AltRequest               // structured params (locale, maxChars, style)
+  prompt: string                    // composed prompt for adapters that inject a string
+}
+
+export interface AltRequest {
+  locale: string                    // 'en', 'fr', etc. — direct generation, not translate
+  maxChars: number                  // 125 default per WAI-ARIA convention
+  style: AltStyle
+}
+
+export type AltStyle = 'descriptive'  // closed enum; future: 'marketing', 'technical'
+
+export interface AltSuggestion {
+  text: string
+  /** True when the model declined or couldn't describe the image. */
+  refused: boolean
+  /** Human-readable reason when refused; null otherwise. */
+  refusalReason: string | null
+}
+```
+
+**No `confidence` field.** Considered and rejected — providers don't expose calibrated confidence for free-form generation; a hardcoded null would be a stub-on-the-interface (LSP violation per [team-preferences.md rule 18](team-preferences.md)). Refusal is the structured signal that earns its place.
+
+**`AltGenerateInput` carries both structured request AND composed prompt.** Adapters that have native parameters (Anthropic's `max_tokens` derivable from `request.maxChars`) use the structured form; adapters that just need a prompt string use the composed form. Both are computed once by the suggester; adapters consume what suits them.
+
+### The orchestration layer
+
+```ts
+// alt/suggester.ts
+export interface AltSuggester {
+  /** True when adapter is configured AND adapter.supports(mime) is true. */
+  available(mime: string): boolean
+  /** Returns structured suggestion or null when call couldn't complete. */
+  suggest(input: SuggestInput, signal?: AbortSignal): Promise<AltSuggestion | null>
+}
+
+export interface SuggestInput {
+  bytes: Uint8Array
+  mime: string
+  hash: string                      // identifies asset; used for diagnostics, not cache
+  locale: string
+  /** When the source is animated, callers pass the analyzer's first-frame poster. */
+  posterBytes?: Uint8Array
+}
+```
+
+The suggester:
+- Builds the typed `AltRequest` from inputs + defaults.
+- Composes the prompt via `composePrompt(request, policies)`.
+- Calls `prepareForVision(bytes, posterBytes, mime, maxImageEdge)` to resize before the adapter call.
+- Forwards `AbortSignal` to the adapter.
+- Catches transport errors → returns null + emits structured event for UI toast.
+- Returns the adapter's `AltSuggestion` directly (including `refused`).
+
+**Stateless** — no memoization. Multi-replica admin scales horizontally without divergent caches. If memoization later proves operationally necessary, it lands as a `CachedAltSuggester` decorator wrapping the base — additive, multi-replica-correct via shared storage. The contract stays cache-free.
+
+### Why no cache
+
+Considered: per-replica `Map<(hash, locale), Promise<AltSuggestion>>` to avoid re-billing for the same image across an auto-suggest + on-demand-click pair. Rejected because:
+
+1. **Multi-replica admin is a documented constraint** ([design-media-implementation.md](design-media-implementation.md) explicitly rejected in-memory designs for the asset-refs index for the same reason).
+2. **Real hit rate is low.** Auto-suggest + immediate-click is rare. Auto-suggest + days-later-click is common, but admin processes restart between sessions — a per-replica cache wouldn't help anyway.
+3. **The orchestration responsibilities that DO belong on the suggester** (cancellation, error handling, refusal events) don't depend on caching. Removing caching doesn't impair the abstraction; it makes it leaner.
+
+When caching genuinely earns its keep (operationally measured, not speculatively designed), the decorator pattern lands additively.
+
+### Refusal detection
+
+Lives at `ai/refusal.ts` because it's cross-task: a translation refusal looks the same as an alt-text refusal (provider says "I can't comply" via 200 OK with refusal text in the content field).
+
+```ts
+// ai/refusal.ts
+const SHARED_REFUSAL_MARKERS = [
+  "i can't describe",
+  "i'm not able to describe",
+  "i cannot describe",
+  "i'm unable to provide",
+  // ... maintained list of cross-provider refusal phrases
+]
+
+export function detectRefusal(
+  text: string,
+  adapterMarkers: readonly string[] = [],
+): { refused: boolean; reason: string | null } {
+  const lower = text.toLowerCase()
+  const allMarkers = [...SHARED_REFUSAL_MARKERS, ...adapterMarkers]
+  for (const marker of allMarkers) {
+    if (lower.includes(marker)) {
+      return { refused: true, reason: text.slice(0, 200) }
+    }
+  }
+  if (text.trim().length < 5) {
+    return { refused: true, reason: 'Empty or unusably short response' }
+  }
+  return { refused: false, reason: null }
+}
+```
+
+Each adapter calls `detectRefusal(rawText, ANTHROPIC_SPECIFIC_MARKERS)` (or its provider's equivalent) and constructs the `AltSuggestion` with structured fields. The UI consumes the structured signal directly — never inspects `text` for refusal substrings (DIP violation prevented).
+
+### Vision preprocessing
+
+```ts
+// ai/vision-prep.ts
+export interface PreparedImage {
+  bytes: Uint8Array
+  mime: string                      // 'image/jpeg' | 'image/png' (post-prep)
+}
+
+export async function prepareForVision(input: {
+  bytes: Uint8Array
+  mime: string
+  posterBytes?: Uint8Array          // animated-image first-frame, when applicable
+  maxEdge?: number                  // default 768
+}): Promise<PreparedImage>
+```
+
+**Default 768 max edge.** Smallest size that fits all three v1.5 providers natively without quality loss:
+
+| Provider | Native input | At 768 |
+|---|---|---|
+| Ollama llama3.2-vision | 1120×1120 | Fits, no downsample |
+| Anthropic Claude (non-Opus) | 1568px long edge | ~786 tokens (well under 1568 ceiling) |
+| OpenAI gpt-4o (high detail) | 768 short-edge target | Exactly 4 tiles + base = 765 tokens |
+
+768 is also where OpenAI's high-detail mode targets the short edge — chosen by OpenAI because it's where text in images remains legible for their model. Below 768 starts trading documented quality for cost.
+
+**`maxImageEdge` is per-task** because vision tasks may want different sizes (a future tag-suggestion task on detailed product shots might want 1024). Default 768; per-task site-level override; per-target task-level override.
+
+**Animated images use the analyzer-extracted poster.** The animated-image analyzer (shipped in media v1 step 31) already extracts a first-frame PNG poster. The suggester passes those bytes to `prepareForVision` instead of re-rasterizing. Cross-feature reuse, no duplication.
+
+**SVG rasterizes to PNG** at MAX_EDGE before the vision call (sharp via SVG renderer at 144 dpi). OpenAI doesn't accept SVG natively; uniform handling beats per-adapter SVG fallback.
+
+**Skip resize when source ≤ MAX_EDGE.** No re-encode; original bytes pass through.
+
+### Prompt composition
+
+The prompt is **policy**, not a string. Composing it from typed dimensions per [team-preferences.md rule 18](team-preferences.md) ("build structurally right from the start").
+
+```ts
+// ai/prompt-policies.ts — each policy contributes one paragraph
+export function taskFramingPolicy(req: AltRequest): string
+export function styleGuidancePolicy(req: AltRequest): string
+export function lengthPolicy(req: AltRequest): string
+export function localePolicy(req: AltRequest): string
+export function outputDisciplinePolicy(req: AltRequest): string
+
+// ai/compose-prompt.ts
+export type PromptPolicy = (req: AltRequest) => string
+
+export function composePrompt(
+  req: AltRequest,
+  policies: readonly PromptPolicy[] = DEFAULT_POLICIES,
+): string
+```
+
+**Why typed policies, not a single string constant:**
+- SRP: each policy changes for one reason. Locale strategy change → `localePolicy` only. WCAG guidance update → `styleGuidancePolicy` only.
+- OCP: new style (e.g., `'marketing'`, `'technical'`) extends the `AltStyle` enum + adds a switch arm. Other policies untouched.
+- Testability: each policy unit-tests independently; the composer tests assembly.
+
+**Locale-aware generation, not translation.** `localePolicy` adds "Write the description in {locale}." when locale ≠ 'en'. Modern vision models are competently multilingual. Translation as a separate pipeline (vision → English → translate) was rejected: more API calls, translation artifacts (e.g., translating UI text like button labels that should stay in source language), and a parallel `TranslationAdapter` system before its second consumer exists.
+
+If Ollama's non-English quality proves insufficient in real use, an opt-in `translateFrom: 'en'` per-task field activates a translation pipeline. Additive; no v1.5 design cost.
+
+## Provider adapters
+
+### What each adapter owns
+
+- Provider SDK construction (with literal `apiKey` from factory)
+- Request shape: convert `AltGenerateInput` → provider-specific request body
+- Response parsing: extract text from provider response shape
+- Refusal detection: call `detectRefusal` with provider-specific markers
+- AbortSignal forwarding
+- Provider-specific error → `AltAdapterError` translation
+
+### What no adapter owns
+
+- Reading env vars (factory does this)
+- Image preprocessing (`vision-prep.ts` does this)
+- Prompt composition (`compose-prompt.ts` does this)
+- Memoization (the suggester is stateless; no memoization in v1.5)
+- UI concerns (consumers handle errors and refusals)
+
+### Three providers in v1.5
+
+| Provider | API | Auth | Model default | Why ship |
+|---|---|---|---|---|
+| **Anthropic** | `messages.create` with image content block | `ANTHROPIC_API_KEY` | `claude-haiku-4-5` | Aligned with the codebase's tooling; well-priced; multilingually competent |
+| **OpenAI** | `chat.completions` with `image_url` (base64 data URL) | `OPENAI_API_KEY` | `gpt-4o-mini` | Wide adoption; cheapest paid SaaS; required for substitution proof |
+| **Ollama** | HTTP to `/api/generate` (or `/api/chat`) | None (local) | `llama3.2-vision` | Self-hosted; zero-cost; bytes never leave operator infra; required for self-hosted parity |
+
+Three providers prove the abstraction holds (one paid, one paid alternative, one self-hosted). Future adapters (Gemini, Cloudflare Workers AI) land additively.
+
+### Why three, not one
+
+If only Anthropic shipped, we'd be guessing whether the interface generalizes. Two adapters force real generalization (auth shape, request shape, response parsing, error taxonomy). Three confirms — and importantly, gives self-hosted operators a path that doesn't depend on cloud SaaS.
+
+## Runtime model
+
+### When AI runs
+
+| Trigger | Where | Decision |
+|---|---|---|
+| Asset uploaded, `auto: true`, target has adapter, MIME supported | `AssetUploadZone.vue` upload-list row | Auto-fire `POST /api/assets/:name/suggest-alt` after upload completes |
+| Author clicks "✨ Suggest" in detail pane | `AssetAltEditor.vue` | Fire suggest call on demand, regardless of `auto` |
+| Author types into alt input while suggest is in flight | `AssetUploadZone.vue` row | Abort the suggest call; author intent wins |
+
+**Auto-suggest is post-upload, client-driven, one extra HTTP round-trip.** Folding the AI call into the upload pipeline (server-side at upload time) was rejected: AI failure would fail the upload itself; latency on bulk uploads stacks unacceptably; SRP violation in `ingest.ts`.
+
+### The route
+
+```
+POST /api/assets/:name/suggest-alt?target=&locale=
+→ 200 { text: "...", refused: false, refusalReason: null }
+→ 200 { text: "I can't describe this image.", refused: true, refusalReason: "..." }
+→ 503 { code: 'alt_adapter_unavailable' }
+→ 502 { code: 'alt_suggestion_failed' }
+→ 404 { code: 'asset_not_found' }
+→ 400 { code: 'invalid_request' }
+```
+
+**Refusal returns 200 with `refused: true`.** The API call succeeded; the model declined. This matches the existing pattern (`POST /api/publish` returns 200 with `{ ok: false, errors }` when content validation fails). HTTP status reflects API success/failure; body fields reflect domain results.
+
+**Server fetches bytes from storage.** Upload-list row passes `name`; server reads bytes via the existing storage abstraction. Doesn't accept fresh bytes in the POST body — that would either duplicate the upload route's contract or split the surface (one route accepting name, another accepting bytes; ISP violation). The "saved storage read" optimization is sub-perceptible (~50ms hot cache hit for fresh writes).
+
+### How the UI knows
+
+`/api/targets` reports `TargetInfo.altText: { available, auto }` per target. The UI reads this on admin load and on `site.yaml` reload (existing SSE infrastructure). No probe-by-failure; no separate capability endpoint.
+
+```vue
+<!-- AssetUploadZone.vue (excerpt) -->
+<script setup>
+async function onUploadComplete(result) {
+  if (activeTarget.value.altText.available && activeTarget.value.altText.auto) {
+    fireSuggestAlt(result.name)  // background, non-blocking
+  }
+}
+</script>
+
+<!-- AssetAltEditor.vue (excerpt) -->
+<Button v-if="activeTarget.altText.available" @click="suggest">
+  ✨ Suggest
+</Button>
+```
+
+## Security
+
+### Provider trust boundary
+
+Bytes leave the admin process when the suggester calls a SaaS adapter. Operators choosing Anthropic/OpenAI accept that asset bytes are sent to those providers' servers, subject to those providers' data-handling policies. Ollama operators keep bytes local.
+
+**Documented prominently** in `docs/content-assets.md` (AI alt section): "When using Anthropic or OpenAI, asset bytes are sent to the provider for description. Use Ollama for self-hosted privacy."
+
+### Content moderation
+
+We do **not** add a moderation layer. Provider safety policies apply (Claude refuses certain content; gpt-4o has its own categories; Ollama has minimal filtering). Refusals surface structurally so authors see why their image wasn't described. We don't second-guess provider decisions.
+
+### API key exposure
+
+Keys live in `.env.local` (gitignored, per [operations.md](operations.md)). Adapter modules read `process.env.X_API_KEY` at construction. Never logged. Never returned in API responses. Never in `site.yaml`.
+
+If a key is missing for a configured provider, `isAltAdapterConfigured(target)` returns false at the capability check; the route returns `503 alt_adapter_unavailable`; the UI hides affordances. No leak path.
+
+### Prompt injection
+
+User-uploaded images could theoretically contain text that influences the model's response. The current prompt structure (model receives image + instruction) makes prompt-injection-via-image hard but not impossible. Mitigations:
+
+- The composed prompt is explicit about the task ("Output the description only, no preamble or quotes") which the model treats as system-level guidance.
+- Refusal detection catches "I won't follow these new instructions" responses.
+- The output is alt text shown to the author for review (unless `auto: true` AND no refusal, in which case it pre-fills the input — author can still edit before save).
+
+For sites uploading user-generated content (future use case), authors should review AI-suggested alt before publish. The `altText.auto: false` flag puts review-first mode in operator control.
+
+## Distinctive choices
+
+### Compared to other CMSes
+
+- **Strapi Growth** — built-in AI alt, but coupled to Strapi's specific deployment model. Gazetta's adapter abstraction is provider-agnostic and admin-process-local.
+- **Storyblok** — AI alt as a paid add-on. Gazetta ships in v1.5, no upsell.
+- **Directus 11.16** — three-provider adapter pattern (similar architectural choice). Gazetta's pattern is similar but explicitly cross-task-ready (the `ai:` block + `ai/` infrastructure code anticipates translation, summarization, etc.).
+- **Sanity / Contentful / Payload** — no shipped AI alt as of design time. Operators wire their own integrations.
+
+### Architectural choices
+
+**Per-task config blocks, not a single AI block.** Each AI capability has its own concerns; bundling them creates SRP violations. The shared `ai:` block carries only truly cross-task fields (`provider`, `defaultModel`).
+
+**Cross-task code under `ai/` from the start.** Not after the second consumer materializes. Refusal detection, prompt composition, vision preprocessing are conceptually cross-task even with one consumer in v1.5. Right structure now beats right structure later, because translation is on the documented roadmap.
+
+**Stateless suggester (no memoization).** Multi-replica admin correctness over per-replica optimization. Caching is a future decorator, additive.
+
+**Direct multilingual generation, not translation pipeline.** Lower latency, lower cost, better idiomatic output, and avoids designing a `TranslationAdapter` system before its second consumer exists.
+
+**Refusal as structured signal, not confidence number.** The honest categorical: did the model decline? Not a fake graduated score. Consumers branch on `refused`, not `confidence < threshold`.
+
+**Process-level credentials, target-level behavior.** Reflects operational reality: one operator, one set of API accounts; per-target workflow differs (`auto: false` on prod, default on staging).
+
+## Migration
+
+### Existing sites
+
+`site.yaml` files without `ai:` or `altText:` blocks continue to work — AI alt is a v1.5 feature behind explicit config. Operators opt in by adding the blocks.
+
+### Existing assets
+
+The detail-pane "✨ Suggest" button works on assets uploaded before AI alt was configured. Backfill is per-asset, on-demand. No bulk-suggest in v1.5; deferred to a CLI command (`gazetta assets suggest-alt --all`) when the use case surfaces.
+
+### Provider switching
+
+Changing `ai.provider` from `anthropic` to `openai` requires:
+- Updating `.env.local` to provide the new credentials
+- Restarting the admin process (config is read at boot for env, at first use for adapter)
+
+No data migration. Existing alt text on assets is unchanged. New suggestions come from the new provider.

--- a/.claude/rules/design-media-implementation.md
+++ b/.claude/rules/design-media-implementation.md
@@ -268,7 +268,7 @@ From competitor research (Sanity, Payload, Strapi, Storyblok, Directus, Contentf
 
 | Feature | Competitors shipping it | Notes |
 |---|---|---|
-| **AI alt-text adapter** | Strapi (Growth default), Storyblok, Directus (v11.16, 3-provider adapter pattern) | Universal expectation in 2026. Same adapter interface as transforms — pluggable per target. |
+| ✓ **AI alt-text adapter** (shipped in v1.5) | Strapi (Growth default), Storyblok, Directus (v11.16, 3-provider adapter pattern) | Universal expectation in 2026. Three providers shipped: Anthropic, OpenAI, Ollama. See [`design-ai.md`](design-ai.md) and [`design-ai-implementation.md`](design-ai-implementation.md). |
 | **Paste-URL / import-from-URL upload** | Payload (`pasteURL` w/ allowList), Strapi (`strapi.fetch`) | Low-cost convenience. Safer than "download then re-upload." Needs SSRF allowlist from day one. |
 | **MIME allowlist + magic-bytes validation** | Directus (hardened across 3 releases in Q1 2026) | Security. Cheap to ship right the first time. Pair with the existing `file-type` MIME sniffing. |
 | **Asset versions with "sync all usage"** | Sanity (2026 — Asset Versions in Media Library) | Our replace-and-delete destroys history; versioning preserves it. Fits our content-addressed model naturally — each byte change is already a new hash. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ Stateless CMS that structures websites as composable fragments. All state lives 
 - `.claude/rules/design-media.md` — Asset model, storage, refs, resolver, delete-with-replace, admin UX, i18n, distinctive choices
 - `.claude/rules/design-media-reference.md` — Fact-checked tooling specifics, library versions, licensing, codebase-alignment notes
 - `.claude/rules/design-media-implementation.md` — v1 scope + estimates, phased alt, out-of-v1, v1.5/v2 capabilities, frontier opportunities, open questions, migration
+- `.claude/rules/design-ai.md` — AI integration: layered architecture, alt-text task, providers (Anthropic/OpenAI/Ollama), refusal handling, prompt composition
+- `.claude/rules/design-ai-implementation.md` — v1.5 commit sequence, scope, deferred items, open questions, migration
 - `.claude/rules/architecture.md` — System architecture and package layout
 - `.claude/rules/testing-plan.md` — Active testing coverage + e2e restructure plan (auto-loads when editing tests)
 

--- a/apps/admin/src/client/api/assets.ts
+++ b/apps/admin/src/client/api/assets.ts
@@ -245,3 +245,41 @@ async function parseAssetError(res: Response, fallbackPrefix: string): Promise<A
   }
   return new AssetApiError(body.message ?? `${fallbackPrefix}: ${res.status}`, res.status, body.code)
 }
+
+/**
+ * Result shape for `suggestAlt`. Mirrors the server's
+ * `SuggestAltResponseSchema`: text + structured refusal info.
+ *
+ * UI consumers branch on `refused` to decide whether to display the
+ * suggestion or surface `refusalReason` (e.g., as a toast).
+ */
+export interface SuggestAltResult {
+  text: string
+  refused: boolean
+  refusalReason: string | null
+}
+
+/**
+ * Generate alt text for the named asset using the configured AI
+ * adapter. The server fetches asset bytes from storage; the client
+ * passes name + optional locale.
+ *
+ * `signal` aborts the in-flight request — used by the upload-list row
+ * to cancel suggestions when the author starts typing alt manually
+ * (author intent always wins).
+ *
+ * Returns a structured result on 200 (including refusals — refusal is
+ * not an error). Throws `AssetApiError` on 400/404/502/503.
+ */
+export async function suggestAlt(name: string, locale?: string, signal?: AbortSignal): Promise<SuggestAltResult> {
+  const params = new URLSearchParams()
+  if (locale) params.set('locale', locale)
+  const qs = params.toString() ? `?${params.toString()}` : ''
+  const res = await fetch(apiUrl(`/assets/${encodeURIComponent(name)}/suggest-alt${qs}`), {
+    method: 'POST',
+    headers: authHeaders(),
+    signal,
+  })
+  if (res.ok) return (await res.json()) as SuggestAltResult
+  throw await parseAssetError(res, 'Alt-text suggestion failed')
+}

--- a/apps/admin/src/client/components/AssetDetail.vue
+++ b/apps/admin/src/client/components/AssetDetail.vue
@@ -7,13 +7,15 @@
  * Reads from `assetsSelection` + `assetsList`. If the selection points to
  * an asset not in the list (stale after a refresh), shows an empty state.
  */
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import Button from 'primevue/button'
 import { formatBytes } from 'gazetta/format'
-import { updateAssetMetadata } from '../api/assets.js'
+import { suggestAlt, updateAssetMetadata, type SuggestAltResult } from '../api/assets.js'
+import { useActiveTargetStore } from '../stores/activeTarget.js'
 import { useAssetsListStore } from '../stores/assetsList.js'
 import { useAssetsSelectionStore } from '../stores/assetsSelection.js'
 import { useAssetsDeleteStore } from '../stores/assetsDelete.js'
+import { useLocaleStore } from '../stores/locale.js'
 import { buildAssetUrl, extFromMime } from '../utils/assetUrl.js'
 import AssetAltEditor from './AssetAltEditor.vue'
 import AssetDetailLocaleSection from './AssetDetailLocaleSection.vue'
@@ -22,6 +24,8 @@ import AssetFocalPointEditor from './AssetFocalPointEditor.vue'
 const list = useAssetsListStore()
 const selection = useAssetsSelectionStore()
 const del = useAssetsDeleteStore()
+const activeTarget = useActiveTargetStore()
+const locale = useLocaleStore()
 
 function onDelete(): void {
   if (!asset.value) return
@@ -61,6 +65,49 @@ async function onFocalPointUpdate(value: { x: number; y: number } | null): Promi
 }
 
 const isImage = computed(() => asset.value?.mime?.startsWith('image/') ?? false)
+
+/**
+ * AI alt-text capability for the active target. The detail-pane
+ * "✨ Suggest" button renders only when the adapter is configured
+ * (independent of the `auto` flag — auto controls upload-time
+ * pre-fill, not on-demand button visibility).
+ */
+const aiAvailable = computed(() => activeTarget.activeTarget?.altText.available ?? false)
+
+/** True while a suggestion is in-flight; gates the "Generating…" indicator. */
+const aiPending = ref(false)
+/** Refusal reason from the last suggest call. Null when not refused or unset. */
+const aiRefusalReason = ref<string | null>(null)
+
+/**
+ * Trigger an AI alt-text suggestion for the currently-selected asset.
+ * On success, commits the suggestion to the manifest via the existing
+ * `onAltUpdate` flow — same path as if the author had typed manually.
+ * Refusals surface inline; transport errors log to console (toast
+ * surface is a follow-up).
+ */
+async function onSuggestAlt(): Promise<void> {
+  if (!asset.value) return
+  const name = asset.value.name
+  aiPending.value = true
+  aiRefusalReason.value = null
+  let result: SuggestAltResult | null = null
+  try {
+    result = await suggestAlt(name, locale.activeLocale ?? undefined)
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(`AI alt suggestion failed for ${name}:`, err)
+    return
+  } finally {
+    aiPending.value = false
+  }
+  if (!result) return
+  if (result.refused) {
+    aiRefusalReason.value = result.refusalReason ?? 'Model declined'
+    return
+  }
+  await onAltUpdate(result.text)
+}
 
 const asset = computed(() => {
   if (!selection.selectedName) return null
@@ -114,6 +161,22 @@ function formatDate(iso: string): string {
           <dt>Alt</dt>
           <dd>
             <AssetAltEditor :model-value="asset.alt" @update:model-value="onAltUpdate" />
+            <div v-if="aiAvailable" class="asset-detail-alt-ai">
+              <Button
+                label="✨ Suggest"
+                text
+                size="small"
+                :loading="aiPending"
+                :disabled="aiPending"
+                data-testid="asset-detail-suggest-alt"
+                @click="onSuggestAlt" />
+              <p
+                v-if="aiRefusalReason"
+                class="asset-detail-alt-refusal"
+                data-testid="asset-detail-ai-refusal">
+                ✨ AI declined: {{ aiRefusalReason }}
+              </p>
+            </div>
           </dd>
         </div>
         <div v-if="isImage && previewUrl" class="asset-detail-focal">
@@ -231,6 +294,20 @@ function formatDate(iso: string): string {
 .asset-detail-alt dd,
 .asset-detail-focal dd {
   text-align: start;
+}
+
+.asset-detail-alt-ai {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 0.375rem;
+}
+
+.asset-detail-alt-refusal {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--p-amber-600);
+  font-style: italic;
 }
 
 .asset-detail-actions {

--- a/apps/admin/src/client/components/AssetUploadZone.vue
+++ b/apps/admin/src/client/components/AssetUploadZone.vue
@@ -11,16 +11,18 @@
  * "prompt for alt at upload" UX lands with the wide rollout.
  */
 import { ref, watch } from 'vue'
-import { updateAssetMetadata } from '../api/assets.js'
+import { suggestAlt, updateAssetMetadata, type SuggestAltResult } from '../api/assets.js'
 import { useAssetsUploadStore } from '../stores/assetsUpload.js'
 import { useAssetsUploadPromptStore } from '../stores/assetsUploadPrompt.js'
 import { useAssetsListStore } from '../stores/assetsList.js'
 import { useLocaleStore } from '../stores/locale.js'
+import { useActiveTargetStore } from '../stores/activeTarget.js'
 
 const uploads = useAssetsUploadStore()
 const list = useAssetsListStore()
 const promptStore = useAssetsUploadPromptStore()
 const locale = useLocaleStore()
+const activeTarget = useActiveTargetStore()
 
 /**
  * Per-upload-entry alt state. Keyed by `entry.id` so multiple successful
@@ -189,6 +191,127 @@ async function commitAlt(assetName: string, alt: string | null): Promise<void> {
     console.warn(`Failed to update alt for ${assetName}:`, err)
   }
 }
+
+/**
+ * Per-upload-entry AI-suggestion state.
+ *
+ *   - `aiPending`: true while a suggest call is in-flight; controls
+ *     the "✨ generating…" indicator
+ *   - `aiSuggested`: true once a suggestion has arrived AND the
+ *     author hasn't typed over it; controls the "✨ AI suggested"
+ *     hint label
+ *   - `aiAborts`: per-entry AbortController so typing into the
+ *     input cancels the in-flight suggestion (author intent wins)
+ *   - `aiRefusalReasons`: when the model declines, surface the
+ *     reason near the input so the author understands the empty state
+ */
+const aiPending = ref<Map<string, boolean>>(new Map())
+const aiSuggested = ref<Map<string, boolean>>(new Map())
+const aiRefusalReasons = ref<Map<string, string>>(new Map())
+const aiAborts = new Map<string, AbortController>()
+
+function aiPendingFor(id: string): boolean {
+  return aiPending.value.get(id) ?? false
+}
+function aiSuggestedFor(id: string): boolean {
+  return aiSuggested.value.get(id) ?? false
+}
+function aiRefusalFor(id: string): string | null {
+  return aiRefusalReasons.value.get(id) ?? null
+}
+
+/**
+ * Fire an AI suggestion for the given upload entry. Pre-fills the
+ * alt input and commits to the server (matches "alt fills itself"
+ * promise). Author can edit + blur to overwrite. Refusals leave the
+ * input empty and surface the reason inline.
+ */
+async function autoSuggestAlt(id: string, assetName: string): Promise<void> {
+  const controller = new AbortController()
+  aiAborts.set(id, controller)
+  aiPending.value.set(id, true)
+  let result: SuggestAltResult | null = null
+  try {
+    result = await suggestAlt(assetName, locale.activeLocale ?? undefined, controller.signal)
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      // User typed over the suggestion before it arrived. Silent abort.
+      return
+    }
+    // 503/502 etc. — the adapter is configured but the call failed.
+    // Don't pre-fill; leave the author to type manually. No toast in
+    // this commit; library-card no-alt badge surfaces the unset state.
+    // eslint-disable-next-line no-console
+    console.warn(`AI alt suggestion failed for ${assetName}:`, err)
+    return
+  } finally {
+    aiPending.value.set(id, false)
+    aiAborts.delete(id)
+  }
+
+  if (!result) return
+  if (result.refused) {
+    aiRefusalReasons.value.set(id, result.refusalReason ?? 'Model declined')
+    return
+  }
+  // Pre-fill the local input AND commit to the server. Local input
+  // value updates instantly; commit sends the PATCH so subsequent
+  // page loads see the suggestion as the asset's alt.
+  altText.value.set(id, result.text)
+  aiSuggested.value.set(id, true)
+  await commitAlt(assetName, result.text)
+}
+
+/**
+ * Watch successful uploads and auto-fire AI suggestion when:
+ *   1. The active target has `altText.available && altText.auto`
+ *   2. The upload was a default asset (locale-bytes overrides
+ *      inherit alt from default; per-locale alt is a future surface)
+ *   3. The MIME is an image (vision adapters only)
+ *
+ * Idempotent: tracks fired entries via aiSuggested/aiPending so
+ * watcher re-runs don't double-fire.
+ */
+watch(
+  () => uploads.uploads.filter(u => u.status === 'success').map(u => u.id),
+  (ids, prev) => {
+    const previousSet = new Set(prev ?? [])
+    const newIds = ids.filter(id => !previousSet.has(id))
+    if (newIds.length === 0) return
+
+    const cap = activeTarget.activeTarget?.altText
+    if (!cap?.available || !cap.auto) return
+
+    for (const id of newIds) {
+      const entry = uploads.uploads.find(u => u.id === id)
+      if (!entry) continue
+      if (entry.kind !== 'default') continue
+      if (!(entry.file.type ?? '').startsWith('image/')) continue
+      // Skip if we've already fired or are about to.
+      if (aiPendingFor(id) || aiSuggestedFor(id)) continue
+      void autoSuggestAlt(id, entry.name)
+    }
+  },
+)
+
+/**
+ * Cancel an in-flight AI suggestion when the author starts typing
+ * into the alt input — author intent wins over AI. Also clear the
+ * "AI suggested" hint so the author's edits aren't tagged as AI
+ * output.
+ */
+function onAltInput(id: string): void {
+  const controller = aiAborts.get(id)
+  if (controller && !controller.signal.aborted) {
+    controller.abort()
+    aiAborts.delete(id)
+    aiPending.value.set(id, false)
+  }
+  // The author is now driving — drop the "AI suggested" hint.
+  if (aiSuggestedFor(id)) {
+    aiSuggested.value.set(id, false)
+  }
+}
 </script>
 
 <template>
@@ -236,21 +359,42 @@ async function commitAlt(assetName: string, alt: string | null): Promise<void> {
         "
         class="upload-entry-alt"
         :data-testid="`upload-${entry.id}-alt`">
-        <input
-          type="text"
-          placeholder="Alt text (describe the image for accessibility)"
-          :value="altValueFor(entry.id)"
-          :disabled="altDecorativeFor(entry.id)"
-          :data-testid="`upload-${entry.id}-alt-input`"
-          @blur="onAltBlur($event, entry.id, entry.name)" />
-        <label class="upload-entry-decorative">
+        <div class="upload-entry-alt-row">
           <input
-            type="checkbox"
-            :checked="altDecorativeFor(entry.id)"
-            :data-testid="`upload-${entry.id}-alt-decorative`"
-            @change="onDecorativeChange($event, entry.id, entry.name)" />
-          Decorative
-        </label>
+            type="text"
+            placeholder="Alt text (describe the image for accessibility)"
+            :value="altValueFor(entry.id)"
+            :disabled="altDecorativeFor(entry.id)"
+            :data-testid="`upload-${entry.id}-alt-input`"
+            @input="onAltInput(entry.id)"
+            @blur="onAltBlur($event, entry.id, entry.name)" />
+          <label class="upload-entry-decorative">
+            <input
+              type="checkbox"
+              :checked="altDecorativeFor(entry.id)"
+              :data-testid="`upload-${entry.id}-alt-decorative`"
+              @change="onDecorativeChange($event, entry.id, entry.name)" />
+            Decorative
+          </label>
+        </div>
+        <p
+          v-if="aiPendingFor(entry.id)"
+          class="upload-entry-ai-state"
+          :data-testid="`upload-${entry.id}-ai-pending`">
+          ✨ Generating alt suggestion…
+        </p>
+        <p
+          v-else-if="aiSuggestedFor(entry.id)"
+          class="upload-entry-ai-state"
+          :data-testid="`upload-${entry.id}-ai-suggested`">
+          ✨ AI suggested — edit or accept
+        </p>
+        <p
+          v-else-if="aiRefusalFor(entry.id)"
+          class="upload-entry-ai-refusal"
+          :data-testid="`upload-${entry.id}-ai-refused`">
+          ✨ AI declined — please write alt manually
+        </p>
       </div>
     </div>
   </div>
@@ -313,6 +457,12 @@ async function commitAlt(assetName: string, alt: string | null): Promise<void> {
 
 .upload-entry-alt {
   display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.upload-entry-alt-row {
+  display: flex;
   align-items: center;
   gap: 0.5rem;
 }
@@ -339,5 +489,19 @@ async function commitAlt(assetName: string, alt: string | null): Promise<void> {
   font-size: 0.75rem;
   color: var(--p-text-muted-color);
   white-space: nowrap;
+}
+
+.upload-entry-ai-state {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--p-text-muted-color);
+  font-style: italic;
+}
+
+.upload-entry-ai-refusal {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--p-amber-600);
+  font-style: italic;
 }
 </style>

--- a/apps/admin/src/client/components/PreviewPanel.vue
+++ b/apps/admin/src/client/components/PreviewPanel.vue
@@ -458,11 +458,39 @@ onUnmounted(() => {
   sse?.close()
 })
 
+// Concurrency control for fetchPreview. Without this, rapid route /
+// target / locale changes fire parallel fetches; their responses
+// land in arbitrary order and `applyHtml` runs morphdom on a
+// document tree that may already be mid-mutation from the previous
+// invocation. That surfaces as a transient
+// `Cannot read properties of null (reading 'querySelector')` page
+// error from morphdom's internal traversal.
+//
+// Two-layer guard:
+//   1. `inFlightController` aborts the previous fetch before starting
+//      a new one — drops the network round-trip when we already know
+//      the response is stale.
+//   2. `fetchGeneration` discards stale responses that completed
+//      between abort and `applyHtml` — the abort may not be checked
+//      until the next microtask, so an in-progress `await res.text()`
+//      can still resolve. The generation check at the apply site
+//      makes that response a no-op.
+let inFlightController: AbortController | null = null
+let fetchGeneration = 0
+
 async function fetchPreview(morph = true) {
   if (!previewPath.value) {
     currentHtml = ''
     return
   }
+  // Cancel any in-flight fetch and bump the generation counter. The
+  // counter increment must happen before any await so the captured
+  // `myGen` below holds the new value.
+  inFlightController?.abort()
+  const controller = new AbortController()
+  inFlightController = controller
+  const myGen = ++fetchGeneration
+
   loading.value = true
   try {
     const overrides = editing.allOverrides
@@ -473,21 +501,29 @@ async function fetchPreview(morph = true) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ overrides }),
+        signal: controller.signal,
       })
     } else {
-      res = await fetch(previewPath.value)
+      res = await fetch(previewPath.value, { signal: controller.signal })
     }
     const html = injectBridge(await res.text())
+    // If a newer fetch was started while this one was in flight,
+    // discard our response — applying it would race with the newer
+    // call's `applyHtml` and corrupt morphdom's tree.
+    if (myGen !== fetchGeneration) return
     applyHtml(html, morph)
     // Send initial bridge mode + scope after iframe loads
     setTimeout(() => {
       sendBridgeMode()
       sendScope()
     }, 100)
-  } catch {
+  } catch (err) {
+    // Abort errors are expected — just bail out silently.
+    if (err instanceof DOMException && err.name === 'AbortError') return
+    if (myGen !== fetchGeneration) return
     applyHtml('<pre style="color:red;padding:2rem">Failed to load preview</pre>', false)
   } finally {
-    loading.value = false
+    if (myGen === fetchGeneration) loading.value = false
   }
 }
 

--- a/apps/admin/tests/ActiveTargetIndicator.test.ts
+++ b/apps/admin/tests/ActiveTargetIndicator.test.ts
@@ -58,14 +58,30 @@ describe('ActiveTargetIndicator', () => {
     })
 
     it('hides when no active target is set', () => {
-      const targets: TargetInfo[] = [{ name: 'local', environment: 'local', type: 'static', editable: true }]
+      const targets: TargetInfo[] = [
+        {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText: { available: false, auto: false },
+        },
+      ]
       setup(targets, null)
       const w = mountWithGlobals()
       expect(w.find('[data-testid="active-target-indicator"]').exists()).toBe(false)
     })
 
     it('shows the pill with 1 target and active set', () => {
-      const targets: TargetInfo[] = [{ name: 'local', environment: 'local', type: 'static', editable: true }]
+      const targets: TargetInfo[] = [
+        {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText: { available: false, auto: false },
+        },
+      ]
       setup(targets, 'local')
       const w = mountWithGlobals()
       expect(w.find('[data-testid="active-target-indicator"]').exists()).toBe(true)
@@ -75,28 +91,60 @@ describe('ActiveTargetIndicator', () => {
 
   describe('environment chrome', () => {
     it('applies env-local for local environment', () => {
-      const targets: TargetInfo[] = [{ name: 'local', environment: 'local', type: 'static', editable: true }]
+      const targets: TargetInfo[] = [
+        {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText: { available: false, auto: false },
+        },
+      ]
       setup(targets, 'local')
       const w = mountWithGlobals()
       expect(w.find('[data-testid="active-target-indicator"]').classes()).toContain('env-local')
     })
 
     it('applies env-staging for staging environment', () => {
-      const targets: TargetInfo[] = [{ name: 'staging', environment: 'staging', type: 'static', editable: false }]
+      const targets: TargetInfo[] = [
+        {
+          name: 'staging',
+          environment: 'staging',
+          type: 'static',
+          editable: false,
+          altText: { available: false, auto: false },
+        },
+      ]
       setup(targets, 'staging')
       const w = mountWithGlobals()
       expect(w.find('[data-testid="active-target-indicator"]').classes()).toContain('env-staging')
     })
 
     it('applies env-production for production environment', () => {
-      const targets: TargetInfo[] = [{ name: 'prod', environment: 'production', type: 'static', editable: false }]
+      const targets: TargetInfo[] = [
+        {
+          name: 'prod',
+          environment: 'production',
+          type: 'static',
+          editable: false,
+          altText: { available: false, auto: false },
+        },
+      ]
       setup(targets, 'prod')
       const w = mountWithGlobals()
       expect(w.find('[data-testid="active-target-indicator"]').classes()).toContain('env-production')
     })
 
     it('falls back to env-local when environment is unset', () => {
-      const targets: TargetInfo[] = [{ name: 'unset', environment: undefined, type: 'static', editable: true }]
+      const targets: TargetInfo[] = [
+        {
+          name: 'unset',
+          environment: undefined,
+          type: 'static',
+          editable: true,
+          altText: { available: false, auto: false },
+        },
+      ]
       setup(targets, 'unset')
       const w = mountWithGlobals()
       expect(w.find('[data-testid="active-target-indicator"]').classes()).toContain('env-local')
@@ -105,21 +153,45 @@ describe('ActiveTargetIndicator', () => {
 
   describe('editable vs read-only', () => {
     it('shows the read-only badge for non-editable targets', () => {
-      const targets: TargetInfo[] = [{ name: 'prod', environment: 'production', type: 'static', editable: false }]
+      const targets: TargetInfo[] = [
+        {
+          name: 'prod',
+          environment: 'production',
+          type: 'static',
+          editable: false,
+          altText: { available: false, auto: false },
+        },
+      ]
       setup(targets, 'prod')
       const w = mountWithGlobals()
       expect(w.find('[data-testid="active-target-indicator"]').text()).toContain('read-only')
     })
 
     it('omits the read-only badge for editable targets', () => {
-      const targets: TargetInfo[] = [{ name: 'local', environment: 'local', type: 'static', editable: true }]
+      const targets: TargetInfo[] = [
+        {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText: { available: false, auto: false },
+        },
+      ]
       setup(targets, 'local')
       const w = mountWithGlobals()
       expect(w.find('[data-testid="active-target-indicator"]').text()).not.toContain('read-only')
     })
 
     it('reflects editable in the title attribute', () => {
-      const targetsRO: TargetInfo[] = [{ name: 'prod', environment: 'production', type: 'static', editable: false }]
+      const targetsRO: TargetInfo[] = [
+        {
+          name: 'prod',
+          environment: 'production',
+          type: 'static',
+          editable: false,
+          altText: { available: false, auto: false },
+        },
+      ]
       setup(targetsRO, 'prod')
       const w = mountWithGlobals()
       expect(w.find('[data-testid="active-target-indicator"]').attributes('title')).toContain('read-only')
@@ -128,7 +200,15 @@ describe('ActiveTargetIndicator', () => {
 
   describe('interactivity', () => {
     it('marks the pill interactive with ≥1 target', () => {
-      const targets: TargetInfo[] = [{ name: 'local', environment: 'local', type: 'static', editable: true }]
+      const targets: TargetInfo[] = [
+        {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText: { available: false, auto: false },
+        },
+      ]
       setup(targets, 'local')
       const w = mountWithGlobals()
       const pill = w.find('[data-testid="active-target-indicator"]')
@@ -138,8 +218,20 @@ describe('ActiveTargetIndicator', () => {
 
     it('shows a chevron when interactive', () => {
       const targets: TargetInfo[] = [
-        { name: 'local', environment: 'local', type: 'static', editable: true },
-        { name: 'staging', environment: 'staging', type: 'static', editable: false },
+        {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText: { available: false, auto: false },
+        },
+        {
+          name: 'staging',
+          environment: 'staging',
+          type: 'static',
+          editable: false,
+          altText: { available: false, auto: false },
+        },
       ]
       setup(targets, 'local')
       const w = mountWithGlobals()
@@ -148,8 +240,20 @@ describe('ActiveTargetIndicator', () => {
 
     it('renders the switcher Menu component when interactive', () => {
       const targets: TargetInfo[] = [
-        { name: 'local', environment: 'local', type: 'static', editable: true },
-        { name: 'staging', environment: 'staging', type: 'static', editable: false },
+        {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText: { available: false, auto: false },
+        },
+        {
+          name: 'staging',
+          environment: 'staging',
+          type: 'static',
+          editable: false,
+          altText: { available: false, auto: false },
+        },
       ]
       setup(targets, 'local')
       const w = mountWithGlobals()
@@ -162,9 +266,27 @@ describe('ActiveTargetIndicator', () => {
   describe('switcher menu items', () => {
     it('flat list when ≤3 targets', () => {
       const targets: TargetInfo[] = [
-        { name: 'local', environment: 'local', type: 'static', editable: true },
-        { name: 'staging', environment: 'staging', type: 'static', editable: false },
-        { name: 'prod', environment: 'production', type: 'static', editable: false },
+        {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText: { available: false, auto: false },
+        },
+        {
+          name: 'staging',
+          environment: 'staging',
+          type: 'static',
+          editable: false,
+          altText: { available: false, auto: false },
+        },
+        {
+          name: 'prod',
+          environment: 'production',
+          type: 'static',
+          editable: false,
+          altText: { available: false, auto: false },
+        },
       ]
       setup(targets, 'local')
       const w = mountWithGlobals()
@@ -178,10 +300,34 @@ describe('ActiveTargetIndicator', () => {
 
     it('groups same-environment targets at 4+ total', () => {
       const targets: TargetInfo[] = [
-        { name: 'local', environment: 'local', type: 'static', editable: true },
-        { name: 'staging', environment: 'staging', type: 'static', editable: false },
-        { name: 'prod-us', environment: 'production', type: 'static', editable: false },
-        { name: 'prod-eu', environment: 'production', type: 'static', editable: false },
+        {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText: { available: false, auto: false },
+        },
+        {
+          name: 'staging',
+          environment: 'staging',
+          type: 'static',
+          editable: false,
+          altText: { available: false, auto: false },
+        },
+        {
+          name: 'prod-us',
+          environment: 'production',
+          type: 'static',
+          editable: false,
+          altText: { available: false, auto: false },
+        },
+        {
+          name: 'prod-eu',
+          environment: 'production',
+          type: 'static',
+          editable: false,
+          altText: { available: false, auto: false },
+        },
       ]
       setup(targets, 'local')
       const w = mountWithGlobals()
@@ -197,7 +343,15 @@ describe('ActiveTargetIndicator', () => {
     })
 
     it('always includes a View history action at the bottom', () => {
-      const targets: TargetInfo[] = [{ name: 'local', environment: 'local', type: 'static', editable: true }]
+      const targets: TargetInfo[] = [
+        {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText: { available: false, auto: false },
+        },
+      ]
       setup(targets, 'local')
       const w = mountWithGlobals()
       const menu = w.findComponent({ name: 'Menu' })

--- a/apps/admin/tests/AssetDetail.test.ts
+++ b/apps/admin/tests/AssetDetail.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import AssetDetail from '../src/client/components/AssetDetail.vue'
+import { useActiveTargetStore } from '../src/client/stores/activeTarget.js'
 import { useAssetsListStore } from '../src/client/stores/assetsList.js'
 import { useAssetsSelectionStore } from '../src/client/stores/assetsSelection.js'
 import type { AssetSummary } from '../src/client/api/client.js'
@@ -181,6 +182,94 @@ describe('AssetDetail', () => {
 
       const wrapper = mount(AssetDetail)
       expect(wrapper.find('[data-testid="focal-default-hint"]').exists()).toBe(true)
+    })
+  })
+
+  describe('AI ✨ Suggest button', () => {
+    it('hides the button when target altText.available is false', () => {
+      const list = useAssetsListStore()
+      const selection = useAssetsSelectionStore()
+      const targets = useActiveTargetStore()
+      targets.targets = [
+        {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText: { available: false, auto: false },
+        },
+      ]
+      targets.activeTargetName = 'local'
+      list.assets = [sample()]
+      selection.select('hero')
+
+      const wrapper = mount(AssetDetail)
+      expect(wrapper.find('[data-testid="asset-detail-suggest-alt"]').exists()).toBe(false)
+    })
+
+    it('shows the button when target altText.available is true', () => {
+      const list = useAssetsListStore()
+      const selection = useAssetsSelectionStore()
+      const targets = useActiveTargetStore()
+      targets.targets = [
+        {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText: { available: true, auto: true },
+        },
+      ]
+      targets.activeTargetName = 'local'
+      list.assets = [sample()]
+      selection.select('hero')
+
+      const wrapper = mount(AssetDetail)
+      expect(wrapper.find('[data-testid="asset-detail-suggest-alt"]').exists()).toBe(true)
+    })
+
+    it('shows the button regardless of auto flag (auto controls upload-time, not on-demand)', () => {
+      const list = useAssetsListStore()
+      const selection = useAssetsSelectionStore()
+      const targets = useActiveTargetStore()
+      targets.targets = [
+        {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText: { available: true, auto: false },
+        },
+      ]
+      targets.activeTargetName = 'local'
+      list.assets = [sample()]
+      selection.select('hero')
+
+      const wrapper = mount(AssetDetail)
+      expect(wrapper.find('[data-testid="asset-detail-suggest-alt"]').exists()).toBe(true)
+    })
+
+    it('hides the button for non-image assets even when AI is available', () => {
+      const list = useAssetsListStore()
+      const selection = useAssetsSelectionStore()
+      const targets = useActiveTargetStore()
+      targets.targets = [
+        {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText: { available: true, auto: true },
+        },
+      ]
+      targets.activeTargetName = 'local'
+      list.assets = [sample({ kind: 'downloadable', mime: 'application/pdf' })]
+      selection.select('hero')
+
+      const wrapper = mount(AssetDetail)
+      // The alt section is replaced by a plain text dd for non-images,
+      // so the suggest button never gets rendered.
+      expect(wrapper.find('[data-testid="asset-detail-suggest-alt"]').exists()).toBe(false)
     })
   })
 })

--- a/apps/admin/tests/AssetUploadZone.test.ts
+++ b/apps/admin/tests/AssetUploadZone.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import AssetUploadZone from '../src/client/components/AssetUploadZone.vue'
+import { useActiveTargetStore } from '../src/client/stores/activeTarget.js'
 import { useAssetsUploadStore } from '../src/client/stores/assetsUpload.js'
 import { useAssetsListStore } from '../src/client/stores/assetsList.js'
 import { useAssetsUploadPromptStore } from '../src/client/stores/assetsUploadPrompt.js'
@@ -320,6 +321,196 @@ describe('AssetUploadZone', () => {
 
       const altWrap = wrapper.find(`[data-testid="upload-${id}-alt"]`)
       expect(altWrap.exists()).toBe(false)
+    })
+  })
+
+  describe('AI alt-text auto-suggestion', () => {
+    function activateTargetWithAi(available: boolean, auto: boolean) {
+      const targets = useActiveTargetStore()
+      targets.targets = [
+        {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText: { available, auto },
+        },
+      ]
+      targets.activeTargetName = 'local'
+    }
+
+    function stubFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+      const originalFetch = globalThis.fetch
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+        return handler(url, init)
+      }) as typeof globalThis.fetch
+      return () => {
+        globalThis.fetch = originalFetch
+      }
+    }
+
+    it('does not fire suggestion when target altText.available is false', async () => {
+      activateTargetWithAi(false, true)
+      const suggestSpy = vi.fn()
+      const restore = stubFetch(url => {
+        if (url.includes('/suggest-alt')) {
+          suggestSpy()
+        }
+        return new Response(null, { status: 404 })
+      })
+      try {
+        const uploads = useAssetsUploadStore()
+        uploads.configure({
+          uploadAsset: vi.fn(async () => ({ manifest: {} as never, bytesPath: 'assets/x' })),
+        })
+        mount(AssetUploadZone)
+        uploads.enqueue(fakeFile('hero.jpg'), 'hero', null)
+        await flushPromises()
+        expect(suggestSpy).not.toHaveBeenCalled()
+      } finally {
+        restore()
+      }
+    })
+
+    it('does not fire suggestion when altText.auto is false (review-first mode)', async () => {
+      activateTargetWithAi(true, false)
+      const suggestSpy = vi.fn()
+      const restore = stubFetch(url => {
+        if (url.includes('/suggest-alt')) suggestSpy()
+        return new Response(null, { status: 404 })
+      })
+      try {
+        const uploads = useAssetsUploadStore()
+        uploads.configure({
+          uploadAsset: vi.fn(async () => ({ manifest: {} as never, bytesPath: 'assets/x' })),
+        })
+        mount(AssetUploadZone)
+        uploads.enqueue(fakeFile('hero.jpg'), 'hero', null)
+        await flushPromises()
+        expect(suggestSpy).not.toHaveBeenCalled()
+      } finally {
+        restore()
+      }
+    })
+
+    it('fires suggestion + populates the alt input on success', async () => {
+      activateTargetWithAi(true, true)
+      const restore = stubFetch(url => {
+        if (url.includes('/suggest-alt')) {
+          return new Response(JSON.stringify({ text: 'A cat on a windowsill', refused: false, refusalReason: null }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        if (url.includes('/assets/') && !url.includes('suggest-alt')) {
+          // PATCH commit — return updated manifest.
+          return new Response(JSON.stringify({ manifest: {} }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        return new Response(null, { status: 404 })
+      })
+      try {
+        const uploads = useAssetsUploadStore()
+        uploads.configure({
+          uploadAsset: vi.fn(async () => ({ manifest: {} as never, bytesPath: 'assets/x' })),
+        })
+
+        const wrapper = mount(AssetUploadZone)
+        const id = uploads.enqueue(fakeFile('hero.jpg'), 'hero', null)
+        await flushPromises()
+        // Allow the AI fetch + PATCH commit to finish.
+        await flushPromises()
+        await flushPromises()
+
+        const altInput = wrapper.find<HTMLInputElement>(`[data-testid="upload-${id}-alt-input"]`)
+        expect(altInput.exists()).toBe(true)
+        expect(altInput.element.value).toBe('A cat on a windowsill')
+        expect(wrapper.find(`[data-testid="upload-${id}-ai-suggested"]`).exists()).toBe(true)
+      } finally {
+        restore()
+      }
+    })
+
+    it('shows refusal hint and leaves alt input empty when model declines', async () => {
+      activateTargetWithAi(true, true)
+      const restore = stubFetch(url => {
+        if (url.includes('/suggest-alt')) {
+          return new Response(
+            JSON.stringify({
+              text: "I can't describe this image.",
+              refused: true,
+              refusalReason: "I can't describe this image.",
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          )
+        }
+        return new Response(null, { status: 404 })
+      })
+      try {
+        const uploads = useAssetsUploadStore()
+        uploads.configure({
+          uploadAsset: vi.fn(async () => ({ manifest: {} as never, bytesPath: 'assets/x' })),
+        })
+
+        const wrapper = mount(AssetUploadZone)
+        const id = uploads.enqueue(fakeFile('hero.jpg'), 'hero', null)
+        await flushPromises()
+        await flushPromises()
+
+        const altInput = wrapper.find<HTMLInputElement>(`[data-testid="upload-${id}-alt-input"]`)
+        expect(altInput.element.value).toBe('')
+        expect(wrapper.find(`[data-testid="upload-${id}-ai-refused"]`).exists()).toBe(true)
+      } finally {
+        restore()
+      }
+    })
+
+    it('does not fire for non-image uploads (PDF) even when AI is configured', async () => {
+      activateTargetWithAi(true, true)
+      const suggestSpy = vi.fn()
+      const restore = stubFetch(url => {
+        if (url.includes('/suggest-alt')) suggestSpy()
+        return new Response(null, { status: 404 })
+      })
+      try {
+        const uploads = useAssetsUploadStore()
+        uploads.configure({
+          uploadAsset: vi.fn(async () => ({ manifest: {} as never, bytesPath: 'assets/x' })),
+        })
+        mount(AssetUploadZone)
+        const pdf = new File([new Uint8Array([0x25, 0x50, 0x44, 0x46])], 'doc.pdf', {
+          type: 'application/pdf',
+        })
+        uploads.enqueue(pdf, 'doc', null)
+        await flushPromises()
+        expect(suggestSpy).not.toHaveBeenCalled()
+      } finally {
+        restore()
+      }
+    })
+
+    it('does not fire for locale-bytes uploads (only default uploads)', async () => {
+      activateTargetWithAi(true, true)
+      const suggestSpy = vi.fn()
+      const restore = stubFetch(url => {
+        if (url.includes('/suggest-alt')) suggestSpy()
+        return new Response(null, { status: 404 })
+      })
+      try {
+        const uploads = useAssetsUploadStore()
+        uploads.configure({
+          uploadLocaleBytes: vi.fn(async () => ({ manifest: {} as never, bytesPath: 'assets/x' })),
+        })
+        mount(AssetUploadZone)
+        uploads.enqueueLocaleBytes(fakeFile('hero.jpg'), 'hero', { locale: 'fr' })
+        await flushPromises()
+        expect(suggestSpy).not.toHaveBeenCalled()
+      } finally {
+        restore()
+      }
     })
   })
 })

--- a/apps/admin/tests/PublishPanel.test.ts
+++ b/apps/admin/tests/PublishPanel.test.ts
@@ -160,8 +160,20 @@ describe('PublishPanel', () => {
     it('shows a fixed source chip when only one editable target exists', async () => {
       installTargets(
         [
-          { name: 'local', environment: 'local', type: 'static', editable: true },
-          { name: 'prod', environment: 'production', type: 'static', editable: false },
+          {
+            name: 'local',
+            environment: 'local',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'prod',
+            environment: 'production',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
         ],
         'local',
       )
@@ -175,9 +187,27 @@ describe('PublishPanel', () => {
     it('shows a dropdown when 2+ editable targets exist', async () => {
       installTargets(
         [
-          { name: 'local', environment: 'local', type: 'static', editable: true },
-          { name: 'staging', environment: 'staging', type: 'static', editable: true },
-          { name: 'prod', environment: 'production', type: 'static', editable: false },
+          {
+            name: 'local',
+            environment: 'local',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'staging',
+            environment: 'staging',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'prod',
+            environment: 'production',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
         ],
         'local',
       )
@@ -190,8 +220,20 @@ describe('PublishPanel', () => {
     it('defaults source to the active target when it is editable', async () => {
       installTargets(
         [
-          { name: 'local', environment: 'local', type: 'static', editable: true },
-          { name: 'staging', environment: 'staging', type: 'static', editable: true },
+          {
+            name: 'local',
+            environment: 'local',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'staging',
+            environment: 'staging',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
         ],
         'staging',
       )
@@ -205,8 +247,20 @@ describe('PublishPanel', () => {
     it('defaults source to the first editable when active is read-only', async () => {
       installTargets(
         [
-          { name: 'staging', environment: 'staging', type: 'static', editable: true },
-          { name: 'prod', environment: 'production', type: 'static', editable: false },
+          {
+            name: 'staging',
+            environment: 'staging',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'prod',
+            environment: 'production',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
         ],
         'prod',
       )
@@ -221,9 +275,27 @@ describe('PublishPanel', () => {
     it('renders one chip per non-source target (flat ≤3)', async () => {
       installTargets(
         [
-          { name: 'local', environment: 'local', type: 'static', editable: true },
-          { name: 'staging', environment: 'staging', type: 'static', editable: false },
-          { name: 'prod', environment: 'production', type: 'static', editable: false },
+          {
+            name: 'local',
+            environment: 'local',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'staging',
+            environment: 'staging',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'prod',
+            environment: 'production',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
         ],
         'local',
       )
@@ -238,10 +310,34 @@ describe('PublishPanel', () => {
     it('shows a group header for same-environment members at 4+ total', async () => {
       installTargets(
         [
-          { name: 'local', environment: 'local', type: 'static', editable: true },
-          { name: 'staging', environment: 'staging', type: 'static', editable: false },
-          { name: 'prod-us', environment: 'production', type: 'static', editable: false },
-          { name: 'prod-eu', environment: 'production', type: 'static', editable: false },
+          {
+            name: 'local',
+            environment: 'local',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'staging',
+            environment: 'staging',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'prod-us',
+            environment: 'production',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'prod-eu',
+            environment: 'production',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
         ],
         'local',
       )
@@ -255,8 +351,20 @@ describe('PublishPanel', () => {
     it('preselects initialDestination when provided', async () => {
       installTargets(
         [
-          { name: 'local', environment: 'local', type: 'static', editable: true },
-          { name: 'staging', environment: 'staging', type: 'static', editable: false },
+          {
+            name: 'local',
+            environment: 'local',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'staging',
+            environment: 'staging',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
         ],
         'local',
       )
@@ -269,8 +377,20 @@ describe('PublishPanel', () => {
     it('shows read-only badge on non-editable destinations', async () => {
       installTargets(
         [
-          { name: 'local', environment: 'local', type: 'static', editable: true },
-          { name: 'prod', environment: 'production', type: 'static', editable: false },
+          {
+            name: 'local',
+            environment: 'local',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'prod',
+            environment: 'production',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
         ],
         'local',
       )
@@ -284,8 +404,20 @@ describe('PublishPanel', () => {
     it('disables the publish button until source + destinations + items are all set', async () => {
       installTargets(
         [
-          { name: 'local', environment: 'local', type: 'static', editable: true },
-          { name: 'staging', environment: 'staging', type: 'static', editable: false },
+          {
+            name: 'local',
+            environment: 'local',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'staging',
+            environment: 'staging',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
         ],
         'local',
       )
@@ -298,8 +430,20 @@ describe('PublishPanel', () => {
     it('computes label as "Publish N items → M targets"', async () => {
       installTargets(
         [
-          { name: 'local', environment: 'local', type: 'static', editable: true },
-          { name: 'staging', environment: 'staging', type: 'static', editable: false },
+          {
+            name: 'local',
+            environment: 'local',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'staging',
+            environment: 'staging',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
         ],
         'local',
       )
@@ -312,8 +456,20 @@ describe('PublishPanel', () => {
     it('calls publishApi.publishStream on publish, with items + destinations + source', async () => {
       installTargets(
         [
-          { name: 'local', environment: 'local', type: 'static', editable: true },
-          { name: 'staging', environment: 'staging', type: 'static', editable: false },
+          {
+            name: 'local',
+            environment: 'local',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'staging',
+            environment: 'staging',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
         ],
         'local',
       )
@@ -346,8 +502,20 @@ describe('PublishPanel', () => {
     it('shows results with per-target success + undo button after a successful publish', async () => {
       installTargets(
         [
-          { name: 'local', environment: 'local', type: 'static', editable: true },
-          { name: 'staging', environment: 'staging', type: 'static', editable: false },
+          {
+            name: 'local',
+            environment: 'local',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'staging',
+            environment: 'staging',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
         ],
         'local',
       )
@@ -372,8 +540,20 @@ describe('PublishPanel', () => {
     it('requires explicit confirmation when a production destination is selected', async () => {
       installTargets(
         [
-          { name: 'local', environment: 'local', type: 'static', editable: true },
-          { name: 'prod', environment: 'production', type: 'static', editable: false },
+          {
+            name: 'local',
+            environment: 'local',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'prod',
+            environment: 'production',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
         ],
         'local',
       )
@@ -398,8 +578,20 @@ describe('PublishPanel', () => {
     it('skips confirmation when no production destination is selected', async () => {
       installTargets(
         [
-          { name: 'local', environment: 'local', type: 'static', editable: true },
-          { name: 'staging', environment: 'staging', type: 'static', editable: false },
+          {
+            name: 'local',
+            environment: 'local',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'staging',
+            environment: 'staging',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
         ],
         'local',
       )
@@ -420,8 +612,20 @@ describe('PublishPanel', () => {
     it('calls historyApi.undoLastWrite when result undo is clicked', async () => {
       installTargets(
         [
-          { name: 'local', environment: 'local', type: 'static', editable: true },
-          { name: 'staging', environment: 'staging', type: 'static', editable: false },
+          {
+            name: 'local',
+            environment: 'local',
+            type: 'static',
+            editable: true,
+            altText: { available: false, auto: false },
+          },
+          {
+            name: 'staging',
+            environment: 'staging',
+            type: 'static',
+            editable: false,
+            altText: { available: false, auto: false },
+          },
         ],
         'local',
       )

--- a/apps/admin/tests/SyncIndicators.test.ts
+++ b/apps/admin/tests/SyncIndicators.test.ts
@@ -48,7 +48,15 @@ describe('SyncIndicators', () => {
   })
 
   it('renders nothing when there are no non-active targets', () => {
-    const targets: TargetInfo[] = [{ name: 'local', environment: 'local', type: 'static', editable: true }]
+    const targets: TargetInfo[] = [
+      {
+        name: 'local',
+        environment: 'local',
+        type: 'static',
+        editable: true,
+        altText: { available: false, auto: false },
+      },
+    ]
     setupStores(targets, 'local')
     const w = mount(SyncIndicators)
     expect(w.find('[data-testid="sync-indicators"]').exists()).toBe(false)
@@ -56,9 +64,27 @@ describe('SyncIndicators', () => {
 
   it('renders a chip for each non-active target (flat, ≤3 targets)', () => {
     const targets: TargetInfo[] = [
-      { name: 'local', environment: 'local', type: 'static', editable: true },
-      { name: 'staging', environment: 'staging', type: 'static', editable: false },
-      { name: 'prod', environment: 'production', type: 'static', editable: false },
+      {
+        name: 'local',
+        environment: 'local',
+        type: 'static',
+        editable: true,
+        altText: { available: false, auto: false },
+      },
+      {
+        name: 'staging',
+        environment: 'staging',
+        type: 'static',
+        editable: false,
+        altText: { available: false, auto: false },
+      },
+      {
+        name: 'prod',
+        environment: 'production',
+        type: 'static',
+        editable: false,
+        altText: { available: false, auto: false },
+      },
     ]
     const { syncStore } = setupStores(targets, 'local')
     syncStore.statuses.set('staging', { changedCount: 3, firstPublish: false, result: mkResult() })
@@ -72,8 +98,20 @@ describe('SyncIndicators', () => {
 
   it('shows "N behind" for a target with changes', () => {
     const targets: TargetInfo[] = [
-      { name: 'local', environment: 'local', type: 'static', editable: true },
-      { name: 'staging', environment: 'staging', type: 'static', editable: false },
+      {
+        name: 'local',
+        environment: 'local',
+        type: 'static',
+        editable: true,
+        altText: { available: false, auto: false },
+      },
+      {
+        name: 'staging',
+        environment: 'staging',
+        type: 'static',
+        editable: false,
+        altText: { available: false, auto: false },
+      },
     ]
     const { syncStore } = setupStores(targets, 'local')
     syncStore.statuses.set('staging', { changedCount: 3, firstPublish: false, result: mkResult() })
@@ -84,8 +122,20 @@ describe('SyncIndicators', () => {
 
   it('shows "in sync" for a target with no changes', () => {
     const targets: TargetInfo[] = [
-      { name: 'local', environment: 'local', type: 'static', editable: true },
-      { name: 'staging', environment: 'staging', type: 'static', editable: false },
+      {
+        name: 'local',
+        environment: 'local',
+        type: 'static',
+        editable: true,
+        altText: { available: false, auto: false },
+      },
+      {
+        name: 'staging',
+        environment: 'staging',
+        type: 'static',
+        editable: false,
+        altText: { available: false, auto: false },
+      },
     ]
     const { syncStore } = setupStores(targets, 'local')
     syncStore.statuses.set('staging', { changedCount: 0, firstPublish: false, result: mkResult() })
@@ -96,8 +146,20 @@ describe('SyncIndicators', () => {
 
   it('shows "not yet published" when firstPublish is true', () => {
     const targets: TargetInfo[] = [
-      { name: 'local', environment: 'local', type: 'static', editable: true },
-      { name: 'staging', environment: 'staging', type: 'static', editable: false },
+      {
+        name: 'local',
+        environment: 'local',
+        type: 'static',
+        editable: true,
+        altText: { available: false, auto: false },
+      },
+      {
+        name: 'staging',
+        environment: 'staging',
+        type: 'static',
+        editable: false,
+        altText: { available: false, auto: false },
+      },
     ]
     const { syncStore } = setupStores(targets, 'local')
     syncStore.statuses.set('staging', { changedCount: 0, firstPublish: true, result: mkResult({ firstPublish: true }) })
@@ -108,8 +170,20 @@ describe('SyncIndicators', () => {
 
   it('shows "…" while loading', () => {
     const targets: TargetInfo[] = [
-      { name: 'local', environment: 'local', type: 'static', editable: true },
-      { name: 'staging', environment: 'staging', type: 'static', editable: false },
+      {
+        name: 'local',
+        environment: 'local',
+        type: 'static',
+        editable: true,
+        altText: { available: false, auto: false },
+      },
+      {
+        name: 'staging',
+        environment: 'staging',
+        type: 'static',
+        editable: false,
+        altText: { available: false, auto: false },
+      },
     ]
     const { syncStore } = setupStores(targets, 'local')
     syncStore.loading.add('staging')
@@ -120,8 +194,20 @@ describe('SyncIndicators', () => {
 
   it('shows "?" on error', () => {
     const targets: TargetInfo[] = [
-      { name: 'local', environment: 'local', type: 'static', editable: true },
-      { name: 'staging', environment: 'staging', type: 'static', editable: false },
+      {
+        name: 'local',
+        environment: 'local',
+        type: 'static',
+        editable: true,
+        altText: { available: false, auto: false },
+      },
+      {
+        name: 'staging',
+        environment: 'staging',
+        type: 'static',
+        editable: false,
+        altText: { available: false, auto: false },
+      },
     ]
     const { syncStore } = setupStores(targets, 'local')
     syncStore.errors.set('staging', 'network error')
@@ -132,8 +218,20 @@ describe('SyncIndicators', () => {
 
   it('applies env-production class to production targets', () => {
     const targets: TargetInfo[] = [
-      { name: 'local', environment: 'local', type: 'static', editable: true },
-      { name: 'prod', environment: 'production', type: 'static', editable: false },
+      {
+        name: 'local',
+        environment: 'local',
+        type: 'static',
+        editable: true,
+        altText: { available: false, auto: false },
+      },
+      {
+        name: 'prod',
+        environment: 'production',
+        type: 'static',
+        editable: false,
+        altText: { available: false, auto: false },
+      },
     ]
     const { syncStore } = setupStores(targets, 'local')
     syncStore.statuses.set('prod', { changedCount: 0, firstPublish: false, result: mkResult() })
@@ -144,8 +242,20 @@ describe('SyncIndicators', () => {
 
   it('emits select with target name on chip click', async () => {
     const targets: TargetInfo[] = [
-      { name: 'local', environment: 'local', type: 'static', editable: true },
-      { name: 'staging', environment: 'staging', type: 'static', editable: false },
+      {
+        name: 'local',
+        environment: 'local',
+        type: 'static',
+        editable: true,
+        altText: { available: false, auto: false },
+      },
+      {
+        name: 'staging',
+        environment: 'staging',
+        type: 'static',
+        editable: false,
+        altText: { available: false, auto: false },
+      },
     ]
     const { syncStore } = setupStores(targets, 'local')
     syncStore.statuses.set('staging', { changedCount: 1, firstPublish: false, result: mkResult() })
@@ -157,10 +267,34 @@ describe('SyncIndicators', () => {
 
   describe('grouping at 4+ targets', () => {
     const fourTargets: TargetInfo[] = [
-      { name: 'local', environment: 'local', type: 'static', editable: true },
-      { name: 'staging', environment: 'staging', type: 'static', editable: false },
-      { name: 'prod-us', environment: 'production', type: 'static', editable: false },
-      { name: 'prod-eu', environment: 'production', type: 'static', editable: false },
+      {
+        name: 'local',
+        environment: 'local',
+        type: 'static',
+        editable: true,
+        altText: { available: false, auto: false },
+      },
+      {
+        name: 'staging',
+        environment: 'staging',
+        type: 'static',
+        editable: false,
+        altText: { available: false, auto: false },
+      },
+      {
+        name: 'prod-us',
+        environment: 'production',
+        type: 'static',
+        editable: false,
+        altText: { available: false, auto: false },
+      },
+      {
+        name: 'prod-eu',
+        environment: 'production',
+        type: 'static',
+        editable: false,
+        altText: { available: false, auto: false },
+      },
     ]
 
     it('collapses same-environment targets into a group chip', () => {

--- a/apps/admin/tests/activeTarget.test.ts
+++ b/apps/admin/tests/activeTarget.test.ts
@@ -11,9 +11,21 @@ import type { TargetInfo } from '../src/client/api/client.js'
 import { useActiveTargetStore, type LoadTargets } from '../src/client/stores/activeTarget.js'
 
 const TARGETS: TargetInfo[] = [
-  { name: 'local', environment: 'local', type: 'static', editable: true },
-  { name: 'staging', environment: 'staging', type: 'static', editable: false },
-  { name: 'prod', environment: 'production', type: 'static', editable: false },
+  { name: 'local', environment: 'local', type: 'static', editable: true, altText: { available: false, auto: false } },
+  {
+    name: 'staging',
+    environment: 'staging',
+    type: 'static',
+    editable: false,
+    altText: { available: false, auto: false },
+  },
+  {
+    name: 'prod',
+    environment: 'production',
+    type: 'static',
+    editable: false,
+    altText: { available: false, auto: false },
+  },
 ]
 
 function fixedLoader(list: TargetInfo[]): LoadTargets {
@@ -41,8 +53,20 @@ describe('useActiveTargetStore', () => {
 
   it('falls back to the first target when none are editable', async () => {
     const readOnly: TargetInfo[] = [
-      { name: 'staging', environment: 'staging', type: 'static', editable: false },
-      { name: 'prod', environment: 'production', type: 'static', editable: false },
+      {
+        name: 'staging',
+        environment: 'staging',
+        type: 'static',
+        editable: false,
+        altText: { available: false, auto: false },
+      },
+      {
+        name: 'prod',
+        environment: 'production',
+        type: 'static',
+        editable: false,
+        altText: { available: false, auto: false },
+      },
     ]
     const store = useActiveTargetStore()
     store.configure({ loadTargets: fixedLoader(readOnly) })

--- a/apps/admin/tests/api-contract.test.ts
+++ b/apps/admin/tests/api-contract.test.ts
@@ -214,13 +214,41 @@ describe('GET /api/fields contract', () => {
 describe('GET /api/targets contract', () => {
   describe('TargetInfo', () => {
     it('accepts a well-formed entry', () => {
-      const entry: TargetInfo = { name: 'local', environment: 'local', type: 'static', editable: true }
+      const entry: TargetInfo = {
+        name: 'local',
+        environment: 'local',
+        type: 'static',
+        editable: true,
+        altText: { available: false, auto: false },
+      }
       expect(TargetInfoSchema.safeParse(entry).success).toBe(true)
     })
 
     it('rejects entries missing required fields', () => {
       expect(TargetInfoSchema.safeParse({ name: 'local', environment: 'local', type: 'static' }).success).toBe(false)
       expect(TargetInfoSchema.safeParse({ environment: 'local', type: 'static', editable: true }).success).toBe(false)
+      // altText is required per the v1.5 capability surface.
+      expect(
+        TargetInfoSchema.safeParse({ name: 'local', environment: 'local', type: 'static', editable: true }).success,
+      ).toBe(false)
+    })
+
+    it('accepts altText capability with both availability and auto values', () => {
+      const cases = [
+        { available: false, auto: false },
+        { available: true, auto: false },
+        { available: true, auto: true },
+      ]
+      for (const altText of cases) {
+        const entry: TargetInfo = {
+          name: 'local',
+          environment: 'local',
+          type: 'static',
+          editable: true,
+          altText,
+        }
+        expect(TargetInfoSchema.safeParse(entry).success).toBe(true)
+      }
     })
   })
 

--- a/apps/admin/tests/saveButtonBinding.test.ts
+++ b/apps/admin/tests/saveButtonBinding.test.ts
@@ -7,10 +7,34 @@ import { describe, it, expect } from 'vitest'
 import type { TargetInfo } from '../src/client/api/client.js'
 import { isSavingToProd, saveButtonLabel, saveButtonSeverity } from '../src/client/composables/saveButtonBinding.js'
 
-const LOCAL: TargetInfo = { name: 'local', environment: 'local', type: 'static', editable: true }
-const STAGING: TargetInfo = { name: 'staging', environment: 'staging', type: 'static', editable: true }
-const PROD_READONLY: TargetInfo = { name: 'prod', environment: 'production', type: 'static', editable: false }
-const PROD_HOTFIX: TargetInfo = { name: 'prod', environment: 'production', type: 'static', editable: true }
+const LOCAL: TargetInfo = {
+  name: 'local',
+  environment: 'local',
+  type: 'static',
+  editable: true,
+  altText: { available: false, auto: false },
+}
+const STAGING: TargetInfo = {
+  name: 'staging',
+  environment: 'staging',
+  type: 'static',
+  editable: true,
+  altText: { available: false, auto: false },
+}
+const PROD_READONLY: TargetInfo = {
+  name: 'prod',
+  environment: 'production',
+  type: 'static',
+  editable: false,
+  altText: { available: false, auto: false },
+}
+const PROD_HOTFIX: TargetInfo = {
+  name: 'prod',
+  environment: 'production',
+  type: 'static',
+  editable: true,
+  altText: { available: false, auto: false },
+}
 
 describe('isSavingToProd', () => {
   it('true only when target is editable AND environment is production', () => {
@@ -43,7 +67,13 @@ describe('saveButtonLabel', () => {
   })
 
   it('uses the target name so multi-region prod (e.g. prod-us) is unambiguous', () => {
-    const prodUs: TargetInfo = { name: 'prod-us', environment: 'production', type: 'static', editable: true }
+    const prodUs: TargetInfo = {
+      name: 'prod-us',
+      environment: 'production',
+      type: 'static',
+      editable: true,
+      altText: { available: false, auto: false },
+    }
     expect(saveButtonLabel(prodUs)).toBe('Save to prod-us')
   })
 

--- a/apps/admin/tests/syncStatus.test.ts
+++ b/apps/admin/tests/syncStatus.test.ts
@@ -10,9 +10,21 @@ import type { TargetInfo, CompareResult } from '../src/client/api/client.js'
 import { useSyncStatusStore, type CompareFn } from '../src/client/stores/syncStatus.js'
 
 const TARGETS: TargetInfo[] = [
-  { name: 'local', environment: 'local', type: 'static', editable: true },
-  { name: 'staging', environment: 'staging', type: 'static', editable: false },
-  { name: 'prod', environment: 'production', type: 'static', editable: false },
+  { name: 'local', environment: 'local', type: 'static', editable: true, altText: { available: false, auto: false } },
+  {
+    name: 'staging',
+    environment: 'staging',
+    type: 'static',
+    editable: false,
+    altText: { available: false, auto: false },
+  },
+  {
+    name: 'prod',
+    environment: 'production',
+    type: 'static',
+    editable: false,
+    altText: { available: false, auto: false },
+  },
 ]
 
 const EMPTY_RESULT: CompareResult = {

--- a/apps/admin/tests/targetGrouping.test.ts
+++ b/apps/admin/tests/targetGrouping.test.ts
@@ -12,7 +12,13 @@ import {
 } from '../src/client/composables/targetGrouping.js'
 
 function T(name: string, environment: 'local' | 'staging' | 'production'): TargetInfo {
-  return { name, environment, type: 'static', editable: environment === 'local' }
+  return {
+    name,
+    environment,
+    type: 'static',
+    editable: environment === 'local',
+    altText: { available: false, auto: false },
+  }
 }
 
 describe('shouldGroup', () => {

--- a/docs/content-assets.md
+++ b/docs/content-assets.md
@@ -50,6 +50,11 @@ Three behaviors:
 Alt is non-blocking at upload — fill it now, fill it later via the
 detail pane, or override per-use on each page that references the asset.
 
+If AI alt-text is configured for the target (see "AI alt-text"
+below), the input pre-fills with a model-generated description after
+upload. Type into the input to override; the in-flight suggestion
+aborts when you start typing.
+
 ### Locale-bytes upload (when active locale ≠ default)
 
 If the **active locale** is not the site's default locale, and you
@@ -96,6 +101,99 @@ Uploaded     2026-04-22 14:23
 ### Editing alt
 
 Inline three-state input + "Decorative" checkbox. Commits on blur.
+
+When AI alt-text is configured for the active target, a `✨ Suggest`
+button appears below the alt editor. Clicking it asks the configured
+provider to describe the image; the suggestion fills the alt input
+and commits to the manifest. Edit and tab away to override the
+suggestion. See "AI alt-text" below for setup.
+
+### AI alt-text (optional)
+
+When the active target has `altText:` configured (see "Configuring
+AI alt-text" below), the asset library and upload list gain AI
+suggestions:
+
+- **At upload time** (when `auto: true`, the default): every
+  successful image upload triggers a suggestion in the background.
+  The alt input pre-fills with the model's description and the
+  hint `✨ AI suggested — edit or accept` appears. Type into the
+  input to override; the in-flight suggestion aborts.
+- **On demand** (always available when AI is configured): the
+  detail pane's `✨ Suggest` button generates alt for any image
+  asset, regardless of the `auto` setting. Useful for assets
+  uploaded before AI was configured, or when a previous suggestion
+  was rejected.
+
+Multilingual: the model writes alt directly in the active locale.
+Switching to French in the locale picker and clicking `✨ Suggest`
+returns French alt text.
+
+When the model declines (some images trigger provider safety
+filters), the alt stays empty and an inline `✨ AI declined — please
+write alt manually` hint appears. Refusal is rare for typical
+content; uploads always succeed regardless.
+
+#### Configuring AI alt-text
+
+Two layers in `site.yaml`:
+
+```yaml
+# Cross-task AI configuration — provider account choice
+ai:
+  provider: anthropic            # anthropic | openai | ollama
+  defaultModel: claude-haiku-4-5 # optional; per-provider sensible default
+
+# Per-task config — alt-text behavior
+altText:
+  auto: true                     # default; auto-fire on upload
+  maxImageEdge: 768              # default; vision-call image-resize cap
+  # model: claude-sonnet-4-5     # optional override of ai.defaultModel
+```
+
+API credentials live in `.env.local` (gitignored, never in
+`site.yaml`):
+
+```
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+# OLLAMA_BASE_URL=http://localhost:11434  (optional; default shown)
+```
+
+**Per-target overrides** — typically used to disable auto-fire on
+production for review-first publishing:
+
+```yaml
+targets:
+  production:
+    altText:
+      auto: false                # require explicit click on prod
+```
+
+Provider and credentials are operationally global — they don't
+appear at the target level. Behavior fields (`auto`, `maxImageEdge`,
+`model`) can be overridden per target.
+
+#### Provider choice
+
+| Provider | What it costs | What's it good for |
+|---|---|---|
+| `anthropic` | ~$0.003/image (Haiku); higher for Sonnet/Opus | Default SaaS choice. Strong multilingual quality. |
+| `openai` | Varies — gpt-4o-mini's vision pricing differs from text. Benchmark against your asset library before optimizing | Wide adoption; easy if your team already has an OpenAI account |
+| `ollama` | Zero (self-hosted) | Privacy-first or air-gapped deployments. Bytes never leave the server running Ollama. Slower on CPU; needs `ollama pull llama3.2-vision:11b` first |
+
+#### Privacy considerations
+
+When using Anthropic or OpenAI, asset bytes are sent to the
+provider's servers for description. Each provider has its own data-
+handling and retention policy — review them before configuring AI
+alt-text on a target with sensitive imagery. Use `ollama` for
+fully self-hosted workflows where no asset data leaves your
+infrastructure.
+
+The model's response (alt text) is stored in the asset's manifest
+in the same target storage as the rest of your content. No AI-
+specific data is recorded outside the asset manifest.
 
 ### Setting a focal point
 
@@ -225,4 +323,5 @@ are a v1.5 UX surface (the data model already supports them).
 
 - [`.claude/rules/design-media.md`](../.claude/rules/design-media.md) — full design model
 - [`.claude/rules/design-editor-ux.md`](../.claude/rules/design-editor-ux.md) — active-target UX, switching, undo
+- [`.claude/rules/design-ai.md`](../.claude/rules/design-ai.md) — AI integration design (alt-text + future tasks)
 - [template-assets.md](template-assets.md) — for template developers

--- a/examples/starter/sites/main/site.yaml
+++ b/examples/starter/sites/main/site.yaml
@@ -5,6 +5,19 @@ locales:
   supported: [en, fr, ar, ja]
 systemPages:
   - "404"
+
+# AI integration (optional). Uncomment to enable AI-powered alt-text
+# generation. Provider credentials live in `.env.local` (gitignored)
+# — never in this file. See docs/content-assets.md for setup.
+#
+# ai:
+#   provider: anthropic            # anthropic | openai | ollama
+#   defaultModel: claude-haiku-4-5 # optional; falls back to per-provider default
+#
+# altText:
+#   auto: true                     # default: pre-fill alt on every image upload
+#   maxImageEdge: 768              # default; bump to 1024 for text-heavy assets
+
 targets:
   local:
     storage:
@@ -29,3 +42,7 @@ targets:
       connectionString: "UseDevelopmentStorage=true"
       container: "gazetta-production"
     environment: production
+    # Uncomment alongside the top-level `altText:` block to require
+    # explicit click-to-suggest on production (review-first workflow):
+    # altText:
+    #   auto: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,26 @@
         "zod": "^4.3.6"
       }
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.92.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.92.0.tgz",
+      "integrity": "sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
@@ -3862,6 +3882,31 @@
         }
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.8",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.8.tgz",
+      "integrity": "sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
@@ -3898,6 +3943,31 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6132,6 +6202,16 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ssh2": {
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
@@ -6166,6 +6246,13 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -8700,6 +8787,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -8758,6 +8855,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
       }
     },
     "node_modules/hono": {
@@ -8932,6 +9040,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
@@ -9218,6 +9333,19 @@
       "integrity": "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -9995,6 +10123,73 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.2.tgz",
+      "integrity": "sha512-D2bTe0tpuf9nw4DA39wFaqUD/hRPKj0DKpo2lAqu+A47Ifg4+h0hbfn6QxVOsiUY2uhgEN6TTpGSHDsc+ysYNg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.7",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/msw/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/muggle-string": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
@@ -10269,6 +10464,13 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/package-json-from-dist": {
@@ -11164,6 +11366,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/rettime": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.10.tgz",
+      "integrity": "sha512-zzgUfAF20wZtfDs72M15qiX6EutHxgEZ1PAEJUsWQsOi4aOdcK8BJ3/WSDHBhJ7P27fQjd6iOE1+CWIO8t3XOA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -11350,6 +11559,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -11679,6 +11895,13 @@
         "text-decoder": "^1.1.0"
       }
     },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -11820,6 +12043,19 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tar-fs": {
       "version": "3.1.2",
@@ -12041,6 +12277,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -12099,6 +12341,22 @@
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "dev": true,
       "license": "Unlicense"
+    },
+    "node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -12321,6 +12579,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -13018,6 +13286,7 @@
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.92.0",
         "@clack/prompts": "^1.2.0",
         "@floating-ui/dom": "^1.7.6",
         "@hello-pangea/dnd": "^18.0.1",
@@ -13061,6 +13330,7 @@
         "@types/write-file-atomic": "^4.0.3",
         "@vitejs/plugin-vue": "^6.0.6",
         "fast-check": "^4.6.0",
+        "msw": "^2.14.2",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2",
         "vite": "^8.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10130,7 +10130,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -10458,6 +10457,27 @@
         "oniguruma-parser": "^0.12.1",
         "regex": "^6.1.0",
         "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.35.0.tgz",
+      "integrity": "sha512-L/skwIGnt5xQZHb0UfTu9uAUKbis3ehKypOuJKi20QvG7UStV6C8IC3myGYHcdiF4kms/bAvOJ9UqqNWqi8x/Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/orderedmap": {
@@ -13306,6 +13326,7 @@
         "js-yaml": "^4.1.0",
         "marked": "^18.0.0",
         "music-metadata": "^11.12.3",
+        "openai": "^6.35.0",
         "postcss": "^8.5.8",
         "postcss-prefix-selector": "^2.1.1",
         "sharp": "^0.34.0",

--- a/packages/gazetta/package.json
+++ b/packages/gazetta/package.json
@@ -91,6 +91,7 @@
     "js-yaml": "^4.1.0",
     "marked": "^18.0.0",
     "music-metadata": "^11.12.3",
+    "openai": "^6.35.0",
     "postcss": "^8.5.8",
     "postcss-prefix-selector": "^2.1.1",
     "sharp": "^0.34.0",

--- a/packages/gazetta/package.json
+++ b/packages/gazetta/package.json
@@ -71,6 +71,7 @@
     "test:mutation": "stryker run"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.92.0",
     "@clack/prompts": "^1.2.0",
     "@floating-ui/dom": "^1.7.6",
     "@hello-pangea/dnd": "^18.0.1",
@@ -129,6 +130,7 @@
     "@types/write-file-atomic": "^4.0.3",
     "@vitejs/plugin-vue": "^6.0.6",
     "fast-check": "^4.6.0",
+    "msw": "^2.14.2",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
     "vite": "^8.0.8",

--- a/packages/gazetta/scripts/smoke-ollama-alt.ts
+++ b/packages/gazetta/scripts/smoke-ollama-alt.ts
@@ -1,0 +1,105 @@
+/**
+ * End-to-end smoke against a real local Ollama instance.
+ *
+ * Run with:
+ *   cd packages/gazetta
+ *   npx tsx scripts/smoke-ollama-alt.ts
+ *
+ * Requires:
+ *   - Ollama running at http://localhost:11434
+ *   - llama3.2-vision:11b pulled (`ollama pull llama3.2-vision:11b`)
+ *
+ * Loads a real JPEG, runs the full suggester pipeline (vision-prep,
+ * prompt composition, adapter call), prints the result.
+ *
+ * Not part of CI. CI uses msw-mocked tests for determinism.
+ */
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { createOllamaAltAdapter } from '../src/alt/ollama.js'
+import { createAltSuggester } from '../src/alt/suggester.js'
+
+const TEST_IMAGE_PATH = resolve(
+  import.meta.dirname,
+  '..',
+  '..',
+  '..',
+  'examples',
+  'starter',
+  'sites',
+  'main',
+  'targets',
+  'local',
+  'assets',
+  'test-pattern-2092f9b7.jpg',
+)
+
+async function main(): Promise<void> {
+  console.log(`Loading test image: ${TEST_IMAGE_PATH}`)
+  const bytes = new Uint8Array(await readFile(TEST_IMAGE_PATH))
+  console.log(`  → ${bytes.byteLength} bytes`)
+
+  console.log()
+  console.log('Building Ollama adapter (default model: llama3.2-vision:11b)...')
+  const adapter = createOllamaAltAdapter()
+  console.log(`  → adapter.name = ${adapter.name}`)
+  console.log(`  → adapter.supports('image/jpeg') = ${adapter.supports('image/jpeg')}`)
+
+  console.log()
+  console.log('Building suggester...')
+  const suggester = createAltSuggester({ adapter })
+  console.log(`  → suggester.available('image/jpeg') = ${suggester.available('image/jpeg')}`)
+
+  // English run.
+  console.log()
+  console.log('Calling suggester.suggest({ locale: "en" })...')
+  console.log('  (this may take 5-30s depending on hardware)')
+  const startEn = Date.now()
+  const resultEn = await suggester.suggest({
+    bytes,
+    mime: 'image/jpeg',
+    hash: '2092f9b7',
+    locale: 'en',
+  })
+  const elapsedEn = Date.now() - startEn
+  console.log(`  → completed in ${elapsedEn}ms`)
+  console.log()
+
+  if (resultEn === null) {
+    console.error('FAIL: suggester returned null')
+    process.exit(1)
+  }
+  console.log('=== English result ===')
+  console.log(`  refused:        ${resultEn.refused}`)
+  console.log(`  refusalReason:  ${resultEn.refusalReason}`)
+  console.log(`  text:           ${JSON.stringify(resultEn.text)}`)
+  console.log(`  text length:    ${resultEn.text.length} chars`)
+
+  // French run — exercises the locale-policy branch (Ollama's
+  // multilingual quality is the empirical question here).
+  console.log()
+  console.log('Calling suggester.suggest({ locale: "fr" })...')
+  const startFr = Date.now()
+  const resultFr = await suggester.suggest({
+    bytes,
+    mime: 'image/jpeg',
+    hash: '2092f9b7',
+    locale: 'fr',
+  })
+  const elapsedFr = Date.now() - startFr
+  console.log(`  → completed in ${elapsedFr}ms`)
+  console.log()
+  if (resultFr === null) {
+    console.error('FAIL: French suggester returned null')
+    process.exit(1)
+  }
+  console.log('=== French result ===')
+  console.log(`  refused:        ${resultFr.refused}`)
+  console.log(`  text:           ${JSON.stringify(resultFr.text)}`)
+  console.log(`  text length:    ${resultFr.text.length} chars`)
+}
+
+main().catch(err => {
+  console.error('ERROR:', err)
+  process.exit(1)
+})

--- a/packages/gazetta/src/admin-api/routes/assets.ts
+++ b/packages/gazetta/src/admin-api/routes/assets.ts
@@ -24,6 +24,7 @@ import { updateAssetMetadata, type AssetMetadataPatch } from '../../assets/updat
 import { buildSelector, type Selector } from '../../schema/dimensions.js'
 import { isValidLocale } from '../../locale.js'
 import { isValidTheme } from '../../themes.js'
+import { suggestAltForAsset } from '../../alt/route-handler.js'
 import { respondWithAssetError } from '../error-response.js'
 import type { SourceContextResolver } from '../source-context.js'
 
@@ -281,6 +282,73 @@ export function assetRoutes(resolve: SourceContextResolver) {
         history: source.history,
       })
       return c.body(null, 204)
+    } catch (err) {
+      const res = respondWithAssetError(c, err)
+      if (res) return res
+      throw err
+    }
+  })
+
+  /**
+   * POST /api/assets/:name/suggest-alt — generate alt text for the
+   * named asset using the configured AI adapter.
+   *
+   * Server fetches asset bytes from storage; client only passes the
+   * name and target. Locale (?locale=fr) controls the language the
+   * model writes in (direct generation, no translation pipeline).
+   *
+   * Refusals return 200 with `{ refused: true, refusalReason }` —
+   * the API call succeeded; the model declined. UI consumers branch
+   * on `refused` to decide whether to surface the text or the reason.
+   *
+   * Responses:
+   *   200 OK            — { text, refused, refusalReason }
+   *   400 Bad Request   — invalid locale code
+   *   404 Not Found     — asset doesn't exist on this target
+   *   502 Bad Gateway   — adapter call failed (network, auth, etc.)
+   *   503 Unavailable   — no adapter configured / MIME unsupported
+   */
+  app.post('/api/assets/:name/suggest-alt', async c => {
+    const name = c.req.param('name')
+    const localeRaw = c.req.query('locale')
+    if (localeRaw !== undefined && !isValidLocale(localeRaw)) {
+      return c.json({ code: 'BAD_REQUEST', message: `Invalid locale code: ${localeRaw}` }, 400)
+    }
+    const locale = localeRaw ?? 'en'
+
+    const source = await resolve(c.req.query('target'))
+    if (!source.manifest) {
+      // Without the site manifest we can't read `ai:` / `altText:`
+      // config. Treat as unconfigured rather than failing — same
+      // posture as a missing block.
+      return c.json(
+        { code: 'AI_ADAPTER_UNAVAILABLE', message: 'Site manifest not available; AI alt-text not configured.' },
+        503,
+      )
+    }
+
+    const targetConfig = source.targetName ? source.manifest.targets?.[source.targetName] : undefined
+
+    try {
+      const result = await suggestAltForAsset({
+        name,
+        assetsRoot: ASSETS_ROOT,
+        storage: source.storage,
+        site: source.manifest,
+        target: targetConfig,
+        locale,
+      })
+
+      switch (result.kind) {
+        case 'ok':
+          return c.json(result.suggestion, 200)
+        case 'unavailable':
+          return c.json({ code: 'AI_ADAPTER_UNAVAILABLE', message: result.message }, 503)
+        case 'failed':
+          return c.json({ code: 'AI_ADAPTER_FAILED', message: result.message }, 502)
+        case 'not-found':
+          return c.json({ code: 'ASSET_MANIFEST_NOT_FOUND', message: result.message }, 404)
+      }
     } catch (err) {
       const res = respondWithAssetError(c, err)
       if (res) return res

--- a/packages/gazetta/src/admin-api/routes/publish.ts
+++ b/packages/gazetta/src/admin-api/routes/publish.ts
@@ -18,6 +18,8 @@ import {
 import { loadSiteFromSource } from '../source-context.js'
 import { publishPageAllLocales, publishFragmentAllLocales } from '../../publish-locale.js'
 import { resolveEnvVars } from '../../targets.js'
+import { isAltAdapterConfigured } from '../../alt/factory.js'
+import { resolveAltConfig } from '../../alt/config.js'
 import { scanTemplates, templateHashesFrom, type TemplateInfo } from '../../templates-scan.js'
 import { hashManifest } from '../../hash.js'
 import { createContentRoot } from '../../content-root.js'
@@ -115,14 +117,31 @@ export function publishRoutes(
 
   app.get('/api/targets', async c => {
     const t = await getTargets()
+    // Resolve once — the site manifest is the same across all
+    // targets in this loop. resolve(undefined) returns the source
+    // context whose .manifest holds `ai:` and `altText:`.
+    const source = await resolve(undefined)
+    const site = source.manifest
     return c.json(
       [...t.keys()].map(name => {
         const cfg = getTargetConfig(name)
+        // AI alt-text capability — site + target inherit chain. When
+        // the site manifest isn't available (legacy/test setups), the
+        // feature is reported off uniformly.
+        const altResolved = site ? resolveAltConfig(site, cfg) : null
+        const altAvailable = site ? isAltAdapterConfigured(site, cfg) : false
         return {
           name,
           environment: cfg ? getEnvironment(cfg) : 'local',
           type: cfg ? getType(cfg) : 'static',
           editable: cfg ? isEditable(cfg) : true,
+          altText: {
+            available: altAvailable,
+            // When not configured, the resolved value is null — surface
+            // false rather than the hardcoded default so the UI doesn't
+            // imply "auto-fire is on" for an unconfigured target.
+            auto: altResolved?.auto ?? false,
+          },
         }
       }),
     )

--- a/packages/gazetta/src/admin-api/schemas/assets.ts
+++ b/packages/gazetta/src/admin-api/schemas/assets.ts
@@ -65,3 +65,20 @@ export const AssetNameCollisionResponseSchema = z.object({
   newName: z.string(),
 })
 export type AssetNameCollisionResponse = z.infer<typeof AssetNameCollisionResponseSchema>
+
+/**
+ * Body of a 200 response on POST /api/assets/:name/suggest-alt — the AI
+ * adapter's structured suggestion. `refused: true` means the model
+ * declined; consumers display `refusalReason` instead of auto-filling
+ * the alt input. Refusals are NOT errors — the API call succeeded.
+ *
+ * 503 (no adapter / unsupported MIME) and 502 (adapter call failed)
+ * use the generic `{ code, message }` shape — see `AIErrorCode` in
+ * `ai/errors.ts` for the code values.
+ */
+export const SuggestAltResponseSchema = z.object({
+  text: z.string(),
+  refused: z.boolean(),
+  refusalReason: z.string().nullable(),
+})
+export type SuggestAltResponse = z.infer<typeof SuggestAltResponseSchema>

--- a/packages/gazetta/src/admin-api/schemas/targets.ts
+++ b/packages/gazetta/src/admin-api/schemas/targets.ts
@@ -14,11 +14,31 @@ export type TargetEnvironment = z.infer<typeof TargetEnvironmentSchema>
 export const TargetTypeSchema = z.enum(['static', 'dynamic'])
 export type TargetType = z.infer<typeof TargetTypeSchema>
 
+/**
+ * AI alt-text capability for a target. Surfaced via /api/targets so
+ * the UI can render affordances based on configuration without probing
+ * via 503 fallback.
+ *
+ *   - `available`: true when the target has a configured adapter AND
+ *     credentials are present in the environment. False otherwise — the
+ *     UI hides AI affordances.
+ *   - `auto`: when `true` and `available`, upload flows fire suggest
+ *     after the upload completes. When `false`, suggestion is on-demand
+ *     only (detail-pane button).
+ */
+export const AltTextCapabilitySchema = z.object({
+  available: z.boolean(),
+  auto: z.boolean(),
+})
+export type AltTextCapability = z.infer<typeof AltTextCapabilitySchema>
+
 /** Entry in the list response for GET /api/targets. */
 export const TargetInfoSchema = z.object({
   name: z.string(),
   environment: TargetEnvironmentSchema,
   type: TargetTypeSchema,
   editable: z.boolean(),
+  /** AI alt-text capability resolved from site + target config. */
+  altText: AltTextCapabilitySchema,
 })
 export type TargetInfo = z.infer<typeof TargetInfoSchema>

--- a/packages/gazetta/src/ai/compose-prompt.ts
+++ b/packages/gazetta/src/ai/compose-prompt.ts
@@ -1,0 +1,56 @@
+/**
+ * Generic prompt composer — assembles a final prompt string from an
+ * ordered list of `PromptPolicy<T>` functions, where `T` is the typed
+ * request shape for the calling task.
+ *
+ * # Why generic over `T`
+ *
+ * Each AI task has its own typed request (alt-text has `AltRequest`
+ * with `locale`, `maxChars`, `style`; future translation will have its
+ * own with source/target language pairs, formality, etc.). The
+ * composer doesn't need to know task-specific fields — it just calls
+ * each policy in order and joins the non-empty results.
+ *
+ * Putting the composer in `ai/` (not in `alt/`) means the second task
+ * doesn't reimplement composition. Each task contributes its own
+ * `PromptPolicy<TaskRequest>` modules that import this composer.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns "ordered policies → final prompt string"
+ *   - OCP: callers pass their own policy array; the default policy set
+ *     is the task's responsibility, not this module's
+ *   - LSP: every policy is `(req: T) => string`; trivially substitutable
+ *   - DIP: tasks depend on this generic composer, not on each other
+ *
+ * # Empty-string convention
+ *
+ * Policies that don't apply (e.g., the locale policy when locale is
+ * the default 'en') return an empty string. The composer filters these
+ * out before joining, so empty paragraphs don't appear in the final
+ * prompt. This keeps each policy decision local — no callers need to
+ * reason about "should I include this policy?"
+ */
+
+/**
+ * One dimension of prompt content. A function from a typed request to
+ * a string paragraph. Empty string means "this policy doesn't apply
+ * for this request" and is dropped before assembly.
+ */
+export type PromptPolicy<TRequest> = (req: TRequest) => string
+
+/**
+ * Assemble policies into a prompt. Joins non-empty results with two
+ * newlines (paragraph break) — model providers parse this as natural
+ * structure. Order matters: callers pass the array in the order they
+ * want paragraphs to appear.
+ *
+ * Tests can pass a custom policy array to validate composition without
+ * coupling to any task's default set.
+ */
+export function composePrompt<TRequest>(req: TRequest, policies: readonly PromptPolicy<TRequest>[]): string {
+  return policies
+    .map(policy => policy(req))
+    .filter(paragraph => paragraph.length > 0)
+    .join('\n\n')
+}

--- a/packages/gazetta/src/ai/errors.ts
+++ b/packages/gazetta/src/ai/errors.ts
@@ -1,0 +1,74 @@
+/**
+ * Typed errors for the AI domain — one class per failure mode, each
+ * carrying an HTTP status so route handlers don't pattern-match on
+ * messages.
+ *
+ * Pattern mirrors `assets/errors.ts`: subclass `AIError`, declare the
+ * `code` and `httpStatus` on the class, override `toResponseBody()` if
+ * extra structured fields are needed.
+ *
+ * Adding a new AI error is one new subclass + one new code in the
+ * union. Routes pick up the new HTTP status via the `httpStatus`
+ * property — no route-handler edits required (OCP).
+ */
+
+export type AIErrorCode = 'AI_ADAPTER_UNAVAILABLE' | 'AI_ADAPTER_FAILED' | 'AI_INVALID_RESPONSE'
+
+export type AIErrorHttpStatus = 502 | 503
+
+export interface AIErrorResponseBody {
+  readonly code: AIErrorCode
+  readonly message: string
+}
+
+/**
+ * Base class. Subclasses set `code` and `httpStatus` as readonly
+ * properties; the base provides the `toResponseBody()` machinery.
+ */
+export abstract class AIError extends Error {
+  abstract readonly code: AIErrorCode
+  abstract readonly httpStatus: AIErrorHttpStatus
+
+  toResponseBody(): AIErrorResponseBody {
+    return { code: this.code, message: this.message }
+  }
+}
+
+/**
+ * No adapter is configured for the target, OR the adapter is configured
+ * but its credentials are missing, OR the adapter doesn't support the
+ * requested MIME. UI hides AI affordances; route returns 503.
+ *
+ * Distinct from `AIAdapterFailedError` because this is a configuration
+ * state, not a runtime failure — retrying won't help.
+ */
+export class AIAdapterUnavailableError extends AIError {
+  readonly code = 'AI_ADAPTER_UNAVAILABLE'
+  readonly httpStatus = 503
+}
+
+/**
+ * Adapter was reached but the call failed — network error, auth
+ * rejection, rate limit not handled by the SDK's own retry, malformed
+ * response. Route returns 502 (we're acting as a gateway to the
+ * upstream provider).
+ *
+ * The provider-specific cause is attached as `cause` (per the standard
+ * Error.cause property) so logs can drill into the underlying failure
+ * without leaking provider details into the API response.
+ */
+export class AIAdapterFailedError extends AIError {
+  readonly code = 'AI_ADAPTER_FAILED'
+  readonly httpStatus = 502
+}
+
+/**
+ * Adapter received a response from the provider, but it didn't parse
+ * into the expected shape (missing content field, unexpected null,
+ * etc.). 502 — same gateway semantics as `AIAdapterFailedError`, but
+ * the cause is parsing rather than transport.
+ */
+export class AIInvalidResponseError extends AIError {
+  readonly code = 'AI_INVALID_RESPONSE'
+  readonly httpStatus = 502
+}

--- a/packages/gazetta/src/ai/index.ts
+++ b/packages/gazetta/src/ai/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Public surface of `ai/` — cross-task AI infrastructure shared by
+ * per-task implementations (alt-text in v1.5; translation, tag
+ * suggestion, summarization in future).
+ *
+ * `ai/` is a code library, not an inheritance hierarchy. Tasks compose
+ * these utilities — they don't extend a base class. Per
+ * [team-preferences.md] convention 1: composition over inheritance.
+ */
+
+export type { AIProvider, ResolvedAIBase } from './provider.js'
+export {
+  AIError,
+  AIAdapterUnavailableError,
+  AIAdapterFailedError,
+  AIInvalidResponseError,
+  type AIErrorCode,
+  type AIErrorHttpStatus,
+  type AIErrorResponseBody,
+} from './errors.js'
+export { detectRefusal, type RefusalDetection } from './refusal.js'
+export { composePrompt, type PromptPolicy } from './compose-prompt.js'
+export { prepareForVision, MAX_EDGE, type PrepareInput, type PreparedImage } from './vision-prep.js'

--- a/packages/gazetta/src/ai/provider.ts
+++ b/packages/gazetta/src/ai/provider.ts
@@ -1,0 +1,31 @@
+/**
+ * Cross-task AI primitives — the provider type and shared base config.
+ *
+ * `AIProvider` is a closed enum. Adding a fourth provider extends it; no
+ * other module needs to know the full set (per-task factories switch on
+ * it locally). Closed because the v1.5 ship is exactly three: Anthropic,
+ * OpenAI, Ollama. Future providers (Gemini, Cloudflare Workers AI) land
+ * via additive enum extension + factory case.
+ *
+ * `ResolvedAIBase` carries fields shared by every AI task. v1.5 has two:
+ * `provider` (which SDK to use) and `defaultModel` (per-task override
+ * starting point). Vision-task-specific fields like `maxImageEdge` stay
+ * on per-task resolved configs — they don't apply to text tasks like a
+ * future translation feature, so putting them on the cross-task base
+ * would be an ISP violation.
+ *
+ * See `.claude/rules/design-ai.md` for the three-layer config rationale.
+ */
+
+/** Closed enum of providers shipped in v1.5. Extend additively. */
+export type AIProvider = 'anthropic' | 'openai' | 'ollama'
+
+/**
+ * Cross-task config resolved from `site.yaml`'s `ai:` block. Per-task
+ * resolvers compose this with their own task-specific config.
+ */
+export interface ResolvedAIBase {
+  provider: AIProvider
+  /** Per-provider sensible default; tasks may override. */
+  defaultModel: string
+}

--- a/packages/gazetta/src/ai/provider.ts
+++ b/packages/gazetta/src/ai/provider.ts
@@ -27,5 +27,21 @@ export type AIProvider = 'anthropic' | 'openai' | 'ollama'
 export interface ResolvedAIBase {
   provider: AIProvider
   /** Per-provider sensible default; tasks may override. */
-  defaultModel: string
+  defaultModel: string | null
+}
+
+/**
+ * Resolve the cross-task AI base config from a `SiteManifest`. Returns
+ * null when the `ai:` block is absent — per-task resolvers fall back
+ * to their own provider field (or report the task as unconfigured).
+ *
+ * Pure function. No I/O. No env-var reads. Tests pass `SiteManifest`
+ * fragments directly.
+ */
+export function resolveAIBase(site: { ai?: { provider: AIProvider; defaultModel?: string } }): ResolvedAIBase | null {
+  if (!site.ai) return null
+  return {
+    provider: site.ai.provider,
+    defaultModel: site.ai.defaultModel ?? null,
+  }
 }

--- a/packages/gazetta/src/ai/refusal.ts
+++ b/packages/gazetta/src/ai/refusal.ts
@@ -1,0 +1,108 @@
+/**
+ * Refusal detection for AI provider responses.
+ *
+ * # Why this lives in `ai/` and not `alt/`
+ *
+ * Provider safety refusals look the same regardless of task. Whether
+ * the model is asked to describe an image (alt-text) or translate a
+ * paragraph (future), a refusal arrives as a 200 OK with text like
+ * "I can't help with that" in the response body — structurally
+ * indistinguishable from a successful response without inspection.
+ *
+ * v1.5's only consumer is `alt/`, but refusal detection is conceptually
+ * cross-task. Right structure now beats right structure later, per
+ * [team-preferences rule 18]: "extract shared code when you first see
+ * the split concern". Translation as the documented next consumer
+ * (per [design-ai-implementation.md]) makes this a known split.
+ *
+ * # Marker maintenance
+ *
+ * The marker list below MUST stay current as providers tune their
+ * safety messaging. Plan: review at every major model version bump
+ * (e.g., when an adapter's `defaultModel` jumps a major). Provider-
+ * specific phrases live in the adapter (passed via `adapterMarkers`)
+ * so generic markers and provider-specific ones can evolve
+ * independently.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns "raw text → structured refusal info"
+ *   - OCP: per-adapter markers extend without touching the shared list
+ *   - DIP: callers depend on `detectRefusal`, not on substring inspection
+ *     scattered across the codebase
+ */
+
+/**
+ * Cross-provider refusal phrases. Lowercase substrings — the matcher
+ * lowercases both sides, so casing in the upstream response doesn't
+ * matter. Order is irrelevant; `Array.some` is fine at this size.
+ *
+ * Each entry corresponds to a phrase observed across at least two
+ * providers' refusal outputs. Provider-specific phrasing belongs in
+ * the adapter, passed via `adapterMarkers`.
+ */
+const SHARED_REFUSAL_MARKERS: readonly string[] = [
+  "i can't describe",
+  'i cannot describe',
+  "i'm not able to describe",
+  'i am not able to describe',
+  "i'm unable to describe",
+  'i am unable to describe',
+  "i can't provide",
+  'i cannot provide',
+  "i'm unable to provide",
+  'i am unable to provide',
+  "i can't help",
+  'i cannot help',
+  "i'm not able to help",
+  "i'm sorry, but",
+]
+
+/**
+ * Minimum useful response length. Below this, even a non-refusal
+ * response is too short to be a real description — treat as a refusal
+ * with a generic reason. Calibrated for the alt-text use case where
+ * five chars is below "Cat." (4) but above "Hi" (2); empty responses
+ * also fall through here.
+ *
+ * If a future task has different length expectations (e.g., a single-
+ * word tag), the consumer should normalize the response before passing
+ * it to `detectRefusal`, OR the threshold becomes a parameter. Don't
+ * generalize speculatively — wait for the second task to force the
+ * shape.
+ */
+const MIN_USEFUL_LENGTH = 5
+
+export interface RefusalDetection {
+  refused: boolean
+  /** Truncated reason text when refused; null when not. */
+  reason: string | null
+}
+
+/**
+ * Detect whether `text` is a refusal. Caller passes adapter-specific
+ * markers (e.g., Anthropic's particular phrasing) on top of the shared
+ * list.
+ *
+ * Returns `{ refused: false, reason: null }` for descriptive responses;
+ * `{ refused: true, reason: <truncated text> }` otherwise. Reason is
+ * truncated to 200 chars so logs and UI toasts don't render arbitrarily
+ * long refusal blocks.
+ */
+export function detectRefusal(text: string, adapterMarkers: readonly string[] = []): RefusalDetection {
+  const lower = text.toLowerCase()
+  for (const marker of SHARED_REFUSAL_MARKERS) {
+    if (lower.includes(marker)) {
+      return { refused: true, reason: text.slice(0, 200) }
+    }
+  }
+  for (const marker of adapterMarkers) {
+    if (lower.includes(marker.toLowerCase())) {
+      return { refused: true, reason: text.slice(0, 200) }
+    }
+  }
+  if (text.trim().length < MIN_USEFUL_LENGTH) {
+    return { refused: true, reason: 'Empty or unusably short response' }
+  }
+  return { refused: false, reason: null }
+}

--- a/packages/gazetta/src/ai/vision-prep.ts
+++ b/packages/gazetta/src/ai/vision-prep.ts
@@ -1,0 +1,141 @@
+/**
+ * Image preprocessing for vision-using AI tasks.
+ *
+ * # Single responsibility
+ *
+ * Take raw asset bytes; return bytes suitable for sending to a vision
+ * provider. Concretely:
+ *
+ *   - Resize to `MAX_EDGE` long-edge (default 768) preserving aspect ratio
+ *   - Re-encode to JPEG (or PNG if alpha) post-resize
+ *   - Rasterize SVG to PNG at MAX_EDGE
+ *   - Pass through if already small (no needless re-encode)
+ *   - Use the analyzer-extracted poster bytes for animated images
+ *
+ * No knowledge of providers, prompts, refusal, or task-specific config.
+ *
+ * # Why 768
+ *
+ * Smallest size that fits all v1.5 providers natively without quality
+ * loss:
+ *
+ *   - Ollama llama3.2-vision native input is 1120×1120
+ *   - Anthropic Claude (non-Opus) recommended max long edge is 1568
+ *   - OpenAI gpt-4o "high detail" mode targets 768 as the short-edge
+ *     value when tiling 512×512 — chosen by OpenAI as the size where
+ *     in-image text remains legible
+ *
+ * 768 sits below all three ceilings, makes OpenAI tile to exactly
+ * 4 tiles + base = 765 tokens, and produces predictable cost on
+ * Anthropic (~786 tokens for a 768×768 image, well under the 1568
+ * token ceiling).
+ *
+ * Going lower (e.g., 512) hits OpenAI's "low detail" tier which the
+ * provider's own docs mark as worse for in-image text. Going higher
+ * exceeds Ollama's native input so the model downsamples internally
+ * — we'd be paying upload bandwidth for bytes that get discarded.
+ *
+ * # Per-task override
+ *
+ * Vision tasks that need different sizing (e.g., a future tag-suggestion
+ * task on detailed product shots wanting 1024) pass `maxEdge` per call.
+ * `MAX_EDGE` is the default; `prepareForVision` accepts an override.
+ *
+ * # Animated images
+ *
+ * The animated-image analyzer (shipped in media v1) extracts a
+ * first-frame PNG poster as a supplementary file. Suggester callers
+ * pass those bytes via `posterBytes` — `prepareForVision` skips its
+ * own rasterization and uses the poster directly. Cross-feature reuse
+ * over duplication.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns "raw asset bytes → vision-call bytes"
+ *   - OCP: a future `pdf-prep.ts` peer handles document tasks the same way
+ *   - DIP: callers depend on `prepareForVision`, not on sharp directly
+ */
+import sharp from 'sharp'
+
+/** Default long-edge cap. Per-call override available via `maxEdge`. */
+export const MAX_EDGE = 768
+
+export interface PrepareInput {
+  /** Source bytes (raw asset bytes, post-preprocess). */
+  bytes: Uint8Array
+  /** Source MIME type from the asset manifest. */
+  mime: string
+  /**
+   * For animated images, the analyzer's extracted first-frame poster
+   * bytes (always PNG). When provided, used directly — no further
+   * rasterization. Skip for static images.
+   */
+  posterBytes?: Uint8Array
+  /** Long-edge cap override; defaults to {@link MAX_EDGE}. */
+  maxEdge?: number
+}
+
+export interface PreparedImage {
+  /** Bytes ready to send to a vision provider. */
+  bytes: Uint8Array
+  /** MIME of the prepared bytes — `image/jpeg` or `image/png`. */
+  mime: string
+}
+
+/**
+ * SVG rasterization density. 144 dpi is a sensible doubled-72-dpi
+ * default that produces ~2x the nominal SVG dimensions. Combined with
+ * the resize step, the final output is bounded by `maxEdge` regardless
+ * of the SVG's intrinsic size — density only affects rendering quality
+ * before the cap kicks in.
+ */
+const SVG_DENSITY = 144
+
+/**
+ * Prepare image bytes for a vision-call. Single async call that picks
+ * the right code path based on input.
+ *
+ * Throws on hard failures (corrupt source bytes that sharp can't
+ * decode, even past metadata). Callers wrap in their adapter's error
+ * taxonomy.
+ */
+export async function prepareForVision(input: PrepareInput): Promise<PreparedImage> {
+  const maxEdge = input.maxEdge ?? MAX_EDGE
+
+  // Animated source: use the pre-extracted poster bytes (always PNG).
+  // Posters are extracted at upload time and already represent the
+  // first frame; for vision-call purposes that's what we want.
+  if (input.posterBytes) {
+    return { bytes: input.posterBytes, mime: 'image/png' }
+  }
+
+  // SVG: rasterize to PNG at the cap. Vector input has no intrinsic
+  // pixel size; we pick density × resize to bound the output.
+  if (input.mime === 'image/svg+xml') {
+    const buf = await sharp(input.bytes, { density: SVG_DENSITY })
+      .resize({ width: maxEdge, height: maxEdge, fit: 'inside' })
+      .png()
+      .toBuffer()
+    return { bytes: new Uint8Array(buf), mime: 'image/png' }
+  }
+
+  // Raster: resize if larger than maxEdge on long edge; otherwise pass
+  // through. Avoids a no-op JPEG-of-JPEG re-encode that would lose
+  // quality without saving bandwidth.
+  const meta = await sharp(input.bytes).metadata()
+  const longEdge = Math.max(meta.width ?? 0, meta.height ?? 0)
+  if (longEdge > 0 && longEdge <= maxEdge) {
+    return { bytes: input.bytes, mime: input.mime }
+  }
+
+  // Preserve PNG when source has alpha (logos with transparency lose
+  // semantically when flattened to JPEG). Otherwise JPEG quality 85 —
+  // sharp's default for `.jpeg()`, well-balanced for AI input.
+  const hasAlpha = meta.hasAlpha === true
+  const pipeline = sharp(input.bytes).resize({ width: maxEdge, height: maxEdge, fit: 'inside' })
+  const buf = hasAlpha ? await pipeline.png().toBuffer() : await pipeline.jpeg({ quality: 85 }).toBuffer()
+  return {
+    bytes: new Uint8Array(buf),
+    mime: hasAlpha ? 'image/png' : 'image/jpeg',
+  }
+}

--- a/packages/gazetta/src/alt/adapter.ts
+++ b/packages/gazetta/src/alt/adapter.ts
@@ -1,0 +1,152 @@
+/**
+ * `AltTextAdapter` — provider-substitutable interface for generating
+ * alt text from image bytes.
+ *
+ * Three concrete implementations ship in v1.5: `anthropicAltAdapter`,
+ * `openAIAltAdapter`, `ollamaAltAdapter` (commits 3-5). One safe
+ * default also ships: `nullAltAdapter` (this commit), used when no
+ * adapter is configured for the target.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns the alt-text task contracts (request,
+ *     suggestion, adapter interface). Nothing else lives here.
+ *   - OCP: new providers implement the interface and slot into the
+ *     factory (commit 6). No existing module changes.
+ *   - LSP: every adapter — including `nullAltAdapter` — honors the
+ *     same contract. Substitutable in tests.
+ *   - ISP: adapter exposes only `name`, `supports`, `generate` — no
+ *     UI concerns, no config concerns.
+ *   - DIP: callers depend on this interface, not on Anthropic SDK,
+ *     OpenAI SDK, or Ollama HTTP details.
+ *
+ * # Why `AltSuggestion` carries refused state
+ *
+ * Vision providers can return a 200 OK with refusal text in the
+ * content field (e.g., "I can't describe this image"). The structural
+ * cut: refusal is a *successful API call with a domain-level no*.
+ * Treating refusal as a structured field — not as inspecting `text`
+ * for substrings in every consumer — keeps DIP. UI consumers branch
+ * on `refused`, not on text patterns.
+ *
+ * Considered and rejected: a `confidence: number | null` field.
+ * Vision providers don't expose calibrated confidence for free-form
+ * description tasks; a hardcoded null would be a stub-on-the-interface
+ * (LSP violation, per [team-preferences rule 18]). If a future
+ * provider exposes real calibrated confidence, it lands as a separate
+ * field — not as a retrofit of a placeholder.
+ */
+import type { PromptPolicy } from '../ai/compose-prompt.js'
+
+/**
+ * What the caller wants. Provider-agnostic. Each field has a documented
+ * default applied by the factory when callers don't specify.
+ */
+export interface AltRequest {
+  /**
+   * Target language for the description (BCP 47 locale code; 'en',
+   * 'fr', 'pt-BR'). The model writes alt directly in this language —
+   * no separate translation pass. Default 'en'.
+   */
+  locale: string
+  /**
+   * Soft length suggestion in characters. Used in prompt guidance
+   * ("Maximum N characters") and as native `max_tokens` derivation
+   * for adapters that have it. Default 125 (WAI-ARIA convention).
+   *
+   * NOT enforced by the suggester or adapter — if the model returns
+   * longer text, the consumer sees the full string and can edit. Hard
+   * truncation would lose meaning.
+   */
+  maxChars: number
+  /**
+   * Output style. Closed enum; extended additively (future:
+   * `'marketing' | 'technical'`).
+   */
+  style: AltStyle
+}
+
+/** Closed enum; extends additively. */
+export type AltStyle = 'descriptive'
+
+/** Default `AltRequest` values, applied by the suggester when callers omit fields. */
+export const DEFAULT_ALT_REQUEST: AltRequest = {
+  locale: 'en',
+  maxChars: 125,
+  style: 'descriptive',
+}
+
+/**
+ * What the suggester delivers. `text` is the model's output (which may
+ * be a refusal). `refused` is the structured signal: when true, don't
+ * auto-fill, surface `refusalReason` to the author instead.
+ */
+export interface AltSuggestion {
+  text: string
+  /** True when the model declined or couldn't describe the image. */
+  refused: boolean
+  /** Truncated reason text when refused; null otherwise. */
+  refusalReason: string | null
+}
+
+/**
+ * Input to an adapter's `generate` call. The suggester does prep:
+ *
+ *   - Resolves `AltRequest` from caller-provided fields + defaults
+ *   - Composes the prompt via `composePrompt(request, policies)`
+ *   - Calls `prepareForVision` on the bytes
+ *
+ * The adapter receives both the structured request (for native params
+ * like Anthropic's `max_tokens`) and the composed prompt string (for
+ * adapters that just inject text). Pre-computed once per call.
+ */
+export interface AltGenerateInput {
+  /** Bytes ready to send to the provider (post-prep, ≤ maxImageEdge). */
+  bytes: Uint8Array
+  /** MIME of the prepared bytes — `image/jpeg` or `image/png`. */
+  mime: string
+  /** Structured request — adapters with native parameters use this. */
+  request: AltRequest
+  /** Composed prompt string — adapters that just need a prompt use this. */
+  prompt: string
+}
+
+/**
+ * Per-task adapter contract. Every implementation honors this exactly;
+ * substitutable across tests and production via the factory.
+ *
+ * Throws on transport / provider errors (`AIAdapterFailedError` from
+ * `ai/errors.ts`). Refusals are NOT thrown — they're returned in the
+ * structured `AltSuggestion`. The distinction: throws are runtime
+ * failures (retryable; gateway-level concern); refusals are domain
+ * outcomes (not retryable; user-level concern).
+ */
+export interface AltTextAdapter {
+  /** Stable identifier for diagnostics ('anthropic', 'openai', 'ollama', 'null'). */
+  readonly name: string
+
+  /**
+   * True when this adapter can describe the given MIME. v1.5 adapters
+   * support image MIMEs only. The null adapter returns false for
+   * everything.
+   */
+  supports(mime: string): boolean
+
+  /**
+   * Generate alt text. Forwards `signal` to the underlying provider
+   * call so consumers can cancel in-flight requests (e.g., when the
+   * author starts typing into the alt field).
+   *
+   * Throws `AIAdapterFailedError` / `AIInvalidResponseError` on
+   * transport or response-shape failures. Returns refusals as
+   * `AltSuggestion` with `refused: true`.
+   */
+  generate(input: AltGenerateInput, signal?: AbortSignal): Promise<AltSuggestion>
+}
+
+/**
+ * Type alias for prompt policies operating on alt-text requests.
+ * Per-task policy modules implement these and pass arrays to the
+ * generic `composePrompt<AltRequest>(req, policies)`.
+ */
+export type AltPromptPolicy = PromptPolicy<AltRequest>

--- a/packages/gazetta/src/alt/anthropic.ts
+++ b/packages/gazetta/src/alt/anthropic.ts
@@ -1,0 +1,188 @@
+/**
+ * Anthropic Claude adapter — alt-text via the `messages.create` vision API.
+ *
+ * # Defaults
+ *
+ *   - Model: `claude-haiku-4-5` (cost-effective vision; ~$0.003/image).
+ *     Sites needing higher quality override via `altText.model` in `site.yaml`.
+ *
+ * # API contract details (verified against @anthropic-ai/sdk v0.92.0)
+ *
+ *   - Image content: `{ type: 'image', source: { type: 'base64',
+ *     media_type, data: <base64-string> } }`. SDK requires base64-encoded
+ *     string, not raw bytes/Uint8Array.
+ *   - Accepted MIME types: `image/jpeg`, `image/png`, `image/gif`,
+ *     `image/webp`. After `prepareForVision`, our bytes are always JPEG
+ *     or PNG, both supported.
+ *   - `max_tokens` is required by the API. We derive it from
+ *     `request.maxChars` (≈4 chars/token; floor at 64 to give the model
+ *     headroom for short descriptions).
+ *   - `system` parameter at the top level (not a message role). The
+ *     composed prompt is the system prompt; the user message holds the
+ *     image.
+ *
+ * # AbortSignal
+ *
+ *   - Passed via `messages.create(body, { signal })`. SDK throws
+ *     `APIUserAbortError` on abort; we let the suggester layer translate
+ *     that to `null` via its abort-detection logic.
+ *
+ * # Errors
+ *
+ *   - SDK throws typed subclasses: `RateLimitError`,
+ *     `AuthenticationError`, `BadRequestError`,
+ *     `APIConnectionError`/`APIConnectionTimeoutError`,
+ *     `InternalServerError`, etc.
+ *   - We translate to our own `AIAdapterFailedError` so the suggester
+ *     contract stays provider-agnostic. The original SDK error attaches
+ *     as `cause` for log/debug visibility.
+ *
+ * # SOLID
+ *
+ *   - SRP: this module owns Anthropic-specific request shape, response
+ *     parsing, and error translation. Nothing else.
+ *   - LSP: implements `AltTextAdapter` exactly — substitutable.
+ *   - DIP: callers/factory depend on `createAnthropicAltAdapter` returning
+ *     `AltTextAdapter`; never on `Anthropic` SDK type directly.
+ */
+import Anthropic from '@anthropic-ai/sdk'
+import { AIAdapterFailedError, AIInvalidResponseError } from '../ai/errors.js'
+import { detectRefusal } from '../ai/refusal.js'
+import type { AltGenerateInput, AltSuggestion, AltTextAdapter } from './adapter.js'
+
+/**
+ * Anthropic-specific refusal phrases observed in production responses
+ * but not yet in `ai/refusal.ts`'s shared list. Maintained here so
+ * provider-specific markers evolve independently of the shared list.
+ */
+const ANTHROPIC_REFUSAL_MARKERS: readonly string[] = ['i cannot create captions', 'i cannot generate descriptions']
+
+/**
+ * Default model for the Anthropic adapter. Haiku is the cost-optimized
+ * choice for the alt-text task (~$0.003/image at 768x768 input). Sites
+ * needing higher quality set `altText.model` in `site.yaml` to a Sonnet
+ * or Opus model.
+ */
+export const ANTHROPIC_DEFAULT_MODEL = 'claude-haiku-4-5'
+
+/**
+ * Approximate characters-per-token for output sizing. Short, factual
+ * descriptions skew slightly higher than this (≈3.5 chars/token in
+ * English) but the safety margin is fine. Floor of 64 ensures the model
+ * has room even for the smallest configured maxChars.
+ */
+const CHARS_PER_TOKEN = 4
+const MIN_MAX_TOKENS = 64
+
+export interface AnthropicAltAdapterOptions {
+  apiKey: string
+  /** Model ID; defaults to {@link ANTHROPIC_DEFAULT_MODEL}. */
+  model?: string
+  /**
+   * Optional override of the SDK base URL — handy for tests pointing
+   * at msw, or future operators routing through a private proxy.
+   */
+  baseURL?: string
+  /**
+   * Override the SDK's retry count (default 2). Tests pass 0 to keep
+   * runs deterministic and fast; production sticks with the default
+   * so transient 429/5xx are auto-retried with backoff.
+   */
+  maxRetries?: number
+}
+
+/** Encode a Uint8Array as a base64 string for the API call. */
+function toBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64')
+}
+
+/**
+ * Anthropic only accepts a subset of image MIME types. After
+ * `prepareForVision` our bytes are JPEG or PNG, but defending here
+ * means a future caller invoking the adapter directly with WebP or
+ * GIF still gets the right answer.
+ */
+const ANTHROPIC_SUPPORTED_MIMES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp'])
+
+/**
+ * Construct the Anthropic alt-text adapter. Pure factory — caller
+ * supplies a literal `apiKey`. The factory in `alt/index.ts` (commit 6)
+ * reads env vars and constructs us; tests pass literal keys. No
+ * `process.env` reads inside the adapter.
+ */
+export function createAnthropicAltAdapter(opts: AnthropicAltAdapterOptions): AltTextAdapter {
+  const client = new Anthropic({
+    apiKey: opts.apiKey,
+    baseURL: opts.baseURL,
+    maxRetries: opts.maxRetries,
+  })
+  const model = opts.model ?? ANTHROPIC_DEFAULT_MODEL
+
+  return {
+    name: 'anthropic',
+    supports(mime: string) {
+      return ANTHROPIC_SUPPORTED_MIMES.has(mime)
+    },
+    async generate(input: AltGenerateInput, signal?: AbortSignal): Promise<AltSuggestion> {
+      // Derive max_tokens from the request's character budget. Floor so
+      // very small maxChars still gives the model space to respond.
+      const maxTokens = Math.max(MIN_MAX_TOKENS, Math.ceil(input.request.maxChars / CHARS_PER_TOKEN))
+
+      let response: Anthropic.Message
+      try {
+        response = await client.messages.create(
+          {
+            model,
+            max_tokens: maxTokens,
+            system: input.prompt,
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'image',
+                    source: {
+                      type: 'base64',
+                      // SDK accepts the four MIMEs above; cast is safe
+                      // because supports() guards entry.
+                      media_type: input.mime as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
+                      data: toBase64(input.bytes),
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+          { signal },
+        )
+      } catch (err) {
+        // Let aborts propagate as-is — the suggester checks
+        // `signal.aborted` and returns null. Wrapping into an
+        // AIAdapterFailedError would lose the abort signal.
+        if (err instanceof Anthropic.APIUserAbortError) throw err
+        // Translate every other SDK error into our domain error,
+        // preserving cause for diagnostics.
+        if (err instanceof Error) {
+          throw new AIAdapterFailedError(`Anthropic alt-text generation failed: ${err.message}`, { cause: err })
+        }
+        throw new AIAdapterFailedError('Anthropic alt-text generation failed: unknown error')
+      }
+
+      // Response shape: `content` is an array of blocks; alt-text comes
+      // back as a single text block. Defensive against tool-use blocks
+      // or unexpected shapes by finding the first text block.
+      const textBlock = response.content.find(block => block.type === 'text')
+      if (!textBlock || textBlock.type !== 'text') {
+        throw new AIInvalidResponseError('Anthropic response contained no text content block')
+      }
+
+      const text = textBlock.text.trim()
+      const refusal = detectRefusal(text, ANTHROPIC_REFUSAL_MARKERS)
+      return {
+        text,
+        refused: refusal.refused,
+        refusalReason: refusal.reason,
+      }
+    },
+  }
+}

--- a/packages/gazetta/src/alt/config.ts
+++ b/packages/gazetta/src/alt/config.ts
@@ -1,0 +1,95 @@
+/**
+ * Alt-text config resolver — composes site `ai:` + site `altText:` +
+ * target `altText:` into a single `ResolvedAltConfig`.
+ *
+ * Inheritance: target wins over site task block, site task block wins
+ * over `ai:` base, hardcoded defaults catch absence at the bottom.
+ *
+ * Pure function — no I/O, no env reads, no SDK construction. The
+ * factory in `alt/index.ts` consumes the resolved config + reads
+ * env credentials, then builds the adapter.
+ *
+ * # SOLID
+ *
+ *   - SRP: this module owns "merge config layers into one resolved
+ *     value." Doesn't read env, doesn't construct adapters.
+ *   - DIP: factory (next door) depends on this resolved shape, never
+ *     on raw `SiteManifest`/`TargetConfig`.
+ *   - LSP: resolver is total — every input shape produces either a
+ *     `ResolvedAltConfig` or `null`. No exceptions, no surprises.
+ */
+import { type ResolvedAIBase, resolveAIBase } from '../ai/provider.js'
+import type { AIProvider } from '../ai/provider.js'
+import { MAX_EDGE } from '../ai/vision-prep.js'
+import type { AltTextSiteConfig, AltTextTargetConfig, SiteManifest, TargetConfig } from '../types.js'
+
+/**
+ * Per-provider sensible default model. Used when neither `ai.defaultModel`
+ * nor `altText.model` is set anywhere in the chain.
+ */
+const PROVIDER_DEFAULT_MODELS: Record<AIProvider, string> = {
+  anthropic: 'claude-haiku-4-5',
+  openai: 'gpt-4o-mini',
+  ollama: 'llama3.2-vision:11b',
+}
+
+/** Hardcoded default for the `auto` flag. */
+const DEFAULT_AUTO = true
+
+/**
+ * Fully-resolved alt-text config — what the factory needs to construct
+ * an adapter and what the suggester needs to invoke it. No optional
+ * fields after this point; defaults applied.
+ */
+export interface ResolvedAltConfig {
+  provider: AIProvider
+  /** Concrete model ID. Either explicitly configured or the provider's default. */
+  model: string
+  /** Whether upload flows auto-fire suggest after upload. */
+  auto: boolean
+  /** Long-edge cap for vision-call image bytes. */
+  maxImageEdge: number
+}
+
+/**
+ * Resolve alt-text config from site + target. Returns null when no
+ * adapter is configured at any layer (no `ai:` block AND no
+ * `altText:` block with provider, OR no `altText:` block at all).
+ *
+ * Resolution order, first-defined-wins:
+ *   1. target.altText.{field}
+ *   2. site.altText.{field}
+ *   3. site.ai.{field}  (only `provider`, `defaultModel`)
+ *   4. hardcoded defaults
+ */
+export function resolveAltConfig(
+  site: Pick<SiteManifest, 'ai' | 'altText'>,
+  target: Pick<TargetConfig, 'altText'> | undefined,
+): ResolvedAltConfig | null {
+  const siteAlt: AltTextSiteConfig | undefined = site.altText
+  const targetAlt: AltTextTargetConfig | undefined = target?.altText
+  const base: ResolvedAIBase | null = resolveAIBase(site)
+
+  // Provider must come from somewhere. If neither the site task block
+  // nor the cross-task base specifies one, the feature isn't configured.
+  // (Target level can't specify provider — it's behavior-only.)
+  const provider = siteAlt?.provider ?? base?.provider
+  if (!provider) {
+    // No provider configured anywhere → feature is off. The site might
+    // still have an `altText:` block with only `auto: true` etc., but
+    // that's a misconfiguration; better to surface as "off" than to
+    // pick a provider arbitrarily.
+    return null
+  }
+
+  // Model resolution: target → site task → site base → provider default.
+  const model = targetAlt?.model ?? siteAlt?.model ?? base?.defaultModel ?? PROVIDER_DEFAULT_MODELS[provider]
+
+  // Auto: target → site task → hardcoded default.
+  const auto = targetAlt?.auto ?? siteAlt?.auto ?? DEFAULT_AUTO
+
+  // Vision sizing: target → site task → hardcoded default (MAX_EDGE).
+  const maxImageEdge = targetAlt?.maxImageEdge ?? siteAlt?.maxImageEdge ?? MAX_EDGE
+
+  return { provider, model, auto, maxImageEdge }
+}

--- a/packages/gazetta/src/alt/factory.ts
+++ b/packages/gazetta/src/alt/factory.ts
@@ -1,0 +1,145 @@
+/**
+ * Alt-text adapter factory — the single seam between configuration
+ * (env + `site.yaml`) and adapter construction.
+ *
+ * Two functions:
+ *
+ *   - `buildAltAdapter(site, target)` — returns a fully-constructed
+ *     `AltTextAdapter`. Returns `nullAltAdapter` when no adapter is
+ *     configured OR credentials are missing. Always returns a valid
+ *     adapter (never null) so consumers don't null-check.
+ *
+ *   - `isAltAdapterConfigured(site, target)` — pure config-introspection
+ *     for the capability check exposed via `/api/targets`. Doesn't
+ *     construct an adapter; just reports whether one *would* be
+ *     buildable. Cheap; safe to call on every targets-list response.
+ *
+ * # Why split into two functions
+ *
+ * The factory and the capability check answer different questions:
+ *   - Factory: "give me an adapter to call right now"
+ *   - Capability: "should the UI render AI affordances on this target?"
+ *
+ * The capability check shouldn't allocate SDK clients (every call to
+ * `/api/targets` would). The factory shouldn't be cheap (it constructs
+ * SDK clients with retries, base URLs, etc.).
+ *
+ * Splitting at this seam is SRP: factory owns construction; capability
+ * function owns introspection. Both consume the same `resolveAltConfig`
+ * output for consistency.
+ *
+ * # Why no boot-time validation
+ *
+ * Per the design (Q6 → A′): no eager construction at admin boot. If a
+ * target's API key is missing, the route returns 503 at first call;
+ * the UI hides affordances via the capability flag. This mirrors the
+ * cloudflare TransformAdapter posture (errors at first use, not at
+ * boot) and keeps `gazetta dev` startable when only some targets are
+ * fully configured.
+ *
+ * # Env-var contract
+ *
+ * Process-level credentials only. `.env.local` (gitignored) is the
+ * canonical home; per-target API keys are NOT supported in v1.5.
+ *
+ *   - anthropic → ANTHROPIC_API_KEY
+ *   - openai    → OPENAI_API_KEY
+ *   - ollama    → no key; OLLAMA_BASE_URL optional override
+ *
+ * Adapters never read `process.env` directly. The factory reads;
+ * adapters take literal values. Tests pass literal values; production
+ * goes through the factory.
+ */
+import { createAnthropicAltAdapter } from './anthropic.js'
+import { createOllamaAltAdapter } from './ollama.js'
+import { createOpenAIAltAdapter } from './openai.js'
+import { nullAltAdapter } from './null-adapter.js'
+import { type ResolvedAltConfig, resolveAltConfig } from './config.js'
+import type { AltTextAdapter } from './adapter.js'
+import type { SiteManifest, TargetConfig } from '../types.js'
+
+/**
+ * True when the resolved alt-text config has all required credentials.
+ * Pure: returns the structural state — does NOT verify the credential
+ * works (i.e., doesn't make a network call). Verification surfaces at
+ * first use of the route.
+ *
+ * Reads `process.env` for credentials. Used by `/api/targets` to set
+ * `altText.available`.
+ */
+export function isAltAdapterConfigured(
+  site: Pick<SiteManifest, 'ai' | 'altText'>,
+  target: Pick<TargetConfig, 'altText'> | undefined,
+): boolean {
+  const resolved = resolveAltConfig(site, target)
+  if (!resolved) return false
+  return hasCredentials(resolved.provider)
+}
+
+/**
+ * Construct the alt-text adapter for the resolved config. Returns the
+ * null adapter when:
+ *   - No `ai:` / `altText:` block in `site.yaml`
+ *   - Credentials missing for the configured provider
+ *
+ * Always returns an `AltTextAdapter` — consumers never null-check the
+ * factory's return value. The null adapter throws if `generate()` is
+ * called, but that only happens if a consumer skips the
+ * `supports()` / `available()` capability check.
+ */
+export function buildAltAdapter(
+  site: Pick<SiteManifest, 'ai' | 'altText'>,
+  target: Pick<TargetConfig, 'altText'> | undefined,
+): AltTextAdapter {
+  const resolved = resolveAltConfig(site, target)
+  if (!resolved) return nullAltAdapter
+
+  switch (resolved.provider) {
+    case 'anthropic':
+      return buildAnthropic(resolved)
+    case 'openai':
+      return buildOpenAI(resolved)
+    case 'ollama':
+      return buildOllama(resolved)
+  }
+}
+
+function buildAnthropic(resolved: ResolvedAltConfig): AltTextAdapter {
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (!apiKey) return nullAltAdapter
+  return createAnthropicAltAdapter({ apiKey, model: resolved.model })
+}
+
+function buildOpenAI(resolved: ResolvedAltConfig): AltTextAdapter {
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) return nullAltAdapter
+  return createOpenAIAltAdapter({ apiKey, model: resolved.model })
+}
+
+function buildOllama(resolved: ResolvedAltConfig): AltTextAdapter {
+  // Ollama needs no API key. The optional OLLAMA_BASE_URL env var is the
+  // only env-driven config; everything else comes from `resolved`.
+  return createOllamaAltAdapter({
+    baseUrl: process.env.OLLAMA_BASE_URL,
+    model: resolved.model,
+  })
+}
+
+/**
+ * Cheap credential check. Returns true if the provider's required
+ * credentials are present in `process.env`. Ollama needs nothing —
+ * always true.
+ *
+ * Kept private; consumers go through `isAltAdapterConfigured` which
+ * also resolves config first.
+ */
+function hasCredentials(provider: ResolvedAltConfig['provider']): boolean {
+  switch (provider) {
+    case 'anthropic':
+      return Boolean(process.env.ANTHROPIC_API_KEY)
+    case 'openai':
+      return Boolean(process.env.OPENAI_API_KEY)
+    case 'ollama':
+      return true
+  }
+}

--- a/packages/gazetta/src/alt/index.ts
+++ b/packages/gazetta/src/alt/index.ts
@@ -50,3 +50,5 @@ export {
   OLLAMA_DEFAULT_MODEL,
   createOllamaAltAdapter,
 } from './ollama.js'
+export { type ResolvedAltConfig, resolveAltConfig } from './config.js'
+export { buildAltAdapter, isAltAdapterConfigured } from './factory.js'

--- a/packages/gazetta/src/alt/index.ts
+++ b/packages/gazetta/src/alt/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Public surface of `alt/` — alt-text task. Per [design-ai.md], `alt/`
+ * is one of several per-task directories that compose `ai/` shared
+ * infrastructure (refusal detection, prompt composition, vision
+ * preprocessing).
+ *
+ * v1.5 ships:
+ *   - the `AltTextAdapter` interface + supporting types
+ *   - default policy set + composable prompt policies
+ *   - `nullAltAdapter` (safe default when no adapter is configured)
+ *   - `createAltSuggester` (orchestration)
+ *
+ * v1.5 commits 3-5 add the three real adapters (Anthropic, OpenAI,
+ * Ollama). Commit 6 adds the factory wiring config to adapter.
+ */
+
+export type {
+  AltGenerateInput,
+  AltPromptPolicy,
+  AltRequest,
+  AltStyle,
+  AltSuggestion,
+  AltTextAdapter,
+} from './adapter.js'
+export { DEFAULT_ALT_REQUEST } from './adapter.js'
+export { nullAltAdapter } from './null-adapter.js'
+export {
+  DEFAULT_ALT_PROMPT_POLICIES,
+  lengthPolicy,
+  localePolicy,
+  outputDisciplinePolicy,
+  styleGuidancePolicy,
+  taskFramingPolicy,
+} from './prompt-policies.js'
+export {
+  type AltSuggester,
+  type CreateAltSuggesterOptions,
+  type SuggestInput,
+  createAltSuggester,
+} from './suggester.js'

--- a/packages/gazetta/src/alt/index.ts
+++ b/packages/gazetta/src/alt/index.ts
@@ -38,3 +38,8 @@ export {
   type SuggestInput,
   createAltSuggester,
 } from './suggester.js'
+export {
+  type AnthropicAltAdapterOptions,
+  ANTHROPIC_DEFAULT_MODEL,
+  createAnthropicAltAdapter,
+} from './anthropic.js'

--- a/packages/gazetta/src/alt/index.ts
+++ b/packages/gazetta/src/alt/index.ts
@@ -43,3 +43,4 @@ export {
   ANTHROPIC_DEFAULT_MODEL,
   createAnthropicAltAdapter,
 } from './anthropic.js'
+export { type OpenAIAltAdapterOptions, OPENAI_DEFAULT_MODEL, createOpenAIAltAdapter } from './openai.js'

--- a/packages/gazetta/src/alt/index.ts
+++ b/packages/gazetta/src/alt/index.ts
@@ -44,3 +44,9 @@ export {
   createAnthropicAltAdapter,
 } from './anthropic.js'
 export { type OpenAIAltAdapterOptions, OPENAI_DEFAULT_MODEL, createOpenAIAltAdapter } from './openai.js'
+export {
+  type OllamaAltAdapterOptions,
+  OLLAMA_DEFAULT_BASE_URL,
+  OLLAMA_DEFAULT_MODEL,
+  createOllamaAltAdapter,
+} from './ollama.js'

--- a/packages/gazetta/src/alt/null-adapter.ts
+++ b/packages/gazetta/src/alt/null-adapter.ts
@@ -1,0 +1,46 @@
+/**
+ * `nullAltAdapter` — the safe default returned by the factory when no
+ * adapter is configured for a target.
+ *
+ * # Why this exists (vs. the factory returning null)
+ *
+ * The factory `buildAltAdapter(target)` could return `AltTextAdapter |
+ * null`, forcing every consumer to null-check. That would be the
+ * stub-on-the-interface anti-pattern in disguise — every caller
+ * writes `if (adapter) { ... }`, which is dead code in 99% of cases
+ * (the suggester wraps the adapter and handles the unconfigured case
+ * via `available()` returning false).
+ *
+ * Instead, the factory always returns an `AltTextAdapter`. When
+ * unconfigured, it returns this null implementation: `supports()`
+ * always false, `generate()` throws `AIAdapterUnavailableError` if
+ * ever called. The suggester's `available(mime)` checks `supports`
+ * first and returns false — so `generate` is never reached on the
+ * null adapter in practice. The throw is a defense-in-depth signal
+ * that something has gone wrong if it IS reached.
+ *
+ * This is the LSP validation seam: a real adapter, full contract
+ * surface, no nulls in the type system. Tests can substitute it for
+ * any consumer and verify the consumer handles "unavailable" correctly
+ * via `supports`-returns-false rather than via null-checks.
+ *
+ * # SOLID
+ *
+ *   - LSP: full contract; `supports`/`generate` return real values
+ *   - SRP: single concern — represent "no adapter configured"
+ *   - OCP: not relevant (no extension point here)
+ */
+import { AIAdapterUnavailableError } from '../ai/errors.js'
+import type { AltTextAdapter } from './adapter.js'
+
+export const nullAltAdapter: AltTextAdapter = {
+  name: 'null',
+  supports() {
+    return false
+  },
+  async generate() {
+    throw new AIAdapterUnavailableError(
+      'No AI alt-text adapter is configured. Add `altText:` to site.yaml or set provider credentials in .env.local.',
+    )
+  },
+}

--- a/packages/gazetta/src/alt/ollama.ts
+++ b/packages/gazetta/src/alt/ollama.ts
@@ -1,0 +1,179 @@
+/**
+ * Ollama adapter — alt-text via the local `/api/chat` endpoint.
+ *
+ * # Why no SDK
+ *
+ * Ollama's API is a single endpoint, no auth, no streaming
+ * negotiation, no schema beyond simple JSON. The official
+ * `ollama` npm SDK exists but adds little value over raw `fetch`
+ * for this single-call use case. Skipping the SDK keeps adapter
+ * dependencies minimal.
+ *
+ * # Defaults
+ *
+ *   - Base URL: `http://localhost:11434` (Ollama's documented default).
+ *     Operators running Ollama on a different host configure via
+ *     `OLLAMA_BASE_URL` env (factory) or `baseUrl` (direct).
+ *   - Model: `llama3.2-vision:11b`. The 11B variant is the entry-level
+ *     size; `:90b` is also available for operators who want better
+ *     description quality at higher GPU/RAM cost.
+ *
+ * # API contract details (verified against Ollama API docs)
+ *
+ *   - Endpoint: `POST /api/chat` (not `/api/generate` — chat-style is
+ *     better for multi-message prompts and matches the system+user
+ *     pattern we use)
+ *   - Request body:
+ *     ```json
+ *     {
+ *       "model": "llama3.2-vision:11b",
+ *       "messages": [
+ *         { "role": "system", "content": "<prompt>" },
+ *         { "role": "user", "content": "Describe this.", "images": ["<base64>"] }
+ *       ],
+ *       "stream": false
+ *     }
+ *     ```
+ *   - Images are base64 strings in the per-message `images` array (NOT
+ *     top-level). Different from Anthropic and OpenAI shapes — same
+ *     adapter abstraction holds.
+ *   - Response: `{ message: { content: "..." }, done: true, ... }`
+ *   - Auth: none for local install; we don't send credentials
+ *   - AbortSignal: standard fetch — `fetch(url, { signal })` aborts
+ *     correctly
+ *
+ * # SOLID
+ *
+ *   - SRP: Ollama-specific request/response/error shape only
+ *   - LSP: third concrete `AltTextAdapter` — same contract as
+ *     Anthropic and OpenAI; substitutable in the suggester
+ *   - DIP: callers get `AltTextAdapter`; never see fetch URLs or
+ *     Ollama-specific JSON shapes
+ */
+import { AIAdapterFailedError, AIInvalidResponseError } from '../ai/errors.js'
+import { detectRefusal } from '../ai/refusal.js'
+import type { AltGenerateInput, AltSuggestion, AltTextAdapter } from './adapter.js'
+
+const OLLAMA_REFUSAL_MARKERS: readonly string[] = [
+  // llama3.2-vision tends to refuse with these patterns more than
+  // saas providers; markers maintained per [refusal.ts] convention.
+  "i'm not able to process this image",
+  'i am not able to process this image',
+  'sorry, i cannot',
+]
+
+/** Default base URL when running Ollama locally with default settings. */
+export const OLLAMA_DEFAULT_BASE_URL = 'http://localhost:11434'
+
+/** Default model. Ollama Library publishes 11B and 90B variants of llama3.2-vision. */
+export const OLLAMA_DEFAULT_MODEL = 'llama3.2-vision:11b'
+
+const OLLAMA_SUPPORTED_MIMES = new Set(['image/jpeg', 'image/png'])
+
+export interface OllamaAltAdapterOptions {
+  /** Base URL of the Ollama server. Defaults to {@link OLLAMA_DEFAULT_BASE_URL}. */
+  baseUrl?: string
+  /** Model ID. Defaults to {@link OLLAMA_DEFAULT_MODEL}. */
+  model?: string
+}
+
+interface OllamaChatResponse {
+  message?: { role?: string; content?: string }
+  done?: boolean
+  error?: string
+}
+
+/**
+ * Construct the Ollama alt-text adapter. Pure factory — no env-var
+ * reads inside the adapter. The factory in commit 6 reads
+ * `OLLAMA_BASE_URL` if present and forwards it as `baseUrl`.
+ */
+export function createOllamaAltAdapter(opts: OllamaAltAdapterOptions = {}): AltTextAdapter {
+  const baseUrl = (opts.baseUrl ?? OLLAMA_DEFAULT_BASE_URL).replace(/\/+$/, '')
+  const model = opts.model ?? OLLAMA_DEFAULT_MODEL
+  const endpoint = `${baseUrl}/api/chat`
+
+  return {
+    name: 'ollama',
+    supports(mime: string) {
+      return OLLAMA_SUPPORTED_MIMES.has(mime)
+    },
+    async generate(input: AltGenerateInput, signal?: AbortSignal): Promise<AltSuggestion> {
+      const imageB64 = Buffer.from(input.bytes).toString('base64')
+
+      const body = {
+        model,
+        messages: [
+          { role: 'system', content: input.prompt },
+          {
+            role: 'user',
+            content: 'Describe this image for use as alt text.',
+            images: [imageB64],
+          },
+        ],
+        stream: false,
+      }
+
+      let res: Response
+      try {
+        res = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+          signal,
+        })
+      } catch (err) {
+        // AbortError on signal; let it propagate so the suggester's
+        // signal.aborted check returns null.
+        if (err instanceof Error && err.name === 'AbortError') throw err
+        if (err instanceof Error) {
+          throw new AIAdapterFailedError(
+            `Ollama alt-text generation failed: ${err.message}. Is Ollama running at ${baseUrl}?`,
+            { cause: err },
+          )
+        }
+        throw new AIAdapterFailedError(`Ollama alt-text generation failed: unknown error`)
+      }
+
+      if (!res.ok) {
+        // Ollama returns plain-text errors for connection-level issues
+        // and JSON `{ error: "..." }` for model-level issues. Surface
+        // both as AIAdapterFailedError; the message includes status
+        // code so logs can disambiguate (404 → model not pulled, 400
+        // → malformed request, etc.).
+        let detail = `HTTP ${res.status}`
+        try {
+          const errorBody = await res.text()
+          if (errorBody) detail += `: ${errorBody.slice(0, 200)}`
+        } catch {
+          // Body unreadable; status code alone is the diagnostic.
+        }
+        throw new AIAdapterFailedError(`Ollama alt-text generation failed: ${detail}`)
+      }
+
+      let parsed: OllamaChatResponse
+      try {
+        parsed = (await res.json()) as OllamaChatResponse
+      } catch (err) {
+        throw new AIInvalidResponseError(
+          `Ollama returned non-JSON response: ${err instanceof Error ? err.message : 'unknown'}`,
+        )
+      }
+
+      if (parsed.error) {
+        throw new AIAdapterFailedError(`Ollama: ${parsed.error}`)
+      }
+      if (typeof parsed.message?.content !== 'string') {
+        throw new AIInvalidResponseError('Ollama response had no message.content')
+      }
+
+      const text = parsed.message.content.trim()
+      const refusal = detectRefusal(text, OLLAMA_REFUSAL_MARKERS)
+      return {
+        text,
+        refused: refusal.refused,
+        refusalReason: refusal.reason,
+      }
+    },
+  }
+}

--- a/packages/gazetta/src/alt/openai.ts
+++ b/packages/gazetta/src/alt/openai.ts
@@ -1,0 +1,157 @@
+/**
+ * OpenAI adapter — alt-text via the `chat.completions.create` vision API.
+ *
+ * # Defaults
+ *
+ *   - Model: `gpt-4o-mini` — vision-capable, well-supported. Note that
+ *     OpenAI's vision pricing is non-trivial: while gpt-4o-mini is
+ *     cheaper per text token than gpt-4o, vision token cost differs
+ *     and the math is workload-dependent. Sites comparing costs
+ *     should benchmark against their actual asset library; sites that
+ *     want explicit cost-ceiling pick a specific model in `site.yaml`.
+ *
+ * # API contract details (verified against `openai` SDK v6+)
+ *
+ *   - Image content uses `{ type: 'image_url', image_url: { url } }`.
+ *     The URL is a base64 data URL: `data:{mime};base64,{data}`.
+ *   - Accepted MIMEs: JPEG, PNG, GIF, WebP. After `prepareForVision`
+ *     our bytes are JPEG or PNG.
+ *   - System prompt is a `role: 'system'` message (not a top-level
+ *     parameter like Anthropic). The user message contains the image.
+ *   - `max_tokens` is optional but we set it derived from
+ *     `request.maxChars` for predictable cost. Floor at 64.
+ *
+ * # AbortSignal
+ *
+ *   - Passed via `chat.completions.create(body, { signal })`. SDK
+ *     throws `APIUserAbortError` on abort; adapter rethrows so the
+ *     suggester's `signal.aborted` check can return null.
+ *
+ * # Errors
+ *
+ *   - SDK throws typed subclasses identical in shape to Anthropic's
+ *     SDK: `APIUserAbortError`, `RateLimitError`, `AuthenticationError`,
+ *     `BadRequestError`, etc. Adapter translates non-abort errors to
+ *     `AIAdapterFailedError` with the SDK error as `cause`.
+ *
+ * # SOLID
+ *
+ *   - Same SOLID lenses as Anthropic adapter (commit 3): SRP, LSP, DIP.
+ *     The adapter abstraction holds across both providers — same
+ *     contract, different request/response/error shapes encapsulated
+ *     here.
+ */
+import OpenAI from 'openai'
+import { AIAdapterFailedError, AIInvalidResponseError } from '../ai/errors.js'
+import { detectRefusal } from '../ai/refusal.js'
+import type { AltGenerateInput, AltSuggestion, AltTextAdapter } from './adapter.js'
+
+/**
+ * OpenAI-specific refusal phrases. Layered on top of the shared list
+ * in `ai/refusal.ts`. Kept here so provider-specific drift evolves
+ * independently.
+ */
+const OPENAI_REFUSAL_MARKERS: readonly string[] = [
+  "i'm sorry, i can't assist",
+  "i can't assist with that",
+  'i am unable to assist',
+]
+
+/**
+ * Default model. Vision-capable across OpenAI's gpt-4o family. Sites
+ * with high-volume asset libraries should benchmark cost against
+ * actual workload — gpt-4o-mini's vision token use isn't strictly
+ * cheaper than gpt-4o despite the lower text-token rate.
+ */
+export const OPENAI_DEFAULT_MODEL = 'gpt-4o-mini'
+
+const CHARS_PER_TOKEN = 4
+const MIN_MAX_TOKENS = 64
+
+const OPENAI_SUPPORTED_MIMES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp'])
+
+export interface OpenAIAltAdapterOptions {
+  apiKey: string
+  /** Model ID; defaults to {@link OPENAI_DEFAULT_MODEL}. */
+  model?: string
+  /** Optional override of the SDK base URL — for tests pointing at msw or proxy setups. */
+  baseURL?: string
+  /**
+   * Override the SDK's retry count (default 2). Tests pass 0 to keep
+   * runs deterministic and fast.
+   */
+  maxRetries?: number
+}
+
+function toBase64DataUrl(bytes: Uint8Array, mime: string): string {
+  return `data:${mime};base64,${Buffer.from(bytes).toString('base64')}`
+}
+
+/**
+ * Construct the OpenAI alt-text adapter. Pure factory; caller supplies
+ * literal `apiKey`. Factory wiring (commit 6) reads env vars; this
+ * adapter doesn't.
+ */
+export function createOpenAIAltAdapter(opts: OpenAIAltAdapterOptions): AltTextAdapter {
+  const client = new OpenAI({
+    apiKey: opts.apiKey,
+    baseURL: opts.baseURL,
+    maxRetries: opts.maxRetries,
+  })
+  const model = opts.model ?? OPENAI_DEFAULT_MODEL
+
+  return {
+    name: 'openai',
+    supports(mime: string) {
+      return OPENAI_SUPPORTED_MIMES.has(mime)
+    },
+    async generate(input: AltGenerateInput, signal?: AbortSignal): Promise<AltSuggestion> {
+      const maxTokens = Math.max(MIN_MAX_TOKENS, Math.ceil(input.request.maxChars / CHARS_PER_TOKEN))
+
+      let response: OpenAI.Chat.Completions.ChatCompletion
+      try {
+        response = await client.chat.completions.create(
+          {
+            model,
+            max_tokens: maxTokens,
+            messages: [
+              { role: 'system', content: input.prompt },
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'image_url',
+                    image_url: { url: toBase64DataUrl(input.bytes, input.mime) },
+                  },
+                ],
+              },
+            ],
+          },
+          { signal },
+        )
+      } catch (err) {
+        // Aborts pass through; suggester translates to null.
+        if (err instanceof OpenAI.APIUserAbortError) throw err
+        if (err instanceof Error) {
+          throw new AIAdapterFailedError(`OpenAI alt-text generation failed: ${err.message}`, { cause: err })
+        }
+        throw new AIAdapterFailedError('OpenAI alt-text generation failed: unknown error')
+      }
+
+      // Response shape: choices[0].message.content. May be null when
+      // the model returns a tool-call instead — defensive against that.
+      const content = response.choices[0]?.message.content
+      if (typeof content !== 'string') {
+        throw new AIInvalidResponseError('OpenAI response had no text content')
+      }
+
+      const text = content.trim()
+      const refusal = detectRefusal(text, OPENAI_REFUSAL_MARKERS)
+      return {
+        text,
+        refused: refusal.refused,
+        refusalReason: refusal.reason,
+      }
+    },
+  }
+}

--- a/packages/gazetta/src/alt/prompt-policies.ts
+++ b/packages/gazetta/src/alt/prompt-policies.ts
@@ -1,0 +1,106 @@
+/**
+ * Alt-text prompt policies — five `AltPromptPolicy` modules that each
+ * own one dimension of prompt content.
+ *
+ * # Why split into five
+ *
+ * Per [team-preferences rule 18], "structurally correct from the
+ * start". A single mega-string would be a god-string with five
+ * reasons to change (task framing, style, length, locale, output
+ * discipline). Splitting at the SOLID seam means:
+ *
+ *   - WCAG guidance update → edit `styleGuidancePolicy` only
+ *   - Locale strategy change → edit `localePolicy` only
+ *   - Length convention change → edit `lengthPolicy` only
+ *
+ * Each policy is independently testable. The composer assembles them
+ * via `composePrompt(req, DEFAULT_POLICIES)`.
+ *
+ * # Adding a new style
+ *
+ * Future styles like `'marketing'` or `'technical'` extend the
+ * `AltStyle` enum + add a switch arm in `styleGuidancePolicy`. Other
+ * policies untouched (OCP).
+ *
+ * # Locale handling
+ *
+ * Direct generation: when locale ≠ default, ask the model to write in
+ * that locale. Modern vision models are competently multilingual at
+ * description tasks. Translation as a separate pipeline was rejected
+ * — would require a parallel `TranslationAdapter` system before its
+ * second consumer exists.
+ */
+import type { AltPromptPolicy, AltStyle } from './adapter.js'
+
+/**
+ * The default locale for which `localePolicy` doesn't add anything.
+ * Aligned with the WCAG-grounded prompts being written in English.
+ */
+const DEFAULT_LOCALE = 'en'
+
+/**
+ * Policy 1 — frame the task. Sets the model's frame: this is alt
+ * text generation following web-accessibility conventions, not
+ * caption generation.
+ */
+export const taskFramingPolicy: AltPromptPolicy = () =>
+  `You are writing alt text for a webpage image, following WCAG 2.1 guidelines.`
+
+/**
+ * Policy 2 — style guidance per `request.style`. Currently only
+ * `'descriptive'`; extending the enum adds a switch arm here.
+ *
+ * The descriptive guidance steers the model away from common
+ * caption-style patterns ("Image of...", "A photograph of...") and
+ * toward direct description.
+ */
+export const styleGuidancePolicy: AltPromptPolicy = req => {
+  const style: AltStyle = req.style
+  switch (style) {
+    case 'descriptive':
+      return `Describe what's visually present and meaningful. Be specific and concrete. Don't start with "image of" or "picture of" — write the description directly.`
+  }
+}
+
+/**
+ * Policy 3 — length cap as model guidance. Soft instruction; the
+ * suggester doesn't enforce truncation. WAI-ARIA convention is 125
+ * chars; per-call override via `request.maxChars`.
+ */
+export const lengthPolicy: AltPromptPolicy = req => `Maximum ${req.maxChars} characters.`
+
+/**
+ * Policy 4 — locale instruction. Empty string when locale is the
+ * default (composer drops empty-string policies; the prompt has one
+ * fewer paragraph), non-empty otherwise.
+ *
+ * When locale ≠ 'en', the model writes the description in that
+ * language directly. No translation step.
+ */
+export const localePolicy: AltPromptPolicy = req => {
+  if (req.locale === DEFAULT_LOCALE) return ''
+  return `Write the description in ${req.locale}.`
+}
+
+/**
+ * Policy 5 — output discipline. Clamp the model's tendency to add
+ * preamble or wrapper quotes around its answer. Last in the order
+ * because it's the closing instruction.
+ */
+export const outputDisciplinePolicy: AltPromptPolicy = () => `Output the description only, no preamble or quotes.`
+
+/**
+ * Default policy set, in composition order. Most prompt-tuning lives
+ * in editing the policies above; the order here changes only when
+ * paragraph priority changes (rare).
+ *
+ * Callers can pass a custom array for one-off requests, but the
+ * default is what every alt-text generation uses in production.
+ */
+export const DEFAULT_ALT_PROMPT_POLICIES: readonly AltPromptPolicy[] = [
+  taskFramingPolicy,
+  styleGuidancePolicy,
+  lengthPolicy,
+  localePolicy,
+  outputDisciplinePolicy,
+]

--- a/packages/gazetta/src/alt/route-handler.ts
+++ b/packages/gazetta/src/alt/route-handler.ts
@@ -1,0 +1,164 @@
+/**
+ * Route-level orchestration for `POST /api/assets/:name/suggest-alt`.
+ *
+ * This module owns the wiring between the admin-api HTTP layer and the
+ * alt-text task: loads the asset manifest, reads bytes from storage,
+ * builds the suggester, runs it, returns the response body.
+ *
+ * Lives outside `admin-api/routes/assets.ts` so route handlers stay
+ * thin (HTTP concerns only) and the orchestration is unit-testable
+ * without spinning up Hono.
+ *
+ * # SOLID
+ *
+ *   - SRP: this module owns "given a name + locale + storage + site,
+ *     return a suggestion or a typed error". No HTTP concerns; no
+ *     adapter construction (delegates to `buildAltAdapter`).
+ *   - DIP: depends on `StorageProvider` + `SiteManifest` + factory
+ *     functions, never on a specific provider. Tests substitute via
+ *     the same abstractions.
+ *   - OCP: adding response fields (e.g., locale fallback used) is one
+ *     additional field on the returned shape; no changes to the route.
+ */
+import { readManifest } from '../assets/manifest.js'
+import { assetStoragePaths } from '../assets/asset-paths.js'
+import { AssetManifestNotFoundError } from '../assets/errors.js'
+import type { SiteManifest, StorageProvider, TargetConfig } from '../types.js'
+import { buildAltAdapter } from './factory.js'
+import { resolveAltConfig } from './config.js'
+import { createAltSuggester } from './suggester.js'
+
+/**
+ * Result of orchestration. The route handler maps these to HTTP
+ * responses uniformly:
+ *
+ *   - `'unavailable'` → 503 (no adapter / unsupported MIME)
+ *   - `'failed'`      → 502 (adapter threw)
+ *   - `'not-found'`   → 404 (asset doesn't exist)
+ *   - `'ok'`          → 200 (with body, including possible refused: true)
+ */
+export type SuggestAltResult =
+  | { kind: 'ok'; suggestion: { text: string; refused: boolean; refusalReason: string | null } }
+  | { kind: 'unavailable'; message: string }
+  | { kind: 'failed'; message: string }
+  | { kind: 'not-found'; message: string }
+
+export interface SuggestAltOptions {
+  /** Asset name (from `:name` URL param). */
+  name: string
+  /** Where assets live in storage (typically `'assets'`). */
+  assetsRoot: string
+  /** Storage provider for the resolved target. */
+  storage: StorageProvider
+  /** Site manifest carrying `ai:` and `altText:` blocks. */
+  site: Pick<SiteManifest, 'ai' | 'altText'>
+  /** Resolved target config (target-level overrides applied via factory). */
+  target: Pick<TargetConfig, 'altText'> | undefined
+  /** Locale to generate alt in. Defaults to 'en' upstream. */
+  locale: string
+  /** Optional AbortSignal forwarded to the adapter. */
+  signal?: AbortSignal
+}
+
+/**
+ * Run an alt-text suggestion for an existing asset. Pure orchestration
+ * — no HTTP, no logging, no streaming. Returns a structured result
+ * that the route handler maps to HTTP.
+ */
+export async function suggestAltForAsset(opts: SuggestAltOptions): Promise<SuggestAltResult> {
+  // Resolve config first to validate the feature is configured for
+  // this site/target. No adapter construction yet — cheap.
+  const resolved = resolveAltConfig(opts.site, opts.target)
+  if (!resolved) {
+    return {
+      kind: 'unavailable',
+      message: 'AI alt-text is not configured for this site. Add an `altText:` block to site.yaml.',
+    }
+  }
+
+  // Load the asset manifest. Wrapped in try/catch so we surface
+  // missing-asset as a typed result rather than letting the asset
+  // domain's typed error escape into the route handler's
+  // pattern-match list.
+  let manifest: Awaited<ReturnType<typeof readManifest>>
+  try {
+    manifest = await readManifest(opts.storage, opts.assetsRoot, opts.name)
+  } catch (err) {
+    if (err instanceof AssetManifestNotFoundError) {
+      return { kind: 'not-found', message: `Asset '${opts.name}' not found` }
+    }
+    // Other asset-domain errors bubble — they indicate misconfiguration
+    // (e.g., corrupt manifest), which the route handler maps via
+    // `respondWithAssetError`.
+    throw err
+  }
+
+  // Build the adapter via the factory. Returns nullAltAdapter when
+  // credentials are missing — the suggester's `available()` check
+  // surfaces this as `false` and we map to 503.
+  const adapter = buildAltAdapter(opts.site, opts.target)
+  const suggester = createAltSuggester({ adapter })
+
+  if (!suggester.available(manifest.mime)) {
+    return {
+      kind: 'unavailable',
+      message: `AI alt-text adapter unavailable. Check that '${resolved.provider}' credentials are set in .env.local and that the asset MIME (${manifest.mime}) is supported.`,
+    }
+  }
+
+  // Resolve the bytes path for the default-locale variant. v1.5
+  // suggests against the asset's default bytes regardless of the
+  // requested locale — locale only affects the prompt language. Future
+  // locale-specific bytes (e.g., a French-text-overlay version) could
+  // route through the override slices; deferred until a real consumer
+  // requests it.
+  const paths = assetStoragePaths(opts.assetsRoot, manifest)
+
+  let bytes: Uint8Array
+  try {
+    bytes = await opts.storage.readBytes(paths.defaultBytes)
+  } catch (err) {
+    return {
+      kind: 'failed',
+      message: `Could not read asset bytes for '${opts.name}': ${err instanceof Error ? err.message : 'unknown error'}`,
+    }
+  }
+
+  // Optional poster bytes for animated images — the analyzer extracts
+  // them at upload time and writes a manifest path; we forward to the
+  // suggester so vision-prep skips re-rasterization.
+  let posterBytes: Uint8Array | undefined
+  if (manifest.poster) {
+    try {
+      posterBytes = await opts.storage.readBytes(`${opts.assetsRoot}/${manifest.poster}`)
+    } catch {
+      // Poster missing or unreadable — fall through to source bytes.
+      // Vision-prep handles the rasterize-source path.
+      posterBytes = undefined
+    }
+  }
+
+  const suggestion = await suggester.suggest(
+    {
+      bytes,
+      mime: manifest.mime,
+      hash: manifest.hash,
+      locale: opts.locale,
+      maxImageEdge: resolved.maxImageEdge,
+      posterBytes,
+    },
+    opts.signal,
+  )
+
+  if (suggestion === null) {
+    // The suggester returns null on capability miss, abort, or any
+    // typed AI error. We've already verified availability above, so
+    // here the cause is most likely a transport failure.
+    return {
+      kind: 'failed',
+      message: `Alt-text generation failed. Check ${resolved.provider} status and retry.`,
+    }
+  }
+
+  return { kind: 'ok', suggestion }
+}

--- a/packages/gazetta/src/alt/suggester.ts
+++ b/packages/gazetta/src/alt/suggester.ts
@@ -1,0 +1,191 @@
+/**
+ * `AltSuggester` — orchestration between callers and adapters.
+ *
+ * The suggester is **stateless**. No memoization, no per-replica cache.
+ * Multi-replica admin correctness > per-replica optimization. If
+ * caching ever earns its keep operationally, it lands as a decorator
+ * (`CachedAltSuggester`) wrapping this base — additive, multi-replica
+ * correct via shared storage.
+ *
+ * # What the suggester owns
+ *
+ *   - Build typed `AltRequest` from caller input + defaults
+ *   - Compose the prompt via `composePrompt(request, policies)`
+ *   - Call `prepareForVision` to resize bytes before adapter call
+ *   - Forward `AbortSignal` to adapter
+ *   - Return `AltSuggestion | null` — null = call failed (adapter
+ *     unavailable, error, etc.)
+ *
+ * # What it doesn't own
+ *
+ *   - HTTP / SDK transport (adapter)
+ *   - Provider-specific request shape (adapter)
+ *   - Refusal detection (adapter calls `detectRefusal` and constructs
+ *     the structured `AltSuggestion`; suggester forwards the result)
+ *   - Cache (none; future decorator)
+ *   - UI concerns (consumer)
+ *
+ * # Returning null vs. throwing
+ *
+ * The suggester's contract: returns `AltSuggestion | null`. Null
+ * means "call couldn't complete" — the adapter doesn't support the
+ * MIME, or threw a transport error, or was canceled. Consumers treat
+ * null uniformly (don't auto-fill).
+ *
+ * Refusals (model said no but we got a response) come back as
+ * `AltSuggestion` with `refused: true`. Different from null — the
+ * suggester DID complete, the model just declined. Consumers can
+ * surface `refusalReason` to the author.
+ *
+ * # SOLID
+ *
+ *   - SRP: this module owns one concern (orchestration of the
+ *     adapter call from caller input to result/null)
+ *   - OCP: caching, retry, throttling all land as decorators wrapping
+ *     `AltSuggester` — none requires changing this module
+ *   - DIP: depends on `AltTextAdapter` (abstract), uses `prepareForVision`
+ *     and `composePrompt` (utilities); no knowledge of any provider
+ */
+import { composePrompt } from '../ai/compose-prompt.js'
+import { AIAdapterFailedError, AIAdapterUnavailableError, AIError, AIInvalidResponseError } from '../ai/errors.js'
+import { prepareForVision } from '../ai/vision-prep.js'
+import {
+  type AltGenerateInput,
+  type AltRequest,
+  type AltSuggestion,
+  type AltTextAdapter,
+  DEFAULT_ALT_REQUEST,
+} from './adapter.js'
+import { DEFAULT_ALT_PROMPT_POLICIES } from './prompt-policies.js'
+
+export interface SuggestInput {
+  /** Source asset bytes. */
+  bytes: Uint8Array
+  /** Source MIME from manifest. */
+  mime: string
+  /** For diagnostics (logging); not used for memoization in v1.5. */
+  hash: string
+  /** Target locale for the description. Default 'en'. */
+  locale?: string
+  /**
+   * For animated images: the analyzer-extracted first-frame poster
+   * bytes. The suggester forwards to `prepareForVision` which uses
+   * them directly (no re-rasterization).
+   */
+  posterBytes?: Uint8Array
+  /**
+   * Per-call max-edge override for vision-prep. Defaults to the
+   * `prepareForVision` default (768).
+   */
+  maxImageEdge?: number
+  /** Soft length cap; default 125. */
+  maxChars?: number
+}
+
+/**
+ * The orchestration interface. UI components and route handlers
+ * depend on this; the concrete `createAltSuggester` builds an
+ * implementation backed by an adapter.
+ */
+export interface AltSuggester {
+  /**
+   * True when the wrapped adapter is configured AND supports the
+   * given MIME. UI uses this to decide whether to render AI affordances.
+   */
+  available(mime: string): boolean
+  /**
+   * Run the alt-text suggestion. Returns the structured result from
+   * the adapter (which may have `refused: true`), or null when the
+   * call couldn't complete (unavailable, transport error, abort).
+   */
+  suggest(input: SuggestInput, signal?: AbortSignal): Promise<AltSuggestion | null>
+}
+
+export interface CreateAltSuggesterOptions {
+  adapter: AltTextAdapter
+}
+
+/**
+ * Build a suggester wrapping the given adapter. Pure factory — no I/O,
+ * no env-var reads. Caller (the route handler or test setup) supplies
+ * a fully-constructed adapter.
+ *
+ * Tests substitute by passing `nullAltAdapter`, a recording mock, or
+ * a real adapter with an msw-mocked transport.
+ */
+export function createAltSuggester(opts: CreateAltSuggesterOptions): AltSuggester {
+  const { adapter } = opts
+
+  return {
+    available(mime: string): boolean {
+      return adapter.supports(mime)
+    },
+
+    async suggest(input: SuggestInput, signal?: AbortSignal): Promise<AltSuggestion | null> {
+      // Capability check first — adapter may be null-adapter or may
+      // not support this MIME. Either way: nothing to attempt.
+      if (!adapter.supports(input.mime)) return null
+
+      // Bail on already-aborted signals before doing any work.
+      if (signal?.aborted) return null
+
+      // Build the typed request from input + defaults.
+      const request: AltRequest = {
+        ...DEFAULT_ALT_REQUEST,
+        locale: input.locale ?? DEFAULT_ALT_REQUEST.locale,
+        maxChars: input.maxChars ?? DEFAULT_ALT_REQUEST.maxChars,
+      }
+
+      // Compose prompt and prepare bytes — both pure, both idempotent.
+      const prompt = composePrompt(request, DEFAULT_ALT_PROMPT_POLICIES)
+
+      let prepared: { bytes: Uint8Array; mime: string }
+      try {
+        prepared = await prepareForVision({
+          bytes: input.bytes,
+          mime: input.mime,
+          posterBytes: input.posterBytes,
+          maxEdge: input.maxImageEdge,
+        })
+      } catch {
+        // Vision-prep failure (sharp couldn't decode): treat as
+        // unavailable. The asset's bytes are presumably corrupt or
+        // an unexpected format — not worth calling the model on
+        // garbage.
+        return null
+      }
+
+      const generateInput: AltGenerateInput = {
+        bytes: prepared.bytes,
+        mime: prepared.mime,
+        request,
+        prompt,
+      }
+
+      try {
+        return await adapter.generate(generateInput, signal)
+      } catch (err) {
+        // AbortSignal-induced rejection: surface as null (call canceled).
+        if (signal?.aborted) return null
+
+        // AI errors are expected failure modes — caller maps null →
+        // user-facing toast. Re-throwing would force every caller to
+        // try/catch around `suggest`, which is exactly what the
+        // suggester contract abstracts away.
+        if (err instanceof AIError) return null
+
+        // Non-AI errors (programmer bugs, unexpected exceptions)
+        // bubble — the suggester doesn't swallow these, since they
+        // indicate a real problem worth surfacing.
+        throw err
+      }
+    },
+  }
+}
+
+// Re-export AI error types so callers/tests can pattern-match without
+// importing from `ai/`. Useful during the brief window where adapter
+// implementations distinguish unavailable vs. failed vs. invalid-
+// response; in practice route handlers only need the suggester's
+// null/non-null result.
+export { AIAdapterFailedError, AIAdapterUnavailableError, AIInvalidResponseError }

--- a/packages/gazetta/src/types.ts
+++ b/packages/gazetta/src/types.ts
@@ -231,6 +231,82 @@ export interface TargetConfig {
    *     for the site's content
    */
   assets?: AssetUploadConfig
+  /**
+   * Per-target alt-text behavior overrides. Inherits site-level
+   * `altText:` block; only behavior fields can be overridden
+   * (`auto`, `maxImageEdge`, `model`). Provider and credentials are
+   * operationally global and don't appear at the target level.
+   *
+   * Common pattern: `{ auto: false }` on production targets for
+   * review-first publishing workflows.
+   */
+  altText?: AltTextTargetConfig
+}
+
+/**
+ * Cross-task AI configuration block (`ai:` in `site.yaml`). Carries
+ * fields used by ALL AI-powered tasks (alt-text in v1.5; future
+ * translation, tag suggestion, summarization).
+ *
+ * Per-task config blocks (`altText:`, future `translation:`) inherit
+ * `provider` and `defaultModel` from this base unless overridden.
+ *
+ * Vision-task-specific fields (e.g., `maxImageEdge`) DO NOT live here
+ * — they sit on per-task blocks because they don't apply to text-only
+ * tasks. Putting them on the cross-task base would be an ISP violation.
+ *
+ * See `.claude/rules/design-ai.md` for the three-layer architecture.
+ */
+export interface AIConfig {
+  /** Provider account choice. v1.5 ships these three. */
+  provider: 'anthropic' | 'openai' | 'ollama'
+  /**
+   * Per-provider sensible default model. Per-task blocks override
+   * (`altText.model: claude-sonnet-4-5`) when a task wants different
+   * cost/quality tradeoffs.
+   */
+  defaultModel?: string
+}
+
+/**
+ * Site-level alt-text configuration (`altText:` in `site.yaml`).
+ * Defaults inherited from `ai:` block when fields are unset.
+ */
+export interface AltTextSiteConfig {
+  /** Override `ai.provider` for the alt-text task only. Rare; mostly inherited. */
+  provider?: AIConfig['provider']
+  /** Override `ai.defaultModel` for alt-text. Useful when a task needs higher quality than the default. */
+  model?: string
+  /**
+   * Whether upload flows auto-fire suggest after upload completes.
+   * Default: `true`. Set `false` for review-first workflows where every
+   * alt suggestion is reviewed before being applied.
+   */
+  auto?: boolean
+  /**
+   * Long-edge cap for the image bytes sent to the vision provider.
+   * Default 768 (`MAX_EDGE` in `ai/vision-prep.ts`). Sites with
+   * text-heavy asset libraries (screenshots, scanned documents) may
+   * raise to 1024 to preserve text legibility for the model.
+   */
+  maxImageEdge?: number
+}
+
+/**
+ * Target-level alt-text override. Carries behavior overrides only —
+ * never provider/credentials (those are operationally global).
+ *
+ * The fields that make sense at target level are a subset of
+ * `AltTextSiteConfig`. Common pattern: `auto: false` on `production`
+ * for review-first prod, default elsewhere.
+ */
+export interface AltTextTargetConfig {
+  /** Override site-level `auto`. Common: `false` on production. */
+  auto?: boolean
+  /** Override site-level `maxImageEdge` for this target. */
+  maxImageEdge?: number
+  /** Override site-level `model` for this target. */
+  model?: string
 }
 
 /** Per-target asset upload policy. */
@@ -353,6 +429,23 @@ export interface SiteManifest {
   themes?: ThemesConfig
   /** Default Open Graph image for pages that don't specify their own. */
   defaultOgImage?: string
+  /**
+   * Cross-task AI configuration. Carries shared concerns (provider,
+   * default model). Per-task blocks (`altText:`) inherit these fields
+   * unless they override.
+   *
+   * Absent = no AI features configured. The capability check
+   * (`isAltAdapterConfigured`) treats absence as "AI is off."
+   */
+  ai?: AIConfig
+  /**
+   * Site-level alt-text task config. Inherits from `ai:` block; per-target
+   * blocks (`TargetConfig.altText`) override behavior fields only.
+   *
+   * Absent = alt-text feature is off. Block presence + valid `provider`
+   * (either here or inherited from `ai:`) means AI alt is configured.
+   */
+  altText?: AltTextSiteConfig
   systemPages?: string[]
   targets?: Record<string, TargetConfig>
 }

--- a/packages/gazetta/tests/admin-api-suggest-alt.test.ts
+++ b/packages/gazetta/tests/admin-api-suggest-alt.test.ts
@@ -1,0 +1,292 @@
+/**
+ * HTTP-level tests for `POST /api/assets/:name/suggest-alt`.
+ *
+ * Verifies the route adapter correctly translates orchestration
+ * results (`SuggestAltResult` from `alt/route-handler.ts`) to HTTP
+ * status codes + body shapes. Orchestration correctness is covered by
+ * `alt-route-handler.test.ts`.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { Hono } from 'hono'
+import sharp from 'sharp'
+import { assetRoutes } from '../src/admin-api/routes/assets.js'
+import { staticSourceResolver, createSourceContext } from '../src/admin-api/source-context.js'
+import { createFilesystemProvider } from '../src/providers/filesystem.js'
+import type { SiteManifest } from '../src/types.js'
+import { tempDir } from './_helpers/temp.js'
+
+const testDir = tempDir('http-suggest-alt-test-' + Date.now())
+
+const ENV_KEYS = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'OLLAMA_BASE_URL'] as const
+const savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {}
+
+beforeEach(async () => {
+  await mkdir(testDir, { recursive: true })
+  await writeFile(join(testDir, 'site.yaml'), 'name: test-site\n')
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+})
+
+afterEach(async () => {
+  await rm(testDir, { recursive: true, force: true })
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = savedEnv[key]
+    }
+  }
+})
+
+async function jpegBytes(): Promise<Uint8Array> {
+  const buf = await sharp({
+    create: { width: 200, height: 200, channels: 3, background: { r: 0, g: 0, b: 0 } },
+  })
+    .jpeg()
+    .toBuffer()
+  return new Uint8Array(buf)
+}
+
+function buildApp(siteManifest?: SiteManifest) {
+  const storage = createFilesystemProvider(testDir)
+  const source = createSourceContext({
+    storage,
+    siteDir: '',
+    manifest: siteManifest,
+  })
+  const resolve = staticSourceResolver(source)
+  const app = new Hono()
+  app.route('/', assetRoutes(resolve))
+  return { app, storage }
+}
+
+async function seedAsset(storage: ReturnType<typeof createFilesystemProvider>, name = 'hero', hash = 'abc12345') {
+  const bytes = await jpegBytes()
+  const manifest = {
+    version: 1,
+    name,
+    kind: 'embedded',
+    source: 'internal',
+    mime: 'image/jpeg',
+    size: bytes.byteLength,
+    hash,
+    width: 200,
+    height: 200,
+    duration: null,
+    alt: null,
+    focalPoint: null,
+    tags: [],
+    variants: [],
+    variantsStatus: 'complete',
+    uploadedAt: '2026-05-03T00:00:00Z',
+    uploadedBy: '',
+  }
+  await storage.writeFile(`assets/${name}.asset.json`, JSON.stringify(manifest))
+  await storage.writeBytes(`assets/${name}-${hash}.jpg`, bytes)
+}
+
+describe('POST /api/assets/:name/suggest-alt — happy path', () => {
+  it('200s with structured suggestion when adapter responds', async () => {
+    const site: SiteManifest = {
+      name: 'test',
+      ai: { provider: 'ollama' },
+      altText: { auto: true },
+    }
+    const { app, storage } = buildApp(site)
+    await seedAsset(storage)
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async (input: RequestInfo | URL): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.includes('localhost:11434')) {
+        return new Response(
+          JSON.stringify({
+            message: { role: 'assistant', content: 'A black square.' },
+            done: true,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        )
+      }
+      throw new Error(`unexpected url: ${url}`)
+    }
+    try {
+      const res = await app.request('/api/assets/hero/suggest-alt', { method: 'POST' })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.text).toBe('A black square.')
+      expect(body.refused).toBe(false)
+      expect(body.refusalReason).toBeNull()
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('returns 200 with refused: true when model declines (NOT an error)', async () => {
+    const site: SiteManifest = {
+      name: 'test',
+      ai: { provider: 'ollama' },
+      altText: { auto: true },
+    }
+    const { app, storage } = buildApp(site)
+    await seedAsset(storage)
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async (input: RequestInfo | URL): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.includes('localhost:11434')) {
+        return new Response(
+          JSON.stringify({
+            message: { role: 'assistant', content: "I can't describe this image." },
+            done: true,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        )
+      }
+      throw new Error(`unexpected url: ${url}`)
+    }
+    try {
+      const res = await app.request('/api/assets/hero/suggest-alt', { method: 'POST' })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.refused).toBe(true)
+      expect(body.refusalReason).not.toBeNull()
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
+describe('POST /api/assets/:name/suggest-alt — locale parameter', () => {
+  it('forwards locale query to the adapter', async () => {
+    const site: SiteManifest = {
+      name: 'test',
+      ai: { provider: 'ollama' },
+      altText: { auto: true },
+    }
+    const { app, storage } = buildApp(site)
+    await seedAsset(storage)
+
+    let captured: string | undefined
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.includes('localhost:11434')) {
+        const body = JSON.parse(init?.body as string) as {
+          messages: Array<{ role: string; content: string }>
+        }
+        captured = body.messages.find(m => m.role === 'system')?.content
+        return new Response(JSON.stringify({ message: { role: 'assistant', content: 'description' }, done: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      throw new Error(`unexpected url: ${url}`)
+    }
+    try {
+      const res = await app.request('/api/assets/hero/suggest-alt?locale=fr', { method: 'POST' })
+      expect(res.status).toBe(200)
+      // Composed prompt should mention the locale.
+      expect(captured).toBeDefined()
+      expect(captured).toContain('fr')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('400s on invalid locale code', async () => {
+    const site: SiteManifest = {
+      name: 'test',
+      ai: { provider: 'ollama' },
+      altText: { auto: true },
+    }
+    const { app } = buildApp(site)
+    const res = await app.request('/api/assets/hero/suggest-alt?locale=NOT_A_LOCALE!!!', { method: 'POST' })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.code).toBe('BAD_REQUEST')
+  })
+})
+
+describe('POST /api/assets/:name/suggest-alt — unavailable', () => {
+  it('503s when no adapter is configured', async () => {
+    // No `ai:` block at all.
+    const site: SiteManifest = { name: 'test' }
+    const { app, storage } = buildApp(site)
+    await seedAsset(storage)
+    const res = await app.request('/api/assets/hero/suggest-alt', { method: 'POST' })
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body.code).toBe('AI_ADAPTER_UNAVAILABLE')
+  })
+
+  it('503s when site manifest is unavailable on source', async () => {
+    // No siteManifest passed to buildApp.
+    const { app, storage } = buildApp()
+    await seedAsset(storage)
+    const res = await app.request('/api/assets/hero/suggest-alt', { method: 'POST' })
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body.code).toBe('AI_ADAPTER_UNAVAILABLE')
+  })
+
+  it('503s when configured but credentials missing', async () => {
+    const site: SiteManifest = {
+      name: 'test',
+      ai: { provider: 'anthropic' },
+      altText: { auto: true },
+    }
+    const { app, storage } = buildApp(site)
+    await seedAsset(storage)
+    // No ANTHROPIC_API_KEY.
+    const res = await app.request('/api/assets/hero/suggest-alt', { method: 'POST' })
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body.code).toBe('AI_ADAPTER_UNAVAILABLE')
+  })
+})
+
+describe('POST /api/assets/:name/suggest-alt — failed', () => {
+  it('502s when the adapter call fails', async () => {
+    const site: SiteManifest = {
+      name: 'test',
+      ai: { provider: 'ollama' },
+      altText: { auto: true },
+    }
+    const { app, storage } = buildApp(site)
+    await seedAsset(storage)
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async (): Promise<Response> => {
+      // Network-level error.
+      throw new TypeError('connection refused')
+    }
+    try {
+      const res = await app.request('/api/assets/hero/suggest-alt', { method: 'POST' })
+      expect(res.status).toBe(502)
+      const body = await res.json()
+      expect(body.code).toBe('AI_ADAPTER_FAILED')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
+describe('POST /api/assets/:name/suggest-alt — not found', () => {
+  it('404s when asset does not exist on the target', async () => {
+    const site: SiteManifest = {
+      name: 'test',
+      ai: { provider: 'ollama' },
+      altText: { auto: true },
+    }
+    const { app } = buildApp(site)
+    // No asset seeded.
+    const res = await app.request('/api/assets/missing/suggest-alt', { method: 'POST' })
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.code).toBe('ASSET_MANIFEST_NOT_FOUND')
+  })
+})

--- a/packages/gazetta/tests/ai-compose-prompt.test.ts
+++ b/packages/gazetta/tests/ai-compose-prompt.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for `ai/compose-prompt.ts` — generic composer behavior.
+ * Tests use a synthetic request type to avoid coupling to any specific
+ * task; alt-text-specific policies live in `alt/prompt-policies.ts`
+ * with their own tests.
+ */
+import { describe, expect, it } from 'vitest'
+import { composePrompt, type PromptPolicy } from '../src/ai/compose-prompt.js'
+
+interface TestRequest {
+  flag: boolean
+  value: string
+}
+
+describe('composePrompt', () => {
+  it('joins non-empty policy outputs with paragraph breaks', () => {
+    const policies: PromptPolicy<TestRequest>[] = [
+      () => 'First paragraph.',
+      () => 'Second paragraph.',
+      () => 'Third paragraph.',
+    ]
+    const result = composePrompt({ flag: true, value: 'x' }, policies)
+    expect(result).toBe('First paragraph.\n\nSecond paragraph.\n\nThird paragraph.')
+  })
+
+  it('drops empty-string policy outputs from the result', () => {
+    const policies: PromptPolicy<TestRequest>[] = [() => 'Included.', () => '', () => 'Also included.']
+    const result = composePrompt({ flag: true, value: 'x' }, policies)
+    expect(result).toBe('Included.\n\nAlso included.')
+    expect(result).not.toContain('\n\n\n\n')
+  })
+
+  it('returns empty string when all policies produce empty', () => {
+    const policies: PromptPolicy<TestRequest>[] = [() => '', () => '', () => '']
+    const result = composePrompt({ flag: false, value: '' }, policies)
+    expect(result).toBe('')
+  })
+
+  it('preserves order of non-empty policies', () => {
+    const policies: PromptPolicy<TestRequest>[] = [() => 'C', () => '', () => 'A', () => '', () => 'B']
+    const result = composePrompt({ flag: true, value: 'x' }, policies)
+    expect(result).toBe('C\n\nA\n\nB')
+  })
+
+  it('passes the request through to each policy', () => {
+    const calls: TestRequest[] = []
+    const policies: PromptPolicy<TestRequest>[] = [
+      req => {
+        calls.push(req)
+        return 'p1'
+      },
+      req => {
+        calls.push(req)
+        return 'p2'
+      },
+    ]
+    const req: TestRequest = { flag: true, value: 'hello' }
+    composePrompt(req, policies)
+    expect(calls).toHaveLength(2)
+    expect(calls[0]).toBe(req)
+    expect(calls[1]).toBe(req)
+  })
+
+  it('handles a single-policy array', () => {
+    const policies: PromptPolicy<TestRequest>[] = [() => 'only']
+    expect(composePrompt({ flag: true, value: 'x' }, policies)).toBe('only')
+  })
+
+  it('handles an empty policies array', () => {
+    expect(composePrompt({ flag: true, value: 'x' }, [])).toBe('')
+  })
+
+  it('is generic over request type', () => {
+    // Type-system check: composePrompt works with any T.
+    interface OtherRequest {
+      n: number
+    }
+    const policies: PromptPolicy<OtherRequest>[] = [req => `n=${req.n}`]
+    expect(composePrompt({ n: 42 }, policies)).toBe('n=42')
+  })
+})

--- a/packages/gazetta/tests/ai-errors.test.ts
+++ b/packages/gazetta/tests/ai-errors.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for `ai/errors.ts` — verifies the error-class shape every
+ * route handler relies on: code, httpStatus, toResponseBody().
+ *
+ * The pattern mirrors `assets/errors.ts` (route handlers pattern-match
+ * on error class to map to HTTP status). These tests guard against a
+ * future error subclass forgetting to declare its `httpStatus`.
+ */
+import { describe, expect, it } from 'vitest'
+import { AIAdapterFailedError, AIAdapterUnavailableError, AIError, AIInvalidResponseError } from '../src/ai/errors.js'
+
+describe('AIAdapterUnavailableError', () => {
+  it('has code AI_ADAPTER_UNAVAILABLE and 503', () => {
+    const err = new AIAdapterUnavailableError('no adapter configured')
+    expect(err.code).toBe('AI_ADAPTER_UNAVAILABLE')
+    expect(err.httpStatus).toBe(503)
+  })
+
+  it('serializes to a response body', () => {
+    const err = new AIAdapterUnavailableError('no adapter configured for target staging')
+    expect(err.toResponseBody()).toEqual({
+      code: 'AI_ADAPTER_UNAVAILABLE',
+      message: 'no adapter configured for target staging',
+    })
+  })
+
+  it('extends AIError and Error', () => {
+    const err = new AIAdapterUnavailableError('msg')
+    expect(err).toBeInstanceOf(AIError)
+    expect(err).toBeInstanceOf(Error)
+  })
+})
+
+describe('AIAdapterFailedError', () => {
+  it('has code AI_ADAPTER_FAILED and 502', () => {
+    const err = new AIAdapterFailedError('upstream rejected request')
+    expect(err.code).toBe('AI_ADAPTER_FAILED')
+    expect(err.httpStatus).toBe(502)
+  })
+
+  it('serializes to a response body', () => {
+    const err = new AIAdapterFailedError('rate limited')
+    expect(err.toResponseBody()).toEqual({
+      code: 'AI_ADAPTER_FAILED',
+      message: 'rate limited',
+    })
+  })
+
+  it('preserves cause when constructed with one', () => {
+    const cause = new Error('underlying network error')
+    const err = new AIAdapterFailedError('upstream rejected request', { cause })
+    expect(err.cause).toBe(cause)
+  })
+})
+
+describe('AIInvalidResponseError', () => {
+  it('has code AI_INVALID_RESPONSE and 502', () => {
+    const err = new AIInvalidResponseError('missing content field in response')
+    expect(err.code).toBe('AI_INVALID_RESPONSE')
+    expect(err.httpStatus).toBe(502)
+  })
+
+  it('serializes to a response body', () => {
+    const err = new AIInvalidResponseError('expected string, got null')
+    expect(err.toResponseBody()).toEqual({
+      code: 'AI_INVALID_RESPONSE',
+      message: 'expected string, got null',
+    })
+  })
+})
+
+describe('discriminated union shape', () => {
+  it('every subclass exposes httpStatus typed as 502 | 503', () => {
+    // Type-system check: the union of httpStatus values is constrained.
+    // If a future error subclass adds 500 or 400, this test won't catch
+    // it (compile-time only) — but TypeScript will flag it at the
+    // class declaration site against `AIErrorHttpStatus`.
+    const errors: AIError[] = [
+      new AIAdapterUnavailableError('a'),
+      new AIAdapterFailedError('b'),
+      new AIInvalidResponseError('c'),
+    ]
+    for (const err of errors) {
+      expect([502, 503]).toContain(err.httpStatus)
+    }
+  })
+
+  it('every subclass exposes a unique code', () => {
+    const codes = new Set([
+      new AIAdapterUnavailableError('a').code,
+      new AIAdapterFailedError('b').code,
+      new AIInvalidResponseError('c').code,
+    ])
+    expect(codes.size).toBe(3)
+  })
+})

--- a/packages/gazetta/tests/ai-refusal.test.ts
+++ b/packages/gazetta/tests/ai-refusal.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for `ai/refusal.ts` — refusal detection across shared and
+ * adapter-specific marker lists, plus the empty/short response case.
+ */
+import { describe, expect, it } from 'vitest'
+import { detectRefusal } from '../src/ai/refusal.js'
+
+describe('detectRefusal', () => {
+  describe('shared markers', () => {
+    it('detects "I can\'t describe" variants', () => {
+      expect(detectRefusal("I can't describe this image.").refused).toBe(true)
+      expect(detectRefusal('I cannot describe what is shown.').refused).toBe(true)
+      expect(detectRefusal("I'm not able to describe this.").refused).toBe(true)
+      expect(detectRefusal('I am not able to describe this.').refused).toBe(true)
+    })
+
+    it('detects "I\'m unable to describe" variants', () => {
+      expect(detectRefusal("I'm unable to describe this image.").refused).toBe(true)
+      expect(detectRefusal('I am unable to describe this image.').refused).toBe(true)
+    })
+
+    it('detects "I can\'t provide" variants', () => {
+      expect(detectRefusal("I can't provide a description.").refused).toBe(true)
+      expect(detectRefusal('I cannot provide a description.').refused).toBe(true)
+      expect(detectRefusal("I'm unable to provide that.").refused).toBe(true)
+    })
+
+    it('detects "I can\'t help" variants', () => {
+      expect(detectRefusal("I can't help with that.").refused).toBe(true)
+      expect(detectRefusal('I cannot help with that.').refused).toBe(true)
+      expect(detectRefusal("I'm not able to help with this.").refused).toBe(true)
+    })
+
+    it('detects "I\'m sorry, but" preamble', () => {
+      expect(detectRefusal("I'm sorry, but I cannot complete this task.").refused).toBe(true)
+    })
+
+    it('is case-insensitive', () => {
+      expect(detectRefusal("I CAN'T DESCRIBE THIS.").refused).toBe(true)
+      expect(detectRefusal("i can't describe this.").refused).toBe(true)
+      expect(detectRefusal("I Can'T Describe This.").refused).toBe(true)
+    })
+
+    it('returns truncated reason text on refusal', () => {
+      const longRefusal = "I can't describe this image. " + 'x'.repeat(500)
+      const result = detectRefusal(longRefusal)
+      expect(result.refused).toBe(true)
+      expect(result.reason).not.toBeNull()
+      expect(result.reason?.length).toBe(200)
+    })
+  })
+
+  describe('adapter-specific markers', () => {
+    it('detects matches against adapter-specific markers', () => {
+      const adapterMarkers = ['this content cannot be processed']
+      const result = detectRefusal('This content cannot be processed by our system.', adapterMarkers)
+      expect(result.refused).toBe(true)
+    })
+
+    it('combines shared and adapter-specific markers', () => {
+      const adapterMarkers = ['custom phrase x']
+      // Shared marker still matches even with adapter markers passed.
+      expect(detectRefusal("I can't describe this.", adapterMarkers).refused).toBe(true)
+      // Adapter marker matches.
+      expect(detectRefusal('A custom phrase x appears here.', adapterMarkers).refused).toBe(true)
+    })
+
+    it('adapter markers are case-insensitive', () => {
+      const adapterMarkers = ['Custom Refusal']
+      expect(detectRefusal('CUSTOM REFUSAL message.', adapterMarkers).refused).toBe(true)
+      expect(detectRefusal('a custom refusal message.', adapterMarkers).refused).toBe(true)
+    })
+
+    it('defaults to no adapter markers when not passed', () => {
+      // Sanity: a normal description doesn't trip with no markers.
+      expect(detectRefusal('Mountain at sunset.').refused).toBe(false)
+    })
+  })
+
+  describe('empty/short responses', () => {
+    it('treats empty string as refusal', () => {
+      const result = detectRefusal('')
+      expect(result.refused).toBe(true)
+      expect(result.reason).toBe('Empty or unusably short response')
+    })
+
+    it('treats whitespace-only as refusal', () => {
+      const result = detectRefusal('   \n\t  ')
+      expect(result.refused).toBe(true)
+      expect(result.reason).toBe('Empty or unusably short response')
+    })
+
+    it('treats sub-5-char responses as refusal', () => {
+      expect(detectRefusal('Cat.').refused).toBe(true)
+      expect(detectRefusal('Hi').refused).toBe(true)
+    })
+
+    it('accepts 5+ character descriptions', () => {
+      // "Trees" is 5 chars; passes the threshold.
+      expect(detectRefusal('Trees').refused).toBe(false)
+      expect(detectRefusal('A cat.').refused).toBe(false)
+    })
+  })
+
+  describe('non-refusal text', () => {
+    it('returns refused: false for normal descriptions', () => {
+      const result = detectRefusal('Mountain peak silhouetted against an orange sunset.')
+      expect(result.refused).toBe(false)
+      expect(result.reason).toBeNull()
+    })
+
+    it('does not false-positive on descriptive text containing "I"', () => {
+      expect(detectRefusal('I see a mountain in the distance.').refused).toBe(false)
+      expect(detectRefusal('A scenic landscape that I find peaceful, with rolling hills and a lake.').refused).toBe(
+        false,
+      )
+    })
+
+    it('does not false-positive on multilingual descriptions', () => {
+      expect(detectRefusal('Coucher de soleil sur les montagnes.').refused).toBe(false)
+      expect(detectRefusal('غروب الشمس فوق الجبال').refused).toBe(false)
+      expect(detectRefusal('山に沈む夕日').refused).toBe(false)
+    })
+  })
+})

--- a/packages/gazetta/tests/ai-vision-prep.test.ts
+++ b/packages/gazetta/tests/ai-vision-prep.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for `ai/vision-prep.ts` — image preprocessing for vision
+ * provider calls. Covers:
+ *
+ *   - JPEG path: resize when oversized, pass-through when small
+ *   - PNG with alpha: preserve PNG, don't flatten to JPEG
+ *   - SVG: rasterize to PNG at maxEdge
+ *   - Animated source: use poster bytes directly, skip rasterization
+ *   - maxEdge override: per-call override of the default 768
+ */
+import { describe, expect, it } from 'vitest'
+import sharp from 'sharp'
+import { MAX_EDGE, prepareForVision } from '../src/ai/vision-prep.js'
+
+async function makeJpeg(width: number, height: number): Promise<Uint8Array> {
+  const buf = await sharp({
+    create: { width, height, channels: 3, background: { r: 100, g: 100, b: 100 } },
+  })
+    .jpeg()
+    .toBuffer()
+  return new Uint8Array(buf)
+}
+
+async function makePngWithAlpha(width: number, height: number): Promise<Uint8Array> {
+  const buf = await sharp({
+    create: { width, height, channels: 4, background: { r: 0, g: 0, b: 0, alpha: 0.5 } },
+  })
+    .png()
+    .toBuffer()
+  return new Uint8Array(buf)
+}
+
+const SVG_BYTES = new Uint8Array(
+  Buffer.from(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100" height="100" fill="blue"/></svg>',
+    'utf-8',
+  ),
+)
+
+describe('prepareForVision — default MAX_EDGE', () => {
+  it('exports MAX_EDGE = 768', () => {
+    expect(MAX_EDGE).toBe(768)
+  })
+})
+
+describe('prepareForVision — JPEG', () => {
+  it('resizes a 2000×1500 JPEG to fit within 768', async () => {
+    const bytes = await makeJpeg(2000, 1500)
+    const result = await prepareForVision({ bytes, mime: 'image/jpeg' })
+    expect(result.mime).toBe('image/jpeg')
+
+    const meta = await sharp(result.bytes).metadata()
+    expect(Math.max(meta.width ?? 0, meta.height ?? 0)).toBeLessThanOrEqual(768)
+    // Aspect ratio should be preserved (2000/1500 = 4/3).
+    expect(meta.width).toBe(768)
+    expect(meta.height).toBe(576)
+  })
+
+  it('passes through a JPEG already smaller than maxEdge', async () => {
+    const bytes = await makeJpeg(400, 300)
+    const result = await prepareForVision({ bytes, mime: 'image/jpeg' })
+    // Pass-through: same bytes, same MIME.
+    expect(result.bytes).toBe(bytes)
+    expect(result.mime).toBe('image/jpeg')
+  })
+
+  it('passes through a JPEG exactly at maxEdge', async () => {
+    const bytes = await makeJpeg(768, 768)
+    const result = await prepareForVision({ bytes, mime: 'image/jpeg' })
+    expect(result.bytes).toBe(bytes)
+  })
+})
+
+describe('prepareForVision — PNG with alpha', () => {
+  it('preserves PNG (no flatten to JPEG) when source has alpha', async () => {
+    const bytes = await makePngWithAlpha(2000, 2000)
+    const result = await prepareForVision({ bytes, mime: 'image/png' })
+    expect(result.mime).toBe('image/png')
+
+    const meta = await sharp(result.bytes).metadata()
+    expect(Math.max(meta.width ?? 0, meta.height ?? 0)).toBeLessThanOrEqual(768)
+    expect(meta.hasAlpha).toBe(true)
+  })
+
+  it('passes through a small alpha PNG', async () => {
+    const bytes = await makePngWithAlpha(400, 400)
+    const result = await prepareForVision({ bytes, mime: 'image/png' })
+    expect(result.bytes).toBe(bytes)
+    expect(result.mime).toBe('image/png')
+  })
+})
+
+describe('prepareForVision — SVG', () => {
+  it('rasterizes SVG to PNG at maxEdge', async () => {
+    const result = await prepareForVision({ bytes: SVG_BYTES, mime: 'image/svg+xml' })
+    expect(result.mime).toBe('image/png')
+
+    const meta = await sharp(result.bytes).metadata()
+    // Width/height bounded by maxEdge.
+    expect(Math.max(meta.width ?? 0, meta.height ?? 0)).toBeLessThanOrEqual(768)
+    // Output is real PNG (sharp can read it back).
+    expect(meta.format).toBe('png')
+  })
+
+  it('rasterizes SVG even when SVG is small', async () => {
+    // SVG has no inherent pixel size; we always rasterize.
+    const result = await prepareForVision({ bytes: SVG_BYTES, mime: 'image/svg+xml' })
+    expect(result.mime).toBe('image/png')
+    expect(result.bytes).not.toBe(SVG_BYTES)
+  })
+})
+
+describe('prepareForVision — animated/poster path', () => {
+  it('uses posterBytes directly when provided', async () => {
+    const sourceBytes = await makeJpeg(2000, 1500)
+    const posterBytes = await sharp({
+      create: { width: 100, height: 100, channels: 3, background: { r: 0, g: 0, b: 0 } },
+    })
+      .png()
+      .toBuffer()
+    const result = await prepareForVision({
+      bytes: sourceBytes,
+      mime: 'image/gif',
+      posterBytes: new Uint8Array(posterBytes),
+    })
+    // Result is the poster bytes verbatim, marked as PNG.
+    expect(result.bytes).toEqual(new Uint8Array(posterBytes))
+    expect(result.mime).toBe('image/png')
+  })
+
+  it('does not rasterize when posterBytes provided, even for SVG', async () => {
+    // posterBytes always wins — caller's responsibility to pass the
+    // right bytes for the source.
+    const posterBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]) // PNG magic
+    const result = await prepareForVision({
+      bytes: SVG_BYTES,
+      mime: 'image/svg+xml',
+      posterBytes,
+    })
+    expect(result.bytes).toBe(posterBytes)
+    expect(result.mime).toBe('image/png')
+  })
+})
+
+describe('prepareForVision — maxEdge override', () => {
+  it('respects per-call maxEdge override', async () => {
+    const bytes = await makeJpeg(2000, 2000)
+    const result = await prepareForVision({ bytes, mime: 'image/jpeg', maxEdge: 1024 })
+    const meta = await sharp(result.bytes).metadata()
+    expect(meta.width).toBe(1024)
+    expect(meta.height).toBe(1024)
+  })
+
+  it('passes through when source ≤ override maxEdge', async () => {
+    const bytes = await makeJpeg(900, 900)
+    const result = await prepareForVision({ bytes, mime: 'image/jpeg', maxEdge: 1024 })
+    expect(result.bytes).toBe(bytes)
+  })
+
+  it('honors small maxEdge for cost-extreme cases', async () => {
+    const bytes = await makeJpeg(2000, 2000)
+    const result = await prepareForVision({ bytes, mime: 'image/jpeg', maxEdge: 256 })
+    const meta = await sharp(result.bytes).metadata()
+    expect(meta.width).toBe(256)
+  })
+})

--- a/packages/gazetta/tests/alt-anthropic.test.ts
+++ b/packages/gazetta/tests/alt-anthropic.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Unit tests for `alt/anthropic.ts` — first real provider adapter.
+ *
+ * Uses `msw` (Mock Service Worker) to intercept the Anthropic API at
+ * the network layer. Adapter sends a real request via the SDK; msw
+ * returns canned responses. No real API calls; deterministic;
+ * no API key required.
+ *
+ * Per the test infrastructure plan:
+ *   - Happy path: request shape correctness, response parsing
+ *   - Refusal: structured signal flows through the adapter
+ *   - Errors: typed AI errors with the right cause
+ *   - Abort: AbortSignal forwarded; aborts surface correctly
+ *   - max_tokens: derived from request.maxChars
+ *   - System prompt: composed prompt routes to the system parameter
+ *   - Image content: base64-encoded, correct media_type
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { AIAdapterFailedError, AIInvalidResponseError } from '../src/ai/errors.js'
+import { type AltGenerateInput, DEFAULT_ALT_REQUEST } from '../src/alt/adapter.js'
+import { createAnthropicAltAdapter } from '../src/alt/anthropic.js'
+
+const API_URL = 'https://api.anthropic.com/v1/messages'
+
+interface CapturedRequest {
+  body: {
+    model: string
+    max_tokens: number
+    system?: string
+    messages: Array<{
+      role: string
+      content: Array<
+        | { type: 'text'; text: string }
+        | {
+            type: 'image'
+            source: { type: string; media_type: string; data: string }
+          }
+      >
+    }>
+  }
+  headers: Headers
+}
+
+let captured: CapturedRequest[] = []
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  server.resetHandlers()
+  captured = []
+})
+afterAll(() => server.close())
+
+function mockResponse(text: string, status = 200): void {
+  server.use(
+    http.post(API_URL, async ({ request }) => {
+      captured.push({
+        body: (await request.json()) as CapturedRequest['body'],
+        headers: request.headers,
+      })
+      if (status !== 200) {
+        return HttpResponse.json({ error: { type: 'api_error', message: text } }, { status })
+      }
+      return HttpResponse.json({
+        id: 'msg_test',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text }],
+        model: 'claude-haiku-4-5',
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 100, output_tokens: 20 },
+      })
+    }),
+  )
+}
+
+function mockNetworkError(): void {
+  server.use(
+    http.post(API_URL, () => {
+      return HttpResponse.error()
+    }),
+  )
+}
+
+function makeInput(overrides: Partial<AltGenerateInput> = {}): AltGenerateInput {
+  return {
+    bytes: new Uint8Array([0xff, 0xd8, 0xff]), // arbitrary
+    mime: 'image/jpeg',
+    request: { ...DEFAULT_ALT_REQUEST },
+    prompt: 'You are writing alt text.',
+    ...overrides,
+  }
+}
+
+describe('createAnthropicAltAdapter — basic', () => {
+  it('exposes name "anthropic"', () => {
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    expect(adapter.name).toBe('anthropic')
+  })
+
+  it('supports image MIMEs Anthropic accepts', () => {
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    expect(adapter.supports('image/jpeg')).toBe(true)
+    expect(adapter.supports('image/png')).toBe(true)
+    expect(adapter.supports('image/gif')).toBe(true)
+    expect(adapter.supports('image/webp')).toBe(true)
+  })
+
+  it('rejects unsupported MIMEs', () => {
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    expect(adapter.supports('image/svg+xml')).toBe(false)
+    expect(adapter.supports('audio/mpeg')).toBe(false)
+    expect(adapter.supports('application/pdf')).toBe(false)
+  })
+})
+
+describe('createAnthropicAltAdapter — happy path', () => {
+  it('returns the model output verbatim', async () => {
+    mockResponse('Mountain peak at sunset')
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const result = await adapter.generate(makeInput())
+    expect(result.text).toBe('Mountain peak at sunset')
+    expect(result.refused).toBe(false)
+    expect(result.refusalReason).toBeNull()
+  })
+
+  it('trims whitespace from the model output', async () => {
+    mockResponse('   Trees in autumn.\n  ')
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const result = await adapter.generate(makeInput())
+    expect(result.text).toBe('Trees in autumn.')
+  })
+
+  it('uses the configured model in the request', async () => {
+    mockResponse('ok')
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0, model: 'claude-sonnet-4-5' })
+    await adapter.generate(makeInput())
+    expect(captured[0].body.model).toBe('claude-sonnet-4-5')
+  })
+
+  it('defaults to claude-haiku-4-5 when no model is provided', async () => {
+    mockResponse('ok')
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await adapter.generate(makeInput())
+    expect(captured[0].body.model).toBe('claude-haiku-4-5')
+  })
+
+  it('routes the composed prompt to the system parameter', async () => {
+    mockResponse('ok')
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await adapter.generate(makeInput({ prompt: 'Custom system prompt here.' }))
+    expect(captured[0].body.system).toBe('Custom system prompt here.')
+  })
+
+  it('derives max_tokens from request.maxChars (≈4 chars/token)', async () => {
+    mockResponse('ok')
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await adapter.generate(
+      makeInput({
+        request: { ...DEFAULT_ALT_REQUEST, maxChars: 400 },
+      }),
+    )
+    // 400 chars / 4 = 100 tokens (above the 64 floor).
+    expect(captured[0].body.max_tokens).toBe(100)
+  })
+
+  it('floors max_tokens to give the model headroom for short maxChars', async () => {
+    mockResponse('ok')
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await adapter.generate(
+      makeInput({
+        request: { ...DEFAULT_ALT_REQUEST, maxChars: 50 },
+      }),
+    )
+    // 50 / 4 = 13, but the floor is 64.
+    expect(captured[0].body.max_tokens).toBe(64)
+  })
+
+  it('encodes image bytes as base64', async () => {
+    mockResponse('ok')
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const bytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0])
+    await adapter.generate(makeInput({ bytes }))
+    const block = captured[0].body.messages[0].content[0]
+    expect(block.type).toBe('image')
+    if (block.type === 'image') {
+      expect(block.source.type).toBe('base64')
+      expect(block.source.media_type).toBe('image/jpeg')
+      expect(block.source.data).toBe(Buffer.from(bytes).toString('base64'))
+    }
+  })
+
+  it('passes the asset MIME through as media_type', async () => {
+    mockResponse('ok')
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await adapter.generate(makeInput({ mime: 'image/png' }))
+    const block = captured[0].body.messages[0].content[0]
+    if (block.type === 'image') {
+      expect(block.source.media_type).toBe('image/png')
+    }
+  })
+})
+
+describe('createAnthropicAltAdapter — refusal', () => {
+  it('detects shared refusal markers via detectRefusal', async () => {
+    mockResponse("I can't describe this image.")
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const result = await adapter.generate(makeInput())
+    expect(result.refused).toBe(true)
+    expect(result.refusalReason).not.toBeNull()
+  })
+
+  it('detects Anthropic-specific refusal markers', async () => {
+    mockResponse('I cannot create captions for this image because of content concerns.')
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const result = await adapter.generate(makeInput())
+    expect(result.refused).toBe(true)
+  })
+
+  it('passes through normal descriptions as not-refused', async () => {
+    mockResponse('A cat sitting on a windowsill in the morning sun.')
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const result = await adapter.generate(makeInput())
+    expect(result.refused).toBe(false)
+  })
+})
+
+describe('createAnthropicAltAdapter — errors', () => {
+  it('translates 401 auth errors to AIAdapterFailedError', async () => {
+    mockResponse('invalid api key', 401)
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-bad' })
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIAdapterFailedError)
+  })
+
+  it('translates 429 rate-limit errors to AIAdapterFailedError', async () => {
+    mockResponse('rate limited', 429)
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIAdapterFailedError)
+  })
+
+  it('translates 500 errors to AIAdapterFailedError', async () => {
+    mockResponse('internal error', 500)
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIAdapterFailedError)
+  })
+
+  it('translates network errors to AIAdapterFailedError', async () => {
+    mockNetworkError()
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIAdapterFailedError)
+  })
+
+  it('preserves the underlying SDK error as cause', async () => {
+    mockResponse('rate limited', 429)
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    try {
+      await adapter.generate(makeInput())
+      throw new Error('expected to throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(AIAdapterFailedError)
+      if (err instanceof AIAdapterFailedError) {
+        expect(err.cause).toBeDefined()
+        expect((err.cause as Error).message.length).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('throws AIInvalidResponseError when response has no text block', async () => {
+    server.use(
+      http.post(API_URL, () => {
+        return HttpResponse.json({
+          id: 'msg_test',
+          type: 'message',
+          role: 'assistant',
+          content: [], // no blocks at all
+          model: 'claude-haiku-4-5',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 100, output_tokens: 0 },
+        })
+      }),
+    )
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIInvalidResponseError)
+  })
+})
+
+describe('createAnthropicAltAdapter — AbortSignal', () => {
+  it('aborts an in-flight request when the signal fires', async () => {
+    server.use(
+      http.post(API_URL, async () => {
+        // Hold the response long enough for abort to fire.
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        return HttpResponse.json({
+          id: 'msg_test',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'late response' }],
+          model: 'claude-haiku-4-5',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 100, output_tokens: 5 },
+        })
+      }),
+    )
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const controller = new AbortController()
+    const promise = adapter.generate(makeInput(), controller.signal)
+    // Abort after a tick to ensure the SDK has started the fetch.
+    setTimeout(() => controller.abort(), 10)
+    // Adapter throws on abort — the suggester layer translates this
+    // to null via its `signal.aborted` check.
+    await expect(promise).rejects.toThrow()
+  })
+
+  it('does not start a request when the signal is already aborted', async () => {
+    const requestSpy = vi.fn()
+    server.use(
+      http.post(API_URL, () => {
+        requestSpy()
+        return HttpResponse.json({
+          id: 'msg_test',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'should not see this' }],
+          model: 'claude-haiku-4-5',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 100, output_tokens: 5 },
+        })
+      }),
+    )
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const controller = new AbortController()
+    controller.abort()
+    await expect(adapter.generate(makeInput(), controller.signal)).rejects.toThrow()
+    expect(requestSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('createAnthropicAltAdapter — auth', () => {
+  it('sends the API key in the x-api-key header', async () => {
+    mockResponse('ok')
+    const adapter = createAnthropicAltAdapter({ apiKey: 'sk-mytestkey' })
+    await adapter.generate(makeInput())
+    expect(captured[0].headers.get('x-api-key')).toBe('sk-mytestkey')
+  })
+})

--- a/packages/gazetta/tests/alt-config-resolver.test.ts
+++ b/packages/gazetta/tests/alt-config-resolver.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Unit tests for `alt/config.ts` — resolves alt-text config from
+ * site `ai:` + site `altText:` + target `altText:` layers.
+ *
+ * Pure function tests. No env mocking, no SDK construction.
+ */
+import { describe, expect, it } from 'vitest'
+import { resolveAltConfig } from '../src/alt/config.js'
+import type { SiteManifest, TargetConfig } from '../src/types.js'
+
+describe('resolveAltConfig — null cases', () => {
+  it('returns null when nothing is configured', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {}
+    expect(resolveAltConfig(site, undefined)).toBeNull()
+  })
+
+  it('returns null when ai: is set but altText: is missing AND ai has no provider for tasks to inherit', () => {
+    // ai: must have provider; ai with provider but no altText block is
+    // legitimately unconfigured for the alt-text task — the operator
+    // didn't opt in to alt-text.
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+    }
+    // Without altText block, resolver still returns a result because
+    // the provider is set. But we expect provider inheritance to work
+    // even from an empty altText block. The "unconfigured" answer
+    // requires neither block present.
+    const result = resolveAltConfig(site, undefined)
+    // With ai but no altText, the implementation infers the task is
+    // configured via inheritance — provider comes from ai.
+    expect(result).not.toBeNull()
+    expect(result?.provider).toBe('anthropic')
+  })
+
+  it('returns null when altText is set but has no provider AND no ai block', () => {
+    // The block is present but no provider can be derived.
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      altText: { auto: true },
+    }
+    expect(resolveAltConfig(site, undefined)).toBeNull()
+  })
+})
+
+describe('resolveAltConfig — provider resolution', () => {
+  it('uses altText.provider when set', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      altText: { provider: 'anthropic' },
+    }
+    expect(resolveAltConfig(site, undefined)?.provider).toBe('anthropic')
+  })
+
+  it('inherits from ai.provider when altText.provider is unset', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'openai' },
+      altText: { auto: true },
+    }
+    expect(resolveAltConfig(site, undefined)?.provider).toBe('openai')
+  })
+
+  it('altText.provider wins over ai.provider', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { provider: 'openai' },
+    }
+    expect(resolveAltConfig(site, undefined)?.provider).toBe('openai')
+  })
+
+  it('target cannot override provider (provider is operationally global)', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+    }
+    // Target has no `provider` field on AltTextTargetConfig — TypeScript
+    // forbids it. We just verify provider resolves from site.
+    const target: Pick<TargetConfig, 'altText'> = { altText: { auto: false } }
+    expect(resolveAltConfig(site, target)?.provider).toBe('anthropic')
+  })
+})
+
+describe('resolveAltConfig — model resolution', () => {
+  it('uses provider default when no model is set anywhere', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+    }
+    expect(resolveAltConfig(site, undefined)?.model).toBe('claude-haiku-4-5')
+  })
+
+  it('uses provider default for openai when no model set', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'openai' },
+    }
+    expect(resolveAltConfig(site, undefined)?.model).toBe('gpt-4o-mini')
+  })
+
+  it('uses provider default for ollama when no model set', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'ollama' },
+    }
+    expect(resolveAltConfig(site, undefined)?.model).toBe('llama3.2-vision:11b')
+  })
+
+  it('uses ai.defaultModel when set (overrides provider default)', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic', defaultModel: 'claude-sonnet-4-5' },
+    }
+    expect(resolveAltConfig(site, undefined)?.model).toBe('claude-sonnet-4-5')
+  })
+
+  it('altText.model wins over ai.defaultModel', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic', defaultModel: 'claude-haiku-4-5' },
+      altText: { model: 'claude-sonnet-4-5' },
+    }
+    expect(resolveAltConfig(site, undefined)?.model).toBe('claude-sonnet-4-5')
+  })
+
+  it('target.altText.model wins over site.altText.model', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { model: 'claude-haiku-4-5' },
+    }
+    const target: Pick<TargetConfig, 'altText'> = {
+      altText: { model: 'claude-opus-4-7' },
+    }
+    expect(resolveAltConfig(site, target)?.model).toBe('claude-opus-4-7')
+  })
+})
+
+describe('resolveAltConfig — auto resolution', () => {
+  it('defaults to true when nothing is set', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+    }
+    expect(resolveAltConfig(site, undefined)?.auto).toBe(true)
+  })
+
+  it('uses site.altText.auto when set', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { auto: false },
+    }
+    expect(resolveAltConfig(site, undefined)?.auto).toBe(false)
+  })
+
+  it('target.altText.auto wins over site.altText.auto', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { auto: true },
+    }
+    const target: Pick<TargetConfig, 'altText'> = { altText: { auto: false } }
+    expect(resolveAltConfig(site, target)?.auto).toBe(false)
+  })
+
+  it('common pattern: prod target overrides default auto:true to false', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      // site default: auto: true (review-friendly for staging/local)
+    }
+    const prodTarget: Pick<TargetConfig, 'altText'> = {
+      altText: { auto: false }, // review-first on prod
+    }
+    expect(resolveAltConfig(site, prodTarget)?.auto).toBe(false)
+    // And local target inherits site default.
+    expect(resolveAltConfig(site, undefined)?.auto).toBe(true)
+  })
+})
+
+describe('resolveAltConfig — maxImageEdge resolution', () => {
+  it('defaults to 768 when nothing is set', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+    }
+    expect(resolveAltConfig(site, undefined)?.maxImageEdge).toBe(768)
+  })
+
+  it('uses site.altText.maxImageEdge when set', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { maxImageEdge: 1024 },
+    }
+    expect(resolveAltConfig(site, undefined)?.maxImageEdge).toBe(1024)
+  })
+
+  it('target.altText.maxImageEdge wins over site.altText.maxImageEdge', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { maxImageEdge: 768 },
+    }
+    const target: Pick<TargetConfig, 'altText'> = {
+      altText: { maxImageEdge: 1568 },
+    }
+    expect(resolveAltConfig(site, target)?.maxImageEdge).toBe(1568)
+  })
+})
+
+describe('resolveAltConfig — full integration cases', () => {
+  it('typical site config: ai with anthropic, altText opted in with defaults', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic', defaultModel: 'claude-haiku-4-5' },
+      altText: { auto: true },
+    }
+    expect(resolveAltConfig(site, undefined)).toEqual({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5',
+      auto: true,
+      maxImageEdge: 768,
+    })
+  })
+
+  it('site with self-hosted ollama, prod target opts out of auto', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'ollama' },
+      altText: { auto: true },
+    }
+    const prodTarget: Pick<TargetConfig, 'altText'> = {
+      altText: { auto: false },
+    }
+    expect(resolveAltConfig(site, prodTarget)).toEqual({
+      provider: 'ollama',
+      model: 'llama3.2-vision:11b',
+      auto: false,
+      maxImageEdge: 768,
+    })
+  })
+
+  it('site with text-heavy assets bumps maxImageEdge globally', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'openai' },
+      altText: { maxImageEdge: 1024 },
+    }
+    expect(resolveAltConfig(site, undefined)?.maxImageEdge).toBe(1024)
+  })
+
+  it('multi-target site: each target inherits unless overriding', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { auto: true, maxImageEdge: 768 },
+    }
+    const localTarget: Pick<TargetConfig, 'altText'> | undefined = undefined
+    const prodTarget: Pick<TargetConfig, 'altText'> = { altText: { auto: false } }
+
+    const local = resolveAltConfig(site, localTarget)
+    const prod = resolveAltConfig(site, prodTarget)
+
+    expect(local?.auto).toBe(true)
+    expect(prod?.auto).toBe(false)
+    expect(local?.provider).toBe(prod?.provider)
+    expect(local?.model).toBe(prod?.model)
+    expect(local?.maxImageEdge).toBe(prod?.maxImageEdge)
+  })
+})
+
+describe('resolveAltConfig — pure function properties', () => {
+  it('returns a fresh object each call (no mutation hazards)', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+    }
+    const a = resolveAltConfig(site, undefined)
+    const b = resolveAltConfig(site, undefined)
+    expect(a).not.toBe(b)
+    expect(a).toEqual(b)
+  })
+
+  it('does not mutate input', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { auto: true },
+    }
+    const before = JSON.stringify(site)
+    resolveAltConfig(site, undefined)
+    expect(JSON.stringify(site)).toBe(before)
+  })
+})

--- a/packages/gazetta/tests/alt-factory.test.ts
+++ b/packages/gazetta/tests/alt-factory.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for `alt/factory.ts` — the seam between configuration and
+ * adapter construction.
+ *
+ * Manipulates `process.env` (saved/restored per test) to validate
+ * credential resolution. Adapter construction is observable via the
+ * `name` field — anthropic/openai/ollama/null indicate which path was
+ * taken.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { buildAltAdapter, isAltAdapterConfigured } from '../src/alt/factory.js'
+import type { SiteManifest, TargetConfig } from '../src/types.js'
+
+const ENV_KEYS = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'OLLAMA_BASE_URL'] as const
+const savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {}
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+})
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = savedEnv[key]
+    }
+  }
+})
+
+describe('isAltAdapterConfigured', () => {
+  it('returns false when no AI config exists', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {}
+    expect(isAltAdapterConfigured(site, undefined)).toBe(false)
+  })
+
+  it('returns false for anthropic when API key missing', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { auto: true },
+    }
+    expect(isAltAdapterConfigured(site, undefined)).toBe(false)
+  })
+
+  it('returns true for anthropic when API key present', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test'
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { auto: true },
+    }
+    expect(isAltAdapterConfigured(site, undefined)).toBe(true)
+  })
+
+  it('returns false for openai when API key missing', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'openai' },
+      altText: { auto: true },
+    }
+    expect(isAltAdapterConfigured(site, undefined)).toBe(false)
+  })
+
+  it('returns true for openai when API key present', () => {
+    process.env.OPENAI_API_KEY = 'sk-test'
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'openai' },
+      altText: { auto: true },
+    }
+    expect(isAltAdapterConfigured(site, undefined)).toBe(true)
+  })
+
+  it('returns true for ollama without any env (no key required)', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'ollama' },
+      altText: { auto: true },
+    }
+    expect(isAltAdapterConfigured(site, undefined)).toBe(true)
+  })
+
+  it('does not construct an SDK client (cheap to call repeatedly)', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test'
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { auto: true },
+    }
+    // 1000 calls are cheap because no SDK construction happens.
+    for (let i = 0; i < 1000; i++) {
+      isAltAdapterConfigured(site, undefined)
+    }
+    // No assertion needed — just verifies the call is fast (test
+    // would time out if SDK was constructed each call).
+    expect(true).toBe(true)
+  })
+})
+
+describe('buildAltAdapter — null adapter cases', () => {
+  it('returns nullAltAdapter when no AI config exists', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {}
+    const adapter = buildAltAdapter(site, undefined)
+    expect(adapter.name).toBe('null')
+  })
+
+  it('returns nullAltAdapter when anthropic configured but key missing', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { auto: true },
+    }
+    const adapter = buildAltAdapter(site, undefined)
+    expect(adapter.name).toBe('null')
+  })
+
+  it('returns nullAltAdapter when openai configured but key missing', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'openai' },
+      altText: { auto: true },
+    }
+    const adapter = buildAltAdapter(site, undefined)
+    expect(adapter.name).toBe('null')
+  })
+
+  it('always returns an AltTextAdapter (never null)', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {}
+    const adapter = buildAltAdapter(site, undefined)
+    // Type-system check: TS rejects null comparison if return type is
+    // AltTextAdapter (non-null). Runtime check: name is always defined.
+    expect(typeof adapter.name).toBe('string')
+    expect(typeof adapter.supports).toBe('function')
+    expect(typeof adapter.generate).toBe('function')
+  })
+})
+
+describe('buildAltAdapter — anthropic', () => {
+  it('builds anthropic adapter when configured + key present', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test'
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { auto: true },
+    }
+    const adapter = buildAltAdapter(site, undefined)
+    expect(adapter.name).toBe('anthropic')
+  })
+
+  it('respects model override from site.altText.model', () => {
+    // We can't easily peek at the constructed SDK's internal model
+    // without making a network call. The model resolution is tested
+    // in alt-config-resolver.test.ts; here we just verify the adapter
+    // is constructed without throwing.
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test'
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { model: 'claude-sonnet-4-5' },
+    }
+    expect(() => buildAltAdapter(site, undefined)).not.toThrow()
+  })
+})
+
+describe('buildAltAdapter — openai', () => {
+  it('builds openai adapter when configured + key present', () => {
+    process.env.OPENAI_API_KEY = 'sk-test'
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'openai' },
+      altText: { auto: true },
+    }
+    const adapter = buildAltAdapter(site, undefined)
+    expect(adapter.name).toBe('openai')
+  })
+})
+
+describe('buildAltAdapter — ollama', () => {
+  it('builds ollama adapter without any env vars', () => {
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'ollama' },
+      altText: { auto: true },
+    }
+    const adapter = buildAltAdapter(site, undefined)
+    expect(adapter.name).toBe('ollama')
+  })
+
+  it('uses OLLAMA_BASE_URL when set', () => {
+    // Same as model — internal config not directly inspectable.
+    // We verify construction doesn't throw with a custom base URL.
+    process.env.OLLAMA_BASE_URL = 'http://ollama-server.internal:11434'
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'ollama' },
+      altText: { auto: true },
+    }
+    expect(() => buildAltAdapter(site, undefined)).not.toThrow()
+  })
+})
+
+describe('buildAltAdapter — target overrides', () => {
+  it('target altText override does not change adapter type (provider stays site-level)', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test'
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { auto: true },
+    }
+    const target: Pick<TargetConfig, 'altText'> = {
+      altText: { auto: false },
+    }
+    expect(buildAltAdapter(site, target).name).toBe('anthropic')
+  })
+})
+
+describe('buildAltAdapter — provider switching at runtime', () => {
+  it('switching provider in config changes adapter on next call', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test'
+    process.env.OPENAI_API_KEY = 'sk-test'
+
+    const siteA: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { auto: true },
+    }
+    const siteB: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'openai' },
+      altText: { auto: true },
+    }
+    expect(buildAltAdapter(siteA, undefined).name).toBe('anthropic')
+    expect(buildAltAdapter(siteB, undefined).name).toBe('openai')
+  })
+})

--- a/packages/gazetta/tests/alt-null-adapter.test.ts
+++ b/packages/gazetta/tests/alt-null-adapter.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for `alt/null-adapter.ts` — verifies LSP: the null adapter
+ * honors the `AltTextAdapter` contract (full surface, not stubs that
+ * throw `not implemented`).
+ *
+ * The null adapter is the safe default returned by the factory when
+ * no adapter is configured. `supports()` always returns false; the
+ * suggester checks `supports` first, so `generate` is never reached
+ * in practice — but it's defined and throws a typed error if it IS
+ * reached, as a defense-in-depth signal that something has gone wrong.
+ */
+import { describe, expect, it } from 'vitest'
+import { AIAdapterUnavailableError } from '../src/ai/errors.js'
+import { type AltGenerateInput, DEFAULT_ALT_REQUEST } from '../src/alt/adapter.js'
+import { nullAltAdapter } from '../src/alt/null-adapter.js'
+
+describe('nullAltAdapter', () => {
+  it('has a stable name for diagnostics', () => {
+    expect(nullAltAdapter.name).toBe('null')
+  })
+
+  describe('supports', () => {
+    it('returns false for image MIMEs', () => {
+      expect(nullAltAdapter.supports('image/jpeg')).toBe(false)
+      expect(nullAltAdapter.supports('image/png')).toBe(false)
+      expect(nullAltAdapter.supports('image/svg+xml')).toBe(false)
+      expect(nullAltAdapter.supports('image/gif')).toBe(false)
+    })
+
+    it('returns false for non-image MIMEs', () => {
+      expect(nullAltAdapter.supports('audio/mpeg')).toBe(false)
+      expect(nullAltAdapter.supports('application/pdf')).toBe(false)
+    })
+
+    it('returns false for malformed input', () => {
+      expect(nullAltAdapter.supports('')).toBe(false)
+    })
+  })
+
+  describe('generate', () => {
+    const input: AltGenerateInput = {
+      bytes: new Uint8Array([0]),
+      mime: 'image/jpeg',
+      request: { ...DEFAULT_ALT_REQUEST },
+      prompt: 'test',
+    }
+
+    it('throws AIAdapterUnavailableError when called', async () => {
+      await expect(nullAltAdapter.generate(input)).rejects.toBeInstanceOf(AIAdapterUnavailableError)
+    })
+
+    it('error message guides the operator to the configuration', async () => {
+      try {
+        await nullAltAdapter.generate(input)
+      } catch (err) {
+        if (err instanceof AIAdapterUnavailableError) {
+          expect(err.message.toLowerCase()).toContain('altText'.toLowerCase())
+          expect(err.message.toLowerCase()).toContain('site.yaml'.toLowerCase())
+        } else {
+          throw new Error('expected AIAdapterUnavailableError')
+        }
+      }
+    })
+
+    it('error has 503 httpStatus', async () => {
+      try {
+        await nullAltAdapter.generate(input)
+      } catch (err) {
+        if (err instanceof AIAdapterUnavailableError) {
+          expect(err.httpStatus).toBe(503)
+        } else {
+          throw err
+        }
+      }
+    })
+  })
+})

--- a/packages/gazetta/tests/alt-ollama.test.ts
+++ b/packages/gazetta/tests/alt-ollama.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Unit tests for `alt/ollama.ts` — third provider adapter; the
+ * self-hosted path. No SDK; raw fetch against a local-by-default URL.
+ *
+ * Same test shape as Anthropic and OpenAI adapters. msw intercepts
+ * `http://localhost:11434/api/chat`. No real Ollama instance needed.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { AIAdapterFailedError, AIInvalidResponseError } from '../src/ai/errors.js'
+import { type AltGenerateInput, DEFAULT_ALT_REQUEST } from '../src/alt/adapter.js'
+import { OLLAMA_DEFAULT_BASE_URL, OLLAMA_DEFAULT_MODEL, createOllamaAltAdapter } from '../src/alt/ollama.js'
+
+const API_URL = `${OLLAMA_DEFAULT_BASE_URL}/api/chat`
+
+interface CapturedRequest {
+  body: {
+    model: string
+    stream: boolean
+    messages: Array<{
+      role: string
+      content: string
+      images?: string[]
+    }>
+  }
+}
+
+let captured: CapturedRequest[] = []
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  server.resetHandlers()
+  captured = []
+})
+afterAll(() => server.close())
+
+function mockResponse(text: string, status = 200): void {
+  server.use(
+    http.post(API_URL, async ({ request }) => {
+      captured.push({ body: (await request.json()) as CapturedRequest['body'] })
+      if (status !== 200) {
+        return HttpResponse.text(text, { status })
+      }
+      return HttpResponse.json({
+        model: 'llama3.2-vision:11b',
+        message: { role: 'assistant', content: text },
+        done: true,
+        total_duration: 1_000_000,
+      })
+    }),
+  )
+}
+
+function mockNetworkError(): void {
+  server.use(http.post(API_URL, () => HttpResponse.error()))
+}
+
+function makeInput(overrides: Partial<AltGenerateInput> = {}): AltGenerateInput {
+  return {
+    bytes: new Uint8Array([0xff, 0xd8, 0xff]),
+    mime: 'image/jpeg',
+    request: { ...DEFAULT_ALT_REQUEST },
+    prompt: 'You are writing alt text.',
+    ...overrides,
+  }
+}
+
+describe('createOllamaAltAdapter — basic', () => {
+  it('exposes name "ollama"', () => {
+    const adapter = createOllamaAltAdapter()
+    expect(adapter.name).toBe('ollama')
+  })
+
+  it('supports JPEG and PNG only (post-prep MIMEs)', () => {
+    const adapter = createOllamaAltAdapter()
+    expect(adapter.supports('image/jpeg')).toBe(true)
+    expect(adapter.supports('image/png')).toBe(true)
+  })
+
+  it('rejects non-prepped image formats', () => {
+    const adapter = createOllamaAltAdapter()
+    // After prepareForVision, GIF/WebP are converted to JPEG/PNG.
+    // Adapter only accepts the post-prep MIMEs; defending the suggester contract.
+    expect(adapter.supports('image/gif')).toBe(false)
+    expect(adapter.supports('image/webp')).toBe(false)
+    expect(adapter.supports('image/svg+xml')).toBe(false)
+    expect(adapter.supports('audio/mpeg')).toBe(false)
+  })
+})
+
+describe('createOllamaAltAdapter — happy path', () => {
+  it('returns the model output verbatim', async () => {
+    mockResponse('Mountain at sunset')
+    const adapter = createOllamaAltAdapter()
+    const result = await adapter.generate(makeInput())
+    expect(result.text).toBe('Mountain at sunset')
+    expect(result.refused).toBe(false)
+    expect(result.refusalReason).toBeNull()
+  })
+
+  it('trims whitespace from output', async () => {
+    mockResponse('  Trees in autumn.\n  ')
+    const adapter = createOllamaAltAdapter()
+    const result = await adapter.generate(makeInput())
+    expect(result.text).toBe('Trees in autumn.')
+  })
+
+  it('uses configured model', async () => {
+    mockResponse('ok')
+    const adapter = createOllamaAltAdapter({ model: 'llama3.2-vision:90b' })
+    await adapter.generate(makeInput())
+    expect(captured[0].body.model).toBe('llama3.2-vision:90b')
+  })
+
+  it('defaults to llama3.2-vision:11b', async () => {
+    mockResponse('ok')
+    const adapter = createOllamaAltAdapter()
+    await adapter.generate(makeInput())
+    expect(captured[0].body.model).toBe(OLLAMA_DEFAULT_MODEL)
+  })
+
+  it('disables streaming for single-shot response', async () => {
+    mockResponse('ok')
+    const adapter = createOllamaAltAdapter()
+    await adapter.generate(makeInput())
+    expect(captured[0].body.stream).toBe(false)
+  })
+
+  it('puts the composed prompt in a system message', async () => {
+    mockResponse('ok')
+    const adapter = createOllamaAltAdapter()
+    await adapter.generate(makeInput({ prompt: 'Custom system prompt.' }))
+    const sys = captured[0].body.messages.find(m => m.role === 'system')
+    expect(sys).toBeDefined()
+    expect(sys?.content).toBe('Custom system prompt.')
+  })
+
+  it('puts the image in the user message images[] array (base64)', async () => {
+    mockResponse('ok')
+    const adapter = createOllamaAltAdapter()
+    const bytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0])
+    await adapter.generate(makeInput({ bytes }))
+    const userMsg = captured[0].body.messages.find(m => m.role === 'user')
+    expect(userMsg).toBeDefined()
+    expect(userMsg?.images).toBeDefined()
+    expect(userMsg?.images?.[0]).toBe(Buffer.from(bytes).toString('base64'))
+  })
+
+  it('strips trailing slashes from baseUrl', async () => {
+    mockResponse('ok')
+    const adapter = createOllamaAltAdapter({ baseUrl: 'http://localhost:11434/' })
+    // Should still hit the same URL — no double slash.
+    await adapter.generate(makeInput())
+    expect(captured.length).toBe(1)
+  })
+})
+
+describe('createOllamaAltAdapter — refusal', () => {
+  it('detects shared refusal markers', async () => {
+    mockResponse("I can't describe this image.")
+    const adapter = createOllamaAltAdapter()
+    const result = await adapter.generate(makeInput())
+    expect(result.refused).toBe(true)
+  })
+
+  it('detects Ollama-specific refusal phrases', async () => {
+    mockResponse("I'm not able to process this image due to its content.")
+    const adapter = createOllamaAltAdapter()
+    const result = await adapter.generate(makeInput())
+    expect(result.refused).toBe(true)
+  })
+
+  it('passes through normal descriptions as not-refused', async () => {
+    mockResponse('A cat sitting on a windowsill in the morning sun.')
+    const adapter = createOllamaAltAdapter()
+    const result = await adapter.generate(makeInput())
+    expect(result.refused).toBe(false)
+  })
+})
+
+describe('createOllamaAltAdapter — errors', () => {
+  it('translates 404 (model not pulled) to AIAdapterFailedError', async () => {
+    mockResponse('model "llama3.2-vision:11b" not found, try `ollama pull`', 404)
+    const adapter = createOllamaAltAdapter()
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIAdapterFailedError)
+  })
+
+  it('includes the status code in the error message', async () => {
+    mockResponse('not found', 404)
+    const adapter = createOllamaAltAdapter()
+    try {
+      await adapter.generate(makeInput())
+      throw new Error('expected to throw')
+    } catch (err) {
+      if (err instanceof AIAdapterFailedError) {
+        expect(err.message).toContain('404')
+      }
+    }
+  })
+
+  it('translates 500 errors', async () => {
+    mockResponse('internal error', 500)
+    const adapter = createOllamaAltAdapter()
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIAdapterFailedError)
+  })
+
+  it('translates network errors (Ollama not running)', async () => {
+    mockNetworkError()
+    const adapter = createOllamaAltAdapter()
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIAdapterFailedError)
+  })
+
+  it('error message hints at running Ollama on connection failure', async () => {
+    mockNetworkError()
+    const adapter = createOllamaAltAdapter()
+    try {
+      await adapter.generate(makeInput())
+      throw new Error('expected to throw')
+    } catch (err) {
+      if (err instanceof AIAdapterFailedError) {
+        expect(err.message.toLowerCase()).toContain('ollama')
+      }
+    }
+  })
+
+  it('throws AIAdapterFailedError when JSON has top-level error field', async () => {
+    server.use(http.post(API_URL, () => HttpResponse.json({ error: 'context too long' })))
+    const adapter = createOllamaAltAdapter()
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIAdapterFailedError)
+  })
+
+  it('throws AIInvalidResponseError when message.content is missing', async () => {
+    server.use(
+      http.post(API_URL, () =>
+        HttpResponse.json({
+          model: 'llama3.2-vision:11b',
+          message: { role: 'assistant' }, // no content
+          done: true,
+        }),
+      ),
+    )
+    const adapter = createOllamaAltAdapter()
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIInvalidResponseError)
+  })
+
+  it('throws AIInvalidResponseError when response is not JSON', async () => {
+    server.use(http.post(API_URL, () => new HttpResponse('plain text not json', { status: 200 })))
+    const adapter = createOllamaAltAdapter()
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIInvalidResponseError)
+  })
+})
+
+describe('createOllamaAltAdapter — AbortSignal', () => {
+  it('aborts an in-flight request when the signal fires', async () => {
+    server.use(
+      http.post(API_URL, async () => {
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        return HttpResponse.json({
+          model: 'llama3.2-vision:11b',
+          message: { role: 'assistant', content: 'late' },
+          done: true,
+        })
+      }),
+    )
+    const adapter = createOllamaAltAdapter()
+    const controller = new AbortController()
+    const promise = adapter.generate(makeInput(), controller.signal)
+    setTimeout(() => controller.abort(), 10)
+    await expect(promise).rejects.toThrow()
+  })
+
+  it('does not start a request when signal already aborted', async () => {
+    const requestSpy = vi.fn()
+    server.use(
+      http.post(API_URL, () => {
+        requestSpy()
+        return HttpResponse.json({
+          model: 'llama3.2-vision:11b',
+          message: { role: 'assistant', content: 'should not see' },
+          done: true,
+        })
+      }),
+    )
+    const adapter = createOllamaAltAdapter()
+    const controller = new AbortController()
+    controller.abort()
+    await expect(adapter.generate(makeInput(), controller.signal)).rejects.toThrow()
+    expect(requestSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('createOllamaAltAdapter — custom baseUrl', () => {
+  it('respects custom baseUrl for non-default Ollama installs', async () => {
+    const customUrl = 'http://ollama-server.internal:11434'
+    server.use(
+      http.post(`${customUrl}/api/chat`, async ({ request }) => {
+        captured.push({ body: (await request.json()) as CapturedRequest['body'] })
+        return HttpResponse.json({
+          model: 'llama3.2-vision:11b',
+          message: { role: 'assistant', content: 'remote ok' },
+          done: true,
+        })
+      }),
+    )
+    const adapter = createOllamaAltAdapter({ baseUrl: customUrl })
+    const result = await adapter.generate(makeInput())
+    expect(result.text).toBe('remote ok')
+  })
+})

--- a/packages/gazetta/tests/alt-openai.test.ts
+++ b/packages/gazetta/tests/alt-openai.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Unit tests for `alt/openai.ts` — second provider adapter.
+ *
+ * Same test shape as Anthropic adapter (commit 3), validating that
+ * the abstraction holds across providers. Uses `msw` to intercept
+ * OpenAI API at the network layer; no real API calls.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { AIAdapterFailedError, AIInvalidResponseError } from '../src/ai/errors.js'
+import { type AltGenerateInput, DEFAULT_ALT_REQUEST } from '../src/alt/adapter.js'
+import { createOpenAIAltAdapter } from '../src/alt/openai.js'
+
+const API_URL = 'https://api.openai.com/v1/chat/completions'
+
+interface CapturedRequest {
+  body: {
+    model: string
+    max_tokens?: number
+    messages: Array<{
+      role: string
+      content: string | Array<{ type: 'text'; text: string } | { type: 'image_url'; image_url: { url: string } }>
+    }>
+  }
+  headers: Headers
+}
+
+let captured: CapturedRequest[] = []
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  server.resetHandlers()
+  captured = []
+})
+afterAll(() => server.close())
+
+function mockResponse(text: string, status = 200): void {
+  server.use(
+    http.post(API_URL, async ({ request }) => {
+      captured.push({
+        body: (await request.json()) as CapturedRequest['body'],
+        headers: request.headers,
+      })
+      if (status !== 200) {
+        return HttpResponse.json({ error: { message: text, type: 'api_error' } }, { status })
+      }
+      return HttpResponse.json({
+        id: 'chatcmpl-test',
+        object: 'chat.completion',
+        created: 0,
+        model: 'gpt-4o-mini',
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: text },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 100, completion_tokens: 20, total_tokens: 120 },
+      })
+    }),
+  )
+}
+
+function mockNetworkError(): void {
+  server.use(http.post(API_URL, () => HttpResponse.error()))
+}
+
+function makeInput(overrides: Partial<AltGenerateInput> = {}): AltGenerateInput {
+  return {
+    bytes: new Uint8Array([0xff, 0xd8, 0xff]),
+    mime: 'image/jpeg',
+    request: { ...DEFAULT_ALT_REQUEST },
+    prompt: 'You are writing alt text.',
+    ...overrides,
+  }
+}
+
+describe('createOpenAIAltAdapter — basic', () => {
+  it('exposes name "openai"', () => {
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    expect(adapter.name).toBe('openai')
+  })
+
+  it('supports OpenAI-accepted image MIMEs', () => {
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    expect(adapter.supports('image/jpeg')).toBe(true)
+    expect(adapter.supports('image/png')).toBe(true)
+    expect(adapter.supports('image/gif')).toBe(true)
+    expect(adapter.supports('image/webp')).toBe(true)
+  })
+
+  it('rejects unsupported MIMEs', () => {
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    expect(adapter.supports('image/svg+xml')).toBe(false)
+    expect(adapter.supports('audio/mpeg')).toBe(false)
+  })
+})
+
+describe('createOpenAIAltAdapter — happy path', () => {
+  it('returns the model output verbatim', async () => {
+    mockResponse('Mountain at sunset')
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const result = await adapter.generate(makeInput())
+    expect(result.text).toBe('Mountain at sunset')
+    expect(result.refused).toBe(false)
+    expect(result.refusalReason).toBeNull()
+  })
+
+  it('trims whitespace from output', async () => {
+    mockResponse('  Trees in autumn.\n  ')
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const result = await adapter.generate(makeInput())
+    expect(result.text).toBe('Trees in autumn.')
+  })
+
+  it('uses configured model', async () => {
+    mockResponse('ok')
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0, model: 'gpt-4o' })
+    await adapter.generate(makeInput())
+    expect(captured[0].body.model).toBe('gpt-4o')
+  })
+
+  it('defaults to gpt-4o-mini', async () => {
+    mockResponse('ok')
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await adapter.generate(makeInput())
+    expect(captured[0].body.model).toBe('gpt-4o-mini')
+  })
+
+  it('routes the composed prompt as a system message', async () => {
+    mockResponse('ok')
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await adapter.generate(makeInput({ prompt: 'Custom system prompt.' }))
+    const sys = captured[0].body.messages.find(m => m.role === 'system')
+    expect(sys).toBeDefined()
+    expect(sys?.content).toBe('Custom system prompt.')
+  })
+
+  it('derives max_tokens from request.maxChars (≈4 chars/token)', async () => {
+    mockResponse('ok')
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await adapter.generate(
+      makeInput({
+        request: { ...DEFAULT_ALT_REQUEST, maxChars: 400 },
+      }),
+    )
+    expect(captured[0].body.max_tokens).toBe(100)
+  })
+
+  it('floors max_tokens at 64 for short maxChars', async () => {
+    mockResponse('ok')
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await adapter.generate(
+      makeInput({
+        request: { ...DEFAULT_ALT_REQUEST, maxChars: 50 },
+      }),
+    )
+    expect(captured[0].body.max_tokens).toBe(64)
+  })
+
+  it('encodes image bytes as a base64 data URL', async () => {
+    mockResponse('ok')
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const bytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0])
+    await adapter.generate(makeInput({ bytes }))
+    const userMsg = captured[0].body.messages.find(m => m.role === 'user')
+    expect(userMsg).toBeDefined()
+    expect(Array.isArray(userMsg?.content)).toBe(true)
+    if (Array.isArray(userMsg?.content)) {
+      const block = userMsg.content[0]
+      expect(block.type).toBe('image_url')
+      if (block.type === 'image_url') {
+        const expectedB64 = Buffer.from(bytes).toString('base64')
+        expect(block.image_url.url).toBe(`data:image/jpeg;base64,${expectedB64}`)
+      }
+    }
+  })
+
+  it('passes the asset MIME through in the data URL', async () => {
+    mockResponse('ok')
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await adapter.generate(makeInput({ mime: 'image/png' }))
+    const userMsg = captured[0].body.messages.find(m => m.role === 'user')
+    if (Array.isArray(userMsg?.content)) {
+      const block = userMsg.content[0]
+      if (block.type === 'image_url') {
+        expect(block.image_url.url.startsWith('data:image/png;base64,')).toBe(true)
+      }
+    }
+  })
+})
+
+describe('createOpenAIAltAdapter — refusal', () => {
+  it('detects shared refusal markers', async () => {
+    mockResponse("I can't describe this image.")
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const result = await adapter.generate(makeInput())
+    expect(result.refused).toBe(true)
+  })
+
+  it('detects OpenAI-specific "I\'m sorry, I can\'t assist"', async () => {
+    mockResponse("I'm sorry, I can't assist with this request.")
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const result = await adapter.generate(makeInput())
+    expect(result.refused).toBe(true)
+  })
+
+  it('passes through normal descriptions as not-refused', async () => {
+    mockResponse('A cat sitting on a windowsill in the morning sun.')
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const result = await adapter.generate(makeInput())
+    expect(result.refused).toBe(false)
+  })
+})
+
+describe('createOpenAIAltAdapter — errors', () => {
+  it('translates 401 auth errors to AIAdapterFailedError', async () => {
+    mockResponse('invalid api key', 401)
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-bad', maxRetries: 0 })
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIAdapterFailedError)
+  })
+
+  it('translates 429 rate-limit errors', async () => {
+    mockResponse('rate limited', 429)
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIAdapterFailedError)
+  })
+
+  it('translates 500 errors', async () => {
+    mockResponse('internal error', 500)
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIAdapterFailedError)
+  })
+
+  it('translates network errors', async () => {
+    mockNetworkError()
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIAdapterFailedError)
+  })
+
+  it('preserves the underlying SDK error as cause', async () => {
+    mockResponse('rate limited', 429)
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    try {
+      await adapter.generate(makeInput())
+      throw new Error('expected to throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(AIAdapterFailedError)
+      if (err instanceof AIAdapterFailedError) {
+        expect(err.cause).toBeDefined()
+      }
+    }
+  })
+
+  it('throws AIInvalidResponseError when message has no text content', async () => {
+    server.use(
+      http.post(API_URL, () =>
+        HttpResponse.json({
+          id: 'chatcmpl-test',
+          object: 'chat.completion',
+          created: 0,
+          model: 'gpt-4o-mini',
+          choices: [
+            {
+              index: 0,
+              // null content — happens when the model returns tool calls.
+              message: { role: 'assistant', content: null },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 100, completion_tokens: 0, total_tokens: 100 },
+        }),
+      ),
+    )
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    await expect(adapter.generate(makeInput())).rejects.toBeInstanceOf(AIInvalidResponseError)
+  })
+})
+
+describe('createOpenAIAltAdapter — AbortSignal', () => {
+  it('aborts an in-flight request when the signal fires', async () => {
+    server.use(
+      http.post(API_URL, async () => {
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        return HttpResponse.json({
+          id: 'chatcmpl-test',
+          object: 'chat.completion',
+          created: 0,
+          model: 'gpt-4o-mini',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'late' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 100, completion_tokens: 5, total_tokens: 105 },
+        })
+      }),
+    )
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const controller = new AbortController()
+    const promise = adapter.generate(makeInput(), controller.signal)
+    setTimeout(() => controller.abort(), 10)
+    await expect(promise).rejects.toThrow()
+  })
+
+  it('does not start a request when signal already aborted', async () => {
+    const requestSpy = vi.fn()
+    server.use(
+      http.post(API_URL, () => {
+        requestSpy()
+        return HttpResponse.json({
+          id: 'chatcmpl-test',
+          object: 'chat.completion',
+          created: 0,
+          model: 'gpt-4o-mini',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'should not see' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 100, completion_tokens: 5, total_tokens: 105 },
+        })
+      }),
+    )
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-test', maxRetries: 0 })
+    const controller = new AbortController()
+    controller.abort()
+    await expect(adapter.generate(makeInput(), controller.signal)).rejects.toThrow()
+    expect(requestSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('createOpenAIAltAdapter — auth', () => {
+  it('sends the API key in the Authorization header as Bearer', async () => {
+    mockResponse('ok')
+    const adapter = createOpenAIAltAdapter({ apiKey: 'sk-mytestkey', maxRetries: 0 })
+    await adapter.generate(makeInput())
+    expect(captured[0].headers.get('authorization')).toBe('Bearer sk-mytestkey')
+  })
+})

--- a/packages/gazetta/tests/alt-prompt-policies.test.ts
+++ b/packages/gazetta/tests/alt-prompt-policies.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for `alt/prompt-policies.ts` — five alt-text-specific
+ * policies + the default policy set + composition behavior with the
+ * generic `composePrompt`.
+ */
+import { describe, expect, it } from 'vitest'
+import { composePrompt } from '../src/ai/compose-prompt.js'
+import { DEFAULT_ALT_REQUEST, type AltRequest } from '../src/alt/adapter.js'
+import {
+  DEFAULT_ALT_PROMPT_POLICIES,
+  lengthPolicy,
+  localePolicy,
+  outputDisciplinePolicy,
+  styleGuidancePolicy,
+  taskFramingPolicy,
+} from '../src/alt/prompt-policies.js'
+
+const REQ_DEFAULT: AltRequest = { ...DEFAULT_ALT_REQUEST }
+const REQ_FRENCH: AltRequest = { ...DEFAULT_ALT_REQUEST, locale: 'fr' }
+const REQ_LONG: AltRequest = { ...DEFAULT_ALT_REQUEST, maxChars: 500 }
+
+describe('taskFramingPolicy', () => {
+  it('mentions WCAG and alt-text framing', () => {
+    const result = taskFramingPolicy(REQ_DEFAULT)
+    expect(result).toContain('WCAG')
+    expect(result.toLowerCase()).toContain('alt text')
+  })
+
+  it('returns the same string regardless of request fields', () => {
+    expect(taskFramingPolicy(REQ_DEFAULT)).toBe(taskFramingPolicy(REQ_FRENCH))
+    expect(taskFramingPolicy(REQ_DEFAULT)).toBe(taskFramingPolicy(REQ_LONG))
+  })
+})
+
+describe('styleGuidancePolicy', () => {
+  it('produces descriptive guidance for style: descriptive', () => {
+    const result = styleGuidancePolicy(REQ_DEFAULT)
+    expect(result).toContain('Describe')
+    // Mentions the anti-pattern guidance.
+    expect(result.toLowerCase()).toContain('image of')
+    expect(result.toLowerCase()).toContain('picture of')
+  })
+})
+
+describe('lengthPolicy', () => {
+  it('embeds the maxChars value', () => {
+    expect(lengthPolicy(REQ_DEFAULT)).toContain('125')
+    expect(lengthPolicy(REQ_LONG)).toContain('500')
+  })
+
+  it('uses "Maximum N characters" wording', () => {
+    expect(lengthPolicy(REQ_DEFAULT)).toMatch(/Maximum \d+ characters/)
+  })
+})
+
+describe('localePolicy', () => {
+  it('returns empty string for default locale (en)', () => {
+    expect(localePolicy(REQ_DEFAULT)).toBe('')
+  })
+
+  it('asks for target language when locale ≠ en', () => {
+    const result = localePolicy(REQ_FRENCH)
+    expect(result).not.toBe('')
+    expect(result.toLowerCase()).toContain('write the description')
+    expect(result).toContain('fr')
+  })
+
+  it('handles BCP 47 locale codes verbatim', () => {
+    const reqPtBR: AltRequest = { ...DEFAULT_ALT_REQUEST, locale: 'pt-BR' }
+    expect(localePolicy(reqPtBR)).toContain('pt-BR')
+  })
+
+  it('handles non-Latin locale codes', () => {
+    const reqAr: AltRequest = { ...DEFAULT_ALT_REQUEST, locale: 'ar' }
+    expect(localePolicy(reqAr)).toContain('ar')
+  })
+})
+
+describe('outputDisciplinePolicy', () => {
+  it('asks for description-only output', () => {
+    const result = outputDisciplinePolicy(REQ_DEFAULT)
+    expect(result.toLowerCase()).toContain('output')
+    // Suggests no preamble.
+    expect(result.toLowerCase()).toContain('preamble')
+  })
+})
+
+describe('DEFAULT_ALT_PROMPT_POLICIES', () => {
+  it('has five policies in the documented order', () => {
+    expect(DEFAULT_ALT_PROMPT_POLICIES).toHaveLength(5)
+    expect(DEFAULT_ALT_PROMPT_POLICIES[0]).toBe(taskFramingPolicy)
+    expect(DEFAULT_ALT_PROMPT_POLICIES[1]).toBe(styleGuidancePolicy)
+    expect(DEFAULT_ALT_PROMPT_POLICIES[2]).toBe(lengthPolicy)
+    expect(DEFAULT_ALT_PROMPT_POLICIES[3]).toBe(localePolicy)
+    expect(DEFAULT_ALT_PROMPT_POLICIES[4]).toBe(outputDisciplinePolicy)
+  })
+
+  it('composes into a coherent prompt for default request', () => {
+    const result = composePrompt(REQ_DEFAULT, DEFAULT_ALT_PROMPT_POLICIES)
+    // Multi-paragraph (locale policy drops out for 'en'); other 4 stay.
+    expect(result.split('\n\n').length).toBe(4)
+    expect(result).toContain('WCAG')
+    expect(result).toContain('125 characters')
+  })
+
+  it('includes locale paragraph when locale ≠ en', () => {
+    const result = composePrompt(REQ_FRENCH, DEFAULT_ALT_PROMPT_POLICIES)
+    expect(result.split('\n\n').length).toBe(5)
+    expect(result).toContain('Write the description in fr')
+  })
+
+  it('reflects custom maxChars in the composed prompt', () => {
+    const result = composePrompt(REQ_LONG, DEFAULT_ALT_PROMPT_POLICIES)
+    expect(result).toContain('500 characters')
+    expect(result).not.toContain('125 characters')
+  })
+})

--- a/packages/gazetta/tests/alt-route-handler.test.ts
+++ b/packages/gazetta/tests/alt-route-handler.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Unit tests for `alt/route-handler.ts` — orchestration between the
+ * admin-api HTTP layer and the alt-text task domain.
+ *
+ * Tests are pure (no Hono, no msw): in-memory storage + env mocking.
+ * The route-handler integrates the asset-domain (manifest reading) +
+ * the alt-domain (suggester/factory) without HTTP concerns.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import sharp from 'sharp'
+import { memoryStorage, type MemoryStorage } from './_helpers/memory-storage.js'
+import { suggestAltForAsset } from '../src/alt/route-handler.js'
+import type { AssetManifest } from '../src/schema/types.js'
+import type { SiteManifest } from '../src/types.js'
+
+const ENV_KEYS = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'OLLAMA_BASE_URL'] as const
+const savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {}
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+})
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = savedEnv[key]
+    }
+  }
+})
+
+const ASSETS_ROOT = 'assets'
+
+async function makeJpeg(width = 200, height = 200): Promise<Uint8Array> {
+  const buf = await sharp({
+    create: { width, height, channels: 3, background: { r: 0, g: 0, b: 0 } },
+  })
+    .jpeg()
+    .toBuffer()
+  return new Uint8Array(buf)
+}
+
+/**
+ * Seed a fresh storage with one asset (manifest + bytes). Returns
+ * the manifest and storage so tests can verify or mutate.
+ */
+async function seedAsset(
+  name: string,
+  hash = 'abc12345',
+): Promise<{ storage: MemoryStorage; manifest: AssetManifest }> {
+  const storage = memoryStorage()
+  const bytes = await makeJpeg()
+  const manifest: AssetManifest = {
+    version: 1,
+    name,
+    kind: 'embedded',
+    source: 'internal',
+    mime: 'image/jpeg',
+    size: bytes.byteLength,
+    hash,
+    width: 200,
+    height: 200,
+    duration: null,
+    alt: null,
+    focalPoint: null,
+    tags: [],
+    variants: [],
+    variantsStatus: 'complete',
+    uploadedAt: '2026-05-03T00:00:00Z',
+    uploadedBy: '',
+  }
+  await storage.writeFile(`${ASSETS_ROOT}/${name}.asset.json`, JSON.stringify(manifest))
+  await storage.writeBytes(`${ASSETS_ROOT}/${name}-${hash}.jpg`, bytes)
+  return { storage, manifest }
+}
+
+describe('suggestAltForAsset — unconfigured', () => {
+  it('returns kind: unavailable when site has no AI config', async () => {
+    const { storage } = await seedAsset('hero')
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {}
+    const result = await suggestAltForAsset({
+      name: 'hero',
+      assetsRoot: ASSETS_ROOT,
+      storage,
+      site,
+      target: undefined,
+      locale: 'en',
+    })
+    expect(result.kind).toBe('unavailable')
+  })
+
+  it('returns kind: unavailable when adapter configured but credentials missing', async () => {
+    const { storage } = await seedAsset('hero')
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'anthropic' },
+      altText: { auto: true },
+    }
+    // No ANTHROPIC_API_KEY in env.
+    const result = await suggestAltForAsset({
+      name: 'hero',
+      assetsRoot: ASSETS_ROOT,
+      storage,
+      site,
+      target: undefined,
+      locale: 'en',
+    })
+    expect(result.kind).toBe('unavailable')
+    if (result.kind === 'unavailable') {
+      expect(result.message.toLowerCase()).toContain('anthropic')
+    }
+  })
+})
+
+describe('suggestAltForAsset — asset not found', () => {
+  it('returns kind: not-found when asset name does not exist on target', async () => {
+    process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
+    const storage = memoryStorage()
+    // Empty storage — no asset seeded.
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'ollama' },
+      altText: { auto: true },
+    }
+    const result = await suggestAltForAsset({
+      name: 'missing',
+      assetsRoot: ASSETS_ROOT,
+      storage,
+      site,
+      target: undefined,
+      locale: 'en',
+    })
+    expect(result.kind).toBe('not-found')
+    if (result.kind === 'not-found') {
+      expect(result.message).toContain('missing')
+    }
+  })
+})
+
+describe('suggestAltForAsset — happy path (Ollama with mocked HTTP)', () => {
+  it('returns kind: ok with structured suggestion when Ollama responds', async () => {
+    // Ollama doesn't need a real API key, so we can wire it without
+    // env mocking. We rely on msw setup in other tests; here we use
+    // the simpler approach of pointing the adapter at a mock fetch.
+    // Since this test is in the route-handler suite (not adapter
+    // tests), we're integrating against the factory's actual Ollama
+    // adapter. Mock fetch globally to return a happy response.
+
+    const { storage } = await seedAsset('hero')
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'ollama' },
+      altText: { auto: true },
+    }
+
+    // Stub global fetch for this single call. Using Vitest's vi
+    // approach would be cleaner but msw + setupServer is the
+    // established pattern in adapter tests. For the orchestration
+    // layer test, we just need to verify the wiring — simplest is
+    // to skip the actual model call by stubbing fetch.
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.includes('localhost:11434')) {
+        return new Response(
+          JSON.stringify({
+            model: 'llama3.2-vision:11b',
+            message: { role: 'assistant', content: 'A black square.' },
+            done: true,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        )
+      }
+      return originalFetch(input, _init)
+    }
+    try {
+      const result = await suggestAltForAsset({
+        name: 'hero',
+        assetsRoot: ASSETS_ROOT,
+        storage,
+        site,
+        target: undefined,
+        locale: 'en',
+      })
+      expect(result.kind).toBe('ok')
+      if (result.kind === 'ok') {
+        expect(result.suggestion.text).toBe('A black square.')
+        expect(result.suggestion.refused).toBe(false)
+        expect(result.suggestion.refusalReason).toBeNull()
+      }
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('returns kind: ok with refused: true when model declines', async () => {
+    const { storage } = await seedAsset('hero')
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'ollama' },
+      altText: { auto: true },
+    }
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async (input: RequestInfo | URL): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.includes('localhost:11434')) {
+        return new Response(
+          JSON.stringify({
+            message: { role: 'assistant', content: "I can't describe this image." },
+            done: true,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        )
+      }
+      throw new Error(`unexpected url: ${url}`)
+    }
+    try {
+      const result = await suggestAltForAsset({
+        name: 'hero',
+        assetsRoot: ASSETS_ROOT,
+        storage,
+        site,
+        target: undefined,
+        locale: 'en',
+      })
+      expect(result.kind).toBe('ok')
+      if (result.kind === 'ok') {
+        expect(result.suggestion.refused).toBe(true)
+        expect(result.suggestion.refusalReason).not.toBeNull()
+      }
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
+describe('suggestAltForAsset — adapter call failure', () => {
+  it('returns kind: failed when adapter throws', async () => {
+    const { storage } = await seedAsset('hero')
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'ollama' },
+      altText: { auto: true },
+    }
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async (input: RequestInfo | URL): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.includes('localhost:11434')) {
+        // 500 from the upstream provider — adapter wraps as
+        // AIAdapterFailedError, suggester returns null, route-handler
+        // surfaces as `failed`.
+        return new Response('internal error', { status: 500 })
+      }
+      throw new Error(`unexpected url: ${url}`)
+    }
+    try {
+      const result = await suggestAltForAsset({
+        name: 'hero',
+        assetsRoot: ASSETS_ROOT,
+        storage,
+        site,
+        target: undefined,
+        locale: 'en',
+      })
+      expect(result.kind).toBe('failed')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
+describe('suggestAltForAsset — locale parameter forwarding', () => {
+  it('passes locale through to the adapter (visible in request body)', async () => {
+    const { storage } = await seedAsset('hero')
+    const site: Pick<SiteManifest, 'ai' | 'altText'> = {
+      ai: { provider: 'ollama' },
+      altText: { auto: true },
+    }
+    let capturedSystemPrompt: string | undefined
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.includes('localhost:11434')) {
+        const body = JSON.parse(init?.body as string) as {
+          messages: Array<{ role: string; content: string }>
+        }
+        capturedSystemPrompt = body.messages.find(m => m.role === 'system')?.content
+        return new Response(
+          JSON.stringify({
+            message: { role: 'assistant', content: 'description in french' },
+            done: true,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        )
+      }
+      throw new Error(`unexpected url: ${url}`)
+    }
+    try {
+      await suggestAltForAsset({
+        name: 'hero',
+        assetsRoot: ASSETS_ROOT,
+        storage,
+        site,
+        target: undefined,
+        locale: 'fr',
+      })
+      // The composed prompt should include the locale instruction.
+      expect(capturedSystemPrompt).toBeDefined()
+      expect(capturedSystemPrompt).toContain('fr')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})

--- a/packages/gazetta/tests/alt-suggester.test.ts
+++ b/packages/gazetta/tests/alt-suggester.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Unit tests for `alt/suggester.ts` — orchestration:
+ *
+ *   - `available` delegates to adapter.supports
+ *   - `suggest` returns null when adapter doesn't support the MIME
+ *   - `suggest` builds AltRequest from input + defaults
+ *   - `suggest` composes prompt and calls prepareForVision once each
+ *   - `suggest` forwards AbortSignal to adapter
+ *   - `suggest` returns null on aborted signal (pre-call)
+ *   - `suggest` returns null on aborted signal (post-call rejection)
+ *   - `suggest` returns null on AIError; rethrows non-AI errors
+ *   - `suggest` returns AltSuggestion on success (including refused: true)
+ *   - posterBytes are forwarded to prepareForVision
+ *
+ * Adapters in tests are recording mocks — they capture the
+ * `AltGenerateInput` and return canned suggestions. Real provider
+ * adapters with msw fixtures land in commits 3-5.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import sharp from 'sharp'
+import { AIAdapterFailedError, AIAdapterUnavailableError } from '../src/ai/errors.js'
+import { type AltGenerateInput, type AltSuggestion, type AltTextAdapter } from '../src/alt/adapter.js'
+import { nullAltAdapter } from '../src/alt/null-adapter.js'
+import { createAltSuggester } from '../src/alt/suggester.js'
+
+async function makeJpeg(width = 200, height = 200): Promise<Uint8Array> {
+  const buf = await sharp({
+    create: { width, height, channels: 3, background: { r: 0, g: 0, b: 0 } },
+  })
+    .jpeg()
+    .toBuffer()
+  return new Uint8Array(buf)
+}
+
+function makeRecordingAdapter(suggestion: AltSuggestion = makeSuggestion('Mountain at sunset')): {
+  adapter: AltTextAdapter
+  calls: AltGenerateInput[]
+  signals: (AbortSignal | undefined)[]
+} {
+  const calls: AltGenerateInput[] = []
+  const signals: (AbortSignal | undefined)[] = []
+  const adapter: AltTextAdapter = {
+    name: 'recording',
+    supports(mime: string) {
+      return mime.startsWith('image/')
+    },
+    async generate(input, signal) {
+      calls.push(input)
+      signals.push(signal)
+      return suggestion
+    },
+  }
+  return { adapter, calls, signals }
+}
+
+function makeSuggestion(text: string, refused = false): AltSuggestion {
+  return { text, refused, refusalReason: refused ? text : null }
+}
+
+describe('available', () => {
+  it('delegates to adapter.supports', () => {
+    const { adapter } = makeRecordingAdapter()
+    const suggester = createAltSuggester({ adapter })
+    expect(suggester.available('image/jpeg')).toBe(true)
+    expect(suggester.available('audio/mpeg')).toBe(false)
+  })
+
+  it('returns false with nullAltAdapter for any MIME', () => {
+    const suggester = createAltSuggester({ adapter: nullAltAdapter })
+    expect(suggester.available('image/jpeg')).toBe(false)
+    expect(suggester.available('image/png')).toBe(false)
+  })
+})
+
+describe('suggest — capability check', () => {
+  it('returns null when adapter does not support the MIME', async () => {
+    const { adapter, calls } = makeRecordingAdapter()
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    const result = await suggester.suggest({
+      bytes,
+      mime: 'audio/mpeg',
+      hash: 'abc',
+    })
+    expect(result).toBeNull()
+    expect(calls).toHaveLength(0)
+  })
+
+  it('returns null with nullAltAdapter (never reaches generate)', async () => {
+    const suggester = createAltSuggester({ adapter: nullAltAdapter })
+    const bytes = await makeJpeg()
+    const result = await suggester.suggest({
+      bytes,
+      mime: 'image/jpeg',
+      hash: 'abc',
+    })
+    expect(result).toBeNull()
+  })
+})
+
+describe('suggest — request building', () => {
+  it('applies default locale when not provided', async () => {
+    const { adapter, calls } = makeRecordingAdapter()
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc' })
+    expect(calls[0].request.locale).toBe('en')
+  })
+
+  it('applies default maxChars when not provided', async () => {
+    const { adapter, calls } = makeRecordingAdapter()
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc' })
+    expect(calls[0].request.maxChars).toBe(125)
+  })
+
+  it('applies default style: descriptive', async () => {
+    const { adapter, calls } = makeRecordingAdapter()
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc' })
+    expect(calls[0].request.style).toBe('descriptive')
+  })
+
+  it('uses provided locale when given', async () => {
+    const { adapter, calls } = makeRecordingAdapter()
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc', locale: 'fr' })
+    expect(calls[0].request.locale).toBe('fr')
+  })
+
+  it('uses provided maxChars when given', async () => {
+    const { adapter, calls } = makeRecordingAdapter()
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc', maxChars: 250 })
+    expect(calls[0].request.maxChars).toBe(250)
+  })
+})
+
+describe('suggest — prompt + bytes prep', () => {
+  it('composes a non-empty prompt and passes it to the adapter', async () => {
+    const { adapter, calls } = makeRecordingAdapter()
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc' })
+    expect(calls[0].prompt.length).toBeGreaterThan(0)
+    expect(calls[0].prompt).toContain('WCAG')
+    expect(calls[0].prompt).toContain('125 characters')
+  })
+
+  it('includes locale paragraph in prompt when locale ≠ default', async () => {
+    const { adapter, calls } = makeRecordingAdapter()
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc', locale: 'fr' })
+    expect(calls[0].prompt).toContain('fr')
+  })
+
+  it('passes prepared bytes to the adapter (smaller than source after resize)', async () => {
+    const { adapter, calls } = makeRecordingAdapter()
+    const suggester = createAltSuggester({ adapter })
+    // Force a resize by using bytes larger than max edge.
+    const bytes = await makeJpeg(2000, 2000)
+    await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc' })
+    // Prepared bytes should differ from source (after resize+re-encode).
+    expect(calls[0].bytes).not.toBe(bytes)
+    // Verify dimensions were resized.
+    const meta = await sharp(calls[0].bytes).metadata()
+    expect(Math.max(meta.width ?? 0, meta.height ?? 0)).toBeLessThanOrEqual(768)
+  })
+
+  it('uses posterBytes when provided (animated-image path)', async () => {
+    const { adapter, calls } = makeRecordingAdapter()
+    const suggester = createAltSuggester({ adapter })
+    const sourceBytes = await makeJpeg(2000, 2000)
+    const posterBytes = await sharp({
+      create: { width: 100, height: 100, channels: 3, background: { r: 255, g: 0, b: 0 } },
+    })
+      .png()
+      .toBuffer()
+    await suggester.suggest({
+      bytes: sourceBytes,
+      mime: 'image/gif',
+      hash: 'abc',
+      posterBytes: new Uint8Array(posterBytes),
+    })
+    // Adapter received the poster bytes verbatim (or a copy of them).
+    expect(calls[0].bytes).toEqual(new Uint8Array(posterBytes))
+    expect(calls[0].mime).toBe('image/png')
+  })
+
+  it('respects maxImageEdge override', async () => {
+    const { adapter, calls } = makeRecordingAdapter()
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg(2000, 2000)
+    await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc', maxImageEdge: 1024 })
+    const meta = await sharp(calls[0].bytes).metadata()
+    expect(meta.width).toBe(1024)
+  })
+
+  it('returns null when prepareForVision throws (corrupt bytes)', async () => {
+    const { adapter, calls } = makeRecordingAdapter()
+    const suggester = createAltSuggester({ adapter })
+    // Garbage bytes that sharp can't decode.
+    const garbage = new Uint8Array([0xff, 0xff, 0xff, 0xff])
+    const result = await suggester.suggest({ bytes: garbage, mime: 'image/jpeg', hash: 'abc' })
+    expect(result).toBeNull()
+    expect(calls).toHaveLength(0) // adapter never called
+  })
+})
+
+describe('suggest — AbortSignal forwarding', () => {
+  it('forwards the AbortSignal to adapter.generate', async () => {
+    const { adapter, signals } = makeRecordingAdapter()
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    const controller = new AbortController()
+    await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc' }, controller.signal)
+    expect(signals[0]).toBe(controller.signal)
+  })
+
+  it('returns null when signal is already aborted', async () => {
+    const { adapter, calls } = makeRecordingAdapter()
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    const controller = new AbortController()
+    controller.abort()
+    const result = await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc' }, controller.signal)
+    expect(result).toBeNull()
+    expect(calls).toHaveLength(0)
+  })
+
+  it('returns null when adapter throws after abort', async () => {
+    const adapter: AltTextAdapter = {
+      name: 'aborting',
+      supports: () => true,
+      async generate(_input, signal) {
+        // Simulate adapter throwing because signal aborted mid-call.
+        signal?.throwIfAborted()
+        return makeSuggestion('unreachable')
+      },
+    }
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    const controller = new AbortController()
+    // Setup: pass a not-yet-aborted signal so the suggester proceeds,
+    // but abort it before the adapter resolves. The adapter throws.
+    const promise = suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc' }, controller.signal)
+    controller.abort()
+    const result = await promise
+    expect(result).toBeNull()
+  })
+})
+
+describe('suggest — error handling', () => {
+  it('returns null when adapter throws AIAdapterFailedError', async () => {
+    const adapter: AltTextAdapter = {
+      name: 'failing',
+      supports: () => true,
+      async generate() {
+        throw new AIAdapterFailedError('upstream rejected')
+      },
+    }
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    const result = await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc' })
+    expect(result).toBeNull()
+  })
+
+  it('returns null when adapter throws AIAdapterUnavailableError', async () => {
+    const adapter: AltTextAdapter = {
+      name: 'unavailable',
+      supports: () => true,
+      async generate() {
+        throw new AIAdapterUnavailableError('something missing')
+      },
+    }
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    const result = await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc' })
+    expect(result).toBeNull()
+  })
+
+  it('rethrows non-AI errors (programmer bugs surface)', async () => {
+    const adapter: AltTextAdapter = {
+      name: 'buggy',
+      supports: () => true,
+      async generate() {
+        throw new TypeError('cannot read property of undefined')
+      },
+    }
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    await expect(suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc' })).rejects.toBeInstanceOf(TypeError)
+  })
+})
+
+describe('suggest — successful generation', () => {
+  it('returns the adapter result on success', async () => {
+    const expected = makeSuggestion('Trees in autumn')
+    const { adapter } = makeRecordingAdapter(expected)
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    const result = await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc' })
+    expect(result).toEqual(expected)
+  })
+
+  it('returns refusal verbatim from adapter', async () => {
+    const refusal = makeSuggestion("I can't describe this image.", true)
+    const { adapter } = makeRecordingAdapter(refusal)
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    const result = await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc' })
+    expect(result).toEqual(refusal)
+    expect(result?.refused).toBe(true)
+    expect(result?.refusalReason).not.toBeNull()
+  })
+})
+
+describe('suggest — adapter is called exactly once per suggest call', () => {
+  it('does not retry on its own', async () => {
+    const adapter: AltTextAdapter = {
+      name: 'flaky',
+      supports: () => true,
+      generate: vi.fn(async () => makeSuggestion('First call')),
+    }
+    const suggester = createAltSuggester({ adapter })
+    const bytes = await makeJpeg()
+    await suggester.suggest({ bytes, mime: 'image/jpeg', hash: 'abc' })
+    expect(adapter.generate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -86,16 +86,7 @@ test.describe('Custom field', () => {
 })
 
 test.describe('Rapid selection', () => {
-  test('last click wins when rapidly switching pages', { retry: 1 }, async ({ page }, testInfo) => {
-    // Racing two clicks in quick succession can leave a half-mounted
-    // PrimeVue component briefly accessing a now-detached DOM node,
-    // surfacing as a transient `Cannot read properties of null
-    // (reading 'querySelector')` page error. The test's invariant —
-    // "last click wins" — passes regardless; the console error is
-    // intrinsic to the race we're intentionally inducing. Opt out of
-    // the fixture's strict console-error policy.
-    testInfo.annotations.push({ type: 'allow-console-errors' })
-
+  test('last click wins when rapidly switching pages', { retry: 1 }, async ({ page }) => {
     await page.goto('/admin')
     const tree = new SiteTreePom(page)
     await expect(tree.pageRow('home')).toBeVisible()

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -86,7 +86,16 @@ test.describe('Custom field', () => {
 })
 
 test.describe('Rapid selection', () => {
-  test('last click wins when rapidly switching pages', { retry: 1 }, async ({ page }) => {
+  test('last click wins when rapidly switching pages', { retry: 1 }, async ({ page }, testInfo) => {
+    // Racing two clicks in quick succession can leave a half-mounted
+    // PrimeVue component briefly accessing a now-detached DOM node,
+    // surfacing as a transient `Cannot read properties of null
+    // (reading 'querySelector')` page error. The test's invariant —
+    // "last click wins" — passes regardless; the console error is
+    // intrinsic to the race we're intentionally inducing. Opt out of
+    // the fixture's strict console-error policy.
+    testInfo.annotations.push({ type: 'allow-console-errors' })
+
     await page.goto('/admin')
     const tree = new SiteTreePom(page)
     await expect(tree.pageRow('home')).toBeVisible()

--- a/tests/e2e/locale.spec.ts
+++ b/tests/e2e/locale.spec.ts
@@ -25,16 +25,22 @@ test.describe('Locale picker', () => {
     await page.click('[data-testid="locale-fr"]')
     await expect(page.locator('[data-testid="locale-fr"]')).toHaveClass(/active/)
     await expect(page.locator('[data-testid="locale-en"]')).not.toHaveClass(/active/)
-    await page.waitForURL(/locale=fr/)
-    expect(page.url()).toContain('locale=fr')
+    // Vue Router's pushState doesn't fire a `load` event, so
+    // `waitForURL` (which defaults to `waitUntil: 'load'`) can hang
+    // up to its full timeout even though the URL has already
+    // updated. `expect(page).toHaveURL` polls via the test runner
+    // and uses `commit` semantics — works for pushState transitions.
+    await expect(page).toHaveURL(/locale=fr/)
   })
 
   test('click EN removes ?locale from URL', async ({ page }) => {
     await page.goto('/admin/pages/home?locale=fr')
     await page.click('[data-testid="locale-en"]')
     await expect(page.locator('[data-testid="locale-en"]')).toHaveClass(/active/)
-    await page.waitForURL(/\/pages\/home(?!\?locale)/)
-    expect(page.url()).not.toContain('locale=')
+    // Same pushState concern as above — assert the URL via
+    // `expect(page).toHaveURL` rather than `page.waitForURL` to
+    // avoid hanging on the absent `load` event.
+    await expect(page).toHaveURL(/\/pages\/home(?!\?locale)/)
   })
 
   test('hidden when site has no locales config', async ({ page }) => {
@@ -92,7 +98,10 @@ test.describe('Locale URL persistence', () => {
     await page.goto('/admin/pages/home?locale=fr')
     // Click about page in tree
     await page.locator('.site-tree .node-label', { hasText: 'about' }).click()
-    await page.waitForURL(/\/pages\/about/)
+    // Same pushState concern as the locale-picker tests above —
+    // `expect(page).toHaveURL` polls via the test runner instead
+    // of waiting on a `load` event that never fires.
+    await expect(page).toHaveURL(/\/pages\/about/)
     expect(page.url()).toContain('locale=fr')
   })
 


### PR DESCRIPTION
## Summary

Ships AI-powered alt-text generation as the v1.5 feature, plus the layered architecture for future AI tasks (translation, tag suggestion, summarization). Adds three provider adapters: Anthropic Claude, OpenAI gpt-4o, and Ollama (self-hosted).

**Commits 1-5 of 9 included; opening early per the plan to validate the abstraction with CI before the user-facing layers (config wiring, admin route, UI, docs) land.**

### Architecture

Three orthogonal layers (full design in [.claude/rules/design-ai.md](.claude/rules/design-ai.md)):

| Layer | What lives here | Status |
|---|---|---|
| Provider account | `.env.local` credentials | Not yet wired (commit 6) |
| Task configuration | `site.yaml` `ai:` + per-task blocks (`altText:`) | Not yet wired (commit 6) |
| Cross-task infrastructure | Code under `packages/gazetta/src/ai/` | ✅ shipped (commit 1) |

Per-task adapters under `packages/gazetta/src/alt/` compose `ai/` utilities. No inheritance — composition only.

### Commit-by-commit

| # | Commit | What |
|---|---|---|
| 1 | `cb788ab` | Cross-task `ai/` infrastructure: refusal detection, prompt composition (generic), vision preprocessing (sharp resize-to-768), provider type, errors |
| 2 | `2014164` | `AltTextAdapter` contract + alt-text prompt policies + `nullAltAdapter` (LSP seam) + stateless `AltSuggester` orchestration |
| 3 | `5379813` | Anthropic Claude adapter (`@anthropic-ai/sdk`); first real SDK integration. Adopted `msw` for HTTP mocking |
| 4 | `6395f07` | OpenAI adapter (`openai`); proves abstraction generalizes |
| 5 | `0f3c699` | Ollama adapter (raw fetch, no SDK); self-hosted path |
| 6-9 | pending | Config wiring + admin route + UI + docs |

### What this validates

The `AltTextAdapter` interface (commit 2) needed **zero modifications** through three real provider integrations (commits 3-5). Three substitutable implementations under one contract — Anthropic and OpenAI use SDKs with different request/response shapes; Ollama uses raw fetch with a third shape. Each adapter encapsulates its provider's quirks; nothing leaks into consumers.

### Test coverage

- Pre-AI baseline: 1138 tests
- After commit 5: **1305 tests passing** (+167 new)
- Each adapter has ~24 msw-mocked tests covering: happy path, refusal detection, errors (auth/rate-limit/network/invalid-response), AbortSignal forwarding (in-flight + already-aborted), config (model override, base URL override, etc.)
- Cross-task `ai/` modules have 49 unit tests
- Contract layer has 45 unit tests

### Dependencies added

- `@anthropic-ai/sdk` ^0.92.0 (commit 3)
- `openai` ^6.35.0 (commit 4)
- `msw` ^2.14.2 (dev dep; commit 3)
- Ollama: no SDK; raw fetch

### SOLID posture

Per [team-preferences rule 18](.claude/rules/team-preferences.md): structurally correct from the start. The `ai/` directory exists with one consumer (`alt/`) because refusal detection, prompt composition, and vision preprocessing are conceptually cross-task — translation will reuse them. Right structure now, not "patch in later when forced."

- **SRP**: each module owns one concern; suggester does orchestration only (no transport, no provider knowledge, no UI)
- **OCP**: caching, retry, throttling all land as decorators wrapping `AltSuggester` (additive); new providers slot in via the factory (commit 6)
- **LSP**: validated empirically by three concrete adapters honoring identical contract surface
- **ISP**: minimal interfaces; no `enabled: false` phantom config fields; `AltSuggestion` carries `refused: boolean` instead of fake `confidence: number`
- **DIP**: consumers depend on `AltTextAdapter` and `AltSuggester` abstractions, never on SDK types or fetch URLs

## Test plan

- [x] Typecheck clean (`tsc --noEmit`)
- [x] All 1305 unit tests passing locally
- [x] Format clean (Biome)
- [ ] CI green on this PR (the reason for opening early)
- [ ] Commits 6-9 land on this branch before merge

## Out of scope for this PR (deferred to v1.6+)

Per [.claude/rules/design-ai-implementation.md](.claude/rules/design-ai-implementation.md):
- Per-target adapter override (process-level only in v1.5)
- `CachedAltSuggester` decorator (suggester is stateless; multi-replica admin correct)
- Translation pipeline (would require parallel `TranslationAdapter` system before second consumer exists)
- Bulk-suggest CLI (manual backfill via detail-pane button until scale demands)
- Cost monitoring / budget caps
- Confidence scoring (the field doesn't exist; refusal is the structured signal we ship)

🤖 Generated with [Claude Code](https://claude.com/claude-code)