### PR TITLE
Review workflow design pass complete (#6 of 13) + Collaboration extracted (#13 of 13)

### DIFF
--- a/.claude/rules/design-audit.md
+++ b/.claude/rules/design-audit.md
@@ -8,7 +8,7 @@ paths:
 
 # Audit log
 
-Foundational dimension #5 of 12. Pluggable audit-event recording with multiple provider implementations (history-extended at v1; external sinks reserved). Composes with auth/RBAC's `Principal` for actor identity and with the real-time event-source discipline (audit log = source of real-time events for presence + live publish status).
+Foundational dimension #5 of 13. Pluggable audit-event recording with multiple provider implementations (history-extended at v1; external sinks reserved). Composes with auth/RBAC's `Principal` for actor identity and with the real-time event-source discipline (audit log = source of real-time events for presence + live publish status).
 
 **Status**: design pass complete (2026-05). Implementation phases sit in Tier 3.
 
@@ -500,7 +500,7 @@ v1 ships full-scan only — at envelope (~25K events/year per `design-scale.md`)
 
 ## Foundational checks
 
-How audit log composes with each of the other 11 foundational dimensions plus the multi-instance discipline.
+How audit log composes with each of the other 12 foundational dimensions plus the multi-instance discipline.
 
 ### Multi-instance discipline
 - Per-revision granularity (existing history pattern). Each instance writes its own revisions to ID-keyed files (`rev-{ts}.json`); reads aggregate via `readDir`. Multi-instance-correct by construction — no shared mutable state.

--- a/.claude/rules/design-auth-rbac.md
+++ b/.claude/rules/design-auth-rbac.md
@@ -9,7 +9,7 @@ paths:
 
 # Auth + RBAC
 
-Foundational dimension #4 of 12. Authentication identity model (Gazetta consumes upstream identity, never does auth itself) + role-based access control + capability-based authorization gates.
+Foundational dimension #4 of 13. Authentication identity model (Gazetta consumes upstream identity, never does auth itself) + role-based access control + capability-based authorization gates.
 
 **Status**: design pass complete (2026-05). Implementation phases sit in Tier 3.
 
@@ -184,7 +184,7 @@ Hooks fire with actor context (`Principal` in payload) per `design-hooks.md`'s u
 
 ## Foundational checks
 
-How auth/RBAC composes with each of the other 11 foundational dimensions plus the multi-instance discipline. These compositions are how this dimension lands without retrofitting every other surface later.
+How auth/RBAC composes with each of the other 12 foundational dimensions plus the multi-instance discipline. These compositions are how this dimension lands without retrofitting every other surface later.
 
 ### Multi-instance discipline
 - `Principal` is per-request, derived from request headers by the auth-identity provider. No cross-request state in process; middleware is stateless.

--- a/.claude/rules/design-cache.md
+++ b/.claude/rules/design-cache.md
@@ -7,7 +7,7 @@ paths:
 
 # Cache — design pass pending
 
-Foundational dimension #11 of 12. Pluggable caching layer with multiple provider implementations (memory, Redis, Azure storage, future others). v1 ships memory-only; the abstraction is in place from day one so multi-instance deployments can swap to a shared provider without changing consumers.
+Foundational dimension #11 of 13. Pluggable caching layer with multiple provider implementations (memory, Redis, Azure storage, future others). v1 ships memory-only; the abstraction is in place from day one so multi-instance deployments can swap to a shared provider without changing consumers.
 
 **Status**: design pass pending — reuses the extension-surface pattern from plugins; extended by browser-side providers in `design-offline.md`. See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
 

--- a/.claude/rules/design-collaboration.md
+++ b/.claude/rules/design-collaboration.md
@@ -1,0 +1,165 @@
+---
+paths:
+  - "packages/gazetta/src/admin-api/**"
+  - "**/comment*"
+  - "**/discussion*"
+  - "**/mention*"
+  - "**/notification*"
+---
+
+# Collaboration — design pass pending
+
+Foundational dimension #13 of 13. Comments, mentions, notifications, activity feed, presence — the conversational and awareness layer that team CMSes need.
+
+Discovered while grilling `design-review-workflow.md` Q1 (reject vs request-changes). Surfaced because the "approve-with-caveats" use case ("ship it but please fix typo on line 5") doesn't fit cleanly into a state machine — it's a conversation. Collaboration is the umbrella for those conversations and the surfaces that carry them.
+
+**Status**: design pass pending — sequenced after the team-CMS core (`design-auth-rbac.md`, `design-audit.md`, `design-review-workflow.md`). Likely Tier 3 implementation.
+
+**Companion docs**:
+- [`feature-design-process.md`](feature-design-process.md) — defines the **Collaboration check** every new feature design must answer once this dimension lands
+- [`design-review-workflow.md`](design-review-workflow.md) — review approve/reject is the narrow state-machine; collaboration is the broader conversational surface
+- [`design-auth-rbac.md`](design-auth-rbac.md) — capability vocabulary extends with comment / mention / subscribe gates
+- [`design-audit.md`](design-audit.md) — collaboration events emit audit log entries
+
+## Why this is foundational
+
+Team CMSes don't just have state machines — they have conversations. Authors discuss content, reviewers leave inline feedback, ops coordinate releases, translators flag terminology questions. The collaboration surface is the cross-cutting layer that carries those conversations.
+
+Adding collaboration later means retrofitting:
+- Every content surface (page editor, asset detail, fragment editor) with comment threads
+- Every action surface (review submit, publish request) with discussion attachment
+- Audit log shape with comment events
+- Notification primitives (in-admin, email, Slack, etc.)
+- RBAC capabilities for comment / mention / subscribe / moderate
+
+Doing it in front of the work that depends on it (review workflow's "request changes" semantics, presence's "Alice is typing in this comment thread", multi-author's handoff messaging) keeps the architectural shape clean.
+
+## Surface area sketch (to formalize in design pass)
+
+What collaboration likely covers:
+
+### Comments / discussion threads
+- **Page-level comments** ("This headline isn't right for the campaign")
+- **Inline comments** anchored to a content path within a manifest ("This image needs a redo — too low contrast")
+- **Asset-level comments** ("Use this for blog header but not hero")
+- **Review-event comments** ("Approving with caveats — fix line 5 typo before publish")
+- **Publish-request comments** ("Why is this going to prod outside the release window?")
+- Threading model — flat vs nested vs single-reply
+- Resolution state — open / resolved / archived
+- Edit / delete semantics — author-only edit; admin-moderate; audit retains history
+
+### Mentions
+- `@username` syntax in comments and free-text fields
+- Notification trigger
+- Capability gate — `mention:any` vs `mention:role:editor`
+- Privacy — mentioning someone reveals their existence to the mentioner
+
+### Notifications
+- In-admin (badge + drawer)
+- Out-of-band (email, Slack, webhook) — pluggable surface, possibly Notification Provider as Extension Surface #12
+- Subscription model — opt-in per content / target / global
+- Per-event preferences — "notify me on review requests but not on every save"
+- Digest mode — accumulate and batch (daily, hourly)
+- Quiet hours / timezones
+
+### Activity feed
+- "What happened in the last day across the site?"
+- Per-user feed — "things that touched my work"
+- Per-content feed — "everything that's happened on this page"
+- Composes with audit log as event source (per the real-time event-source discipline)
+
+### Presence (existing reserved Tier 3)
+- "Alice is editing /home"
+- "Bob is reviewing the publish request"
+- Cursor / selection sharing — separate concern (presence-MVP first; concurrent editing far-future)
+
+### Reactions
+- Lightweight signal vs comment ("👍 looks good without writing 'looks good'")
+- Question for design pass: does this earn its place in v1, or is it scope creep?
+
+## Why this isn't part of review workflow
+
+Tempting to fold "comments" into review workflow because that's where the immediate need surfaced. Wrong scope:
+
+- Comments belong on draft content too (mid-edit collaboration before submitting for review)
+- Comments belong on assets (alt-text discussion, licensing notes)
+- Comments belong on publish requests (release-coordination notes)
+- Comments belong on past audit events (incident postmortems)
+
+If we ship comments inside review workflow, we'd retrofit every other surface later. Collaboration is the right umbrella; review workflow consumes it.
+
+## Why this isn't part of audit log
+
+Audit log is structured forensic record. Comments are unstructured human conversation. They share a timestamp + actor concept but the queries differ:
+
+- Audit: "what writes happened in scope X between timestamps Y and Z?"
+- Comments: "what's the discussion on page X?"
+
+Different storage shape (audit is per-revision; comments are per-thread), different retention (audit has compliance retention; comments may be operator-policy retention), different access pattern (audit drawer vs inline-on-content).
+
+Reuse where appropriate (audit records "Alice posted a comment on /home" as an audit event with `action: 'comment'`); separate primitives where the shapes differ.
+
+## Open questions for the design pass
+
+(These are placeholders — the design pass formalizes them.)
+
+### Multi-instance check
+- Comment storage: per-thread file? Per-comment sidecar? `.gazetta/comments/{kind}/{name}/threads/{thread-id}.json`?
+- Mention dispatch: real-time (SSE push) or pull (notification poll)?
+- Notification provider: pluggable (email, Slack, webhook) following the AuditProvider pattern
+
+### Surface composition
+- How do inline comments anchor to content paths that may move (component reorders)? Anchor by content-hash or by structural path?
+- Cross-locale comments — comment on `/home` (en) auto-visible on `/home` (fr)? Or per-locale?
+- Cross-target comments — comment on staging visible on prod? (Probably yes; comments are content metadata, not target-state.)
+
+### Privacy and moderation
+- Comment visibility — gated by `read:` capability of the underlying content
+- Mention visibility leak — mentioning a viewer in a comment reveals their existence
+- Moderation capability — `comment:moderate` for editing/deleting others' comments
+- Right-to-be-forgotten — scrub author + mentions of scrubbed user
+
+### Notification scope
+- Email-required vs in-admin-only
+- Slack / webhook / pluggable Notification Provider as Extension Surface #12
+- Digest vs per-event
+- Operator-default vs user-override
+
+### State machine for comment lifecycle
+- `open` / `resolved` / `archived`
+- Who can resolve — author, mentioned-user, anyone with capability?
+- Re-open semantics
+
+### Composition with review workflow
+- Approver leaves a comment with `state: open` — does that gate approval? (Recommend no; comments are conversation, approval is gate)
+- "Approve once these comments are resolved" — interesting, but feature-creep
+- Reject with a comment — comment becomes part of the rejection record (consistent with current Q1 lock)
+
+### Composition with hooks
+- `afterCommentPosted`, `afterCommentResolved`, `afterMention`
+- Plugin authors can wire external systems (Linear ticket creation on comment-with-`#bug`, Slack on mention)
+
+### Composition with offline
+- Comments queued offline + replayed on reconnect (matches save replay pattern)
+- Mentions in offline comments — notification fires on replay, not on offline write
+
+### Composition with each foundational dimension
+- Scale — comment count per page can grow large; pagination + sidecar shape
+- Locale — per-locale or shared (open question)
+- RBAC — `comment:write`, `comment:moderate`, `mention:any`, `subscribe:any`
+- Audit — every comment write/edit/delete records audit event
+- Plugin — Notification Provider as Extension Surface candidate
+
+## Migration
+
+Sites without collaboration features continue to work — collaboration is additive. Comment threads live in a reserved namespace (`.gazetta/comments/`) that runtime ignores. RBAC defaults grant `comment:write` to editor + admin roles only.
+
+## Future directions
+
+- **Notification Provider as Extension Surface** — pluggable email / Slack / webhook / Discord providers following the AuditProvider pattern
+- **Reactions** — lightweight signals (thumbs up, eyes, etc.) on comments and content
+- **Real-time comment streams** — SSE push of new comments to active viewers (composes with presence)
+- **External system bridges** — GitHub Discussions, Linear, Jira tickets surfaced as comment threads via hooks
+- **Translation discussion** — terminology questions per locale variant; composes with per-field translation
+- **Comment templates** — saved reviewer comments ("Please add alt text" as one-click)
+- **Approval-blocking comments** — opt-in mode where unresolved comments block approval (compliance archetype)

--- a/.claude/rules/design-hooks.md
+++ b/.claude/rules/design-hooks.md
@@ -10,7 +10,7 @@ paths:
 
 # Hooks — design pass pending
 
-Foundational dimension #7 of 12. Extension surface for save/publish/load/render lifecycles. Auto-slugify, auto-tag, validate against external API, enrich content at save time, transform at render time.
+Foundational dimension #7 of 13. Extension surface for save/publish/load/render lifecycles. Auto-slugify, auto-tag, validate against external API, enrich content at save time, transform at render time.
 
 **Status**: design pass pending — sequenced after `design-auth-rbac.md` so hooks can carry actor context via the `Principal` type. See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
 

--- a/.claude/rules/design-i18n.md
+++ b/.claude/rules/design-i18n.md
@@ -19,7 +19,7 @@ File-suffix localization: `page.json` (default locale), `page.fr.json` (French),
 `page.en-gb.json` (British English). Same pattern for fragments: `fragment.fr.json`.
 Zero template changes, zero schema changes. Opt-in via `locales` in site.yaml.
 
-**Foundational dimension #2 of 12.** Locale is a closed dimension peer to theme; every feature must respect locale variants, the locked locale-priority cross-dimension fallback, and the file-suffix model. See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions" — every new feature design answers the **Locale check**.
+**Foundational dimension #2 of 13.** Locale is a closed dimension peer to theme; every feature must respect locale variants, the locked locale-priority cross-dimension fallback, and the file-suffix model. See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions" — every new feature design answers the **Locale check**.
 
 **Status**: design pass complete (2026-05). Implementation 13 of 15 steps shipped (whole-file locale variants, file-suffix model, fallback chain, hreflang, sitemap, admin locale picker, CLI translate, language detection — all live). Two implementation steps remaining: admin "Translate to..." action (step 12, surfaces in editor papercut cluster) and `gazetta validate` locale-file checks (step 15, lands with validation Cut 5 CLI rewrite). See "Implementation sequence" for per-step status.
 
@@ -605,7 +605,7 @@ Publishing a subset of locales is supported — author can publish only the
 
 ## Foundational checks
 
-Locale is itself foundational dimension #2 of 12. This section answers how each of the other 11 foundational dimensions and the multi-instance discipline compose with the locale dimension, per [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
+Locale is itself foundational dimension #2 of 13. This section answers how each of the other 12 foundational dimensions and the multi-instance discipline compose with the locale dimension, per [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
 
 - **Multi-instance check** (discipline) — locale variant resolution is stateless: file-suffix manifests live in storage; resolver reads on demand; locale routing in the runtime is per-request. No cross-instance coordination required. SSE invalidation events for locale-specific saves broadcast to connected clients of the same instance; cross-instance via storage observation is sufficient. Locale-aware search indexes (when added at scale) follow the per-instance memo pattern from `design-cache.md` until shared cache providers are needed.
 

--- a/.claude/rules/design-offline.md
+++ b/.claude/rules/design-offline.md
@@ -8,7 +8,7 @@ paths:
 
 # Admin offline mode — design pass pending
 
-Foundational dimension #12 of 12. Admin works through transient connectivity loss (server restart, Wi-Fi drop, VPN issue) and degrades gracefully. Read paths serve from a local persistent cache; write paths queue and replay on reconnect; conflict resolution preserves author intent.
+Foundational dimension #12 of 13. Admin works through transient connectivity loss (server restart, Wi-Fi drop, VPN issue) and degrades gracefully. Read paths serve from a local persistent cache; write paths queue and replay on reconnect; conflict resolution preserves author intent.
 
 **Status**: design pass pending — last in the sequence; depends on `design-cache.md` (extends taxonomy), `design-auth-rbac.md` (role-aware cache scope), `design-rendering.md` (render contract), real-time event-source discipline (cache invalidation broadcasts). See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
 

--- a/.claude/rules/design-plugins.md
+++ b/.claude/rules/design-plugins.md
@@ -11,7 +11,7 @@ paths:
 
 # Plugin / extensibility — design pass pending
 
-Foundational dimension #10 of 12. Unifying contract for the existing extension surfaces — discovery, loading, lifecycle, composition.
+Foundational dimension #10 of 13. Unifying contract for the existing extension surfaces — discovery, loading, lifecycle, composition.
 
 **Status**: design pass pending — sequenced 8 of 8 (after `design-hooks.md`; hooks are likely the integration point). See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
 

--- a/.claude/rules/design-rendering.md
+++ b/.claude/rules/design-rendering.md
@@ -10,7 +10,7 @@ paths:
 
 # Rendering modes — design pass pending
 
-Foundational dimension #8 of 12. The full taxonomy of when and where rendering happens: static (pre-rendered), ESI (assembled at edge from pre-rendered fragments), request-time SSR (templates execute per request), island (SSR'd + hydrated in browser). Plus listings / render-time queries.
+Foundational dimension #8 of 13. The full taxonomy of when and where rendering happens: static (pre-rendered), ESI (assembled at edge from pre-rendered fragments), request-time SSR (templates execute per request), island (SSR'd + hydrated in browser). Plus listings / render-time queries.
 
 **Status**: design pass pending — sequenced after `design-themes.md` (depends on locale + theme as render-context). See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
 

--- a/.claude/rules/design-review-workflow.md
+++ b/.claude/rules/design-review-workflow.md
@@ -6,14 +6,15 @@ paths:
 
 # Review workflow
 
-Foundational dimension #6 of 12. Content review state machine + per-target publish approval. Operators with team workflows (content quality review, release management gates, compliance approvals) configure their flow per target; solo / small-team workflows bypass.
+Foundational dimension #6 of 13. Content review state machine + per-target publish approval. Operators with team workflows (content quality review, release management gates, compliance approvals) configure their flow per target; solo / small-team workflows bypass.
 
-**Status**: design pass pending — depends on `design-auth-rbac.md` (capability vocabulary + `Principal`) + `design-audit.md` (audit-event recording for every transition). See [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
+**Status**: design pass complete (2026-05). Implementation phases sit in Tier 3.
 
 **Companion docs**:
 - [`feature-design-process.md`](feature-design-process.md) — defines the **Review check** every new feature design must answer
 - [`design-auth-rbac.md`](design-auth-rbac.md) — capability vocabulary + Principal type
 - [`design-audit.md`](design-audit.md) — audit log records every state transition
+- [`design-collaboration.md`](design-collaboration.md) — comments / mentions / notifications layer; review-workflow v1 has narrow comment fields (reject reason); broader conversational surfaces belong in collaboration
 - [`design-publishing.md`](design-publishing.md) — existing publish primitives + history-recorder
 - [`design-editor-ux.md`](design-editor-ux.md) — Active target + Save semantics that review workflow gates on
 
@@ -23,20 +24,44 @@ Different team workflows want different review shapes — some want content revi
 
 Adding review later means retrofitting save/publish handlers, audit log shape, capability vocabulary, and admin UX. Joint design with auth/RBAC and audit because review uses both.
 
-## Locked invariants (already decided)
+## Locked invariants
 
 - **Per-content review** (NOT per-target). Content reviewed once; publishable to any target the actor has `publish:` capability for. Per-target deployment timing is a separate concern (per-target publish approval, optional).
 - **Per-target publish approval** opt-in via `targets.{name}.requiresPublishApproval: true`. When set, publish events on that target need explicit approval beyond content review.
 - **Three content review states**: `draft` → `pending-review` → `approved`. The fourth state I called "published" collapses INTO `approved` + per-target deployment timestamps from existing publish sidecars. Source-side review state vs. target-side deployment state are separate concerns.
 - **Explicit-action invariant**: every state transition requires a deliberate human action recorded as an audit event. No threshold-met daemons; the click that meets the threshold writes the per-approver sidecar AND the new state in one transaction. No time-based auto-transitions.
 - **Edit during pending-review is locked**: `pending-review` state denies edits with 409; author can withdraw submission (returns to `draft`) and edit. Prevents revision-DAG complexity.
+- **Single reject action with mandatory comment.** No "request changes" state; comment captured in audit metadata. "Approve with caveats" is a collaboration concern (`design-collaboration.md`), not a review-state-machine concern.
+- **`requiredApprovers` snapshotted at submit time.** Submission carries the policy-at-submit; subsequent config changes affect future submissions only. SOC 2-friendly (policy at decision time is documented).
+- **`allowSelfApproval` defaults to `true`.** Solo / small-team archetypes (A, B) need it. Compliance archetype E opts out via `false`.
+- **`invalidateOnSave` defaults to `'content-diff'`.** Only logical content changes invalidate approval. Compliance archetype E opts into `'always'`.
+- **Combined "Submit & approve" button** when actor has both capabilities AND self-approval allowed AND `requiredApprovers: 1`. Audit records both events with same timestamp + same actor.
+- **Pages and fragments are reviewable in v1; assets and asset-metadata defer to v2.** Asset uploads / metadata edits / site config changes / template changes bypass review at v1 (gated by their own capabilities).
 
-## Open questions for the design pass
+## Design details
 
 ### State machine details
-- Three content states (`draft` / `pending-review` / `approved`) confirmed; per-content sidecar at source level
+- Three content states (`draft` / `pending-review` / `approved`); per-content sidecar at source level
 - Three publish states per publish event (when `requiresPublishApproval`): `publish-pending` / `publish-approved` / `published`
-- Multi-approver counter: `requiredApprovers` per content; `requiredPublishApprovers` per publish event
+- Multi-approver counter: `requiredApprovers` per content (snapshotted at submit time); `requiredPublishApprovers` per publish event (snapshotted at request time)
+
+### Audit event shape (extends `design-audit.md`'s `action` enum)
+
+```ts
+// Content review transitions
+{ action: 'review-submit',   outcome: 'success', actor, scope }
+{ action: 'review-approve',  outcome: 'success', actor, scope }                                  // metadata.comment optional
+{ action: 'review-reject',   outcome: 'success', actor, scope, metadata: { comment: string } }   // comment required
+{ action: 'review-withdraw', outcome: 'success', actor, scope }                                  // submitter's own action
+
+// Per-target publish approval transitions (only when requiresPublishApproval: true)
+{ action: 'publish-request',  outcome: 'success', actor, scope, metadata: { targetName: string } }
+{ action: 'publish-approve',  outcome: 'success', actor, scope, metadata: { targetName: string } }
+{ action: 'publish-reject',   outcome: 'success', actor, scope, metadata: { targetName: string, comment: string } }
+{ action: 'publish-withdraw', outcome: 'success', actor, scope, metadata: { targetName: string } }
+```
+
+Failure outcomes (`forbidden`, `validation-failed`, `unauthenticated`) follow the standard audit shape from `design-audit.md` Q1.
 
 ### Capability additions
 - `review:submit` — submit content for review
@@ -168,13 +193,71 @@ Each archetype gets a copy-paste-ready `site.yaml` snippet + role mapping + capa
 
 ## Foundational checks
 
-To be filled in when this design pass formally completes. Touchpoints to address:
-- Multi-instance: per-edge sidecar pattern; multi-instance-correct
-- Scale: paginated `/api/reviews` per `design-scale.md`
-- Locale, themes: review state is content-level; locale variants reviewed per variant
-- Team: capability composition with `design-auth-rbac.md`
-- Hook: state transitions fire hooks (touchpoints listed above)
-- Render, Validation, Plugin, Cache, Offline: composition deferred to design pass
+How review workflow composes with each of the other 12 foundational dimensions plus the multi-instance discipline.
+
+### Multi-instance discipline
+- Per-edge sidecars (per-approver files at distinct paths) — concurrent approvals don't race; same pattern as asset-refs.
+- State transitions write the per-approver sidecar AND the state file in one logical transaction; readers compute "is threshold met?" from `readDir` of the approvers directory. Last-write-wins on `state: approved` is idempotent (same target state regardless of which instance wrote it last).
+- Snapshot of `requiredApprovers` lives in the state file at submit time; no runtime config-coordination across instances.
+- Pending review queue (`/api/reviews`) reads from storage on demand per request — no shared in-memory queue.
+
+### Scale (#1)
+- Review queue paginated via prefix-shard + cursor pagination per `design-scale.md`.
+- Per-content review state lookup is O(1) (`.gazetta/review/{kind}/{name}/state.json` is one file).
+- Approver count check is O(N-approvers) via `readDir` (typically 1-3 approvers, never large).
+- AdminCache key includes filter params; per-instance cache via `MemoryCache`.
+
+### Locale (#2)
+- Review state is on the content (the manifest). Per-locale manifests (`page.fr.json`) have their own review state — translators submit French content for review separately from default-locale content.
+- Cross-locale review composition: a future "review default + auto-mark locale variants pending" mode is reserved for the per-field translation work; v1 reviews each manifest variant independently.
+- RTL admin: review drawer / publish-request modal inherit document `dir` from the active locale; CSS logical properties handle the flip.
+
+### Themes (#3)
+- Theme variants don't yet exist for pages/fragments (per `design-themes.md` v1 — presentation-only). When pages gain theme variants, theme-variant manifests are reviewed independently per the locale pattern above.
+
+### Auth + RBAC (#4)
+- Capability extensions: `review:submit`, `review:approve`, `publish:request`, `publish:approve` (plus optional `publish:{target}-emergency`).
+- `Principal` from auth/RBAC is the actor on every review/publish-approval audit event.
+- Self-approval enforced at click-time via principal-vs-submission-actor comparison. `allowSelfApproval: false` with same actor = 403.
+- Capabilities snapshot at submit time captured in audit metadata; live-evaluated at approval time.
+
+### Audit (#5)
+- Every state transition emits an audit event per the shape above.
+- `action` enum extends with 8 new values (4 content-review + 4 publish-approval).
+- Forensic queries answer "who approved what when, with which role at the time" via the existing `actor` snapshot from `design-audit.md` Q2.
+
+### Hooks (#7)
+- State-transition hooks (10 touchpoints listed in original stub: `beforeSubmitForReview`, `afterSubmitForReview`, `beforeApprove`, `afterApprove`, `beforeReject`, `afterReject`, `beforePublishRequest`, `afterPublishRequest`, `beforePublishApprove`, `afterPublishApprove`).
+- Hook payloads carry `Principal` + content/publish-request scope.
+- `before*` hooks can fail/cancel transitions; `after*` are observational.
+
+### Render (#8)
+- Review state doesn't affect render output directly. Approved content publishes as normal; pending-review content can preview but can't publish (per the publish-request gate when enabled).
+- Render-time SSR with `Principal`: a future "show this only to approvers" template hint isn't in v1 review-workflow scope (would belong to RBAC capability checks at render time).
+
+### Validation (#9)
+- Validators run independently of review state. Save-delta validation runs on every save (regardless of review state); pre-publish validation runs on publish (gated by publish approval when enabled).
+- A "ready for review" transition can require zero open errors on the item — composition with validation, not v1.
+- Validator failures during save in `pending-review` state still return 409 + `validation-failed` audit event; review state unchanged because save was rejected.
+
+### Plugin (#10)
+- Future plugin-supplied review providers (e.g., GitHub PR-as-review) reserved per stub. v1 uses hooks for external integration; provider surface deferred until concrete demand.
+- Plugin-contributed admin routes that mutate review state declare their required capabilities via the same Hono middleware contract.
+
+### Cache (#11)
+- Review queue results cached per-request by filter params; per-instance `MemoryCache`.
+- Cache invalidated on every review-state-changing audit event (existing SSE invalidation infrastructure).
+- Capability-scoped: cache entries scoped to role principal at cache time; role change invalidates.
+
+### Offline (#12)
+- Review submit / approve / reject queued offline + replayed on reconnect (per `design-offline.md`'s replay model).
+- Replay capability check at replay time — if the principal lost `review:approve` while offline, replay fails with `outcome: 'forbidden'` recorded.
+- Concurrent online approval may have already met threshold by replay time — replay sidecar write is idempotent (no-op when state is already approved); audit records the replay attempt with `metadata.replayed: true`.
+
+### Collaboration (#13)
+- Reject comment lives in audit metadata as a narrow capture; broader review discussion (inline comments, mentions to reviewers, "request changes" semantics) belongs to collaboration.
+- When collaboration ships, approver behavior expands: "leave non-blocking comments on content + approve" or "reject with reason" (current path).
+- Combined-action ("Submit & approve") UX stays as-is; collaboration adds the conversation layer alongside, not replacing the state machine.
 
 ## Migration
 

--- a/.claude/rules/design-scale.md
+++ b/.claude/rules/design-scale.md
@@ -9,7 +9,7 @@ paths:
 
 # Scale
 
-Foundational dimension #1 of 12. Establishes the operating envelope (target N pages / M assets / K components-per-page) and the strategies for primitives that must hold at scale.
+Foundational dimension #1 of 13. Establishes the operating envelope (target N pages / M assets / K components-per-page) and the strategies for primitives that must hold at scale.
 
 **Status**: design pass complete (2026-05). Implementation phases sit in Tier 3 unless individual primitives surface in feature-driven work.
 

--- a/.claude/rules/design-themes.md
+++ b/.claude/rules/design-themes.md
@@ -9,7 +9,7 @@ paths:
 
 # Themes
 
-Foundational dimension #3 of 12. Establishes presentation theming (light/dark, color schemes, accessibility variants) as a render-context dimension. Asset-level theme variants already shipped per `design-media.md`; this pass formalizes the page/fragment/template contract.
+Foundational dimension #3 of 13. Establishes presentation theming (light/dark, color schemes, accessibility variants) as a render-context dimension. Asset-level theme variants already shipped per `design-media.md`; this pass formalizes the page/fragment/template contract.
 
 **Status**: design pass complete (2026-05). Implementation phases sit in Tier 3 — admin theme switcher already shipped per `css-theming.md`; runtime theme resolution + render-context parameter implementation lands when concrete operator demand surfaces.
 

--- a/.claude/rules/design-validation.md
+++ b/.claude/rules/design-validation.md
@@ -275,7 +275,7 @@ Per-target `publishAudit` config controls whether quality warns block publish. S
 
 ## Foundational checks
 
-Validation is itself foundational dimension #9 of 12. This section answers how each of the other 11 foundational dimensions and the multi-instance discipline compose with the validation system, per [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
+Validation is itself foundational dimension #9 of 13. This section answers how each of the other 12 foundational dimensions and the multi-instance discipline compose with the validation system, per [`feature-design-process.md`](feature-design-process.md) "Foundational dimensions."
 
 - **Multi-instance check** (discipline) — save-delta runs on the instance receiving the save request; no cross-instance coordination. Background scanner (Cut 2) per-page cache is per-admin-instance (each instance scans + caches independently); the multi-instance pattern is "every instance reads source-of-truth from storage on demand, caches results in-process, no cross-instance cache sharing." Per-page content-hash cache key ensures different instances arrive at the same cached result without coordination. Suppression state (when shipped) lives in storage, not in-memory.
 

--- a/.claude/rules/feature-design-process.md
+++ b/.claude/rules/feature-design-process.md
@@ -137,7 +137,7 @@ Most decisions don't pass this bar. The design doc carries the rationale; ADRs a
 
 ## Foundational dimensions
 
-Twelve cross-cutting concerns that every feature design must respect. Each has its own design pass (some shipped, some pending) and corresponds to a check in the "Foundational checks" section of every new `design-{feature}.md`.
+Thirteen cross-cutting concerns that every feature design must respect. Each has its own design pass (some shipped, some pending) and corresponds to a check in the "Foundational checks" section of every new `design-{feature}.md`.
 
 The dimensions are foundational because designing a feature without respecting them is structurally expensive to retrofit later — same principle as locale, themes, validation. These are the "must be right from the beginning" concerns.
 
@@ -155,6 +155,7 @@ The dimensions are foundational because designing a feature without respecting t
 | Plugin / extensibility | `design-plugins.md` | **Plugin check** | Does this surface follow the plugin lifecycle (discovery, loading, composition)? If not an extension surface, N/A |
 | Cache | `design-cache.md` | **Cache check** | Does this feature read or write cached data? Through `AdminCache` (the abstraction)? What invalidation triggers? Per-instance memory cache OK or shared provider needed? |
 | Offline | `design-offline.md` | **Offline check** | Does this feature work when admin is offline? Read paths degrade to cache; write paths queue and replay; conflict resolution on reconnect. If feature is online-only, document the limitation. |
+| Collaboration | `design-collaboration.md` | **Collaboration check** | Does this feature carry conversation (comments, mentions)? Does it generate notifications? Does it appear in the activity feed? If not collaborative, N/A. |
 
 **Status of design passes (sequenced, per current ROADMAP Tier 2):**
 
@@ -164,12 +165,13 @@ The dimensions are foundational because designing a feature without respecting t
 4. `design-themes.md` (complete 2026-05; presentation-theming-only scope; pages/fragments stay theme-agnostic at the data layer)
 5. `design-auth-rbac.md` (complete 2026-05; unblocks audit + review + hooks)
    - `design-audit.md` (complete 2026-05; extends history-recorder; `AuditProvider` Extension Surface #11)
-   - `design-review-workflow.md` (pending — extracted from joint pass; depends on auth/RBAC + audit)
+   - `design-review-workflow.md` (complete 2026-05; per-content state machine + per-target publish approval; depends on auth/RBAC + audit)
 6. `design-rendering.md` (pending — depends on locale + themes)
 7. `design-hooks.md` (pending — depends on RBAC)
 8. `design-plugins.md` (pending — depends on hooks)
 9. `design-cache.md` (pending — `MemoryCache` ships first; provider implementations slot in via the same interface as scale/admin demands materialize)
 10. `design-offline.md` (pending — depends on cache + RBAC + render; extends cache taxonomy with browser-side persistent providers)
+11. `design-collaboration.md` (pending — depends on auth/RBAC + audit + review; comments, mentions, notifications, activity feed, presence)
 
 A feature design started before its required dimension's design pass has shipped MUST document the assumption it's making about the pending dimension's contract — flagged as a retrofit risk. The "Foundational checks" section captures these.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,7 +51,7 @@ Closes part of the deploy-adapters cluster:
 
 ### Foundational design passes
 
-Twelve cross-cutting dimensions that every feature design must respect (see [`feature-design-process.md`](.claude/rules/feature-design-process.md) "Foundational dimensions"). Each is a separate design pass that lands a `design-{name}.md` and adds a check to every new feature design. Implementation phases sit in Tier 3 unless otherwise noted.
+Thirteen cross-cutting dimensions that every feature design must respect (see [`feature-design-process.md`](.claude/rules/feature-design-process.md) "Foundational dimensions"). Each is a separate design pass that lands a `design-{name}.md` and adds a check to every new feature design. Implementation phases sit in Tier 3 unless otherwise noted.
 
 Sequence (per dependency order):
 
@@ -65,7 +65,7 @@ Sequence (per dependency order):
 
    - **`design-audit.md`** (complete 2026-05) — covers #200 (audit log). `AuditProvider` extension surface #11; v1 ships `HistoryAuditProvider` with `outcome` field on every event, structured `actor` snapshot, sync fail-open + parallel fan-out, separable retention, opt-in pseudonymization (sha256 + salt), trust-mode-driven sourceIp extraction; v2 expected order: `HttpWebhookAuditProvider` first, then file → OTel → CloudWatch → Azure Monitor → syslog. Implementation Tier 3.
 
-   - **`design-review-workflow.md`** (extracted to its own pass; pending) — covers #199 (review workflows). Per-content review state machine (`draft / pending-review / approved`) + per-target publish approval; 5 archetype recipes; capability extensions (`review:submit`, `review:approve`, `publish:request`, `publish:approve`).
+   - **`design-review-workflow.md`** (complete 2026-05) — covers #199 (review workflows). Per-content review state machine (`draft / pending-review / approved`) + per-target publish approval (opt-in via `requiresPublishApproval`); 5 archetype recipes (solo / small-content / small-release / mid / compliance); capability extensions (`review:submit`, `review:approve`, `publish:request`, `publish:approve`); single reject with mandatory comment; `requiredApprovers` snapshotted at submit; `allowSelfApproval` defaults true; `invalidateOnSave` defaults `'content-diff'`. Pages + fragments reviewable in v1; assets defer to v2. Implementation Tier 3.
 
 5. **`design-rendering.md`** (1-2 weeks) — full rendering taxonomy (static / ESI / request-SSR / island). Defines target type, component rendering type, when-rendered axes. Includes listings/render-time queries (covers what Algolia would otherwise provide for filtered listings). Sub-task: #80 dynamic route params at request time.
 
@@ -76,6 +76,8 @@ Sequence (per dependency order):
 8. **`design-cache.md`** (1 week) — pluggable caching layer with multiple provider implementations. Ships `MemoryCache` (per-instance, v1 default) + reserved providers for v2 (Redis, Azure storage, file-based, distributed). Same extension-surface pattern as storage providers. Multi-instance discipline: per-instance providers are correct via independence; shared providers via the provider's own coordination.
 
 9. **`design-offline.md`** (1-2 weeks) — admin works through transient connectivity loss. Read paths serve from a browser-side persistent cache (extends cache taxonomy with `IndexedDBCache` + `LocalStorageCache`); write paths queue + replay on reconnect; conflict resolution on stale write. Pending edits persist across browser reload. Composes with cache (extends taxonomy), RBAC (role-aware cache scope), audit log (replay events recorded), real-time event-source (cache invalidation broadcasts).
+
+10. **`design-collaboration.md`** (2-3 weeks) — comments (page-level + inline + asset + review-event), mentions, notifications (in-admin + pluggable Notification Provider as Extension Surface candidate), activity feed, presence (cursor sharing reserved). Composes with auth/RBAC (capability vocabulary extends), audit log (collaboration events recorded), review workflow (approver leaves comment without gating approval), hooks (`afterCommentPosted`, `afterMention`). Discovered while grilling review-workflow Q1 — "approve-with-caveats" is a conversation, not a state-machine state.
 
 ### Validation Cut 2 + 3 (8 days)
 - Cut 2: background scanner + admin UI surfaces (tree dots, "Site health" drawer) — closes #40 fully


### PR DESCRIPTION
## Summary

Two deliverables in one PR:

### 1. `design-review-workflow.md` (#6 of 13, **complete**)

Foundational dimension #6. Per-content review state machine + per-target publish approval. Builds on `design-auth-rbac.md` (capability vocabulary) + `design-audit.md` (event recording).

Seven questions grilled and locked:

- **Q1**: single reject action with mandatory comment in audit metadata. No "request changes" state — that's collaboration territory
- **Q2**: `requiredApprovers` snapshotted at submit time (not live-evaluated)
- **Q3**: `allowSelfApproval` defaults `true` (solo/small-team need it; compliance opts out)
- **Q4**: `invalidateOnSave` defaults `'content-diff'` (only logical changes invalidate)
- **Q5**: combined "Submit & approve" button when conditions safe
- **Q6**: non-content writes bypass review at v1
- **Q7**: pages + fragments reviewable in v1; assets defer to v2

Audit `action` enum extends with 8 new values (4 content-review + 4 publish-approval). Foundational checks compose with all 12 other dimensions + multi-instance.

### 2. `design-collaboration.md` (#13 of 13, **pending**)

Foundational dimension #13, **discovered during Q1 grilling**. The "approve with caveats" use case ("ship it but please fix typo on line 5") doesn't fit cleanly into a state machine — it's a conversation.

Captured as a separate foundational dimension covering:
- Comments / discussion threads (page-level, inline, asset, review-event)
- Mentions (`@username` + notification trigger)
- Notifications (in-admin + pluggable Notification Provider as Extension Surface candidate)
- Activity feed
- Presence (existing reserved Tier 3)
- Reactions

**Why not part of review workflow**: comments belong on draft content, assets, publish requests, and past audit events. Folding into review-workflow would force retrofitting every other surface later. Collaboration is the right umbrella; review workflow consumes it.

**Why not part of audit log**: audit is structured forensic record; comments are unstructured human conversation. Different shape, different retention, different access pattern.

## Dimension count

12 → 13 across all design docs and ROADMAP. Collaboration row added to `feature-design-process.md` dimensions table.

## Test plan

- [ ] `grep "of 12"` returns no hits across `.claude/`, `ROADMAP.md`
- [ ] `grep "the other 11"` returns no hits (now "the other 12")
- [ ] design-review-workflow.md status reads `complete (2026-05)`
- [ ] design-collaboration.md status reads `pending`
- [ ] No code changes; docs-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)