### PR TITLE
ROADMAP: hygiene done; defer #80 (route params at request)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Strategic forward-looking priorities for Gazetta. Captures what's prioritized, what's deferred, and what's a non-goal.
 
-**Updated**: 2026-05-03
+**Updated**: 2026-05-04
 
 ## How to read this
 
@@ -16,10 +16,10 @@ Priorities derive from [`docs/audits/cms-feature-audit.md`](docs/audits/cms-feat
 
 ## Tier 1 — committed (next 4-8 weeks)
 
-### Hygiene
-- Land dependabot PR #219
-- Fix bug #106 (component reordering immediate-save)
-- Fix #80 (dynamic route params at render)
+### Hygiene (done)
+- ✓ Land dependabot PR #219 — shipped
+- ✓ Land `@hono/node-server` v2 bump (PR #224) — shipped
+- ✓ Fix bug #106 (component reordering immediate-save, PR #225) — shipped
 
 ### Validation Cut 1 (4 days)
 Save-time integrity validation per [`design-validation.md`](.claude/rules/design-validation.md). Establishes the `Validator` interface; ships 5 reference-existence validators; closes part of issue #40.
@@ -108,6 +108,7 @@ Per design-validation-implementation. Closes out the validation system.
 | Per-field translation | Whole-file Locale Variants work | Issue #192 — design pass when team-i18n use case lands |
 | OG image preview + JSON-LD helpers | SERP preview shipped | Issue #193 |
 | Solid.js / Svelte template support | Niche; React/Vue/Svelte already covers most | Template Developer asks |
+| Dynamic route params at request time (#80) | Premature — no request-time SSR consumer yet (pages and fragments are pre-rendered today; ESI mode composes pre-rendered HTML, doesn't run templates per request) | Request-time dynamic SSR design starts; params plumbing lands as a sub-task of that |
 
 ## Non-goals (strategic non-fits)
 


### PR DESCRIPTION
## Summary
- Marks Tier 1 hygiene cluster as shipped (PRs #219, #224, #225)
- Moves issue #80 from Tier 1 to the Deferred table with rationale + trigger

## Why defer #80

Audit of \`gazetta serve\`: reads pre-rendered HTML in both static and ESI modes. ESI mode composes pre-rendered fragments at request time but doesn't run templates per request, so route params have no consumer today.

Request-time dynamic component SSR is anticipated by design-publishing.md but not implemented. When that capability is designed, params plumbing lands as a sub-task of the same feature — not as a standalone fix on top. Building #80 now would be speculative plumbing without a real consumer (per team-preferences rule 17 — "build and validate, don't spike").

## Test plan
- [x] Docs-only change, no code/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)