### PR TITLE
grill-with-docs followup: CONTEXT.md domain terms + 2 ADRs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -117,6 +117,14 @@ _Avoid_: To-target, Target (bare in publish context — ambiguous), Sink.
 **Source Context** (internal — admin API plumbing):
 The TypeScript type `SourceContext` in `admin-api/source-context.ts` holds the storage, content root, and history wiring for the **Active Target** in an admin-API request. Distinct from Source Target (which is a publish role). The code-side name predates the role-naming clarification; semantics are unchanged.
 
+**Worker** (Gazetta-specific contract):
+The runtime that handles HTTP requests at the edge for `esi` and `dynamic` Targets — typically Cloudflare Workers, Deno Deploy, or a WinterTC-compatible edge runtime. Gazetta workers route requests, cache responses, and assemble pre-rendered fragments via string concatenation. **Workers never run template code** (locked invariant per [ADR 0007](docs/adr/0007-worker-boundary-discipline.md) and `design-rendering.md` Q1). Template execution happens at publish time (Node/Bun) or at Origin (Node/Bun for `dynamic` Targets).
+_Avoid_: Edge runtime (broader; not Gazetta-specific), Worker process (generic Node concept).
+
+**Origin** (Gazetta-specific contract):
+The Node/Bun server that runs templates per request for `dynamic` Targets. Origin executes Dynamic Fragments with full Node API access (file system, child processes, etc.). Workers call Origin on cache miss for dynamic content; Origin's responses are not cached by the Worker (per `design-cache.md` Q4 — cache only content-addressed responses). For `static` and `esi` Targets, no Origin exists.
+_Avoid_: Server (too generic), Backend (broader infrastructure term).
+
 ### Assets
 
 **Asset**:
