### PR TITLE
Themes design pass complete — presentation-theming-only scope

### DIFF
--- a/.claude/rules/design-themes.md
+++ b/.claude/rules/design-themes.md
@@ -7,11 +7,11 @@ paths:
   - "**/theme*"
 ---
 
-# Themes — design pass pending
+# Themes
 
-Foundational dimension #3 of 10. Extends the asset-side theme dimension to pages/fragments/templates as a first-class render-context dimension.
+Foundational dimension #3 of 10. Establishes presentation theming (light/dark, color schemes, accessibility variants) as a render-context dimension. Asset-level theme variants already shipped per `design-media.md`; this pass formalizes the page/fragment/template contract.
 
-**Status**: design pass pending — sequenced 4 of 10 (after `design-i18n.md`). See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
+**Status**: design pass complete (2026-05). Implementation phases sit in Tier 3 — admin theme switcher already shipped per `css-theming.md`; runtime theme resolution + render-context parameter implementation lands when concrete operator demand surfaces.
 
 **Companion docs**:
 - [`feature-design-process.md`](feature-design-process.md) — defines the **Theme check** every new feature design must answer
@@ -23,9 +23,33 @@ Foundational dimension #3 of 10. Extends the asset-side theme dimension to pages
 
 Themes is half-shipped: assets have full per-theme variant support; admin uses theme tokens via PrimeVue; pages and fragments do NOT have theme variants. Without a uniform contract, every new feature shipped between now and the design pass either ignores theme or guesses how it should behave. Retrofit risk.
 
-## Locked invariants (already decided in `design-media.md`)
+## Scope: presentation theming only
 
