### PR TITLE
Validation v1.5 design — four-phase model, real-tool integration, progressive cuts

### DIFF
--- a/.claude/rules/design-validation-implementation.md
+++ b/.claude/rules/design-validation-implementation.md
@@ -1,0 +1,288 @@
+# Validation — Implementation
+
+Companion to [design-validation.md](design-validation.md). This doc covers what we're doing with the design: phased cut sequence with risk ordering, per-cut scope, deferred items, build order rationale.
+
+See [design-validation.md](design-validation.md) for the design itself.
+
+## Phased cut sequence
+
+**Status legend**: ✓ shipped · ◐ in progress · ☐ pending
+
+Per [team-preferences.md rule 17](team-preferences.md): "Build and validate, don't spike. Each commit must produce real code that stays if the approach works, be independently rollback-able." Each cut is independently shippable and independently valuable; we can stop at any cut.
+
+| Cut | What | Effort | Dependency | Status |
+|---|---|---|---|---|
+| **1** | Validator infrastructure + save-delta | 4 days | None | ☐ |
+| **2** | Background scanner + admin UI surfaces | 4 days | Cut 1 | ☐ |
+| **3** | Render-for-analysis + quality validators (a11y, html-validate) + altRequired | 5 days | Cut 1, Cut 2 | ☐ |
+| **4** | Publish gate + heavy validators (Lighthouse, linkinator) | 5 days | Cut 3 | ☐ |
+| **5** | `gazetta validate` CLI rewrite | 2 days | Cut 1 (more useful after Cut 3) | ☐ |
+| **6** | Template-developer surfaces | 3 days | Cut 2 | ☐ |
+
+**Total: ~23 days** for the full plan.
+
+**Minimum useful ship: Cut 1 (4 days)** — catches the most common author-introduced breaks; establishes the abstraction.
+
+**Recommended first ship: Cut 1 + Cut 2 (8 days)** — gives authors both delta blocking and ambient visibility; the seam is uniform.
+
+**"Real quality" ship: Cut 1 + 2 + 3 (13 days)** — adds a11y + HTML validity + altRequired; validators against rendered output.
+
+## Per-cut scope
+
+### Cut 1 — Validator infrastructure + save-delta (4 days)
+
+**What ships:**
+- `Validator` interface + `Issue` shape (`packages/gazetta/src/validation/types.ts`)
+- Save-delta orchestrator (`packages/gazetta/src/validation/save-delta.ts`) — diff incoming vs. existing manifest; collect refs introduced by this edit
+- Five validator implementations (`packages/gazetta/src/validation/validators/`):
+  - `referenced-asset-exists`
+  - `referenced-fragment-exists`
+  - `referenced-template-exists`
+  - `circular-fragment-introduced`
+  - `dynamic-route-conflict-introduced`
+- Wire into `PUT /api/pages/:name` and `PUT /api/fragments/:name` handlers
+- 409 response shape: `{ code: 'VALIDATION_FAILED', issues: Issue[] }`
+- Schema in `admin-api/schemas/validation.ts`
+- Admin UI banner component (`apps/admin/src/client/components/ValidationBanner.vue`):
+  - Renders when save returns 409
+  - Lists issues with severity icons
+  - "Fix" action on each issue scrolls to the offending field
+  - Disables the Save button until issues clear
+
+**Tests:**
+- Unit tests per validator (refs found / not found / introduced vs. pre-existing)
+- Save-delta orchestrator: only flags new violations; pre-existing issues pass through
+- Admin-api integration: 409 with correct issue structure
+- Vue component: banner renders + "Fix" focuses correct field
+
+**SOLID lenses:**
+- SRP: each validator owns one concern; orchestrator owns diff + dispatch
+- OCP: adding a new validator is one new file + one registry entry
+- LSP: every validator honors the same `Validator` contract
+- ISP: validators don't see UI concerns; UI doesn't see validation logic
+- DIP: route handler depends on the orchestrator's `runSaveDelta` function, not on individual validators
+
+**What it doesn't catch yet:**
+- Anything pre-existing in the site (Cut 2's job)
+- Quality issues (a11y, HTML validity — Cut 3)
+- altRequired (depends on schema walking — Cut 3)
+
+**Risk:** medium. The diff logic is the only novel piece; everything else is straightforward integration.
+
+### Cut 2 — Background scanner + admin UI surfaces (4 days)
+
+**What ships:**
+- Background scanner service (`packages/gazetta/src/validation/scanner.ts`):
+  - Initial full-site scan on admin server boot
+  - Incremental rescan on file watcher events (manifest, template, asset changes)
+  - Per-item validation cache keyed by content hash; only re-runs when something material changed
+  - Result store keyed by item path
+- New admin API: `GET /api/validation/issues` returns current `Issue[]` across the site
+- SSE event: `validation-issues-updated` — pushes new issue counts when the scanner finishes a pass
+- Three new validators (background-only):
+  - `schema-conformance` (full Zod parse against existing content; surfaces `warn` for content that bypassed the form)
+  - `orphaned-locale-file`
+  - `unused-fragment`
+- Pinia store (`apps/admin/src/client/stores/validation.ts`) holds current issues
+- Site tree dots in `SiteTree.vue` — colored circles next to items with issues
+- "Site health" drawer (`apps/admin/src/client/components/SiteHealthDrawer.vue`):
+  - Icon button in top toolbar (next to History)
+  - Lists all current issues, grouped by item, sortable by severity
+  - Click an issue → navigate to the affected item; banner shows the issue inline
+
+**Tests:**
+- Scanner: incremental rescan only re-runs affected items
+- Cache: same content hash returns cached issues without re-validating
+- API: returns current issues; pagination if needed
+- Vue components: dots render correctly; drawer lists + filters; navigation focuses the affected field
+
+**SOLID:**
+- Scanner reuses validator instances from Cut 1; new orchestrator (full-site rather than delta)
+- Cache invalidation is dependency-aware (uses existing sidecar machinery from media v1)
+- SSE notification decouples scanner from UI: scanner pushes; UI pulls
+
+**Risk:** medium-high. Cache invalidation is the load-bearing piece. Wrong invalidation = stale issues or perf cliff.
+
+**What it doesn't catch yet:**
+- Quality issues (a11y, HTML — Cut 3)
+- altRequired (Cut 3)
+
+### Cut 3 — Render-for-analysis + quality + altRequired (5 days)
+
+**What ships:**
+- "Render-for-analysis" service (`packages/gazetta/src/render-for-analysis.ts`):
+  - Same renderer as preview/publish, no storage write
+  - Returns `{ html, css, js }` per page
+  - Caches by content hash + template hash + transitive-dependency hash + locale + theme
+  - Reuses sidecar dependency tracking — fragment edit invalidates only pages using that fragment
+- Three new validators using rendered output:
+  - `accessibility` — axe-core via jsdom; ~50-100ms per page
+  - `html-validity` — html-validate against rendered HTML
+  - `altRequired` — walks the page's template schema, finds `embeddedAsset({ altRequired: true })` fields, resolves the effective alt for each ref, errors when null
+- New dependencies: `axe-core`, `html-validate`, `jsdom`
+- altRequired is `error` at save-delta + background; warns are not promoted (template author's intent IS the gate)
+- Admin UI: new issue categories appear in the existing site-tree dots + Site health drawer (no new surface)
+
+**Tests:**
+- Render-for-analysis: returns same output as preview; cache hit on repeat calls; cache invalidation on dependency change
+- axe-core integration: real fixture pages produce expected issues; rule subset is configurable
+- html-validate integration: real fixture pages produce expected issues
+- altRequired: schema-walks correctly; resolves ref → asset alt chain; flags null
+- End-to-end: edit a page, scanner detects new a11y issue, drawer surfaces it
+
+**SOLID:**
+- Each validator wraps one external tool; tool-specific config isolated to that validator
+- Render-for-analysis is its own module; validators consume the cached output
+- altRequired's schema walker is a separate module from its validator implementation (testable independently)
+
+**Risk:** high. Rendering is the heaviest CMS operation; doing it for analysis introduces a new performance characteristic. Cache must be correct.
+
+**Mitigation:**
+- Render-for-analysis runs in worker pool to avoid blocking the admin event loop (Node `worker_threads`)
+- Cache aggressively; invalidation only on dependency changes
+- Validators run in parallel against the same rendered output
+
+### Cut 4 — Publish gate + heavy validators (5 days)
+
+**What ships:**
+- Pre-publish audit step in publish dialog:
+  - Shows consolidated `Issue[]` for items being published
+  - Per issue: "Fix" / "Ignore once" / "Promote to error"
+  - Block publish on remaining errors
+- Per-target audit config: `targets.production.publishAudit: { strict: boolean }`
+- Two new heavy validators (opt-in via flag):
+  - `lighthouse` — Playwright + Lighthouse against rendered output
+  - `broken-links` — linkinator against rendered output
+- Admin UI: pre-publish modal in `PublishDialog.vue`
+
+**Tests:**
+- Operator config promotes warns to errors when `strict: true`
+- "Ignore once" suppresses for current publish; doesn't persist
+- Publish blocks on remaining errors
+- Lighthouse validator runs in spawned process; doesn't block admin event loop
+
+**Risk:** medium. Lighthouse + Playwright are heavy deps; opt-in keeps the cost behind a flag.
+
+**Why this is last:** these validators are valuable but not critical for daily editor UX. They earn their place at the operator's commitment moment.
+
+### Cut 5 — `gazetta validate` CLI rewrite (2 days)
+
+**What ships:**
+- `gazetta validate` runs all validators in non-interactive mode
+- Output format: per-item ✓/✗ summary; full issue list with `--verbose`
+- Flags:
+  - `--severity error` (default) / `--severity warn` / `--severity all`
+  - `--include-quality` — runs a11y + html-validate (off by default for speed)
+  - `--no-warn-as-error` — exits 0 on warns; exits 1 only on errors
+- Replaces existing ad-hoc walk in `cli/index.ts`
+
+**Tests:**
+- CLI exits 0 on clean site
+- CLI exits 1 on errors
+- `--include-quality` runs the heavier validators
+- Output is greppable
+
+**Risk:** low. The validators already exist; CLI is just a different orchestrator.
+
+**Why this isn't earlier:** the CLI is more useful with quality validators (Cut 3). Without them, it's roughly what the existing `runValidate` already does.
+
+### Cut 6 — Template-developer surfaces (3 days)
+
+**What ships:**
+- When a template's schema changes (file watcher), run `schema-conformance` against all content using that template
+- New admin UI panel: "Template impact" — shows which content items are affected by the template change
+- Per-item: green ✓ (still conforms), amber ⚠ (warning), red ✗ (errors)
+- One-click "Migrate" action per item (opens the editor with the affected fields highlighted)
+
+**Tests:**
+- Template schema change triggers re-validation of dependent content
+- Panel surfaces the impact
+- Migrate action focuses the right field
+
+**Risk:** low-medium. The infrastructure exists by Cut 6; this is mostly UI work.
+
+**Why this is last:** it's a power-user feature for template developers, not a daily-author concern. Most daily author workflows don't trigger it.
+
+## What's deferred from this plan
+
+| Item | Trigger to revisit |
+|---|---|
+| Issue suppression mechanism (`_suppressions: {...}`) | Authors ask for "ignore this issue" persistently |
+| Per-validator severity override (vs. coarse strict flag) | Operators ask for per-rule control |
+| Custom validators (site authors plug in their own) | Concrete operator use case for site-specific rules |
+| `css-validity` (stylelint) | Lower priority than a11y/HTML; ship in a follow-up |
+| Performance budget gates (LCP, CLS) | Lighthouse covers this once configured |
+| Cross-content validation (e.g., "every page has a meta description") | Authors ask |
+
+## Open implementation questions
+
+1. **Sidecar machinery integration.** Cache invalidation should reuse `findDependentsFromSidecars` from media v1. Confirm the API surface fits validation's needs before Cut 3.
+
+2. **Worker thread for render-for-analysis.** Investigate Node `worker_threads` vs. spawning a separate Node process. Worker threads share memory (good for the template registry); spawning is more isolation but slower init. Likely worker threads.
+
+3. **axe-core ruleset configuration.** axe-core ships ~90 rules; some are noisy (e.g., color-contrast on dynamic content). Pick a sensible default subset; expose via `site.yaml` for operator customization.
+
+4. **Test pages for quality validators.** Need fixture pages with known issues (`<img>` no alt, broken HTML, contrast fails) to validate the integration. Build small `tests/fixtures/quality-pages/` directory.
+
+5. **SSE channel for validation issues.** Reuse the existing `/__reload` SSE channel? Or new `/__validation` channel? The former couples; the latter adds infra. Likely new channel.
+
+6. **Render-for-analysis vs. preview path.** Preview already renders per-request; render-for-analysis caches. Worth unifying eventually so authors get consistent output. Don't unify in Cut 3 — wait for the seam to stabilize.
+
+## Estimates
+
+Wall-clock for solo dev. Real pace depends on what you hit.
+
+| Cut | Estimate |
+|---|---|
+| Cut 1 — Save-delta + 5 validators | 4 days |
+| Cut 2 — Background scanner + UI | 4 days |
+| Cut 3 — Render-for-analysis + a11y + html + altRequired | 5 days |
+| Cut 4 — Publish gate + Lighthouse | 5 days |
+| Cut 5 — CLI rewrite | 2 days |
+| Cut 6 — Template-developer surfaces | 3 days |
+
+With CI iteration, review feedback, and integration discoveries, budget 1.5x the raw estimate per cut.
+
+## SOLID checks per cut
+
+Each cut's SOLID posture, validated at design time:
+
+- **Cut 1**: SRP per validator. OCP via the `Validator` registry — adding a new ref-existence validator is additive. LSP across validator implementations. DIP — route handler depends on `runSaveDelta`, not on validators directly.
+
+- **Cut 2**: SRP — scanner orchestrates; cache is its own concern; validators are unchanged. OCP — new background-only validators slot in. DIP — UI consumes the Pinia store, not the scanner directly.
+
+- **Cut 3**: SRP — render-for-analysis is its own module; each tool-wrapper validator is its own module. OCP — new tool wrappers add Validators without changing infrastructure. ISP — validators see only the `RenderedOutputAccess` they need.
+
+- **Cut 4**: SRP — publish gate is one orchestrator; per-target config is its own concern. OCP — new heavy validators add to the registry; opt-in is per-validator.
+
+- **Cut 5**: SRP — CLI runner is its own module that calls the same validator runners as the admin server.
+
+- **Cut 6**: SRP — template-watcher is its own concern; UI surface is its own component.
+
+Any cut failing SOLID review at PR time is a structural correction (per [team-preferences.md rule 18](team-preferences.md)), not a patch.
+
+## Migration
+
+### Existing sites
+
+No config required for Cut 1-3. Validators run with default severities; existing content that's broken surfaces as warns/errors but doesn't block save (only newly-introduced breaks block).
+
+### `gazetta validate` users
+
+Cut 5 changes the output format. Document migration in `docs/cli.md` when it ships.
+
+### Template developers
+
+Cut 6 changes how schema changes are surfaced. New panel; existing flow unchanged.
+
+## Why this shape
+
+**Phased so each cut is independently valuable.** Cut 1 alone (4 days) catches the most painful "I broke something" cases. Stopping there is acceptable.
+
+**Real tools, not reimplementation.** axe-core, html-validate, Lighthouse, linkinator. Each plugs into the validator interface. CMS owns scheduling, surfacing, and incremental scope; tools own the analysis.
+
+**Save stays fast.** Cut 1's save-delta only checks introduced refs; everything else is the background scanner. Authors aren't punished for accumulated debt.
+
+**Publish gate is operator-controlled.** Strict workflows enable; loose workflows skip. The CMS doesn't impose a one-size-fits-all severity.
+
+**Surfaces match commitment levels.** Banner (save), drawer (background), modal (publish). Each is its own visual weight. Authors learn one new surface per cut.

--- a/.claude/rules/design-validation.md
+++ b/.claude/rules/design-validation.md
@@ -1,0 +1,306 @@
+# Validation
+
+How the CMS surfaces correctness, integrity, and quality issues to authors and operators. Designed around the editor-UX principle that detection point should match author commitment level — not "everything is checked at every gate."
+
+**This doc covers the design:** four-phase model, validator abstraction, severity model, surfaces, what's in/out of scope, distinctive choices.
+
+**Companion docs:**
+- [design-validation-implementation.md](design-validation-implementation.md) — phased cut sequence, scope, deferred items, build order.
+
+## Scope
+
+**The final goal:** content that ships produces valid, accessible, performant HTML/CSS/JS. The validation system exists to surface deviations from that goal at the earliest cheap detection point that matches author intent.
+
+**In v1.5:**
+- Phase-aware validator abstraction (`Validator` interface + `Issue[]` shape)
+- Save-delta validation (block save on refs the current edit just broke)
+- Background scanner (continuous visibility into accumulated issues across the site)
+- Quality validators using real tools (axe-core, html-validate) against rendered output
+- Pre-publish gate with operator-controlled strictness
+- `gazetta validate` CLI as a non-interactive run of the same validators
+
+**Out of scope:**
+- Real-time keystroke validation (already covered by @rjsf's Zod-driven form layer)
+- Reimplementing accessibility / HTML / CSS analysis (use real tools — axe-core, html-validate, stylelint, Lighthouse, linkinator — under the abstraction)
+- A "site SEO score" or content scoring (per [seo-plan.md](seo-plan.md): weakly correlated with rankings, encourages over-optimization)
+- Blocking save on accumulated pre-existing issues (hostile UX; the background scanner surfaces them visibly without blocking)
+- Server-side keystroke validation (the form layer is sufficient)
+
+## The four-phase model
+
+The load-bearing principle: **detection point should match author commitment level.** A keystroke is not a commitment; a save is light commitment; the background is observational; publishing is the firm commitment. Each phase has its own surface, severity, and timing.
+
+| Phase | Trigger | Severity | Surface | Latency budget |
+|---|---|---|---|---|
+| **1. Format** | Field blur / 300ms idle keystroke | Block field commit | Inline next to field | <100ms |
+| **2. Integrity** | Save click | Block save when this edit introduced the break | Banner + focus-to-first-error | <3s |
+| **3. Quality** | Background, after save | Inform | Site-tree dots + "Site health" drawer | Async; minutes OK |
+| **4. Publish gate** | Publish click | Configured by operator | Pre-publish modal with fix/ignore/override | Pre-commit |
+
+This maps directly onto how successful tools (Sanity, Payload, GitHub PR review) handle validation — the best ones keep phases **distinct** rather than blending them. Where they fall short: their quality surfaces are weak or absent. Gazetta's render pipeline + per-target `editable` flag give it a structural advantage other CMSes don't have.
+
+### Why phase-separation matters
+
+Real-time validation on every keystroke increases user errors per [UX research](https://uxmovement.com/forms/why-users-make-more-errors-with-instant-inline-validation/) — authors are distracted by flashing errors while still composing. Aggregating unrelated issues in one giant list makes authors tune out. Conflating "draft" with "valid" forces premature commitment.
+
+Each phase exists for a real reason:
+- **Format** is for the author who's typing — fix it now while in flow
+- **Integrity** is for the author who's pausing — what did *I* just break?
+- **Quality** is for the author who's working — what's the holistic state?
+- **Publish gate** is for the operator who's committing — am I about to ship something broken?
+
+Mashing them produces hostile UX. Keeping them separate is the design.
+
+### Why save-delta, not save-full
+
+The integrity phase blocks save **only** on issues introduced by the current edit. If the page already had a missing-asset reference before the author touched it, that's the **background scanner's** problem to surface, not the save handler's.
+
+Rationale:
+- Matches author intent: "I touched this; tell me what I broke" — not "tell me about everything that's been broken since I started this morning"
+- Avoids blocking on debt the author can't fix now (different author created it; templates changed; assets got deleted out-of-band)
+- Keeps save fast: O(diff) instead of O(site)
+- Catches the realistic introduction paths: hand-editing JSON, programmatic content imports, custom CLI flows
+
+The background scanner surfaces the rest, visibly but non-blockingly.
+
+### Why the publish gate is distinct from save
+
+In Gazetta's stateless model, **the local target IS the draft**. `editable: true` on local; `editable: false` (default) on staging/prod. That's the natural draft/published boundary already encoded in the data model.
+
+Save commits to the local target — incomplete is fine. Publish commits to a non-local target — that's the operator's "ship it" moment. Gating quality there matches existing semantics; gating it at save would force the author into commitment they didn't intend.
+
+This also means: configured strictness lives at the publish gate. Operators with strict workflows enable quality gates at publish; operators with loose workflows don't. The save handler stays uniform.
+
+## The Validator abstraction
+
+One interface; many implementations; multiple entry points consume the same validators.
+
+```ts
+export interface Validator {
+  /** Stable identifier for diagnostics ('referenced-asset-exists', 'accessibility'). */
+  readonly name: string
+
+  /** Which lifecycle stages this validator runs at. */
+  readonly stages: readonly ValidationStage[]
+
+  /** Default severity per stage. Operators may promote/demote at the publish gate. */
+  defaultSeverity(stage: ValidationStage): Severity
+
+  /** Run the validator. Returns issues; never throws on validation failure. */
+  validate(input: ValidatorInput): Promise<Issue[]>
+}
+
+export type ValidationStage =
+  | 'save-delta'        // diff incoming vs. existing manifest; check only new refs
+  | 'background'        // continuous full-site scan
+  | 'pre-publish'       // run before publish; can be heavy
+  | 'cli'               // gazetta validate non-interactive
+
+export type Severity = 'error' | 'warn' | 'info'
+
+export interface ValidatorInput {
+  stage: ValidationStage
+  site: Site
+  contentRoot: ContentRoot
+  storage: StorageProvider
+  templates: TemplateRegistry
+  /** Scope is stage-specific:
+   *   - save-delta: { item, before, after }
+   *   - background: { item } iterated by the scanner
+   *   - pre-publish: { items: published-set }
+   *   - cli: site-wide
+   */
+  scope: ValidatorScope
+  /** Cached rendered HTML when available (background, pre-publish). */
+  renderedOutput?: RenderedOutputAccess
+}
+
+export interface Issue {
+  validator: string
+  severity: Severity
+  /** Human-readable message. Author-facing. */
+  message: string
+  /** Item path like `pages/home/page.json`. */
+  itemPath: string
+  /** Content-tree path within the manifest, when applicable. */
+  contentPath?: string
+  /** Optional structured suppression hint — `Issue.suppressible: true`
+   *  means a future "ignore this issue" mechanism would apply. */
+  suppressible?: boolean
+}
+```
+
+### What stages look like in practice
+
+- **save-delta**: PUT /api/pages/:name diffs incoming vs. existing manifest. Validators run only against the introduced refs (new `_asset`, new `@fragment`, new component template). 409 with `Issue[]` body if any error-severity issues; 200 otherwise. Fast.
+
+- **background**: Admin server runs a long-lived scanner. Initial scan on admin boot. Incremental rescan when file watcher detects manifest/template/asset changes. Per-page validation run cached by content hash; only re-runs when something material changed. Issues stored in a Pinia store, surfaced in the UI.
+
+- **pre-publish**: Publish dialog gains a "Run audit" affordance (or always-runs for opted-in targets). Heavy validators (Lighthouse) only run here. Operator sees consolidated `Issue[]` with severity per their target's config. Fix / ignore / promote-to-error per issue. Block publish on remaining errors.
+
+- **cli**: `gazetta validate` runs all validators in non-interactive mode. Exit non-zero on any error. Useful for CI gating before deploy.
+
+### Stage × validator matrix
+
+| Validator | save-delta | background | pre-publish | cli |
+|---|---|---|---|---|
+| `referenced-asset-exists` | ✓ error | ✓ error | ✓ error | ✓ error |
+| `referenced-fragment-exists` | ✓ error | ✓ error | ✓ error | ✓ error |
+| `referenced-template-exists` | ✓ error | ✓ error | ✓ error | ✓ error |
+| `circular-fragment` | ✓ error | ✓ error | ✓ error | ✓ error |
+| `dynamic-route-conflict` | ✓ error | ✓ error | ✓ error | ✓ error |
+| `schema-conformance` | — | ✓ warn | ✓ error | ✓ warn |
+| `altRequired` | ✓ error (when introduced) | ✓ error | ✓ error | ✓ error |
+| `accessibility` (axe-core) | — | ✓ warn | ✓ warn (operator promotes) | ✓ warn |
+| `html-validity` (html-validate) | — | ✓ warn | ✓ warn | ✓ warn |
+| `css-validity` (stylelint) | — | ✓ info | ✓ warn | ✓ warn |
+| `broken-links` (linkinator) | — | — | ✓ warn (opt-in) | ✓ warn (opt-in) |
+| `lighthouse` | — | — | ✓ info (opt-in, heavy) | ✓ info (opt-in) |
+| `orphaned-locale-file` | — | ✓ warn | — | ✓ warn |
+| `unused-fragment` | — | ✓ info | — | ✓ info |
+
+**Why save-delta has so few entries:** the save handler should be fast and narrow. Reference-existence checks run; everything else is the background scanner's job.
+
+**Why some validators have `—` at save-delta:** they need full-site context (orphaned-locale-file) or rendered output (a11y, html-validity) — neither of which is available cheaply at save.
+
+## Surfaces
+
+Three distinct UI surfaces, each tied to a phase:
+
+### Banner (save-time integrity)
+
+When PUT returns 409 with `Issue[]`, the editor shows a dismissible banner at the top of the form with the issue list and a "focus" action that scrolls to the offending field. Save button stays disabled until issues clear.
+
+**Visual weight:** high. Red. Author needs to act now.
+
+**Scope:** only issues introduced by THIS save. Pre-existing issues NEVER appear here.
+
+### Site tree dots + "Site health" drawer (background)
+
+Site tree shows colored dots next to items with issues:
+- Red dot — error-severity issue
+- Amber dot — warn-severity issue
+- (No dot for info-severity to avoid noise)
+
+A "Site health" drawer (closed by default; icon in top bar) lists all current issues across the site, grouped by item, sortable by severity. Click an issue to navigate to the affected item with the relevant field highlighted.
+
+**Visual weight:** ambient. Authors see what's broken; nothing blocks.
+
+**Scope:** all current issues across the entire site.
+
+### Pre-publish modal (publish gate)
+
+Existing publish dialog gains a "Pre-publish audit" step before the destination picker. Shows the list of issues that would apply to the items being published. Per issue: "Fix" (jump to item), "Ignore" (mark as known-acceptable for this publish), "Promote to error" (block publish on this).
+
+Operator-configurable per target: `targets.production.publishAudit: { strict: true }` promotes all warns to errors.
+
+**Visual weight:** modal — operator is committing.
+
+**Scope:** items being published × their issues × target config.
+
+## Severity
+
+Three levels:
+
+- **`error`** — blocking at the gate where it appears. Save blocks on save-delta errors; publish blocks on pre-publish errors.
+- **`warn`** — non-blocking; surfaced in UI; CLI exits non-zero by default but `--no-warn-as-error` flag tolerates.
+- **`info`** — visible in detailed views; not surfaced by default; never blocks.
+
+The severity is **per-stage**. The same validator can warn at background but error at pre-publish. Operators promote or demote at the publish-gate config.
+
+## Quality validators: integrate, don't reimplement
+
+The architectural call: use real tools for the actual analysis. Each tool plugs in via the `Validator` interface; the CMS owns scheduling, surfacing, and incremental scope.
+
+| Domain | Tool | Engine notes |
+|---|---|---|
+| Accessibility | `axe-core` | Run via `jsdom` in admin process; ~50-100ms per page. Battle-tested by every major a11y product. |
+| HTML validity | `html-validate` | Fast, configurable, widely used in CI. |
+| CSS lint | `stylelint` | Industry standard. |
+| Broken links | `linkinator` | Crawl rendered output for outbound link rot. |
+| Performance / SEO score | Lighthouse via Playwright | Heavy (5-15s per page). Pre-publish only, opt-in. |
+
+Why this is the right move:
+- These tools encode decades of domain expertise; any in-house validator would be strictly worse
+- Issues from real tools carry credibility (authors don't argue with axe-core results)
+- Tool versions can be pinned and updated independently of Gazetta
+- The CMS focuses on **integration** — scheduling, scope, surfacing, fix-it actions — which is the real CMS work
+
+What we DON'T do:
+- Reimplement a11y rules
+- Build a Yoast-style content score (rejected per [seo-plan.md](seo-plan.md))
+- Run heavy tools (Lighthouse) in the background scanner
+
+## Render-for-analysis
+
+Quality validators need rendered HTML/CSS to do their job. Gazetta already has a render pipeline (preview + publish). The validator framework exposes a "render-for-analysis" entry point that:
+
+- Calls the same renderer used for preview/publish
+- Returns rendered HTML/CSS/JS without writing to storage
+- Caches by content hash + template hash + locale; re-renders only when something material changed
+- Reuses the existing dependency-aware sidecar machinery (`findDependentsFromSidecars`) so a fragment edit only invalidates pages that use that fragment
+
+This is a Gazetta-specific advantage other CMSes don't have. Most CMSes either:
+- Don't have a render pipeline (headless-only) and force authors to wait for deploy
+- Have one but it's coupled to publish (no analysis-only render path)
+- Have one but no dependency-aware caching (re-render everything every time)
+
+Gazetta's incremental sidecar tracking makes per-page quality validation cheap at scale.
+
+## Distinctive choices
+
+### Phase separation, not unification
+
+Most CMSes blur the lines: validation rules fire at every gate, surfaces overlap, severity is one-dimensional. Gazetta keeps four distinct phases with three distinct surfaces, each matching a real author commitment level.
+
+### Save-delta, not save-full
+
+The save handler only blocks on what THIS save introduced. The accumulated state is the background scanner's surface. Authors aren't held responsible for debt they didn't create.
+
+### Local target IS the draft
+
+Other CMSes invent draft/published as a separate concept. Gazetta's `target.editable` already encodes commitment level — local is the draft, prod is the publish. Phase 4 (publish gate) maps onto this naturally without inventing new vocabulary.
+
+### Quality validators integrate real tools
+
+Don't reimplement axe-core. Don't write a Yoast clone. The CMS schedules and surfaces; the tools analyze. Each tool is one Validator implementation behind the same interface.
+
+### Suppression is structural, not field-level
+
+Issues carry a `suppressible: true` hint. Suppression itself is a future operation (operator says "ignore this rule for this content"); designing the field in from day one means we don't retrofit.
+
+### Operator-configurable publish gates
+
+Per-target `publishAudit` config controls whether quality warns block publish. Strict workflows enable; loose workflows skip. The CMS doesn't impose a one-size-fits-all severity.
+
+## Migration
+
+### Existing sites
+
+Sites without any AI/validation config continue to work — validators run with default severities; no errors are introduced retroactively unless content was already broken (in which case authors needed to know).
+
+### Existing `gazetta validate` behavior
+
+The command is rewritten to run all validators in non-interactive mode. Output format stays roughly the same (per-item ✓/✗ summary). Adds new categories (a11y, html-validity) behind `--include-quality` flag (off by default for speed; CI opts in).
+
+### Editor UX migration
+
+Authors see new surfaces gradually:
+- Cut 1 ships: save-time banner appears when an edit breaks a ref. Familiar pattern, low cognitive load.
+- Cut 2 ships: site-tree dots and Site health drawer appear. Authors learn the "ambient visibility" pattern.
+- Cut 3 ships: dots and drawer surface a11y/HTML/CSS issues alongside ref issues. No new UI; same surface.
+- Cut 4 ships: publish dialog gains the audit step. Operators see the new modal at publish time.
+
+Each cut is independently shippable; authors learn one new surface per ship.
+
+## Open questions
+
+1. **Rendered-output caching key.** Content hash + template hash + locale + theme is the obvious key, but: when a referenced fragment changes, every page using that fragment needs re-render-for-analysis. The sidecar dependency tracking knows the affected set; the cache key needs to incorporate the transitive dependency hash. Worth building correctly the first time.
+
+2. **Severity promotion at the publish gate.** Per-target `publishAudit.strict` is a coarse switch. Per-validator override (`publishAudit.accessibility: error`) is cleaner. Compromise: ship the coarse switch in Cut 4; per-validator override lands when an operator asks.
+
+3. **Background scanner cost on huge sites.** A 5000-page site running axe + html-validate on every fragment edit could take minutes. Mitigation already exists (dependency-aware re-validation); needs to be wired correctly.
+
+4. **Suppression UX.** When an author wants to silence a specific issue ("I know this image is decorative even though axe doesn't"), where does the suppression live? Options: per-content (in the manifest as `_suppressions: {...}`), per-asset (on the asset manifest), per-site (in `site.yaml`). Each has different scoping characteristics. Defer designing until authors actually ask.
+
+5. **Validator versioning.** axe-core releases new rules; sites that pass today might fail tomorrow. Pin versions; document update policy. Same as the AI alt refusal-marker maintenance question.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ Stateless CMS that structures websites as composable fragments. All state lives 
 - `.claude/rules/design-media-implementation.md` — v1 scope + estimates, phased alt, out-of-v1, v1.5/v2 capabilities, frontier opportunities, open questions, migration
 - `.claude/rules/design-ai.md` — AI integration: layered architecture, alt-text task, providers (Anthropic/OpenAI/Ollama), refusal handling, prompt composition
 - `.claude/rules/design-ai-implementation.md` — v1.5 commit sequence, scope, deferred items, open questions, migration
+- `.claude/rules/design-validation.md` — Validation: four-phase model (format/integrity/quality/publish-gate), validator abstraction, severity model, surfaces
+- `.claude/rules/design-validation-implementation.md` — Phased cut sequence (save-delta, background scanner, quality validators, publish gate), scope, deferred items
 - `.claude/rules/architecture.md` — System architecture and package layout
 - `.claude/rules/testing-plan.md` — Active testing coverage + e2e restructure plan (auto-loads when editing tests)
 


### PR DESCRIPTION
## Summary

Two design docs for the editor-UX-driven validation system. No code in this PR — design first, build after alignment.

- [.claude/rules/design-validation.md](.claude/rules/design-validation.md) — the design
- [.claude/rules/design-validation-implementation.md](.claude/rules/design-validation-implementation.md) — phased cut sequence

## Why now

We almost shipped \`altRequired\` save-time enforcement as a one-off feature. The grilling pass surfaced that:

1. Many other validations need the same machinery (ref-existence, schema conformance, accessibility, HTML validity, broken links, etc.)
2. Save-time enforcement is hostile UX if it blocks on accumulated debt
3. Quality concerns (a11y, HTML/CSS validity) need rendered output and shouldn't reimplement what real tools already do
4. Different concerns need different commitment levels — keystroke vs. save vs. background vs. publish

Designing validation as a system first lets every future validator slot in without churn.

## Design highlights

### Four phases, four surfaces

| Phase | Trigger | Surface | Severity |
|---|---|---|---|
| **Format** | Field blur / 300ms idle | Inline next to field | Block field commit |
| **Integrity** | Save click | Banner + focus-to-first-error | Block save (delta only) |
| **Quality** | Background, async | Site-tree dots + drawer | Inform |
| **Publish gate** | Publish click | Pre-publish modal | Configured per target |

Phases don't blend. Each has its own visual weight matching author commitment level.

### Save-delta, not save-full

Save blocks only on issues introduced by THIS edit. Pre-existing issues surface in the background scanner. Matches author intent ("I touched it; tell me what I broke") and keeps save fast.

### Local target IS the draft

Gazetta's existing \`target.editable\` already encodes commitment level. Local = draft, prod = publish. Quality gates live at publish naturally — no new draft/publish vocabulary.

### Real tools, not reimplementation

| Domain | Tool |
|---|---|
| Accessibility | axe-core via jsdom |
| HTML validity | html-validate |
| CSS lint | stylelint |
| Performance / SEO score | Lighthouse via Playwright |
| Broken links | linkinator |

Each plugs into one \`Validator\` interface. CMS owns scheduling, surfacing, incremental scope; tools own the analysis. Pinned versions; updated independently.

### Severity is per-stage

Same validator can \`warn\` at background but \`error\` at pre-publish. Operators promote/demote at the publish-gate config (\`targets.production.publishAudit.strict: true\`).

### Render-for-analysis as a Gazetta-specific advantage

The existing sidecar dependency tracking (from media v1) enables incremental quality validation that other CMSes can't do. Fragment edit only invalidates pages using that fragment.

## Implementation plan

Six cuts, each independently shippable:

| Cut | What | Effort |
|---|---|---|
| **1** | Validator infra + save-delta + 5 ref-existence validators | 4 days |
| **2** | Background scanner + admin UI surfaces (tree dots + drawer) | 4 days |
| **3** | Render-for-analysis + a11y + html-validate + altRequired | 5 days |
| **4** | Publish gate + Lighthouse + linkinator | 5 days |
| **5** | \`gazetta validate\` CLI rewrite | 2 days |
| **6** | Template-developer surfaces (impact panel) | 3 days |

**Minimum useful ship: Cut 1 (4 days)** — catches the most painful author-introduced breaks; establishes the abstraction.

**Recommended first ship: Cut 1 + 2 (8 days)** — delta blocking + ambient visibility.

**"Real quality" ship: Cut 1 + 2 + 3 (13 days)** — adds a11y + HTML validity + altRequired.

**Total for full plan: ~23 days.**

## Out of scope (deliberately)

- Real-time keystroke validation (already covered by @rjsf's Zod-driven form)
- Yoast-style content scoring (rejected per [seo-plan.md](.claude/rules/seo-plan.md))
- Reimplementing axe-core / html-validate / etc. — integrate, don't reinvent
- Blocking save on accumulated pre-existing issues (hostile UX)
- Server-side keystroke validation

## Comparison to other CMSes

Researched Sanity Studio, Contentful, Strapi, Payload CMS, Storyblok, plus VSCode and GitHub PR review for cross-domain UX patterns. Key findings:
- Successful tools keep validation phases distinct (don't blend save with publish with background)
- Real-time keystroke validation increases user errors per [UX research](https://uxmovement.com/forms/why-users-make-more-errors-with-instant-inline-validation/)
- Quality surfaces (a11y, link checking) are weak or missing across the field — Gazetta's render pipeline + sidecar tracking is a structural advantage
- The "draft / valid for publish" distinction is consistent across Sanity, Strapi, Payload — Gazetta's \`editable\` flag already encodes this

## Open questions (in design-validation.md)

1. Rendered-output cache key (content hash + dependency hash + locale + theme)
2. Severity promotion granularity (coarse strict flag vs. per-validator override)
3. Background scanner cost on huge sites (mitigated by sidecar dependency tracking)
4. Suppression UX (where does \"ignore this issue for this content\" live?)
5. Validator versioning (axe-core rule changes affect existing sites)

## Test plan

- [x] Docs reviewed for internal consistency
- [x] Implementation plan reviewed against existing infrastructure (sidecar machinery, render pipeline, Pinia store conventions)
- [ ] Reviewer signoff on the four-phase model + cut sequence
- [ ] Reviewer signoff on the "real tools, not reimplementation" stance
- [ ] Build Cut 1 in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)