@@ -188,7 +196,7 @@ The function or module that performs Composition. `resolveComponent` and `resolv
 ### Extension surfaces and providers
 
 **Extension surface**:
-A typed interface defining a category of pluggable functionality. Gazetta has 11: Storage, Cache, Audit, AltText (AI), Transform Adapter, Deploy Adapter, Validator, AuthIdentity, Hook, Admin Editor, Admin Field. Each surface has its own interface and per-surface conventions.
+A typed interface defining a category of pluggable functionality. Gazetta has 12: Storage, Cache, Audit, AltText (AI), Transform Adapter, Deploy Adapter, Validator, AuthIdentity, Hook, Admin Editor, Admin Field, Notification. Each surface has its own interface and per-surface conventions.
 _Avoid_: Plugin slot, Extension point, Hook (collides — Hook is one specific surface).
 
 **Provider**:
@@ -198,6 +206,50 @@ _Avoid_: Plugin (overloaded — a Plugin contains Providers), Backend (too gener
 **Plugin**:
 The unifying contract for discovery, loading, lifecycle, and composition of Providers. Plugins implement one or more Extension Surfaces. v1 plugins are in-tree implementations; v2 supports npm-packaged Providers via the plugin discovery mechanism. The Plugin contract lives in `design-plugins.md`.
 _Avoid_: Provider (narrower — a Plugin contains Providers), Extension (too generic).
+
+### Identity, capabilities, and trust
+
+**Capability**:
+A `verb:domain` permission token (e.g., `read:pages`, `edit:fragments`, `publish:non-production`, `comment:write`). The vocabulary primitive of Gazetta's authorization model. Operators assign Capabilities to Roles in `site.config.ts`; Roles aggregate Capabilities into named sets that map to Principals via the Trust mode's group/claim mapping. Plugin-contributed Capabilities use a plugin-specific prefix (e.g., `search:rebuild-index`) — built-in prefixes (read / edit / delete / publish / configure / review / restore / comment / mention / subscribe) are reserved.
+_Avoid_: Permission (collides with filesystem permissions), Right, Privilege.
+
+**Trust mode**:
+The strategy by which Gazetta extracts a Principal from an incoming request — chosen by the Operator at site config time per `admin.auth.trust`. Six in-tree modes (`none` / `forwarded-user` / `cloudflare-access` / `azure-easy-auth` / `aws-cognito` / `tailscale`) each describe how Gazetta reads the authenticated identity from upstream-provided headers / tokens. Plugin-supplied trust modes register via the AuthIdentity Extension Surface. Locked invariant: Gazetta consumes upstream identity, never authenticates itself.
+_Avoid_: Auth mode (less specific), Auth provider (collides with AuthIdentity Provider — the implementation), Identity strategy.
+
+**Principal** (internal — request-context type):
+The TypeScript type carrying the runtime user identity (id / email? / role / trustMode) propagated through admin-API requests, hook contexts, and audit events. Domain conversation says "Actor" (the role: Content Author / Operator / etc.) or just "user"; "Principal" is the API-surface technical name. Same posture as `ComponentManifest` and `SourceContext`.
+_Avoid_: Using "Principal" in domain conversation — say "actor" or "user."
+
+### Audit and notifications
+
+**Audit event**:
+The unit of forensic record in Gazetta's audit log. Every write (save / publish / delete / restore / configure-roles) emits exactly one Audit event with a structured shape: timestamp, actor (snapshot at decision time), action, outcome, scope, optional metadata. Closed enums for `action` and `outcome`; extension is closed-enum-additive. Stored via the configured AuditProvider — `HistoryAuditProvider` extends each history Revision with audit fields; external sinks (`HttpWebhookAuditProvider`, etc.) emit standalone events.
+_Avoid_: Audit log entry (longer; less precise), Log event (collides with operational logs — see `design-logging.md`).
+
+**Notification**:
+The unit of delivery for collaboration events to a recipient (mention, reply, subscription firing, content-comment). Has a recipient identity, a category, a human-readable message, and a deep-link to the relevant content. Stored at `.gazetta/notifications/{recipient-id}/{notification-id}.json` for in-admin delivery; future external NotificationProviders (email, Slack, webhook) deliver to operator-configured destinations.
+_Avoid_: Alert (too generic, collides with browser notifications), Message (collides with comment messages).
+
+### Collaboration
+
+**Comment thread**:
+A conversation anchored to a Gazetta entity — a Page, Fragment, Asset, or specific position within a Manifest (via stable component ID + optional field path). Contains an ordered list of Messages (text + structured Mentions), open/resolved state, and audit metadata. Stored at `.gazetta/comments/{kind}/{name}/threads/{thread-id}.json` with per-thread granularity for multi-instance correctness. Resolution is reversible; the thread persists.
+_Avoid_: Discussion (less precise), Conversation (broader UX term), Thread (bare — qualify with Comment when ambiguity is possible).
+
+**Mention**:
+A structured reference to an Actor inside a Comment Thread message — `{ type: 'mention', userId: 'bob@example.com' }`. NOT parsed from text; created by the `@`-picker UI which filters to users with content access (privacy gate). Triggers Notification dispatch to the mentioned user.
+_Avoid_: @-mention (decorative; the structured form is the truth), Tag (too generic).
+
+### Editor state
+
+**Pending edits**:
+Form-state changes the Author has made but not yet committed via explicit Save click. Stored per-item in Pinia stores (`editorContent`, `editorStash`, `editorStructural`); persisted to IndexedDB so they survive browser reload, navigation between pages, and offline sessions. The Author can navigate freely between items with multiple pending edits accumulated; each item's pending state is independent. Pending edits never silently apply; saving is always an explicit Author action. Distinct from Save queue.
+_Avoid_: Draft (overloaded with review-state's `draft` value), Working copy (rejected term per `design-decisions.md` #14), Dirty state (UI-only; doesn't capture the persistence semantics), Unsaved changes (acceptable in plain-language UI; less precise as domain noun).
+
+**Save queue**:
+Save attempts the Author committed (clicked Save) while offline that are waiting for the system to deliver to the Server. Stored in IndexedDB; replays on reconnect via Vue Query mutation cache. Each queued save was an explicit commit-of-intent by the Author — Save semantics don't change online vs. offline (per [ADR 0006](docs/adr/0006-save-as-commit-intent.md)). Conflicts on replay surface to the Author for resolution. Distinct from Pending edits — Pending is "I haven't committed," Queue is "I committed but delivery's pending."
+_Avoid_: Outbox (email metaphor; misleading since not sent, just local), Pending saves (collides with "Pending edits" — different concept), Sync queue (less precise; doesn't capture commit-intent).
 
 ### Project, Site, and Workspace
 

--- a/docs/adr/0006-save-as-commit-intent.md
+++ b/docs/adr/0006-save-as-commit-intent.md
@@ -1,0 +1,19 @@
+# Save means "commit intent" — works online or offline
+
+When the Author clicks Save in the Gazetta admin, the semantic is "I'm ready to commit this version" — not "send to the server right now." Save works identically online and offline. The system handles delivery; the Author has expressed intent. Online: save attempts immediately and either succeeds or fails. Offline: save enters the Save queue and replays on reconnect with `If-Match` etag for conflict detection. Both paths produce an audit event recording the Author's intent.
+
+We picked this over "Save disabled while offline" because the alternative treats save as a network operation rather than a logical commitment. Disabling save offline would force the Author to remember to come back online to commit work — a UX hostile to mobile editing, transient connectivity (commercial Wi-Fi, VPN reconnects), and offline-first workflows. The "save as send to server" reading is structurally too literal: pending edits already ARE saved locally; the question is just whether to dispatch to the server. The trade-off accepted: rare conflict-on-replay surfaces (handled per `design-offline.md` Q3) in exchange for unbroken Author flow.
+
+The corollary: Pending edits and the Save queue are distinct concepts. Pending edits = "I'm working; haven't committed yet." Save queue = "I committed; delivery's pending." Authors navigate freely between Pages with accumulated pending edits across many items; explicit Save click moves edits from Pending into either immediate-delivery (online) or the Save queue (offline). The audit event records the moment of commit, not the moment of delivery.
+
+## Consequences
+
+The Save UI affordance is identical online and offline (same button, same "Saved" feedback after click). The cloud-with-slash icon distinguishes "saved locally, not yet delivered" from "fully synced" — visible only when relevant per the Krug-aligned "absence is a state" principle ([team-preferences rule 23](../../.claude/rules/team-preferences.md)).
+
+The audit log records the Author's commit-intent at queue time (`metadata.queuedAt`) plus the eventual delivery time (`metadata.replayedAt`). Forensic queries reconstruct "Alice committed at 14:23; replay landed at 18:45 after offline session" — full chronology preserved.
+
+Conflict handling on replay (per `design-offline.md` Q3) surfaces a diff with two actions: Show diff and Discard. There is no "Save anyway (overwrite)" button — Authors who want to overwrite manually layer their changes onto the current state. This matches Linear / Notion / Figma — collaborative tools that ship offline-first don't expose force-overwrite affordances.
+
+Audit `outcome` extends with closed-enum values for replay-time states (`failed-render`, `timeout`, `hook-cancelled`); see `design-audit.md` Q1 for the full enum. The save event from queue replay carries the same `action` as a normal save plus `metadata.replayed: true`.
+
+Cross-cutting: this decision shapes `design-offline.md` (the queue + replay machinery), `design-audit.md` (the replay metadata), `design-collaboration.md` (comments queue + replay the same way), and `design-review-workflow.md` (review-state transitions also follow commit-intent semantics).

--- a/docs/adr/0007-worker-boundary-discipline.md
+++ b/docs/adr/0007-worker-boundary-discipline.md
@@ -1,0 +1,19 @@
+# Worker boundary discipline — workers never run template code
+
+Gazetta workers (the edge runtime serving `esi` and `dynamic` Targets — Cloudflare Workers, Deno Deploy, WinterTC-compatible runtimes) handle three responsibilities: HTTP routing, response caching, and fragment assembly via string concatenation. They do NOT execute template code. Template execution happens at publish time (Node/Bun for `static` + `island` components) or at Origin (Node/Bun server, per request, for `dynamic` Fragments).
+
+We picked this boundary over "workers can run templates that stay in WinterTC subset" because the boundary serves the Author / Operator workflow, not just the deployment shape. Template code changes are routine — `templates/hero/index.tsx` edits happen during normal Template Developer work. With templates running at the worker, every template change requires a worker redeploy. With templates only at publish time + Origin, template changes propagate via the existing publish pipeline (`esi` re-renders affected fragments) or via Origin reading from storage at request time (`dynamic`); workers stay still.
+
+The trade-off accepted: edge SSR with WinterTC-subset templates is reserved for v2 (when WASM-compiled templates or framework support catches up). v1 ships `dynamic` Targets as Node/Bun-only Origin. Operators who need per-request template execution at the edge wait for v2; operators who can fit their needs into static + island + ESI fragment composition get the full edge benefit (worker = pure cache + assembly = ms-level cold start, no Node runtime).
+
+## Consequences
+
+Worker deploys decouple from content/template lifecycle. Authors and Template Developers ship content and template changes through publish — `gazetta publish` re-renders affected fragments to storage; workers serve from storage on next request. Worker code only changes when Gazetta itself updates routing logic (rare).
+
+Worker cache is content-addressed by design ([design-cache.md](../../.claude/rules/design-cache.md) Q1 lock): immutable hash-in-path URLs. Origin's per-request output is NOT cached by the Worker (would break per-request semantics for dynamic Fragments). Composed pages containing dynamic Fragments are not cached as a whole.
+
+The boundary clarifies the L1-L6 cache model. L3 (Worker) does string-concatenation; never runs templates. L5 (Storage sidecars) memoize derived state across restart. L4 (Origin/Admin AdminCache) memoizes derived computations. The layers compose without overlap.
+
+The boundary forces honest deployment options. `static` Targets need only a CDN (no worker). `esi` Targets need a WinterTC-compatible Worker. `dynamic` Targets need a Worker AND a Node/Bun Origin. Each tier's infrastructure cost matches its capability — operators choose the deployment shape that fits their content needs without paying for unused runtime.
+
+Cross-cutting: this decision shapes `design-rendering.md` (the three Target types), `design-cache.md` (L3 + L4 split, content-addressed Worker cache), `design-plugins.md` (plugin code can register at Worker via routes but can't bypass the boundary to run templates there), `design-offline.md` (browser admin's L6 cache mirrors the L4 Origin shape via Vue Query). The `validate:edge-compatibility` validator (reserved for v2 when edge-Origin lands) checks template API surface against Target runtime — relevant only when v2 enables Origin on WinterTC.


### PR DESCRIPTION
## Summary

Walked the `grill-with-docs` skill's two obligations through 8 grilling rounds:

1. Inline CONTEXT.md updates as terms crystallize
2. ADRs sparingly (3 criteria — hard to reverse + surprising-without-context + real trade-off)

This session's 11 design passes surfaced 11 candidate domain terms; grilled each individually. Two cross-cutting decisions passed all 3 ADR criteria.

## CONTEXT.md additions

**New sections**:
- "Identity, capabilities, and trust" — Capability, Trust mode, Principal (internal)
- "Audit and notifications" — Audit event, Notification
- "Collaboration" — Comment thread, Mention
- "Editor state" — Pending edits, Save queue

**Added to existing sections**:
- "Targets and target roles" — Worker, Origin (Gazetta-specific contracts)

**Updated**: Extension surface count 11 → 12 (NotificationProvider added).

## ADRs

- **ADR-0006**: Save means "commit intent" — works online or offline. Cross-cutting across offline + audit + collaboration + review-workflow. Captures the design-offline.md Q6 reframe.
- **ADR-0007**: Worker boundary discipline — workers never run templates. Cross-cutting across rendering + cache + plugins + offline. Captures the design-rendering.md Q1 lock.

Both link to existing design docs as canonical detail; ADRs serve as discoverable entry points + cross-doc resilience for future readers.

## Why these and not others

The grilling explicitly walked each candidate — Q3-Q7 added domain terms; Q8 evaluated ADR candidates. Specifically rejected:
- **13 foundational dimensions framework** as ADR — already canonical in feature-design-process.md; not a hard-to-reverse decision
- **Comments-first v1 scope** as ADR — not hard-to-reverse (additive)
- **Principal** as full domain term — internal-technical only; same posture as `ComponentManifest`, `SourceContext`

## Test plan

- [ ] CONTEXT.md grew by 11 entries across 4 new sections + 2 added entries
- [ ] ADR-0006 and ADR-0007 follow existing ADR format (single-page; decision + alternatives + consequences)
- [ ] No code changes; docs-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)