### PR TITLE
Foundational dimensions inventory + ROADMAP re-sync

### DIFF
--- a/.claude/rules/design-hooks.md
+++ b/.claude/rules/design-hooks.md
@@ -1,0 +1,82 @@
+---
+paths:
+  - "packages/gazetta/src/admin-api/routes/pages.ts"
+  - "packages/gazetta/src/admin-api/routes/fragments.ts"
+  - "packages/gazetta/src/admin-api/routes/assets.ts"
+  - "packages/gazetta/src/admin-api/routes/publish.ts"
+  - "packages/gazetta/src/renderer.ts"
+  - "**/hook*"
+---
+
+# Hooks — design pass pending
+
+Foundational dimension #5 of 8. Extension surface for save/publish/load/render lifecycles. Auto-slugify, auto-tag, validate against external API, enrich content at save time, transform at render time.
+
+**Status**: design pass pending — sequenced 7 of 8 (after `design-rbac-audit-review.md` so hooks can carry actor context). See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
+
+**Companion docs**:
+- [`feature-design-process.md`](feature-design-process.md) — defines the **Hook check** every new primitive design must answer
+- [`design-rbac-audit-review.md`](design-rbac-audit-review.md) — hook payload includes actor identity (which requires RBAC settled first)
+- [`design-plugins.md`](design-plugins.md) — hooks are an extension surface; plugin contract specifies how they're discovered + composed
+
+**Reference**: [Payload Hooks](https://payloadcms.com/docs/hooks/overview).
+
+## Why this is foundational
+
+Hooks are foundational because every save / publish / load / render operation could fire hooks. Designing late means every primitive becomes hookable retroactively. That's structural rework on every consumer.
+
+Audit category #2 from the CMS feature audit. Template Developer pain point.
+
+## Locked invariants (already decided)
+
+- **Hooks compose with audit log.** A hook firing is an audit-loggable event (recorded actor, target, payload, result).
+- **Hooks compose with RBAC.** Hook handlers receive actor identity; can authorize against role.
+- **Hooks compose with the plugin contract.** Plugins are discovered and loaded per `design-plugins.md`; hooks are one of the things plugins can register.
+
+## Open questions for the design pass
+
+### Lifecycle phases that fire hooks
+- Save — `beforeSave`, `afterSave`?
+- Publish — `beforePublish`, `afterPublish`, `onPublishSuccess`, `onPublishFailure`?
+- Load — `afterLoad` for content transformation on read?
+- Render — `beforeRender`, `afterRender` for output transformation? (Composes with render-pipeline modes per `design-rendering.md`)
+- Asset — `beforeUpload`, `afterUpload`, `beforeTransform`?
+- Validation — hooks at each validation phase?
+
+### Hook contract shape
+- Synchronous (can fail/cancel the operation) vs. async (fire-and-forget)?
+- Both? Different lifecycle phases imply different shapes
+- Payload structure — frozen? Mutable?
+- Return value — modified payload? Cancel signal? Both?
+
+### Composition
+- Multiple hooks for the same phase — order? Per-plugin priority?
+- Hook conflict resolution — first-wins? Last-wins? All apply?
+- Cross-cutting (hooks that fire on multiple phases) vs. single-phase hooks
+
+### Where do hook handlers live?
+- npm packages (per plugin contract)?
+- Site-local in `admin/hooks/`? `sites/{name}/hooks/`?
+- Both?
+
+### Performance
+- Hook overhead per save / publish — measurable cap?
+- Async hooks — do they block the response or run in background?
+- Hook failure — does it fail the operation or log and continue?
+
+### Composition with each other dimension
+- Hooks + RBAC — hook payload carries actor; hook gates by role
+- Hooks + audit — hook firings recorded
+- Hooks + scale — N hooks at scale; performance budget
+- Hooks + render — render-time hooks for output transformation
+- Hooks + validation — hooks fire validators, or validators fire as hooks?
+
+## Migration
+
+Sites without hooks configured continue to work — hook system is opt-in. Adding hooks doesn't change existing primitive shape; hooks are observers/transformers on top.
+
+## Future directions
+
+- Visual hook editor in admin UI — operator configures hooks without code
+- Hook marketplace — npm package discovery for common patterns (slug, SEO defaults, etc.)
+- Cross-site hooks (hooks that fire on multiple sites in a multi-site project) — out of scope for v1

--- a/.claude/rules/design-i18n.md
+++ b/.claude/rules/design-i18n.md
@@ -13,11 +13,24 @@ paths:
   - "**/locale*"
 ---
 
-# i18n Plan
+# i18n / Locale
 
 File-suffix localization: `page.json` (default locale), `page.fr.json` (French),
 `page.en-gb.json` (British English). Same pattern for fragments: `fragment.fr.json`.
 Zero template changes, zero schema changes. Opt-in via `locales` in site.yaml.
+
+**Foundational dimension #2 of 8.** Locale is a closed dimension peer to theme; every feature must respect locale variants, the locked locale-priority cross-dimension fallback, and the file-suffix model. See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions" — every new feature design answers the **Locale check**.
+
+**Migration note**: This doc was previously `i18n-plan.md` (predates the `design-{feature}.md` convention). Renamed in 2026-05 alongside the foundational-dimensions inventory. Per-field translation (#192) lands as the implementation phase under this design's contract; that's when the design/implementation split documented in [`feature-design-process.md`](feature-design-process.md) gets applied to this doc.
+
+**Locked invariants** (referenced by other docs and the foundational-dimensions table):
+
+- **Closed dimension set: locale + theme** — no third dimension without extending `DIMENSION_ORDER`
+- **Locale-priority cross-dimension fallback** — `(fr, dark) → (fr, light) → (default-locale, dark) → (default-locale, light)`. Locale matters more than visual presentation when content has to fall back.
+- **File-suffix model** — `page.json` is the default locale; `page.fr.json` is French; etc. Each file is a complete manifest. Whole-file overlay.
+- **Per-field overlay model (asset-side, future for pages/fragments)** — assets support layered per-locale overrides (metadata-only or with locale-specific bytes). Pages/fragments today are whole-file only; per-field overlays are #192's design space.
+- **Subpath routing default** — `/about` (default locale, no prefix), `/fr/about` (French). Per-domain and hybrid strategies also supported.
+- **hreflang strategy** — HTML `<head>` for subpath targets; sitemap-only for cross-domain targets (avoids timing 404s when one domain publishes before another).
 
 **Status legend:** ☐ todo · ◐ in progress · ✓ done
 

--- a/.claude/rules/design-media.md
+++ b/.claude/rules/design-media.md
@@ -1152,7 +1152,7 @@ Locale and theme are first-class peer dimensions in the data model
 segments. Two reasons:
 
 1. **Consistency across the admin API.** Pages and fragments already
-   address locale via `?locale=fr` query (`i18n-plan.md` "Admin UI"
+   address locale via `?locale=fr` query (`design-i18n.md` "Admin UI"
    section). Splitting between path-style for assets and query-style
    for pages would make admin clients carry two patterns.
 2. **Selector ≠ identity.** The asset's identity is `:name`. The

--- a/.claude/rules/design-plugins.md
+++ b/.claude/rules/design-plugins.md
@@ -1,0 +1,84 @@
+---
+paths:
+  - "packages/gazetta/src/providers/**"
+  - "packages/gazetta/src/alt/*.ts"
+  - "packages/gazetta/src/transforms/**"
+  - "packages/gazetta/src/editor/mount.tsx"
+  - "**/templates/**/index.tsx"
+  - "**/admin/editors/**"
+  - "**/admin/fields/**"
+---
+
+# Plugin / extensibility — design pass pending
+
+Foundational dimension #8 of 8. Unifying contract for the existing extension surfaces — discovery, loading, lifecycle, composition.
+
+**Status**: design pass pending — sequenced 8 of 8 (after `design-hooks.md`; hooks are likely the integration point). See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
+
+**Companion docs**:
+- [`feature-design-process.md`](feature-design-process.md) — defines the **Plugin check** every new extension surface must answer
+- [`design-hooks.md`](design-hooks.md) — hooks are an extension surface; plugins likely register hooks via this contract
+
+## Why this is foundational
+
+Today, eight extension surfaces exist (storage providers, templates, custom editors, custom field widgets, transform adapters, deploy adapters, AI providers, validators) plus hooks (incoming). Each has its own interface contract. Without a unifying plugin contract, future surfaces (whatever 10th or 11th surface gets added) drift toward their own ad-hoc plug-in pattern. Unifying later is structural rework.
+
+Strategic commitment locked: **plugins are foundational** (resolved from "open question"). The named surfaces ARE the plugin system. The unifying contract formalizes how they compose.
+
+## Locked invariants (already decided)
+
+- **Existing surfaces stay distinct interfaces** — `StorageProvider`, `EditorMount`, `FieldMount`, `AltTextAdapter`, `TransformAdapter`, etc. The plugin contract doesn't replace them; it provides discovery + loading + composition rules on top.
+- **MCP schema discipline** — new admin-API routes use the existing Zod schema pattern. MCP tooling auto-generates from these. Plugin contract respects this — plugins that add admin-API routes follow the schema pattern.
+- **Real-time event-source discipline** — plugins that observe save/publish do so via audit log, not by patching handlers. Per `feature-design-process.md` non-foundational disciplines.
+
+## Open questions for the design pass
+
+### Discovery
+- Where do plugins live? npm packages (registered in `package.json`)? Site-local in `admin/plugins/`? Both?
+- How are they discovered? Auto-discovered from `package.json` field? Explicit config in `site.yaml`?
+- Versioning — peer dependency on `gazetta`? SemVer compatibility checks at load time?
+
+### Loading lifecycle
+- When do plugins load? At admin boot? Lazy on first use of their surface?
+- Plugins that need init (network connection, credential validation) — async init?
+- Failure mode — fail boot? Log and skip? Surface error in admin UI?
+
+### Composition
+- Multiple plugins extending the same surface (two storage providers, two AI providers) — how chosen?
+  - Today: `site.yaml` config picks one per surface. Plugins extend the catalog of options.
+- Plugins that add new surfaces (e.g., a plugin that adds a "search backend" surface) — out of scope for v1?
+
+### Sandbox / trust
+- Plugins run with full Node access (current model — npm packages have no sandbox) — accept and document
+- Per-plugin permission model — out of scope for v1
+- Code review for plugin marketplace listings — out of scope
+
+### API contract per surface
+- Is the contract per-surface (current — each surface has its own interface) or unified ("everything's a plugin with `name`, `init`, `dispose`")?
+- Per-surface keeps existing code working; unified is cleaner. Probably per-surface with a thin meta-layer for discovery + lifecycle
+
+### Plugin payload
+- What does a plugin export? A constructor function? A registration object? Default export?
+- TypeScript types for plugin authors — exported from `gazetta/plugin`?
+
+### Composition with hooks
+- Hooks are one surface a plugin can extend. The plugin loads → registers its hooks → audit log records hook firings as actor=plugin-name?
+
+### Composition with each foundational dimension
+- **Scale**: plugins must respect the operating envelope; heavy plugins flagged
+- **Locale + Themes**: plugins that touch render output respect locale/theme dimensions
+- **RBAC**: plugin-added admin actions gate on roles
+- **Audit log**: plugin actions recorded
+- **Render**: plugins respect render-mode taxonomy
+
+## Migration
+
+Existing surfaces continue to work — plugin contract is additive on top. The migration is per-surface as the contract is applied:
+- Built-in storage providers (filesystem, R2, S3, Azure) become "in-tree plugins" registered the same way external plugins would be
+- Templates / custom editors / custom fields stay where they are; the contract applies to npm-packaged versions
+
+## Future directions
+
+- Plugin marketplace — npm registry filter, curated listings — out of scope for v1
+- Custom routes / custom CLI as plugin surface — strategic non-fit per ROADMAP non-goals (waits for concrete demand)
+- Plugin hot-reload — out of scope; reload requires admin restart

--- a/.claude/rules/design-rbac-audit-review.md
+++ b/.claude/rules/design-rbac-audit-review.md
@@ -1,0 +1,80 @@
+---
+paths:
+  - "packages/gazetta/src/admin-api/**"
+  - "packages/gazetta/src/history-recorder.ts"
+  - "packages/gazetta/src/history.ts"
+  - "**/auth*"
+  - "**/role*"
+---
+
+# RBAC + audit log + review workflows — design pass pending
+
+Foundational dimension #4 of 8. Joint design across role-based access control, audit logging, and review workflow state. The team-CMS feature set.
+
+**Status**: design pass pending — sequenced 5 of 8 (after `design-themes.md`). See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
+
+**Companion docs**:
+- [`feature-design-process.md`](feature-design-process.md) — defines the **Team check** every new feature design must answer
+- [`design-publishing.md`](design-publishing.md) — history-recorder is the existing primitive; audit log extends it with actor identity
+- [`design-editor-ux.md`](design-editor-ux.md) — Active target + Save semantics that review workflow gates on
+
+## Why this is foundational
+
+Strategic commitment locked: **Gazetta is a team CMS**, not a solo developer tool. Every API endpoint, every admin action, every save/publish operation gates on roles. Every write records (who, what, when, where). Save/publish flows respect review state.
+
+Adding any of these later means auditing every consumer. Joint design — not three separate designs — because the three concerns interact: review workflows reference audit events; audit events reference roles; roles gate review actions.
+
+## Locked invariants (already decided)
+
+- **history-recorder is the foundation for audit log.** `recordWrite()` already runs on every save and publish ([packages/gazetta/src/history-recorder.ts](../../packages/gazetta/src/history-recorder.ts)). The audit log adds an `actor` field; doesn't replace the existing primitive.
+- **Audit log is the source of real-time events.** Per the real-time event-source discipline in `feature-design-process.md`, save/publish handlers record to audit log; real-time push (presence, live publish status) observes audit log. Not bolted into save/publish handlers directly.
+- **Permission-filtered output composes here, not in a separate search design.** Filtered listings, search results, dependents queries — all filter by role via the same gate.
+- **Per-target review state.** Review workflows are scoped to the destination target (a publish to `staging` is reviewed independently from a publish to `production`), not site-wide.
+
+## Open questions for the design pass
+
+### Roles
+- Built-in role names — `admin` / `editor` / `viewer` / custom? Or fully configurable?
+- Per-target roles vs. site-wide roles? (E.g., editor on staging but viewer on prod)
+- Per-page roles? (E.g., "you can edit /docs/* but not /blog/*") — out of scope for v1?
+
+### Authorization gates
+- Where does the gate live? Hono middleware per-route? Decorator on each handler?
+- Failure mode — 403 with structured reason, or 404 (don't leak existence)?
+- Discovery — should `/api/pages` filter by what the user can see, or return everything and gate edit per-page?
+
+### Audit log shape
+- Fields — `actor` (identity), `action` (type), `target`, `before`/`after` snapshots?
+- Storage — append-only? Pruneable? Same `.gazetta/history/` location or separate `.gazetta/audit/`?
+- Retention — separate from history retention? Compliance-grade (longer)?
+- Events — every write? Or every API call (including reads)?
+- Actor identity — username string? UUID? Provider-specific (OIDC sub, basic-auth user)?
+
+### Review workflow state machine
+- States — `draft` → `review` → `approved` → `published`? Or simpler (`draft` / `published`)?
+- Transitions — who can move state? Per-role?
+- Per-target — does staging require review? Production always? Configurable per `site.yaml`?
+- Composition with active target — review state visible in active target switcher?
+
+### Auth provider
+- Built-in (Basic Auth, magic link, password) or provider-agnostic (OIDC, OAuth, SAML)?
+- Self-hosted operators vs. cloud — same auth model or split?
+
+### Real-time events
+- Presence (who's connected, what they're focused on) — when does this design pass land vs. when does presence implement?
+- Audit log → real-time channel — separate observer; verify the contract here.
+
+### Composition with hooks
+- Hooks fire with actor context — RBAC must be settled before hooks design
+- Audit log records hook firings? Or hooks are infra, not audited?
+
+## Migration
+
+Sites without RBAC config continue to work in single-author mode (current). Adding `auth:` config enables the team-CMS layer. Existing history records get a synthetic `actor: "unknown"` for pre-RBAC entries.
+
+## Future directions
+
+- Concurrent editing (OT/CRDT) — Tier 3 strategic bet, lands after presence-only ships
+- Compliance certifications (SOC 2, HIPAA) — depends on audit log shape; possibly Tier 3
+- Custom workflows — beyond `draft → review → approved → published` — operator-defined state machines
+- Per-component permissions (within a page) — out of scope for v1

--- a/.claude/rules/design-rendering.md
+++ b/.claude/rules/design-rendering.md
@@ -1,0 +1,82 @@
+---
+paths:
+  - "packages/gazetta/src/renderer.ts"
+  - "packages/gazetta/src/resolver.ts"
+  - "packages/gazetta/src/serve.ts"
+  - "packages/gazetta/src/publish-rendered.ts"
+  - "packages/gazetta/src/admin-api/routes/preview.ts"
+  - "packages/gazetta/src/types.ts"
+---
+
+# Rendering modes — design pass pending
+
+Foundational dimension #6 of 8. The full taxonomy of when and where rendering happens: static (pre-rendered), ESI (assembled at edge from pre-rendered fragments), request-time SSR (templates execute per request), island (SSR'd + hydrated in browser). Plus listings / render-time queries.
+
+**Status**: design pass pending — sequenced 6 of 8 (after `design-themes.md`; depends on locale + theme as render-context). See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
+
+**Companion docs**:
+- [`feature-design-process.md`](feature-design-process.md) — defines the **Render check** every new feature design must answer
+- [`design-publishing.md`](design-publishing.md) — current static + ESI render flows
+- [`design-concepts.md`](design-concepts.md) — component rendering types (static / dynamic / island)
+- [`design-i18n.md`](design-i18n.md) — locale enters render context
+- [`design-themes.md`](design-themes.md) — theme enters render context
+
+## Why this is foundational
+
+The rendering taxonomy currently lives implicitly across `design-publishing.md` and `design-concepts.md`. Pulling it into one foundational doc means: future features that touch the render pipeline reason about all four modes (static / ESI / request-SSR / island) uniformly.
+
+Issue #80 (dynamic route params at render) is a sub-task of this design pass — params plumbing is part of the request-time SSR contract, not a standalone fix.
+
+## Locked invariants (already decided)
+
+- **Compose vs. resolve verb split** — composing a tree from references is `compose*`; picking a value from a fallback chain or merging layered config is `resolve*`. Per [docs/adr/0001-compose-vs-resolve-verb-split.md](../../docs/adr/0001-compose-vs-resolve-verb-split.md).
+- **Hash-in-path URLs for assets** — content-addressed; URL changes when bytes change. Per [`design-media.md`](design-media.md).
+- **Content-addressed dedupe at publish** — unchanged items skip re-render via hash sidecars. Per [`design-publishing.md`](design-publishing.md).
+- **Logical comparison only** — compare operates on logical content, not materialized output. Per [`design-decisions.md`](design-decisions.md) #17.
+
+## Open questions for the design pass
+
+### Render mode taxonomy
+- Three modes today (static / ESI / island) — adding request-SSR makes four. Naming clarity — does "dynamic" stay an alias for ESI, or get repurposed for request-SSR? Or both as separate target types?
+- Component rendering types vs. target types — orthogonal axes? A static target can have an island component; can a request-SSR target have a static component?
+
+### Request-time SSR
+- Render context shape — `{ params, headers, cookies, principal, locale, theme }`?
+- Execution environment — Node/Bun only (templates need full Node)? WASM hybrid? Worker-runnable subset?
+- Caching — per-request output usually not cacheable; per-(params, principal) cache? Cache-busting?
+- Auth gate at render time — RBAC composes with render to filter content per role
+- Timeout / fallback — slow template? Fallback to static? Timeout error?
+- Issue #80 — params plumbed through `c.req.param()` → render context. Implementation lands as part of this design pass's implementation phase.
+
+### Listings / render-time queries
+- Templates need to enumerate "all blog pages" or "all pages with tag X" at render time. What's the API?
+- Composes with locale (filter by locale), theme (filter by theme), RBAC (filter by viewer's role)
+- Pagination, sort order, search-as-render-time-query
+- Replaces what Algolia would do for filtered listings (full-text site-search stays delegated per non-goals)
+
+### Routes
+- Static / dynamic route discovery — current model: filesystem-based folder structure
+- Request-SSR routes — same? Or template-declared?
+- Custom routes (plugins) — how do they fit? Per `design-plugins.md`
+
+### Composition with other dimensions
+- **Locale**: render context carries locale; composition with locale-variant manifests already shipped
+- **Theme**: render context carries theme; needs `design-themes.md` to formalize
+- **RBAC**: render-time auth gate; permission-filtered output
+- **Hooks**: render-time hooks for output transformation
+- **Validation**: render-for-analysis (validation Cut 3) is a render mode variant
+
+### Edge runtime constraints
+- WinterTC (Cloudflare Workers, Deno Deploy) — can run static + ESI; can NOT run templates that need Node
+- Node/Bun (gazetta serve) — can run all modes
+- Hybrid — split by mode, edge for static + ESI, Node for request-SSR + island origin
+
+## Migration
+
+Existing sites use static + ESI today. Request-SSR is opt-in via target config. Existing static pages stay static unless explicitly promoted.
+
+## Future directions
+
+- Streaming SSR (HTTP streaming response) — out of scope for v1; depends on per-render perf measurement
+- Edge SSR with WASM-compiled templates — out of scope; edge-runtime constraints are real today
+- Server components (RSC-style) — strategic bet; not on roadmap

--- a/.claude/rules/design-scale.md
+++ b/.claude/rules/design-scale.md
@@ -1,0 +1,82 @@
+---
+paths:
+  - "apps/admin/src/client/components/SiteTree.vue"
+  - "apps/admin/src/client/components/ComponentTree.vue"
+  - "packages/gazetta/src/admin-api/routes/pages.ts"
+  - "packages/gazetta/src/admin-api/routes/fragments.ts"
+  - "packages/gazetta/src/admin-api/routes/assets.ts"
+---
+
+# Scale — design pass pending
+
+Foundational dimension #1 of 8. Establishes the operating envelope (target N pages / M assets / K components-per-page) and the strategies for primitives that must hold at scale.
+
+**Status**: design pass pending — sequenced 1 of 8 (after Validation Cut 1 ships). See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
+
+**Companion docs**: [`feature-design-process.md`](feature-design-process.md) — defines the **Scale check** every new feature design must answer.
+
+## Why this is foundational
+
+Scale isn't a feature; it's a dimension every other feature must respect. Designing primitives at small-site assumption forces structural rework when a real operator brings a 1000-page / 5000-asset site. Some current primitives are scale-aware (per-edge sidecars, save-delta validation); others are not (site tree renders flat list of all pages, `/api/pages` returns everything in one response, asset library, compare/publish dialogs).
+
+## Locked invariants (already decided)
+
+These dimension-level decisions are locked, even before the design pass formalizes them:
+
+- **Per-edge sidecars over aggregate JSON** — the asset-refs index uses `.gazetta/asset-refs/{asset}/{item}` zero-byte files rather than `.refs/{asset}.json`. Multi-instance correct, O(1) writes per edge, O(N) readDir on lookup. Same pattern for `.uses-*` and `.tpl-*` sidecars. Per [`design-media-implementation.md`](design-media-implementation.md) "Asset refs."
+- **Save-delta validation over save-full** — save handlers validate only refs introduced by THIS edit, not the whole site. Per [`design-validation.md`](design-validation.md). O(diff) instead of O(site).
+- **History uses content-addressed blobs** — unchanged items dedupe across revisions. Per [`design-publishing.md`](design-publishing.md) "History." Storage scales with unique content, not revision count.
+
+## Open questions for the design pass
+
+Categorized by primitive:
+
+### Site tree (SiteTree.vue)
+- Target N — what's the supported page count? 1000? 5000? 10,000?
+- Virtualization strategy — virtual scrolling? expand-on-demand? search-driven flat list?
+- Search-as-default — should search be the primary navigation primitive at scale, with the tree as a secondary affordance?
+- Nested route paths (#88) — how to render nested routes (e.g., `blog/[slug]`) so they collapse intuitively without hiding genuinely-different pages?
+
+### Component tree (ComponentTree.vue)
+- K components per page — supported? 50? 200?
+- Deeply-nested fragments — render time grows with depth (recursive resolve); cap or warn?
+
+### Admin API
+- `/api/pages` returning all pages — paginate? 100 per page? cursor-based?
+- `/api/fragments` similarly?
+- `/api/dependents` — already O(N) walk on first call, memoized; check it scales
+
+### Asset library
+- M assets per site — supported? 1000? 10,000?
+- Pagination + filter — required at what threshold?
+- Thumbnail generation cost — pre-generated at upload, O(1) lookup; check it holds
+
+### Compare / publish dialogs
+- Hundreds of changed items — how does the picker stay usable?
+- Multi-target fan-out picker — how does it behave with many destinations?
+
+### Background scanner (validation Cut 2)
+- Per-page validation cache invalidation cost at 1000 pages
+- Initial-scan time on admin boot — incremental?
+
+### Profile / measurement
+- What's the test infrastructure? — fixture site at target scale (e.g., generated 5000-page site) for performance regression detection
+- What metrics matter? — first-load time, search latency, save latency, publish latency
+
+## Concrete operator targets to size against
+
+(To be decided in the design pass — but for now, working assumptions:)
+
+- **Small site**: <100 pages, <500 assets, <20 components/page (current implicit target)
+- **Medium site**: 100-1000 pages, 500-5000 assets, <50 components/page
+- **Large site**: 1000-10,000 pages, 5000-50,000 assets, <100 components/page
+
+The design pass picks a supported envelope and documents both the strategies and the limits.
+
+## Migration
+
+Existing sites are all small-site. Scale-aware primitives can be additive (paginated `/api/pages` with full-set as the default, virtualized tree behind a flag, etc.). The design pass's migration section formalizes how operator sites grow.
+
+## Future directions
+
+Beyond this design's envelope: 100,000-page sites, multi-million-asset libraries. Today, no concrete demand. The envelope chosen here can extend later if a real operator pushes the boundary.

--- a/.claude/rules/design-themes.md
+++ b/.claude/rules/design-themes.md
@@ -1,0 +1,68 @@
+---
+paths:
+  - "packages/gazetta/src/renderer.ts"
+  - "packages/gazetta/src/types.ts"
+  - "apps/admin/src/client/stores/theme.ts"
+  - "apps/admin/src/client/assets/tokens.css"
+  - "**/theme*"
+---
+
+# Themes — design pass pending
+
+Foundational dimension #3 of 8. Extends the asset-side theme dimension to pages/fragments/templates as a first-class render-context dimension.
+
+**Status**: design pass pending — sequenced 4 of 8 (after `design-i18n.md`). See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
+
+**Companion docs**:
+- [`feature-design-process.md`](feature-design-process.md) — defines the **Theme check** every new feature design must answer
+- [`design-media.md`](design-media.md) — locked theme invariants on the asset side
+- [`css-theming.md`](css-theming.md) — admin UI theming via PrimeVue tokens
+- [`design-i18n.md`](design-i18n.md) — sibling foundational dimension; locale + theme compose
+
+## Why this is foundational
+
+Themes is half-shipped: assets have full per-theme variant support; admin uses theme tokens via PrimeVue; pages and fragments do NOT have theme variants. Without a uniform contract, every new feature shipped between now and the design pass either ignores theme or guesses how it should behave. Retrofit risk.
+
+## Locked invariants (already decided in `design-media.md`)
+
+These extend uniformly to pages/fragments when the design pass formalizes:
+
+- **Closed dimension set: locale + theme.** No third dimension without extending `DIMENSION_ORDER` (`packages/gazetta/src/schema/dimensions.ts`).
+- **Locale-priority cross-dimension fallback** — `(fr, dark) → (fr, light) → (default-locale, dark) → (default-locale, light)`. Locked, non-configurable. Locale matters more than visual presentation when content has to fall back.
+- **Filename composition order: locale before theme.** `{name}.asset[.{loc}][.{theme}].json`. Adding a future dimension extends the order; existing filenames stay valid (no value for the new dimension).
+- **Theme name validation** — lowercase ASCII, must NOT collide with valid BCP 47 locale codes (so `hero.asset.en.json` is unambiguously a locale variant, never a theme variant).
+- **Site config opt-in** — `themes.supported: [light, dark]` in `site.yaml` enables the dimension. When absent, the theme dimension is unused.
+
+## Open questions for the design pass
+
+### Render-context shape
+- How does theme reach a template? `params.theme` argument like `params.locale`? Render-context object?
+- How does the runtime decide the theme? `prefers-color-scheme` cookie? URL parameter? Class-based cascade only (current css-theming.md approach)?
+- For dynamic targets, is theme part of the request-context (cookie/header lookup at request time)?
+
+### Pages and fragments with theme variants
+- Filename scheme — `page.fr.dark.json`? Or just metadata declaration in the manifest?
+- Are theme variants partial overlays (like locale variants can be) or whole-file?
+- How do components with theme-variant assets render under different active themes — re-resolve assets at render time?
+
+### Templates
+- Should templates declare which themes they support? Or assume all configured themes work?
+- Theme-aware CSS today is class-based (`.dark .foo`); does that stay, or do templates take theme as a param?
+- Can a template author opt OUT of theme variation (e.g., a logo that's the same in all themes)?
+
+### Admin UX
+- Active theme switcher — does the admin show a per-page theme preview? A site-wide active-theme selector?
+- Editing in theme A while theme B has different content — locale-style editing pattern?
+
+### Composition with locale
+- The asset model already locks `(fr, dark) → (fr, light) → (default-locale, dark) → (default-locale, light)`. The design pass confirms this propagates uniformly to pages/fragments.
+
+## Migration
+
+Sites without `themes.supported` continue to work — theme dimension is unused. Adding `themes:` enables the feature; existing pages/fragments become "default theme" automatically.
+
+## Future directions
+
+- Theme marketplace — npm? Curated registry? Out of scope for v1.
+- Independent theme versioning — out of scope for v1.
+- Admin chrome theming via Theme entity — out of scope; admin theming stays in `css-theming.md`'s scope.

--- a/.claude/rules/feature-design-process.md
+++ b/.claude/rules/feature-design-process.md
@@ -44,6 +44,7 @@ Capture what we're building, why, and the model.
 - **Companion docs** — link to implementation + reference + ADRs
 - **Design model / architecture** — the actual structure
 - **Distinctive choices** — what we picked vs. what we rejected, with reasons. Future-you re-litigates without these.
+- **Foundational checks** — answer each of the 8 gates (Scale / Theme / Locale / Team / Hook / Render / Validation / Plugin) — see "Foundational dimensions" below
 - **Migration** — for existing sites if applicable
 - **Open questions** — known unresolved items
 - **Future directions** — placed at the end. Lists deferred capabilities, v1.5/v2 bets, and frontier ideas that aren't committed work. Above-the-section content is the current shipped/being-built model; below-the-section content is preserved thinking, not a promise. As versions ship, items rotate up into committed scope.
@@ -80,7 +81,7 @@ The status table updates as cuts ship. When the feature is fully shipped, the im
 
 **Naming convention**: `design-{feature}.md`. The prefix matters — it makes `grep .claude/rules/design-*.md` find every feature design.
 
-Three predecessor docs use the `-plan.md` suffix (`i18n-plan.md`, `seo-plan.md`, `testing-plan.md`) and fuse design + implementation into one file. They migrate to the `design-{feature}.md` + `design-{feature}-implementation.md` split when the feature is next touched — splitting them cold without active context risks a bad split. Until then they stay as-is and remain auto-loaded via their `paths:` frontmatter.
+Two predecessor docs use the `-plan.md` suffix (`seo-plan.md`, `testing-plan.md`) and fuse design + implementation into one file. They migrate to the `design-{feature}.md` + `design-{feature}-implementation.md` split when the feature is next touched — splitting them cold without active context risks a bad split. Until then they stay as-is and remain auto-loaded via their `paths:` frontmatter. (`i18n-plan.md` was migrated to `design-i18n.md` in 2026-05 as part of the foundational-dimensions inventory; the design/implementation split happens when per-field translation #192 lands.)
 
 ### 4. Implementation
 
@@ -133,6 +134,56 @@ The skill's `ADR-FORMAT.md` lists what qualifies in concrete terms (architectura
 Most decisions don't pass this bar. The design doc carries the rationale; ADRs are the durable backstop for the load-bearing few.
 
 **Legacy:** `design-decisions.md` (18 entries) predates this two-tier model. Treat it like the `-plan.md` predecessors — lazy migration when a relevant feature is next touched: entries either move to that feature's "Distinctive choices" section or get promoted to ADRs. No new entries land in `design-decisions.md`.
+
+## Foundational dimensions
+
+Eight cross-cutting concerns that every feature design must respect. Each has its own design pass (some shipped, some pending) and corresponds to a check in the "Foundational checks" section of every new `design-{feature}.md`.
+
+The dimensions are foundational because designing a feature without respecting them is structurally expensive to retrofit later — same principle as locale, themes, validation. These are the "must be right from the beginning" concerns.
+
+| Dimension | Design doc | Gate | What every feature answers |
+|---|---|---|---|
+| Scale | `design-scale.md` | **Scale check** | Does this feature work at the documented operating envelope (target N pages / M assets / K components-per-page)? If not, what's the limitation? |
+| Themes | `design-themes.md` | **Theme check** | Does this respect the closed dimension set (locale + theme) and the locked locale-priority cross-dimension fallback? If pages/fragments aren't theme-variant yet but this feature will need them, what's today's contract vs. later? |
+| Locale (i18n) | `design-i18n.md` | **Locale check** | Does this respect locale as a closed dimension peer to theme? Does it use file-suffix locale variants (existing whole-file model) or layered overlays (per-field, future)? RTL coverage? |
+| RBAC + audit + review | `design-rbac-audit-review.md` | **Team check** | How does this feature gate on roles? What does it record to audit log? Does it interact with review workflow state? |
+| Hooks | `design-hooks.md` | **Hook check** | When does this primitive fire hooks? With what payload? Synchronous (can fail/cancel) or async? |
+| Rendering modes | `design-rendering.md` | **Render check** | Which rendering modes does this support (static / ESI / request-SSR / island)? What's the limitation for unsupported modes? Does it expose render-time queries (listings)? |
+| Validation | `design-validation.md` | **Validation check** | Does this feature need a Validator? When does it run (save-delta / background / pre-publish / cli)? What severity? |
+| Plugin / extensibility | `design-plugins.md` | **Plugin check** | Does this surface follow the plugin lifecycle (discovery, loading, composition)? If not an extension surface, N/A |
+
+**Status of design passes (sequenced, per current ROADMAP Tier 2):**
+
+1. Validation Cut 1 (in flight; locks Validator/Issue contract)
+2. `design-scale.md` (pending — gates every UI/API design)
+3. `design-i18n.md` (migrated from `i18n-plan.md` 2026-05; design/implementation split lands with #192)
+4. `design-themes.md` (pending — small, additive on i18n)
+5. `design-rbac-audit-review.md` (pending — unblocks hooks, presence)
+6. `design-rendering.md` (pending — depends on locale + themes)
+7. `design-hooks.md` (pending — depends on RBAC)
+8. `design-plugins.md` (pending — depends on hooks)
+
+A feature design started before its required dimension's design pass has shipped MUST document the assumption it's making about the pending dimension's contract — flagged as a retrofit risk. The "Foundational checks" section captures these.
+
+## Non-foundational disciplines
+
+Two narrower invariants that compose with implementation work but don't rise to dimension level. They get one-line discipline notes in this doc, not full design passes:
+
+- **MCP schema discipline** — new admin-API routes must use the existing Zod schema pattern under `packages/gazetta/src/admin-api/schemas/`. MCP tooling auto-generates from these — non-typed routes break MCP. Applies to every new route, not just MCP-aware features.
+- **Real-time event-source discipline** — save and publish handlers record write events to audit log (covered by `design-rbac-audit-review.md`). Real-time push (presence, live publish status, validation push) is a separate observer layer on top of audit log — never bolted into save/publish handlers directly.
+
+## Issue-classification discipline
+
+Every GitHub issue (bug or enhancement) is classified into a ROADMAP bucket at file time:
+
+- **Tier 1** (committed, 4-8 weeks)
+- **Tier 2** (planned, next quarter — including foundational design passes)
+- **Tier 3** (strategic bet — needs design pass before scoping)
+- **Deferred** (real gap, no current trigger)
+- **Non-goal** (per `docs/non-goals.md`)
+- **Close** (already covered, won't ship, or duplicate)
+
+Unclassified issues are a bug in the process. The retroactive sweep that established this discipline is documented in ROADMAP.md; going forward, every new issue's body should reference its bucket.
 
 ## Lifecycle of an implementation doc
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,12 +7,19 @@ Strategic forward-looking priorities for Gazetta. Captures what's prioritized, w
 ## How to read this
 
 - **Tier 1** = next 4-8 weeks; explicit commitment
-- **Tier 2** = next quarter; planned but not started
-- **Tier 3** = strategic bets; design pass needed before scoping
+- **Tier 2** = next quarter; planned but not started — includes **foundational design passes** (architectural dimensions every feature must respect) alongside committed implementation work
+- **Tier 3** = strategic bets; implementation work that depends on a foundational design pass being done first
 - **Deferred** = real gaps but not the right time
 - **Non-goals** = explicit strategic non-fits — see [`docs/non-goals.md`](docs/non-goals.md)
 
 Priorities derive from [`docs/audits/cms-feature-audit.md`](docs/audits/cms-feature-audit.md). When the audit changes, this roadmap re-derives.
+
+## Strategic commitments
+
+The framing decisions that shape multi-quarter priorities. Resolved (no longer "open questions"):
+
+- **Gazetta is a team CMS** — not a solo developer tool. RBAC + audit log + review workflows are foundational dimensions, not Tier 3 strategic bets. Implementation defers; design lands as a Tier 2 design pass.
+- **Plugins are foundational** — the existing extension surfaces (storage, templates, editors, fields, transforms, deploy adapters, AI providers, hooks, validators) ARE the plugin system. The unifying contract (discovery, lifecycle, composition) gets a Tier 2 design pass; broader runtime extensibility (custom routes, custom CLI) waits for concrete demand.
 
 ## Tier 1 — committed (next 4-8 weeks)
 
@@ -33,16 +40,37 @@ Aggregate small-but-high-impact UX wins:
 - #45 component duplication
 
 ### Onboarding sprint (3-4 weeks)
-Closes the deploy-adapters cluster — 12+ blocked issues:
+Closes part of the deploy-adapters cluster:
 - #203 deploy adapter contract (the foundation; unblocks the rest)
-- 2-3 priority adapters (likely #204 Cloudflare Pages+Functions, #206 Vercel Edge, #209 Netlify static)
+- 3 priority adapters proving the contract: #204 Cloudflare Pages+Functions, #206 Vercel Edge, #209 Netlify static
 - #213 container deployment guide
 - #79 Docker example for `gazetta serve`
+- #214 first-run Cloudflare setup (operator UX)
 
 ## Tier 2 — planned (next quarter)
 
+### Foundational design passes
+
+Eight cross-cutting dimensions that every feature design must respect (see [`feature-design-process.md`](.claude/rules/feature-design-process.md) "Foundational dimensions"). Each is a separate design pass that lands a `design-{name}.md` and adds a check to every new feature design. Implementation phases sit in Tier 3 unless otherwise noted.
+
+Sequence (per dependency order):
+
+1. **`design-scale.md`** (1-2 weeks) — covers #88 (nested route tree + search), #196 (large-site editor profile). Establishes operating envelope (target N pages / M assets / K components). Strategy for tree virtualization, paginated `/api/pages`, search-driven navigation, lazy-load asset library. Gates every UI/API design that follows.
+
+2. **`design-i18n.md`** (1 week) — migrates `i18n-plan.md` to formal design doc. Locks: locale as closed dimension peer to theme; locale-priority cross-dimension fallback; whole-file vs. per-field overlay model. Most plumbing exists; this formalizes the contract.
+
+3. **`design-themes.md`** (1 week) — extends asset-side theme dimension to pages/fragments/templates. Theme as render-context parameter; runtime routing (cookie / `prefers-color-scheme` / class cascade). Implementation is Tier 3.
+
+4. **`design-rbac-audit-review.md`** (1-2 weeks) — covers #194, #199, #200. Roles + authorization gates + audit log shape (extends history-recorder) + review workflow state machine. Implementation is Tier 3 (~6-10 weeks).
+
+5. **`design-rendering.md`** (1-2 weeks) — full rendering taxonomy (static / ESI / request-SSR / island). Defines target type, component rendering type, when-rendered axes. Includes listings/render-time queries (covers what Algolia would otherwise provide for filtered listings). Sub-task: #80 dynamic route params at request time.
+
+6. **`design-hooks.md`** (2 weeks) — extension surface for save/publish/load/render. Auto-slugify, auto-tag, validate against external API, enrich content. Reference: [Payload Hooks](https://payloadcms.com/docs/hooks/overview). Composes with RBAC (actor identity in payload) and audit log (hook firings recorded).
+
+7. **`design-plugins.md`** (1-2 weeks) — unifying plugin contract: discovery, loading, lifecycle, composition. Existing 9 extension surfaces (storage, templates, editors, fields, transforms, deploy adapters, AI providers, hooks, validators) follow the contract.
+
 ### Validation Cut 2 + 3 (8 days)
-- Cut 2: background scanner + admin UI surfaces (tree dots, "Site health" drawer)
+- Cut 2: background scanner + admin UI surfaces (tree dots, "Site health" drawer) — closes #40 fully
 - Cut 3: render-for-analysis + a11y (axe-core) + html-validate + `altRequired`
 
 ### Static publish fan-out (1-2 weeks)
@@ -57,40 +85,69 @@ Issue #202 — real correctness gap. Fragment changes don't trigger fan-out re-r
 ### AI translation task (1 week)
 Per [`design-ai-implementation.md`](.claude/rules/design-ai-implementation.md) deferred items. Adds translation as the second AI task next to alt-text; validates the cross-task `ai/` infrastructure.
 
-### Hooks / extension surface (2 weeks design + 1-2 weeks implementation)
-Audit category #2. Template Developer pain point — auto-slugify, auto-tag, validate against external API, enrich content at save time. Reference: [Payload Hooks](https://payloadcms.com/docs/hooks/overview).
+### More deploy adapters (~2 weeks; demand-driven)
+Post-contract additions to the onboarding sprint:
+- #205 Deno Deploy
+- #207 Netlify Edge Functions
+- #208 GitHub Pages (static-only)
+- #210 Cloudflare Pages (static-only, no Functions)
+- #211 S3 static website
+- #212 Azure Blob static website
 
-Design pass first; scope cut similar to validation's 6-cut sequence.
+### MCP server as alternative admin (1-2 weeks)
+Issue #49. Auto-generates MCP tools from the existing `admin-api/schemas/` Zod schemas; ships an MCP transport (stdio + HTTP); auth via existing API auth. Schema-discipline note in `feature-design-process.md` ensures every new admin-API route stays MCP-compatible. No architectural change required.
 
-## Tier 3 — strategic bets (design pass needed before scoping)
+### Operability cluster (~2 weeks; demand-driven)
+Operator-facing features that mature production deployments:
+- #19 configure cache from CMS admin UI
+- #38 cache dynamic route lookups in worker
+- #39 minimal observability for Cloudflare worker
+- #75 parallelize R2 REST API uploads
+- #76 in-memory cache for `gazetta serve`
+- #195 webhooks / post-publish hooks
+- #198 scheduled publishing
 
-### Themes as a first-class primitive
-Audit category #4. Adoption multiplier. Big design space:
-- Are themes versioned independently? Probably yes.
-- Can a Theme override admin chrome or only template-side rendering? Probably template-side only.
-- Theme switching for existing content — compatibility layer needed?
-- Marketplace mechanics — npm? Curated registry?
+### Compare polish (1 week)
+- #109 compare targets — polish and edge cases
+- #111 standalone compare view
 
-**Design effort**: 2 weeks. **Implementation**: 4-6 weeks. Real bet.
+### E2e infrastructure
+- #184 reload target registry on `site.yaml` change — unblocks the deferred hotfix-from-prod e2e scenario per `testing-plan.md`
 
-### RBAC + audit log + review workflows (joint design)
-Issues #194 + #200 + #199. Combined effort: ~6-10 weeks.
-Without these, Gazetta is a solo-dev tool. With these, it serves teams.
+### Image transformations (media v1.5 followon)
+- #201 image transformations (resize, crop, WebP/AVIF, focal point)
 
-**Design effort**: 1-2 weeks (joint design across the three). **Implementation**: 6-10 weeks.
+### Environment-specific content
+- #62 environment-specific content — design pass needed; sized after design
 
-### Real-time presence (read-only)
-Audit category #1. Sanity Presence as reference. Hardest to retrofit later — adds an architectural primitive (real-time channel) that affects every team feature.
+## Tier 3 — strategic bets (implementation pending foundational design)
 
-**Design effort**: 1 week. **Implementation MVP** (presence-only, no concurrent editing): 4 weeks. Full collab editing (OT/CRDT): 3-6 months.
+### Themes implementation (4-6 weeks)
+After `design-themes.md` lands. Theme variants for pages/fragments + runtime theme routing + admin theme switcher per active page.
+
+### RBAC + audit + review implementation (6-10 weeks)
+After `design-rbac-audit-review.md` lands. The team CMS feature set: roles, authorization gates on every API endpoint, audit log records on every write, per-target review workflow.
+
+### Per-field translation (#192)
+After `design-i18n.md` lands. Layered overlay model on top of existing whole-file locale variants.
+
+### Real-time presence
+After `design-rbac-audit-review.md` lands (audit log is the event source). Sanity Presence as reference. Real-time transport implementation lands as part of presence (1-2 weeks); presence MVP (presence-only, no concurrent editing): 4 weeks.
+
+### Hooks implementation
+After `design-hooks.md` lands. Phased cut sequence similar to validation's 6-cut pattern.
+
+### Plugin implementation
+After `design-plugins.md` lands. Unifies existing extension surfaces under one contract.
 
 ### Validation Cut 4 (publish gate + heavy validators)
-Per [`design-validation-implementation.md`](.claude/rules/design-validation-implementation.md). Adds Lighthouse via Playwright + linkinator. Operator-controlled strictness at publish time.
-
-**Effort**: 5 days.
+Per [`design-validation-implementation.md`](.claude/rules/design-validation-implementation.md). Adds Lighthouse via Playwright + linkinator. Operator-controlled strictness at publish time. **Effort**: 5 days.
 
 ### Validation Cut 5 + 6 (CLI rewrite + template-developer surfaces)
 Per design-validation-implementation. Closes out the validation system.
+
+### Concurrent editing with OT/CRDT
+Huge investment. After presence-only ships and product positioning is clear. 3-6 months.
 
 ## Deferred — real gaps but not now
 
@@ -102,13 +159,14 @@ Per design-validation-implementation. Closes out the validation system.
 | Search index CLI | Bounded but no urgent demand | Operator asks; integrate Algolia/Meilisearch |
 | Synced blocks (inline content reuse) | Fragments cover most cases | Inline-reuse demand materializes |
 | Visual editing mode (parallel to form-driven) | Strategic non-fit absent clear demand | Marketing-team operator asks specifically |
-| Real-time WebSocket subscriptions | Polling + SSE works | Live multi-user features land |
-| Concurrent editing with OT/CRDT | Huge investment | After presence-only ships and product positioning is clear |
 | Bidirectional relations beyond Usages | Notion-specialty, not industry-standard | Wiki-style use case surfaces |
-| Per-field translation | Whole-file Locale Variants work | Issue #192 — design pass when team-i18n use case lands |
 | OG image preview + JSON-LD helpers | SERP preview shipped | Issue #193 |
-| Solid.js / Svelte template support | Niche; React/Vue/Svelte already covers most | Template Developer asks |
-| Dynamic route params at request time (#80) | Premature — no request-time SSR consumer yet (pages and fragments are pre-rendered today; ESI mode composes pre-rendered HTML, doesn't run templates per request) | Request-time dynamic SSR design starts; params plumbing lands as a sub-task of that |
+| `gazetta eject-worker` (#46) | Power-user feature; demand-driven | Operator asks |
+| Pages export fragments for cross-page linking (#56) | Niche; current model covers most cases | Concrete cross-page-export use case |
+| Publish from static target (#92) | Static targets don't store source manifests; would need a separate source-resolution path | Real "publish from static" workflow surfaces |
+| Admin theme.ts JS preset bridge (#135) | Per `css-theming.md`: deferred until product maturity warrants the added surface area | Product matures past prototype phase |
+| Google Cloud Storage provider (#8) | Additive; no concrete operator demand | Operator asks |
+| Worker eject (#46) | Additive | Operator asks |
 
 ## Non-goals (strategic non-fits)
 
@@ -117,23 +175,17 @@ See [`docs/non-goals.md`](docs/non-goals.md) for full rationale. Summary:
 - Memberships / subscriptions / paywalls / native newsletters → Ghost territory
 - Content branching (git-like content branches) → multi-Target covers it
 - Content federation at CMS level → templates handle external data
-- Built-in full-text search → delegate to Algolia / Meilisearch
+- Built-in full-text site-wide search → delegate to Algolia / Meilisearch (filtered listings + permission-filtered output ARE in scope, covered by `design-rendering.md` + `design-rbac-audit-review.md`)
 - Visual editing as primary editor paradigm → form-first by design
 - Database integration → stateless CMS is a defining property
 - E-commerce primitives → out of scope
+- Solid.js / Svelte template support (#65, #69) — niche; React/Vue/Svelte template authoring already works via the template's own framework choice
+- Broad plugin system beyond documented extension surfaces — the named surfaces (storage, templates, editors, fields, transforms, deploy adapters, AI providers, hooks, validators) ARE the plugin system; broader runtime extensibility (custom routes, custom CLI) waits for concrete demand
 
 ## Process
 
-When a Tier 1 item ships, the next item from Tier 2 promotes (or is deliberately re-prioritized). When a strategic Tier 3 design pass completes, it transitions to a sized Tier 2 build.
+When a Tier 1 item ships, the next item from Tier 2 promotes (or is deliberately re-prioritized). When a Tier 2 design pass completes, the corresponding Tier 3 implementation can start.
+
+Every issue is classified into a roadmap bucket at file time per `feature-design-process.md` "Issue-classification discipline." Unclassified issues are a process bug.
 
 Tier transitions are tracked here. Ship-status of individual cuts/items lives in their respective `design-{feature}-implementation.md` files.
-
-## Open strategic questions (no commitment yet)
-
-These are framing decisions that shape multiple roadmap items but haven't been resolved:
-
-1. **Team CMS or developer-team file-based CMS?** First answer pulls in real-time presence + RBAC + concurrent editing (Sanity competitor). Second answer says hooks + themes + AI content ops are enough (Decap / TinaCMS competitor). The decision shapes 2-3 quarters of priorities.
-
-2. **MCP server as alternative admin** (issue #49)? Strategic — would Gazetta be controllable via an LLM agent, opening "AI authors content directly" workflows. No commitment yet.
-
-3. **Plugin system for site authors** (beyond adapters)? Custom field widgets exist; broader plugins (custom routes, custom storage providers, etc.) would be another extension surface. Lower priority than hooks.

--- a/docs/non-goals.md
+++ b/docs/non-goals.md
@@ -121,6 +121,28 @@ The current "last write wins" semantics (per [`operations.md`](../.claude/rules/
 
 ---
 
+## First-class Solid / Svelte / framework-of-the-week template support
+
+**Why not**: Templates are framework-agnostic by contract. Each template imports its own framework, SSRs to the standard `{ html, css, js }` shape, and ships its own framework dependency. The CMS doesn't need to ship first-class anything — React, Vue, Svelte, Solid, plain TS all work today through the same template contract.
+
+Adding "first-class Solid support" or "first-class Svelte support" implies CMS-side machinery the contract doesn't need. Operators who want a particular framework write a template using that framework; the contract handles it.
+
+**Integration path**: write the template using the framework you want.
+
+**Closed issues**: #65 (Svelte template support), #69 (Solid.js JSX support).
+
+---
+
+## Broad plugin system beyond documented extension surfaces
+
+**Why not**: Gazetta has nine documented extension surfaces (storage providers, templates, custom editors, custom field widgets, transform adapters, deploy adapters, AI providers, hooks, validators) with their own typed interfaces. Together they ARE the plugin system — operators extend Gazetta by implementing one of these surfaces. The unifying contract for discovery + lifecycle + composition lands in [`design-plugins.md`](../.claude/rules/design-plugins.md) (Tier 2 design pass).
+
+Broader runtime extensibility — custom Hono routes, custom CLI commands — would be additive, but introduces sandboxing/trust questions that aren't worth answering without concrete operator demand.
+
+**Integration path**: file an issue with the specific extension surface needed and the use case. Most legitimate cases fit one of the existing nine surfaces; the design pass for `design-plugins.md` will formalize how new surfaces get added.
+
+---
+
 ## How to revisit a non-goal
 
 Anyone proposing a feature listed here should:


### PR DESCRIPTION
## Summary

Establishes the **8 architectural dimensions** every future feature design must respect. Outcome of a grilling pass that identified the cross-cutting concerns that — if not designed in early — become structural rework on every consumer (themes, locale, RBAC, hooks, rendering, validation, scale, plugins).

Two prior "open strategic questions" in ROADMAP collapse to stated answers:

- **Gazetta is a team CMS** — RBAC + audit + review promoted from Tier 3 strategic bet to Tier 2 foundational design pass
- **Plugins are foundational** — the 9 existing extension surfaces ARE the plugin system; their unifying contract gets a Tier 2 design pass

## What's in this PR

### Foundational dimensions (8)

Each dimension gets a Tier 2 design pass and a corresponding "<Dimension> check" required in every new `design-{feature}.md`:

| Dimension | Design doc | Status |
|---|---|---|
| Scale | `design-scale.md` | NEW stub |
| Themes | `design-themes.md` | NEW stub |
| Locale (i18n) | `design-i18n.md` | Migrated from `i18n-plan.md` |
| RBAC + audit + review | `design-rbac-audit-review.md` | NEW stub |
| Hooks | `design-hooks.md` | NEW stub |
| Rendering modes | `design-rendering.md` | NEW stub |
| Validation | `design-validation.md` | Existing, in-flight |
| Plugin / extensibility | `design-plugins.md` | NEW stub |

**Stubs include locked invariants** from the grilling (e.g., themes' locked cross-dimension fallback rule, locale-priority composition) plus the open questions for the future design pass to resolve. Each design pass starts mid-way, not from scratch.

### Non-foundational disciplines (2)

One-line invariants in `feature-design-process.md`, not full design passes:

- **MCP schema discipline** — admin-API routes use Zod schemas; MCP tools auto-generate
- **Real-time event-source discipline** — save/publish records to audit log; real-time push observes audit log

### ROADMAP re-sync

All 52 open issues classified into ROADMAP buckets. **Issue-classification discipline** added to `feature-design-process.md`: every new issue is classified at file time.

**Closed as strategic non-fits per non-goals.md:**

- #65 Svelte template support
- #69 Solid.js JSX support

Both were correctly classified — framework-of-the-week template support is an architectural non-fit; the template contract handles any framework.

### Sequence

Design passes ordered by dependency:

1. Validation Cut 1 (in flight)
2. `design-scale.md`
3. `design-i18n.md` (migrated; design/impl split deferred to #192)
4. `design-themes.md` (depends on i18n)
5. `design-rbac-audit-review.md`
6. `design-rendering.md` (depends on locale + themes)
7. `design-hooks.md` (depends on RBAC)
8. `design-plugins.md` (depends on hooks)

Total ~10-12 weeks design across one quarter, intermixed with feature shipping.

## Test plan

- [x] Format check passes (biome)
- [x] No code changes — docs-only PR
- [ ] CI green across format / pack / test / e2e / smoke

## Files changed

- ROADMAP.md restructured — strategic commitments, foundational design passes section, all 52 issues classified
- feature-design-process.md — 8 gates + 2 disciplines + classification rule + sequence; "Foundational checks" section now required in every new design doc
- 6 NEW design stub docs + 1 migration (`i18n-plan.md` → `design-i18n.md`)
- design-media.md cross-reference updated
- non-goals.md — framework-of-the-week + broad-plugin-system sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)