-These extend uniformly to pages/fragments when the design pass formalizes:
+The "themes" dimension covers **presentation theming** — light/dark mode, color schemes, accessibility variants — decided at request time from cookie / `prefers-color-scheme` / URL.
+
+**Out of scope** (each gets its own future design pass when demand materializes):
+
+| Motivation | Future design |
+|---|---|
+| Brand-per-audience, white-label, multi-tenant | Per-target content (#62 — already in deferred backlog) |
+| Seasonal / campaign theming | Time-bounded content (related to scheduled publishing #198) |
+| A/B testing visual variants | Experiment infrastructure — not on roadmap; future Tier 3 |
+| Per-tenant content forks | Multi-target architecture — already supported via separate Gazetta deployments |
+
+**Why narrow scope**: the asset model's `design-media.md` locked `locale + theme` as the closed dimension set; pulling four other motivations into "themes" would conflate semantically different concepts (request-time vs. author-time, per-user vs. per-deployment). Each motivation has different lifecycles, different ownership, different infrastructure. Each gets its own design pass when concrete demand surfaces.
+
+**The architectural seams stay reserved** for those future passes:
+
+- `DIMENSION_ORDER` in `packages/gazetta/src/schema/dimensions.ts` is documented as an extension point — adding a new dimension requires a design pass; not a default extension.
+- Render-context object is already extensible; future `params.audience`, `params.campaign`, `params.experiment` are forward-additive when dimensions ship.
+- `Site` type already separates `pages`/`fragments`/`assets`; future per-audience or per-campaign content tree slots in as new top-level entries.
+- `StorageProvider` is provider-agnostic; per-tenant deployments share the abstraction.
+
+This pass commits to theme-as-presentation only. Other dimensions are designed when needed; the closed-set commitment doesn't pre-commit them.
+
+## Locked invariants
+
+**Asset-side (already locked in `design-media.md`):**
 
 - **Closed dimension set: locale + theme.** No third dimension without extending `DIMENSION_ORDER` (`packages/gazetta/src/schema/dimensions.ts`).
 - **Locale-priority cross-dimension fallback** — `(fr, dark) → (fr, light) → (default-locale, dark) → (default-locale, light)`. Locked, non-configurable. Locale matters more than visual presentation when content has to fall back.
@@ -33,34 +57,42 @@ These extend uniformly to pages/fragments when the design pass formalizes:
 - **Theme name validation** — lowercase ASCII, must NOT collide with valid BCP 47 locale codes (so `hero.asset.en.json` is unambiguously a locale variant, never a theme variant).
 - **Site config opt-in** — `themes.supported: [light, dark]` in `site.yaml` enables the dimension. When absent, the theme dimension is unused.
 
+**Pages/fragments (this design pass commits):**
+
+- **No data-layer theme variants for pages/fragments.** Theme is a render-context dimension, not a content-overlay dimension at the page/fragment level. There are no `page.dark.json` files; no `themes: {}` metadata blocks in page/fragment manifests.
+- **Theme reaches templates as a render-context parameter** — `params.theme` peer to `params.locale`. Templates emit theme-aware CSS via cascade, pick theme-variant assets via the resolver, or branch on the parameter when render-time differences are needed.
+- **Asset variants handle theme-specific imagery** — already shipped per `design-media.md`. A page with `<img>` from a theme-variant asset shows different bytes per active theme. The page manifest stays theme-agnostic; the asset reference resolves per theme.
+- **CSS cascade handles theme-specific styles** — already shipped per `css-theming.md`. Templates emit `.dark .foo` or use `prefers-color-scheme` selectors. The theme parameter just lets templates know which theme is active for runtime decisions (e.g., picking a theme-variant asset reference).
+
 ## Open questions for the design pass
 
-### Multi-instance check
-- Theme variant resolution is stateless — manifests live in storage, resolver reads on demand. No cross-instance coordination needed.
-- Theme-preview state in the admin (which theme the author is currently previewing) is per-browser, never shared across instances.
-- Confirm during design pass: any theme-related cache (e.g., resolved theme tokens for a render-pass) stays per-build / per-request scope, never long-lived across instances.
-
 ### Render-context shape
-- How does theme reach a template? `params.theme` argument like `params.locale`? Render-context object?
-- How does the runtime decide the theme? `prefers-color-scheme` cookie? URL parameter? Class-based cascade only (current css-theming.md approach)?
-- For dynamic targets, is theme part of the request-context (cookie/header lookup at request time)?
+- Theme reaches templates via `params.theme` peer to `params.locale`. Confirmed direction.
+- Open: shape of the parameter. String (`"dark"`)? Enum constrained to configured themes? Object with metadata (`{ name: 'dark', tokens: {...} }`)? Recommend: string matching a configured theme name — minimal, extensible.
+- Open: how templates declare theme support. Should templates list `supportedThemes: ['light', 'dark']` in their manifest? Or assume any configured theme works? Recommend: assume any configured theme works (the simpler default); add explicit declaration only if a real conflict surfaces.
 
-### Pages and fragments with theme variants
-- Filename scheme — `page.fr.dark.json`? Or just metadata declaration in the manifest?
-- Are theme variants partial overlays (like locale variants can be) or whole-file?
-- How do components with theme-variant assets render under different active themes — re-resolve assets at render time?
-
-### Templates
-- Should templates declare which themes they support? Or assume all configured themes work?
-- Theme-aware CSS today is class-based (`.dark .foo`); does that stay, or do templates take theme as a param?
-- Can a template author opt OUT of theme variation (e.g., a logo that's the same in all themes)?
+### Runtime theme resolution
+- For static targets (pre-rendered): theme is decided at publish time per published variant, OR static targets choose a single theme per publish. Recommend: single theme per publish target — adding multi-theme static publish is a future capability if demanded.
+- For dynamic / ESI targets: theme is decided at request time. Sources of truth: `?theme=` URL param > `theme` cookie (set by client-side toggle) > `prefers-color-scheme` header > `themes.default` site config. Recommend: this lookup chain.
+- For preview: admin sends the active theme via `?theme=` to preview endpoint. Already partially shipped (per the css-theming admin pattern).
 
 ### Admin UX
-- Active theme switcher — does the admin show a per-page theme preview? A site-wide active-theme selector?
-- Editing in theme A while theme B has different content — locale-style editing pattern?
+- **Theme switcher in admin chrome** — already shipped per `css-theming.md`. Author toggles between themes; preview iframe respects the active theme.
+- **Editing under different themes** — pages/fragments don't have theme variants at the content layer (locked invariant), so editing IS theme-agnostic. Admin doesn't show a "this content for dark theme" mode; theme switching only changes preview rendering.
+- **Asset-level theme switching in admin** — when editing a page, the active theme affects which asset variant the preview shows. Asset library shows per-theme variant indicators per `design-media.md`. Already shipped on the asset side.
 
-### Composition with locale
-- The asset model already locks `(fr, dark) → (fr, light) → (default-locale, dark) → (default-locale, light)`. The design pass confirms this propagates uniformly to pages/fragments.
+### Composition with each foundational dimension
+
+- **Multi-instance check** (discipline) — theme resolution is stateless: manifests + assets live in storage; resolver reads per-request. No cross-instance coordination. Theme-preview state in admin is per-browser. Server-side `AdminCache` entries are keyed by theme (when caching theme-affected output); per-instance scope is sufficient.
+- **Scale check** — at the operating envelope (5000 pages × 2 themes), no scaling concern at the page/fragment level (pages are theme-agnostic). Asset-level theme variants multiply file count per theme, but cross-dimension fallback means most assets need only the default-theme variant. Cache keys include theme; invalidation per-(content, theme) tuple.
+- **Locale check** — locale is the peer dimension. Cross-dimension fallback per the locked invariant: locale-priority. Templates receive both `params.locale` AND `params.theme`; render context carries them as orthogonal axes.
+- **Team check** — theme is per-user-preference; no role-based theme gating in v1. Audit log records the theme on writes (informational; useful for debugging "why did the published-prod asset look different on Tuesday").
+- **Hook check** — hooks fire with `params.theme` available. A hook on save/publish can branch on theme if needed (rare); usually hooks are theme-agnostic.
+- **Render check** — render context carries theme; render-for-analysis (validation Cut 3) caches per-(content, locale, theme) tuple. All four rendering modes (static, ESI, request-SSR, island) carry theme through their respective contexts.
+- **Validation check** — theme-aware validators are an open design (e.g., a "missing-dark-variant" validator that flags assets without a theme variant when themes are configured). Deferred to validation Cut 3 alongside the locale-aware validators.
+- **Plugin check** — plugin-supplied storage providers, AI providers, etc. see theme via existing context. Plugin-contributed validators that care about theme branch on the same parameter.
+- **Cache check** — `AdminCache` keys include theme where the cached output differs per-theme (rendered HTML, resolved assets). Theme switch invalidates only theme-keyed entries; other entries (page summaries, dependents) stay fresh.
+- **Offline check** — browser-side cache scopes entries by active theme. Offline theme switching reads from cached entries for the new theme; if not cached, surfaces the staleness banner. Save attempts during offline include the active theme in the queued payload.
 
 ## Migration
 

--- a/.claude/rules/feature-design-process.md
+++ b/.claude/rules/feature-design-process.md
@@ -159,7 +159,7 @@ The dimensions are foundational because designing a feature without respecting t
 1. Validation Cut 1 (in flight; locks Validator/Issue contract)
 2. `design-scale.md` (complete 2026-05; closes #88 + #196)
 3. `design-i18n.md` (complete 2026-05; 13 of 15 implementation steps shipped; design/implementation split lands with #192 per-field translation)
-4. `design-themes.md` (pending — small, additive on i18n)
+4. `design-themes.md` (complete 2026-05; presentation-theming-only scope; pages/fragments stay theme-agnostic at the data layer)
 5. `design-rbac-audit-review.md` (pending — unblocks hooks, presence)
 6. `design-rendering.md` (pending — depends on locale + themes)
 7. `design-hooks.md` (pending — depends on RBAC)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,7 +59,7 @@ Sequence (per dependency order):
 
 2. **`design-i18n.md`** (complete 2026-05) — migrated from `i18n-plan.md`. Locked: locale as closed dimension peer to theme; locale-priority cross-dimension fallback; whole-file overlay model; subpath/per-domain/hybrid routing strategies; hreflang via HTML or sitemap. 13 of 15 implementation steps shipped; remaining steps (admin "Translate to..." action + `gazetta validate` locale checks) tracked under editor papercut cluster + validation Cut 5 respectively.
 
-3. **`design-themes.md`** (1 week) — extends asset-side theme dimension to pages/fragments/templates. Theme as render-context parameter; runtime routing (cookie / `prefers-color-scheme` / class cascade). Implementation is Tier 3.
+3. **`design-themes.md`** (complete 2026-05) — presentation theming (light/dark, color schemes, accessibility variants) as a render-context dimension. Pages/fragments stay theme-agnostic at the data layer; theme reaches templates via `params.theme` peer to `params.locale`. Asset-level theme variants already shipped per `design-media.md`. Other variant motivations (audience, campaign, A/B, multi-tenant) are explicitly NOT bundled into themes — each gets its own design pass when concrete demand surfaces.
 
 4. **`design-rbac-audit-review.md`** (1-2 weeks) — covers #194, #199, #200. Roles + authorization gates + audit log shape (extends history-recorder) + review workflow state machine. Implementation is Tier 3 (~6-10 weeks).
 


### PR DESCRIPTION
## Summary

Closes the third foundational design pass (after scale + i18n).

### Strategic decisions

**Scope: presentation theming only** — light/dark / color schemes / accessibility variants. Decided at request time from cookie / `prefers-color-scheme` / URL.

**Categorical separation** — other variant motivations are explicitly NOT bundled into themes:

- Brand-per-audience, white-label, multi-tenant → per-target content (#62)
- Seasonal / campaign theming → time-bounded content (related to #198)
- A/B testing visual variants → experiment infrastructure (future Tier 3)
- Per-tenant content forks → multi-target architecture (already shipped)

Each future motivation gets its own design pass when concrete demand surfaces.

### Page/fragment data layer

**No data-layer theme variants on pages/fragments.** Theme is a render-context dimension, not a content-overlay dimension. Theme reaches templates as `params.theme` peer to `params.locale`. Asset variants + CSS cascade handle theme-specific imagery + styles (already shipped per `design-media.md` + `css-theming.md`).

### Architectural seams reserved

`DIMENSION_ORDER` documented as extension point; render-context object extensible (`params.audience`, `params.campaign`, `params.experiment` forward-additive); `Site` type already separates pages/fragments/assets; `StorageProvider` provider-agnostic. Future variant dimensions slot in via their own design passes without retrofit cost.

### Foundational checks

Composition with each of the other 9 foundational dimensions documented (multi-instance, scale, locale, team, hooks, render, validation, plugins, cache, offline).

## Status updates

- design-themes.md → "design pass complete (2026-05)"
- feature-design-process.md sequence updated
- ROADMAP.md design-passes section updated

## Test plan

- [x] Docs-only — no code changes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)