### PR TITLE
Phase 0: implementation plan + 7 implementation docs

### DIFF
--- a/.claude/rules/design-audit-implementation.md
+++ b/.claude/rules/design-audit-implementation.md
@@ -1,0 +1,192 @@
+---
+paths:
+  - "packages/gazetta/src/audit/**"
+  - "packages/gazetta/src/history-recorder.ts"
+  - "packages/gazetta/src/admin-api/**"
+---
+
+# Audit log — Implementation
+
+Companion to [design-audit.md](design-audit.md). Cut sequence with risk ordering, per-cut scope, deferred items.
+
+See [design-audit.md](design-audit.md) for the design itself.
+
+## Cut sequence
+
+**Status legend**: ✓ shipped · ◐ in progress · ☐ pending
+
+Branch: `audit-v1` off `main` (after AuthIdentity ships per Phase 1 sequencing). **No backwards compatibility** — replaces existing history-recorder behavior; existing pre-RBAC revisions get synthetic `actor: 'unknown'` on read.
+
+| # | Cut | Status | Risk | Validates |
+|---|---|---|---|---|
+| 1 | `audit/` infrastructure: types, schemas, error taxonomy | ☐ | Low | Type-only foundation |
+| 2 | `AuditProvider` interface + `HistoryAuditProvider` (extends history-recorder with `actor` + `outcome` fields) | ☐ | Medium | The seam + v1 default |
+| 3 | Audit-recording middleware + sync fail-open + parallel fan-out | ☐ | Medium | The dispatch layer |
+| 4 | Pseudonymization (`actorPseudonym: 'sha256'` opt-in) + sourceIp / userAgent recording with trust-mode-driven extraction | ☐ | Medium | Privacy posture |
+| 5 | Wire all write handlers (save / publish / delete / restore / configure-roles) to emit audit events | ☐ | Low-medium | Mechanical integration |
+| 6 | Audit query endpoint `GET /api/audit` + admin drawer UI | ☐ | Medium | The visible feature |
+| 7 | `queryUrl()` deep-link UX (drawer behavior matrix when `query()` is null on external sinks — even though v1 ships only history) | ☐ | Low | Forward-compat for v2 sinks |
+| 8 | Retention pruner (audit retention separate from content retention) | ☐ | Medium | Background work |
+| 9 | Capability gating: `read:audit-log` on `/api/audit` | ☐ | Low | RBAC integration |
+| 10 | Docs + audit drawer operator guide | ☐ | Low | User-facing |
+
+## Per-cut scope
+
+### Cut 1: `audit/` infrastructure
+
+**Files added:**
+- `packages/gazetta/src/audit/types.ts` — `AuditEvent`, `AuditQuery`, `AuditOutcome`, `AuditAction` enums
+- `packages/gazetta/src/audit/errors.ts` — `AuditError`, `AuditConfigurationError`
+- `packages/gazetta/src/audit/index.ts` — barrel
+
+**Tests:** schema parsing happy path + closed-enum rejection of unknown values
+
+**Why first:** lowest blast radius; types only.
+
+### Cut 2: `AuditProvider` + `HistoryAuditProvider`
+
+**Files added:**
+- `packages/gazetta/src/audit/provider.ts` — `AuditProvider` interface
+- `packages/gazetta/src/audit/providers/history.ts` — `HistoryAuditProvider`; extends existing history-recorder `Revision` shape with `actor` + `outcome` fields (per design-audit.md "Locked invariants" — audit IS extended history)
+
+**Files modified:**
+- `packages/gazetta/src/history.ts` — `Revision` type extends with optional `audit` field
+- `packages/gazetta/src/history-recorder.ts` — record `actor` snapshot from `Principal`
+
+**Tests:** `HistoryAuditProvider` records every outcome (success / forbidden / validation-failed / unauthenticated) + actor snapshot fidelity + pre-RBAC revisions surface synthetic `actor: 'unknown'` on read
+
+**Why second:** establishes the seam. History extension is additive; existing history readers ignore the new field.
+
+### Cut 3: Audit-recording middleware
+
+**Files added:**
+- `packages/gazetta/src/audit/recorder.ts` — `recordToAll(event, providers)` with `Promise.allSettled` fan-out + failure logging (no payload in failure logs)
+- `packages/gazetta/src/admin-api/middleware/audit.ts` — Hono middleware for capability denial path (records `forbidden`)
+
+**Tests:** parallel fan-out + fail-open + failure-log-no-payload + strict-mode opt-in
+
+**Why now:** the dispatch layer. Required before write handlers can emit events.
+
+### Cut 4: Pseudonymization + sourceIp / userAgent
+
+**Files added:**
+- `packages/gazetta/src/audit/pseudonymize.ts` — `sha256(sub + GAZETTA_AUDIT_ACTOR_SALT)` + 16-char prefix
+- `packages/gazetta/src/audit/source-ip.ts` — trust-mode-driven extraction (Cf-Connecting-IP, X-Forwarded-For with `trustedProxyCount`, etc.)
+- `packages/gazetta/src/audit/user-agent.ts` — full / truncated / none modes
+
+**Tests:** salt rotation + IP truncation per CIDR + trust-mode dispatch + missing-header → omit field
+
+**Why now:** privacy posture; opt-in but ready for compliance contexts.
+
+### Cut 5: Wire write handlers
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/pages.ts` — emit audit on save / delete (success + failure paths)
+- Same across `fragments.ts`, `assets.ts`, `publish.ts`, `history.ts` (restore), `site.ts` (configure-roles)
+
+**Tests:** integration tests per route × per outcome class confirming audit events fire correctly
+
+**Why now:** mechanical integration; each route adds one or two `recordToAll()` calls.
+
+### Cut 6: Audit query endpoint + drawer UI
+
+**Files added:**
+- `packages/gazetta/src/admin-api/routes/audit.ts` — `GET /api/audit` with `AuditQuery` filters + capability-gated
+- `packages/gazetta/src/admin-api/schemas/audit.ts` — Zod schemas for query + response
+- `apps/admin/src/client/components/AuditDrawer.vue` — drawer UI with filter chips + per-row outcome badges + click-to-detail
+- `apps/admin/src/client/stores/audit.ts` — Pinia store
+
+**Tests:** route happy-path + filter combinations + admin drawer renders + filters compose correctly
+
+**Why now:** the visible feature. Operators can browse the audit log.
+
+### Cut 7: `queryUrl()` deep-link UX
+
+**Files added:**
+- `apps/admin/src/client/components/AuditDrawer.vue` — handle 4 drawer states (history-only, history+external, external-only-with-link, external-only-no-link) per design-audit.md Q4 lock
+
+**Why now:** forward-compat for v2 external sinks. Even though v1 ships only `HistoryAuditProvider`, the UI handles all states correctly so v2 plug-in is no UX change.
+
+### Cut 8: Retention pruner
+
+**Files added:**
+- `packages/gazetta/src/audit/retention.ts` — extends history pruner with audit-retention pass; handles audit-only revisions (failure outcomes have no content snapshot) + content-bearing-but-audit-stripped revisions
+- Background job: scheduled at admin boot + every 6 hours
+
+**Tests:** retention budget + age-based eviction + audit-only vs content-bearing distinction
+
+**Why now:** background work; doesn't block other cuts.
+
+### Cut 9: Capability gating
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/audit.ts` — `requireCapability('read:audit-log')` middleware
+
+**Tests:** 403 for non-admin + admin sees full feed
+
+**Why now:** RBAC integration; depends on AuthIdentity (Phase 1 prior).
+
+### Cut 10: Docs
+
+**Files added/modified:**
+- `docs/audit.md` (NEW) — operator guide with provider configurations + privacy posture
+- `docs/cloudflare.md` + `docs/self-hosted.md` — audit configuration sections
+- `examples/starter/site.config.ts` — example `admin.audit` block
+
+**Why last:** code is stable; docs reflect reality.
+
+## Validation gate (definition of done)
+
+- [ ] All 10 cuts merged
+- [ ] At least one Phase 2 feature consumes the `Principal` type via the audit middleware (Hooks foundation will compose; that's the validating consumer)
+- [ ] Operator can review audit drawer following only public docs
+- [ ] Retention pruner has been observed to prune correctly in a manual test scenario
+
+## Deferred items
+
+| Item | Trigger to revisit |
+|---|---|
+| `HttpWebhookAuditProvider` (v2 expected order #1) | First operator request |
+| `FileAuditProvider` (v2 #2) | Self-hosted operator with rsyslog/Fluent Bit demand |
+| `OpenTelemetryAuditProvider` (v2 #3) | OTel adoption signal |
+| `CloudWatchAuditProvider` / `AzureMonitorAuditProvider` (v2 #4-5) | Cloud-specific operator demand |
+| `SyslogAuditProvider` (v2 #6) | Niche; lowest priority |
+| Audit reads (`outcome: 'read'` for GET requests) | Compliance-tier demand |
+| Hook firing audit | Hooks foundation lands; compose then |
+| Index sidecars (`.gazetta/audit-index/`) | Latency p95 > 2s OR event count > 100K OR 3+ operator reports |
+
+## Open implementation questions
+
+1. **`recordToAll` error handling**: when `Promise.allSettled` returns rejected results, log failure + continue. Confirm: structured log entry shape; uses `pino` from `design-logging.md`.
+2. **Audit drawer pagination**: at envelope (~25K events/year), full scan is fine; if drawer query needs cursor pagination, lands in Cut 6 OR deferred to first operator pain.
+3. **Retention pruner concurrency**: two admin instances pruning concurrently — per-revision file-level idempotency means delete-already-deleted is no-op; race-safe.
+
+## Test infrastructure
+
+- **Real-shape audit fixtures**: capture one full audit event per `action` × outcome combination; use as test data
+- **Per-provider contract tests** (`auditProviderContractTests` from `gazetta/testing`): plugin authors validate against the contract; v1 in-tree providers also use the helper
+
+## Estimates
+
+| Cut | Estimate |
+|---|---|
+| 1 (Infrastructure) | 0.5 day |
+| 2 (Provider + HistoryAuditProvider) | 1 day |
+| 3 (Recorder + middleware) | 1 day |
+| 4 (Pseudonymization + sourceIp) | 1.5 days |
+| 5 (Wire write handlers) | 1.5 days |
+| 6 (Query endpoint + drawer) | 2 days |
+| 7 (queryUrl drawer states) | 0.5 day |
+| 8 (Retention pruner) | 1 day |
+| 9 (Capability gate) | 0.5 day |
+| 10 (Docs) | 1 day |
+
+**Total: ~10-11 days.** With CI + integration discoveries, budget ~2 weeks.
+
+## SOLID checks per cut
+
+- **Cut 1-2**: SRP per file. LSP across providers (`HistoryAuditProvider` is the v1 reference). DIP — consumers depend on `AuditProvider` interface.
+- **Cut 3**: SRP — recorder owns dispatch + failure-log; middleware owns capability-denial-recording.
+- **Cut 4**: SRP — each privacy concern in its own module (pseudonymize / sourceIp / userAgent).
+- **Cut 6**: ISP — drawer UI consumes only the query API surface; doesn't touch recorder internals.
+- **Cut 8**: SRP — retention pruner is its own module; doesn't bleed into recorder.

--- a/.claude/rules/design-auth-rbac-implementation.md
+++ b/.claude/rules/design-auth-rbac-implementation.md
@@ -1,0 +1,210 @@
+---
+paths:
+  - "packages/gazetta/src/auth/**"
+  - "packages/gazetta/src/admin-api/middleware/auth*"
+  - "packages/gazetta/src/admin-api/routes/**"
+  - "packages/gazetta/src/types.ts"
+---
+
+# Auth + RBAC — Implementation
+
+Companion to [design-auth-rbac.md](design-auth-rbac.md). Cut sequence with risk ordering, per-cut scope, deferred items.
+
+See [design-auth-rbac.md](design-auth-rbac.md) for the design itself.
+
+## Cut sequence
+
+**Status legend**: ✓ shipped · ◐ in progress · ☐ pending
+
+Branch: `auth-rbac-v1` off `main` (after TS config migration is shipped per Phase 1 sequencing). Commits ordered low-risk-first per [team-preferences.md rule 17](team-preferences.md). Pre-1.0 product; **no backwards compatibility** — cutovers replace existing code wholesale.
+
+| # | Cut | Status | Risk | Validates |
+|---|---|---|---|---|
+| 1 | `auth/` infrastructure: types, config schema, trust-mode dispatcher | ☐ | Low | Type-only foundation; no runtime |
+| 2 | `AuthIdentityProvider` interface + `none` trust mode | ☐ | Low | The seam; `none` is the trivial case |
+| 3 | `forwarded-user` trust mode + header validation | ☐ | Medium | Most flexible; basic header parsing |
+| 4 | `cloudflare-access` trust mode + JWT verification | ☐ | Medium-high | First provider needing crypto |
+| 5 | `azure-easy-auth`, `aws-cognito`, `tailscale` trust modes | ☐ | Medium | Provider proliferation |
+| 6 | Capability vocabulary + role aliases + Zod schema | ☐ | Low | Static data structures |
+| 7 | `Principal` request context + auth middleware | ☐ | Medium | Hono integration |
+| 8 | Capability-check middleware + 401 / 403 responses | ☐ | Medium | Per-route capability enforcement |
+| 9 | Wire all 10 admin-API routes with capability gates | ☐ | Low-medium | Mechanical integration |
+| 10 | Trust-mode integration tests with real header fixtures | ☐ | Medium | Validates each trust mode end-to-end |
+| 11 | Docs: per-trust-mode operator guide + capability reference | ☐ | Low | User-facing |
+
+## Per-cut scope
+
+### Cut 1: `auth/` infrastructure
+
+**Files added:**
+- `packages/gazetta/src/auth/types.ts` — `Principal`, `TrustMode`, `Capability`, `Role`, `RoleMapping`
+- `packages/gazetta/src/auth/config.ts` — Zod schema for `admin.auth` block
+- `packages/gazetta/src/auth/index.ts` — barrel export
+
+**Tests:** schema parsing happy path + invalid config rejection
+
+**Why first:** lowest blast radius. Types + schema; no runtime behavior. Reverting one file rolls back.
+
+### Cut 2: `AuthIdentityProvider` interface + `none` trust mode
+
+**Files added:**
+- `packages/gazetta/src/auth/provider.ts` — `AuthIdentityProvider` interface + factory contract
+- `packages/gazetta/src/auth/providers/none.ts` — `nonePrincipalProvider` (always returns `{ id: 'unknown', role: 'unknown', trustMode: 'none' }`)
+
+**Tests:** `nonePrincipalProvider` returns canonical `unknown` Principal; doesn't error on any request shape
+
+**Why second:** establishes the seam. `none` is the LSP test bed — proves the contract works before adding real providers.
+
+### Cut 3: `forwarded-user` trust mode
+
+**Files added:**
+- `packages/gazetta/src/auth/providers/forwarded-user.ts` — reads `X-Forwarded-User`, `X-Forwarded-Email`, `X-Forwarded-Groups`
+- Header-spoofing protection: requires source IP whitelist OR explicit operator opt-in (`admin.auth.allowAnyOrigin: true`)
+
+**Tests:** header parsing + missing-header fallback + IP whitelist enforcement
+
+**Why now:** simplest real provider. Establishes header-extraction pattern + spoofing-protection pattern that other providers reuse.
+
+### Cut 4: `cloudflare-access` trust mode
+
+**Files added:**
+- `packages/gazetta/src/auth/providers/cloudflare-access.ts` — JWT verification via Cloudflare's JWKS endpoint
+- `package.json` — add `jose` dependency for JWT validation
+
+**Tests:** msw-mocked JWKS endpoint + valid signed JWT + expired JWT + missing kid + algorithm enforcement
+
+**Why now:** first provider needing JWT verification. Riskiest crypto integration; landing it early surfaces issues.
+
+### Cut 5: `azure-easy-auth`, `aws-cognito`, `tailscale` trust modes
+
+**Files added:**
+- `packages/gazetta/src/auth/providers/azure-easy-auth.ts` — base64-decodes `X-MS-CLIENT-PRINCIPAL`
+- `packages/gazetta/src/auth/providers/aws-cognito.ts` — JWT validation for `x-amzn-oidc-data` (Cognito + ALB)
+- `packages/gazetta/src/auth/providers/tailscale.ts` — reads `Tailscale-User-Login`
+
+**Tests:** per-provider header parsing + provider-specific edge cases
+
+**Why now:** provider proliferation after the JWT pattern is established. Each is small.
+
+### Cut 6: Capability vocabulary + role aliases
+
+**Files added:**
+- `packages/gazetta/src/auth/capabilities.ts` — built-in capability constants (`READ_PAGES`, `EDIT_PAGES`, etc.)
+- `packages/gazetta/src/auth/roles.ts` — built-in role aliases (`admin`, `editor`, `viewer`)
+- `packages/gazetta/src/auth/role-resolver.ts` — `resolveRole(principal, siteConfig)` function
+
+**Tests:** role resolution from group claims + custom role registration + role aliases expansion + reserved-prefix validation
+
+**Why now:** static data structures; doesn't need a Principal yet. Can be tested in isolation.
+
+### Cut 7: `Principal` request context + auth middleware
+
+**Files added/modified:**
+- `packages/gazetta/src/admin-api/middleware/auth.ts` — Hono middleware that calls `AuthIdentityProvider.extractPrincipal(req)`, attaches `Principal` to request context
+- Hono app integration: middleware runs before all routes
+- Request context type extension: `c.var.principal: Principal`
+
+**Tests:** middleware integration + Principal injection + provider failure surfaces as 401
+
+**Why now:** wires the auth layer into Hono. Required before capability checks can run.
+
+### Cut 8: Capability-check middleware + 401 / 403 responses
+
+**Files added:**
+- `packages/gazetta/src/admin-api/middleware/capability.ts` — `requireCapability(cap)` middleware factory
+- `packages/gazetta/src/admin-api/error-response.ts` — extend with `403 FORBIDDEN` + `401 UNAUTHENTICATED` shapes
+
+**Tests:** capability check pass + 403 with `missing` field + 401 with `WWW-Authenticate` hint + admin role wildcard expansion
+
+**Why now:** the enforcement layer. Routes can opt in incrementally in Cut 9.
+
+### Cut 9: Wire all 10 admin-API routes with capability gates
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/pages.ts` — `requireCapability('read:pages')` on GET; `requireCapability('edit:pages')` on PUT/POST/DELETE
+- Same pattern across `fragments.ts`, `assets.ts`, `compare.ts`, `fields.ts`, `history.ts`, `preview.ts`, `publish.ts`, `site.ts`, `templates.ts`
+
+**Tests:** integration tests per route × per role (admin/editor/viewer) confirming 200 / 403 matrix
+
+**Why now:** mechanical integration. Each route adds one middleware line.
+
+### Cut 10: Trust-mode integration tests with real header fixtures
+
+**Tests added:**
+- `packages/gazetta/tests/auth-integration.test.ts` — fixture-driven; one test per trust mode × happy path + error cases
+- Real-shape headers from each provider's docs (e.g., real Cloudflare Access JWT structure; real Azure `X-MS-CLIENT-PRINCIPAL` payload)
+
+**Why now:** validates the design corpus matches real provider behavior. Catches "we read the header wrong" class of bugs.
+
+### Cut 11: Docs
+
+**Files added/modified:**
+- `docs/auth.md` (NEW) — per-trust-mode operator setup guide
+- `docs/cloudflare.md` — add Cloudflare Access section
+- `docs/self-hosted.md` — add `forwarded-user` configuration
+- `docs/operations.md` — extend with auth/RBAC operational concerns
+- `examples/starter/site.config.ts` — example `admin.auth` block
+
+**Why last:** code is stable; docs reflect reality.
+
+## Validation gate (definition of done)
+
+Cut 1-9 ship the implementation. Cut 10-11 are validation + docs. The foundation is "shipped" when:
+
+- [ ] All 11 cuts merged
+- [ ] Integration tests pass for all 6 trust modes
+- [ ] `audit/` foundation (next in Phase 1) has at least one consumer of the `Principal` type — proves the contract works for downstream foundations
+- [ ] Operator can configure auth for at least one trust mode following only the public docs
+
+## Deferred items
+
+| Item | Trigger to revisit |
+|---|---|
+| Per-target roles (`editor` on staging, `viewer` on prod) | Concrete operator demand; capability vocabulary is forward-compatible |
+| Per-page roles (path-pattern visibility filtering) | Concrete operator demand; `read:pages:{pattern}` extension is forward-compatible |
+| Multi-role per principal | Rare in practice; complexity not justified yet |
+| `admin.auth.strict: true` validation mode | After at least one operator hits ambiguity in custom-role definitions |
+| Plugin-supplied trust modes (e.g., SAML, custom OAuth) | 3+ operator requests for unlisted platform within 6 months |
+
+## Open implementation questions
+
+1. **JWT validation library**: `jose` is a strong default (well-maintained; widely used; supports JWKS rotation). Confirm before Cut 4.
+2. **Source-IP whitelist semantics**: `forwarded-user` mode needs operator config for trusted proxy IPs. Default behavior when whitelist empty: refuse all (fail-closed) vs. accept (fail-open with warning)? Recommend fail-closed.
+3. **Role-mapping edge cases**: what if upstream returns multiple groups, multiple of which map to roles? Per Q2 lock (single role per principal), pick highest-priority match. Define priority order: array order in `map` config (first match wins).
+4. **Boot-time config validation**: invalid role-mapping (e.g., custom role references unknown capability) — fail boot loudly per locked Q3 strict-mode-error vs. log-warning. Recommend fail boot in production; warn in dev.
+
+## Test infrastructure
+
+- **`@anthropic-ai/sdk`-style adapter pattern**: each trust mode's tests use msw to mock upstream auth provider responses. No real cloud calls in CI.
+- **Real-shape fixtures**: capture one real-payload sample per provider in `tests/fixtures/auth/`. Update on provider format changes.
+- **Per-cut tests independent**: each cut's tests don't depend on subsequent cuts.
+
+## Estimates
+
+Wall-clock for solo dev:
+
+| Cut | Estimate |
+|---|---|
+| 1 (Infra) | 0.5 day |
+| 2 (Provider interface + none) | 0.5 day |
+| 3 (`forwarded-user`) | 1 day |
+| 4 (`cloudflare-access` JWT) | 1.5 days |
+| 5 (Azure + Cognito + Tailscale) | 1 day |
+| 6 (Capabilities + roles) | 1 day |
+| 7 (Request context + middleware) | 1 day |
+| 8 (Capability middleware) | 0.5 day |
+| 9 (Wire routes) | 1.5 days |
+| 10 (Integration tests) | 1.5 days |
+| 11 (Docs) | 1.5 days |
+
+**Total: ~10-12 days.** With CI iteration + integration discoveries, budget ~2-2.5 weeks.
+
+## SOLID checks per cut
+
+- **Cut 1-2**: SRP per file (types / config / interface separated). DIP — consumers depend on `AuthIdentityProvider` interface, not concrete classes.
+- **Cut 3-5**: LSP across trust-mode providers. Each provider has its own error type translating to `AuthError`. SRP — each provider owns one trust mode's mechanics.
+- **Cut 6**: SRP — capability vocabulary in one file; role resolver is a separate function. OCP — adding a new capability is a constant + an enum entry.
+- **Cut 7-8**: ISP — middleware factories produce narrow Hono middleware; one concern per factory.
+- **Cut 9**: mechanical; no SOLID concerns beyond preserving route-handler purity.
+
+Any cut failing SOLID review at PR time is a structural correction (per [team-preferences rule 18](team-preferences.md)), not a patch.

--- a/.claude/rules/design-cache-implementation.md
+++ b/.claude/rules/design-cache-implementation.md
@@ -1,0 +1,166 @@
+---
+paths:
+  - "packages/gazetta/src/cache/**"
+  - "packages/gazetta/src/admin-api/**"
+---
+
+# Cache — Implementation
+
+Companion to [design-cache.md](design-cache.md). Cut sequence with risk ordering.
+
+See [design-cache.md](design-cache.md) for the design itself.
+
+## Cut sequence
+
+**Status legend**: ✓ shipped · ◐ in progress · ☐ pending
+
+Branch: `cache-v1` off `main`. **No backwards compatibility** — replaces existing memos in-place.
+
+| # | Cut | Status | Risk | Validates |
+|---|---|---|---|---|
+| 1 | `cache/` infrastructure: types, errors, key conventions | ☐ | Low | Type-only foundation |
+| 2 | `AdminCache` interface + `MemoryCache` provider with bounded LRU eviction | ☐ | Medium | The seam + v1 default |
+| 3 | Key conventions: colon-separated, automatic Gazetta-major-version prefix, 255-char overflow-hash | ☐ | Low | Key-handling utility |
+| 4 | SSE invalidation broadcast + `subscribe()` method | ☐ | Medium | Cross-instance coordination primitive |
+| 5 | Sweep existing memos: `findDependentsFromSidecars`, template-scan cache, locale-cache → migrate to `AdminCache.MemoryCache` | ☐ | Medium | Real consumers; replaces ad-hoc memos |
+| 6 | Save handler invalidation: `cache.invalidatePrefix('pages:')` etc. on save / publish | ☐ | Low-medium | Explicit per-feature invalidation |
+| 7 | Stats: hit / miss / size / errors counters + structured log every 5 min + `GET /api/system/cache/stats` | ☐ | Low | Observability |
+| 8 | `CacheError` taxonomy: `CacheConfigurationError`, `CacheSchemaError` | ☐ | Low | Error contracts |
+| 9 | Per-site cache instance + per-site key auto-prefix | ☐ | Medium | Multi-site isolation |
+| 10 | `adminCacheContractTests` test helper exported from `gazetta/testing` | ☐ | Low | Plugin author validation surface |
+| 11 | Docs + operator config examples | ☐ | Low | User-facing |
+
+## Per-cut scope
+
+### Cut 1: Infrastructure
+
+**Files added:**
+- `packages/gazetta/src/cache/types.ts` — `AdminCache`, `CacheStats`, `InvalidationEvent`
+- `packages/gazetta/src/cache/errors.ts` — error taxonomy
+- `packages/gazetta/src/cache/keys.ts` — `encodeCacheKey()`, prefix utilities
+
+**Tests:** key encoding + special-char handling
+
+### Cut 2: `AdminCache` + `MemoryCache`
+
+**Files added:**
+- `packages/gazetta/src/cache/provider.ts` — `AdminCache` interface
+- `packages/gazetta/src/cache/providers/memory.ts` — `MemoryCache` with default 10K entries / 50MB cap; LRU eviction
+
+**Tests:** get-set-invalidate round-trip + LRU eviction at cap + invalidatePrefix returns count
+
+### Cut 3: Key conventions
+
+**Files modified:**
+- `packages/gazetta/src/cache/keys.ts` — automatic Gazetta-major-version prefix; 255-char cap with sha256 overflow-hash
+
+**Tests:** version prefix preserves consumer-clean keys + overflow keys preserve prefix-invalidation
+
+### Cut 4: SSE invalidation broadcast
+
+**Files added:**
+- `packages/gazetta/src/cache/sse.ts` — server-side broadcast on invalidate / invalidatePrefix
+- `packages/gazetta/src/cache/providers/memory.ts` — `subscribe()` via Node EventEmitter
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/middleware/sse.ts` (extends existing dev-server reload SSE) — adds invalidation channel
+
+**Tests:** invalidation broadcasts + subscribers receive events + auto-reconnect with backoff (single-process; trivial case)
+
+### Cut 5: Sweep existing memos
+
+**Files modified:**
+- `packages/gazetta/src/source-sidecars.ts` (memoization) — migrate to `AdminCache`
+- `packages/gazetta/src/locale.ts` (locale cache) — migrate
+- `packages/gazetta/src/manifest.ts` (template-scan cache) — migrate
+- Other ad-hoc memos identified during cut
+
+**Tests:** equivalence tests confirm cache hits return same shapes as pre-migration
+
+### Cut 6: Save handler invalidation
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/pages.ts` — explicit `cache.invalidatePrefix('pages:')` on save; sidecar-driven cascade invalidates dependent pages
+- Similar in `fragments.ts`, `assets.ts`, `publish.ts`
+
+**Tests:** save invalidates correct prefix; sidecar cascade invalidates dependents
+
+### Cut 7: Stats
+
+**Files added:**
+- `packages/gazetta/src/cache/stats.ts` — counter increment on every operation
+- `packages/gazetta/src/admin-api/routes/system.ts` (NEW) — `GET /api/system/cache/stats`
+- Periodic 5-minute structured log via `setInterval` in cache provider
+
+**Tests:** stats accuracy + logging cadence (mocked timer)
+
+### Cut 8: `CacheError` taxonomy
+
+**Files modified:**
+- `packages/gazetta/src/cache/errors.ts` — flesh out subclasses
+- `packages/gazetta/src/cache/providers/memory.ts` — throw `CacheConfigurationError` on bad config
+
+**Tests:** error classes have correct names + stack preservation
+
+### Cut 9: Per-site cache instance + key prefix
+
+**Files modified:**
+- `packages/gazetta/src/cache/factory.ts` — `createAdminCache(site)` returns per-site instance with auto-prefix
+- Loader: each site's cache initialized at site-load time
+
+**Tests:** two sites in same project don't collide on cache keys
+
+### Cut 10: Contract test helper
+
+**Files added:**
+- `packages/gazetta/testing/admin-cache-contract.ts` — `adminCacheContractTests(factory, name)` test suite for plugin authors
+
+**Tests:** the helper itself runs against `MemoryCache` (proves it's correct); plugin authors run it against their providers
+
+### Cut 11: Docs
+
+**Files added/modified:**
+- `docs/cache.md` (NEW) — operator guide
+- `examples/starter/site.config.ts` — example `admin.cache` block
+
+## Validation gate (definition of done)
+
+- [ ] All 11 cuts merged
+- [ ] Existing memos all migrated to `AdminCache`
+- [ ] Stats endpoint returns expected counters
+- [ ] Plugin authors can run `adminCacheContractTests` against their provider
+
+## Deferred items
+
+| Item | Trigger to revisit |
+|---|---|
+| `RedisCache` provider | Multi-instance deployment with concrete cache-hit-rate concern |
+| `AzureCache` provider | Azure-deployment operator demand |
+| `FileCache` provider | Single-server operator demand for restart-survival |
+| `EtagCapableCache extends AdminCache` (RMW interface) | First read-modify-write consumer (warming hooks future) |
+| Cache warming hooks | After Hooks foundation lands; concrete demand for boot-time cache pre-population |
+| Stats `bytesApproximate` field | Operator demand for byte-level monitoring |
+| Per-validator severity override at publish gate | Per-validator config; deferred from validation Cut 4 |
+
+## Estimates
+
+| Cut | Estimate |
+|---|---|
+| 1-2 | 1 day |
+| 3-4 | 1 day |
+| 5 | 1.5 days |
+| 6 | 0.5 day |
+| 7 | 0.5 day |
+| 8 | 0.5 day |
+| 9 | 0.5 day |
+| 10 | 0.5 day |
+| 11 | 0.5 day |
+
+**Total: ~6-7 days.**
+
+## SOLID checks per cut
+
+- **Cut 1-2**: SRP per file. DIP — consumers depend on `AdminCache` interface.
+- **Cut 5**: each migration replaces ad-hoc memo with `AdminCache` consumption; consumer site doesn't grow more responsibility.
+- **Cut 9**: per-site factory keeps multi-site concerns out of provider implementations.
+- **Cut 10**: contract test helper enforces LSP across providers.

--- a/.claude/rules/design-collaboration-implementation.md
+++ b/.claude/rules/design-collaboration-implementation.md
@@ -1,0 +1,225 @@
+---
+paths:
+  - "packages/gazetta/src/collaboration/**"
+  - "packages/gazetta/src/notifications/**"
+  - "apps/admin/src/client/components/comments/**"
+---
+
+# Collaboration — Implementation
+
+Companion to [design-collaboration.md](design-collaboration.md). Cut sequence with risk ordering.
+
+See [design-collaboration.md](design-collaboration.md) for the design itself.
+
+## Cut sequence
+
+**Status legend**: ✓ shipped · ◐ in progress · ☐ pending
+
+Branch: `collaboration-v1` off `main`. Sequenced after AuthIdentity + Audit + Component IDs + NotificationProvider per Phase 1 dependency order. **No backwards compatibility**.
+
+| # | Cut | Status | Risk | Validates |
+|---|---|---|---|---|
+| 1 | Component ID generation: auto-generate stable IDs on save when missing | ☐ | Medium | Anchor primitive |
+| 2 | `collaboration/` infrastructure: `Comment`, `CommentThread`, `Mention` types | ☐ | Low | Type foundation |
+| 3 | Storage: per-thread sidecars at `.gazetta/comments/{kind}/{name}/threads/{id}.json` | ☐ | Medium | Per-edge storage shape |
+| 4 | Etag-based concurrency: `If-Match` on thread updates | ☐ | Medium-high | Thread-update race correctness |
+| 5 | API endpoints: `GET/POST/PATCH/DELETE /api/comments/{kind}/{name}` | ☐ | Medium | Server-side comment CRUD |
+| 6 | RBAC capabilities: `read:comments`, `comment:write`, `comment:moderate`, `mention:any`, `subscribe:any` | ☐ | Low | Capability vocabulary extension |
+| 7 | Mention picker UI + structured mention storage (not text-parsed) | ☐ | Medium | Mention authoring UX |
+| 8 | NotificationProvider: `InAdminNotificationProvider` v1 + dispatch on mention | ☐ | Medium | Notification primitive |
+| 9 | Notification storage: `.gazetta/notifications/{recipient}/{id}.json` per-edge | ☐ | Low-medium | Notification persistence |
+| 10 | Notification UI: bell icon + panel + read state | ☐ | Medium | Visible feature |
+| 11 | Comment thread UI: site tree badge + editor toolbar bubble + inline floating popup | ☐ | High | Comment UX surface (largest UI work) |
+| 12 | Per-item meta.json aggregation: open-thread count for site-tree badges | ☐ | Low | Performance for tree rendering |
+| 13 | RTBF scrub extension: comments + mentions + notifications | ☐ | Low | Compliance |
+| 14 | 6 hook phases: `beforeCommentPosted`, `afterCommentPosted`, `afterCommentEdited`, `afterCommentDeleted`, `afterCommentResolved`, `afterMention` | ☐ | Low-medium | Hooks integration |
+| 15 | Audit integration: 9 new `action` enum values | ☐ | Low | Audit composition |
+| 16 | Docs + example | ☐ | Low | User-facing |
+
+## Per-cut scope
+
+### Cut 1: Component ID generation
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/pages.ts` + `fragments.ts` — on save, components without `id` field get auto-generated IDs (NanoID format)
+- `packages/gazetta/src/types.ts` — `ComponentManifest` extends with optional `id?: string` (always populated post-save)
+
+**Tests:** save adds IDs to ID-less components; existing IDs preserved across saves
+
+**Why first:** anchor primitive for inline comments; needs to land before any inline-anchored comment can exist.
+
+### Cut 2: Infrastructure
+
+**Files added:**
+- `packages/gazetta/src/collaboration/types.ts` — `Comment`, `CommentThread`, `Mention`, `MessageBody` (structured segments)
+- `packages/gazetta/src/collaboration/errors.ts`
+- `packages/gazetta/src/collaboration/index.ts`
+
+### Cut 3: Storage
+
+**Files added:**
+- `packages/gazetta/src/collaboration/storage.ts` — read / write thread files; per-edge granularity
+
+**Tests:** thread CRUD round-trip; multi-instance write isolation
+
+### Cut 4: Etag concurrency
+
+**Files modified:**
+- `packages/gazetta/src/collaboration/storage.ts` — `If-Match` enforcement on thread writes; throw `409 STALE` on mismatch
+
+**Files added:**
+- Storage provider extensions: etag-conditional-write where supported (R2, S3, Azure native; filesystem provider via write-then-rename + content-hash)
+
+**Tests:** concurrent writes to same thread → second fails with STALE; client retry resolves
+
+### Cut 5: API endpoints
+
+**Files added:**
+- `packages/gazetta/src/admin-api/routes/comments.ts` — CRUD endpoints
+- `packages/gazetta/src/admin-api/schemas/comments.ts` — Zod schemas
+
+**Tests:** API integration tests per endpoint
+
+### Cut 6: RBAC capabilities
+
+**Files modified:**
+- `packages/gazetta/src/auth/capabilities.ts` — add 5 new capabilities
+- `packages/gazetta/src/auth/roles.ts` — extend default role aliases (editor: + comment:write, mention:any, subscribe:any; viewer: + read:comments)
+- `comments.ts` route — gate endpoints on capabilities
+
+**Tests:** 403 for missing capability; comment visibility cascades from content read access
+
+### Cut 7: Mention picker
+
+**Files added:**
+- `apps/admin/src/client/components/comments/MentionPicker.vue` — `@`-triggered picker; filters by content access
+- `apps/admin/src/client/components/comments/MessageEditor.vue` — text + structured mentions
+
+**Tests:** typing `@` opens picker; selection inserts structured reference; user list filtered correctly
+
+### Cut 8: NotificationProvider + dispatch
+
+**Files added:**
+- `packages/gazetta/src/notifications/types.ts` — `Notification`, `NotificationProvider` interface
+- `packages/gazetta/src/notifications/providers/in-admin.ts` — `InAdminNotificationProvider`
+- `packages/gazetta/src/notifications/dispatcher.ts` — fan-out to configured providers
+
+**Tests:** mention triggers notification dispatch; provider receives notification
+
+### Cut 9: Notification storage
+
+**Files modified:**
+- `packages/gazetta/src/notifications/providers/in-admin.ts` — per-edge sidecar storage; retention pruner (100-recent + 30-day cap)
+
+**Tests:** notification persists; retention prunes correctly
+
+### Cut 10: Notification UI
+
+**Files added:**
+- `apps/admin/src/client/components/notifications/NotificationBell.vue` — bell icon with unread count
+- `apps/admin/src/client/components/notifications/NotificationPanel.vue` — chronological list
+- `apps/admin/src/client/stores/notifications.ts` — Pinia store
+
+**Tests:** unread count updates; click marks read; navigation to comment works
+
+### Cut 11: Comment thread UI
+
+**Files added:**
+- `apps/admin/src/client/components/comments/CommentBubble.vue` — universal icon component
+- `apps/admin/src/client/components/comments/CommentPanel.vue` — page-level side panel
+- `apps/admin/src/client/components/comments/InlineCommentPopup.vue` — floating popup for inline anchors
+- `apps/admin/src/client/components/comments/CommentThread.vue` — thread display
+- `apps/admin/src/client/components/comments/AssetCommentBadge.vue` — asset library card badge
+
+**Tests:** comment workflow end-to-end (post / reply / resolve)
+
+### Cut 12: meta.json aggregation
+
+**Files modified:**
+- `packages/gazetta/src/collaboration/storage.ts` — atomic update of `.gazetta/comments/{kind}/{name}/meta.json` on thread state changes
+
+**Tests:** site tree reads meta.json; counts accurate
+
+### Cut 13: RTBF scrub
+
+**Files modified:**
+- `packages/gazetta/src/audit/scrub.ts` (extends from audit Phase 1) — extend to scrub comments + mentions + notifications
+
+**Tests:** scrubbing actor X removes / redacts X's comments + mentions of X + X's notifications
+
+### Cut 14: Hook phases
+
+**Files modified:**
+- `packages/gazetta/src/hooks/types.ts` — add 6 hook phase types
+- Comment CRUD endpoints — `dispatchBefore` / `dispatchAfter` per phase
+
+**Tests:** hooks fire on comment lifecycle; can cancel via beforeCommentPosted
+
+### Cut 15: Audit integration
+
+**Files modified:**
+- `packages/gazetta/src/audit/types.ts` — extend `action` enum with `comment-post`, `comment-edit`, `comment-delete`, `comment-resolve`, `comment-reopen`, `mention-fired`, `notification-sent`, `comment-moderate`, `comment-scrub`
+
+**Tests:** every comment lifecycle event records audit
+
+### Cut 16: Docs
+
+**Files added/modified:**
+- `docs/collaboration.md` (NEW)
+- `examples/starter` — add example use case
+
+## Validation gate (definition of done)
+
+- [ ] All 16 cuts merged
+- [ ] End-to-end author workflow: post comment → mention colleague → colleague gets notification → reply → resolve
+- [ ] Hooks fire correctly across comment lifecycle
+- [ ] Audit log records all collaboration actions
+
+## Deferred items
+
+| Item | Trigger to revisit |
+|---|---|
+| Email/Slack/Webhook/Teams/Discord NotificationProviders (v2 expected order) | Operator demand per provider |
+| Per-user notification preferences UI | Lands with email provider |
+| Activity feed | Operator demand; composes from audit log |
+| Reactions on comments | Operator demand |
+| Comment templates | Operator demand |
+| Approval-blocking comments | Compliance archetype demand |
+| File attachments | Operator demand |
+| Markdown formatting | Operator demand |
+| Per-locale comments | Concrete demand |
+| Real-time presence | Tier 3 strategic bet (deferred) |
+| Live comment streams (SSE push of new comments) | Composes with presence |
+
+## Open implementation questions
+
+1. **NanoID vs UUID for component IDs**: NanoID is shorter (21 chars vs 36) and URL-safe; recommend NanoID. Component IDs appear in audit metadata; shorter is friendlier.
+2. **Comment count badge update strategy**: Vue Query invalidation cascade — when thread state changes, invalidate `comments:meta:{kind}:{name}`; site tree refetches.
+3. **Mention picker user list source**: at v1, audit log actors who've performed write events on this content + content access list. Cached per-page; refreshed on write events.
+
+## Estimates
+
+| Cut | Estimate |
+|---|---|
+| 1 (Component IDs) | 1 day |
+| 2-3 (Infra + storage) | 1.5 days |
+| 4 (Etag) | 1 day |
+| 5-6 (API + RBAC) | 1.5 days |
+| 7 (Mention picker) | 1.5 days |
+| 8-9 (Notification dispatch + storage) | 1.5 days |
+| 10 (Notification UI) | 1.5 days |
+| 11 (Comment UI — largest cut) | 3 days |
+| 12-13 (meta.json + RTBF) | 1 day |
+| 14-15 (Hooks + audit) | 1 day |
+| 16 (Docs) | 1 day |
+
+**Total: ~16-17 days.** Largest scope of any Phase 1 foundation; budget ~3-4 weeks with iteration.
+
+## SOLID checks per cut
+
+- **Cut 1**: SRP — component ID generation is one concern; auto-generate is a save-handler enrichment, not buried in unrelated logic.
+- **Cut 3-4**: storage shape isolated; etag concurrency is a separate module.
+- **Cut 7**: mention picker is one component; structured mention storage is one type.
+- **Cut 11**: comment UI components have single responsibilities each (bubble icon = display badge; popup = inline thread; panel = page-level threads).
+- **Cut 13**: RTBF scrub composes with audit's existing scrub primitive; doesn't duplicate logic.
+- **Cut 14-15**: hook integration + audit integration are additive; comment CRUD doesn't change shape.

--- a/.claude/rules/design-hooks-implementation.md
+++ b/.claude/rules/design-hooks-implementation.md
@@ -1,0 +1,182 @@
+---
+paths:
+  - "packages/gazetta/src/hooks/**"
+  - "packages/gazetta/src/admin-api/**"
+  - "packages/gazetta/src/admin-api/routes/**"
+---
+
+# Hooks — Implementation
+
+Companion to [design-hooks.md](design-hooks.md). Cut sequence with risk ordering, per-cut scope, deferred items.
+
+See [design-hooks.md](design-hooks.md) for the design itself.
+
+## Cut sequence
+
+**Status legend**: ✓ shipped · ◐ in progress · ☐ pending
+
+Branch: `hooks-v1` off `main`. Sequenced after AuthIdentity + Audit per Phase 1 dependency order. **No backwards compatibility**; existing save/publish handlers update wholesale.
+
+| # | Cut | Status | Risk | Validates |
+|---|---|---|---|---|
+| 1 | `hooks/` infrastructure: types, signatures, HookContext shape | ☐ | Low | Type-only foundation |
+| 2 | Hook registry + priority-based dispatch + per-hook timeout | ☐ | Medium | The dispatch core |
+| 3 | Discovery: site-local `admin/hooks/` walker | ☐ | Medium | File-based discovery |
+| 4 | Wire `beforeSave` / `afterSave` / `afterLoad` into save/load handlers | ☐ | Medium | First production hook integration |
+| 5 | Wire `beforePublish` / `afterPublish` into publish handler | ☐ | Medium | Publish-lifecycle hooks |
+| 6 | Wire `beforeUpload` / `afterUpload` into asset upload handler | ☐ | Low-medium | Asset hooks compose with existing UploadPreprocessor/Analyzer |
+| 7 | Audit integration: `action: 'hook-fired'` + `outcome: 'hook-cancelled'` extensions | ☐ | Low | Composes with audit foundation |
+| 8 | Review-lifecycle hook phases (10 phases per design-review-workflow.md) | ☐ | Medium | Forward-compat for review-workflow feature |
+| 9 | `optional()` wrapper + plugin-supplied registration via plugin contract | ☐ | Medium | Forward-compat for plugins foundation |
+| 10 | Docs + example hooks in starter | ☐ | Low | User-facing |
+
+## Per-cut scope
+
+### Cut 1: `hooks/` infrastructure
+
+**Files added:**
+- `packages/gazetta/src/hooks/types.ts` — `HookPhase`, `HookHandler<T>`, `HookContext`, `HookRegistration`, `HookOptions`
+- `packages/gazetta/src/hooks/errors.ts` — `HookCancellation`, `HookTimeout`, `RegistrationAfterInitError`
+- `packages/gazetta/src/hooks/index.ts` — barrel
+
+**Tests:** type-level checks only
+
+**Why first:** lowest blast radius.
+
+### Cut 2: Hook registry + dispatch + timeout
+
+**Files added:**
+- `packages/gazetta/src/hooks/registry.ts` — `HookRegistry` with priority-sorted insertion + tie-break by registration order
+- `packages/gazetta/src/hooks/dispatch.ts` — `dispatchBefore<T>(phase, payload, ctx, timeout)` chains; `dispatchAfter(phase, result, ctx)` parallel via `Promise.allSettled`
+- Per-hook timeout enforcement via `Promise.race`
+
+**Tests:** priority order + chaining + cancellation propagation + timeout enforcement + after-fire-and-forget failure isolation
+
+**Why second:** the core. Subsequent cuts integrate against this.
+
+### Cut 3: Discovery — site-local walker
+
+**Files added:**
+- `packages/gazetta/src/hooks/discovery.ts` — walks `admin/hooks/*.{ts,js}`; dynamic-imports each; extracts named exports (`beforeSave`, `afterPublish`, etc.) + optional `meta`; registers against the registry
+
+**Tests:** discovery picks up all phase exports + missing files don't error + invalid exports surface clear errors
+
+**Why now:** required before hooks can actually fire.
+
+### Cut 4: Wire save / load handlers
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/pages.ts` — call `dispatchBefore('beforeSave', payload, ctx)` after validation; `dispatchAfter('afterSave', result, ctx)` after storage write
+- Same pattern in `fragments.ts`
+- Add `dispatchAfter('afterLoad', result, ctx)` in load paths
+
+**Tests:** integration tests for hook firing during real save → confirms order: validators → beforeSave → storage → afterSave
+
+**Why now:** first production hook integration. Validates the dispatch in real conditions.
+
+### Cut 5: Wire publish handler
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/publish.ts` — `dispatchBefore('beforePublish', items, ctx)` + `dispatchAfter('afterPublish', result, ctx)`
+
+**Tests:** integration during publish → confirms hook chain works for multi-item publishes
+
+**Why now:** publish is more complex than save; landing it after save patterns are stable.
+
+### Cut 6: Wire asset upload handler
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/assets.ts` — `dispatchBefore('beforeUpload', { asset, bytes }, ctx)` BEFORE existing UploadPreprocessor / UploadAnalyzer pipeline; `dispatchAfter('afterUpload', result, ctx)` after manifest write
+
+**Tests:** integration confirms hooks compose cleanly with existing preprocessor/analyzer (which run first per design-hooks.md asset-upload-note)
+
+**Why now:** straightforward integration; benefits from save/publish patterns being established.
+
+### Cut 7: Audit integration
+
+**Files modified:**
+- `packages/gazetta/src/audit/types.ts` — extend `action` enum with `'hook-fired'`; extend `outcome` enum with `'hook-cancelled'` + `'timeout'`
+- `packages/gazetta/src/hooks/dispatch.ts` — emit audit event per hook firing with name + priority + phase + durationMs
+
+**Tests:** dispatch emits audit events correctly; failure outcomes record correctly
+
+**Why now:** depends on Audit foundation (Phase 1 prior).
+
+### Cut 8: Review-lifecycle hook phases
+
+**Files added:**
+- 10 review-phase types in `packages/gazetta/src/hooks/types.ts`: `BeforeSubmitForReviewHook`, `AfterSubmitForReviewHook`, `BeforeApproveHook`, `AfterApproveHook`, `BeforeRejectHook`, `AfterRejectHook`, `BeforePublishRequestHook`, `AfterPublishRequestHook`, `BeforePublishApproveHook`, `AfterPublishApproveHook`
+
+**Tests:** types compile; registry accepts review phases
+
+**Why now:** types only; the actual review state machine that fires these is Phase 2 work. Forward-compat preparation.
+
+### Cut 9: `optional()` wrapper + plugin registration
+
+**Files added:**
+- `packages/gazetta/src/hooks/optional.ts` — `optional(plugin)` returns `PluginRegistration` with `optional: true`
+- `packages/gazetta/src/plugins/api.ts` — extend `PluginAPI` interface with `registerHook<TPhase>(...)` (this code lives in plugins/ but is hook-API-shaped)
+
+**Tests:** optional plugin failure → log + continue; plugin-registered hooks land in priority band 100-999
+
+**Why now:** depends on Plugin loader (later in Phase 1). For this cut, ship the `optional()` helper but plugin-supplied hook discovery wires up when plugins land.
+
+### Cut 10: Docs
+
+**Files added/modified:**
+- `docs/hooks.md` (NEW) — site-local hook authoring guide + plugin-supplied hook reference + service-account capabilities forward-pointer
+- `examples/starter/admin/hooks/` (NEW directory) — at least one example: `auto-slugify.ts` for blog pages
+- `examples/starter/site.config.ts` — example `admin.hooks.disable` reference (deferred-config; just for forward-compat doc)
+
+**Why last:** code is stable.
+
+## Validation gate (definition of done)
+
+- [ ] All 10 cuts merged
+- [ ] At least one example hook exists in `examples/starter/admin/hooks/` and runs in the starter site
+- [ ] Audit log records hook firings correctly (composing with audit foundation)
+- [ ] Plugin loader (next foundation) integrates against `registerHook` cleanly
+
+## Deferred items
+
+| Item | Trigger to revisit |
+|---|---|
+| Render-lifecycle hooks (`beforeRender`, `afterRender`) | Render formalization in Phase 3; render hooks reserved per design-rendering.md |
+| Validation hooks | Permanently rejected (validators are pure functions per design-validation.md) |
+| Audit hooks | Audit observes via the audit log itself; no hook firings |
+| `beforeLoad` | Nothing to mutate yet |
+| Fire-and-forget mode (`mode: 'async'`) | Concrete operator demand; v1 is sync-blocking only |
+| Total operation timeout | Per-hook timeout is the cap; total cap reserved if observed pain surfaces |
+| Hot-reload of hook files | Out of scope; v1 hooks require admin restart |
+| Disable-by-config (`admin.hooks.disable`) | v2 ergonomic; v1 disable = delete file |
+
+## Open implementation questions
+
+1. **Dynamic import vs static glob**: site-local hook discovery via `import.meta.glob` (Vite) or runtime `await import()` (Node)? Recommend `await import()` for Node compatibility; Vite's glob is admin-specific.
+2. **HookContext.storage as ReadOnlyStorageProvider**: implement as a Proxy filtering write methods, or a separate type? Recommend Proxy for less code duplication.
+3. **Per-hook timeout default tunable per phase?** v1 ships uniform 5s default. Per-phase override deferred unless concrete operator pain surfaces.
+
+## Estimates
+
+| Cut | Estimate |
+|---|---|
+| 1 (Infrastructure) | 0.5 day |
+| 2 (Registry + dispatch) | 1.5 days |
+| 3 (Discovery) | 1 day |
+| 4 (Wire save/load) | 1 day |
+| 5 (Wire publish) | 0.5 day |
+| 6 (Wire asset upload) | 0.5 day |
+| 7 (Audit integration) | 0.5 day |
+| 8 (Review-lifecycle phases) | 0.5 day |
+| 9 (Optional + plugin) | 0.5 day |
+| 10 (Docs) | 1 day |
+
+**Total: ~7-8 days.** With CI iteration, budget ~1.5 weeks.
+
+## SOLID checks per cut
+
+- **Cut 1-2**: SRP per file (registry / dispatch / errors). DIP — consumers depend on `HookHandler<T>` type.
+- **Cut 3**: SRP — discovery is one module; doesn't bleed into dispatch.
+- **Cut 4-6**: each route handler integrates uniformly; no per-route dispatch logic. ISP — handlers see only the dispatch API.
+- **Cut 7**: composition with audit; doesn't break either layer's contracts.
+- **Cut 9**: `optional()` is a typed wrapper; doesn't change `Plugin` shape.

--- a/.claude/rules/design-offline-implementation.md
+++ b/.claude/rules/design-offline-implementation.md
@@ -1,0 +1,211 @@
+---
+paths:
+  - "apps/admin/src/client/**"
+  - "packages/gazetta/src/admin-api/**"
+  - "**/offline*"
+  - "**/service-worker*"
+---
+
+# Admin offline mode — Implementation
+
+Companion to [design-offline.md](design-offline.md). Cut sequence with risk ordering.
+
+See [design-offline.md](design-offline.md) for the design itself.
+
+## Cut sequence
+
+**Status legend**: ✓ shipped · ◐ in progress · ☐ pending
+
+Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCache` interface for L6 provider). **No backwards compatibility**; existing pending-edits stores migrate to IndexedDB-backed persistence.
+
+| # | Cut | Status | Risk | Validates |
+|---|---|---|---|---|
+| 1 | npm dependencies + setup: `idb`, `@tanstack/vue-query`, `@tanstack/query-async-storage-persister`, `vite-plugin-pwa` | ☐ | Low | Tooling foundation |
+| 2 | `IndexedDBCache` provider (browser-side `AdminCache`) using `idb` | ☐ | Medium | The L6 cache primitive |
+| 3 | Provider selection: `IndexedDBCache` primary; `MemoryCache` fallback when IndexedDB unavailable | ☐ | Low | Graceful degradation |
+| 4 | BroadcastChannel cross-tab invalidation | ☐ | Low | Multi-tab coordination |
+| 5 | Vue Query setup + `IndexedDBPersister` bridge to L6 | ☐ | Medium | Query/mutation cache + offline queue |
+| 6 | Connection state Pinia store: hybrid `navigator.onLine` + heartbeat to `/api/health` | ☐ | Medium | 5-state model |
+| 7 | Health endpoint `GET /api/health` | ☐ | Low | Server-side support |
+| 8 | Pending-edits store migration: persist to IndexedDB; survive reload | ☐ | Medium | Editor state persistence |
+| 9 | Save queue: client-generated thread IDs + chained If-Match etag projections | ☐ | High | Conflict-on-replay machinery |
+| 10 | Conflict UX: 409 STALE handling; field-by-field semantic diff banner; Show / Discard actions | ☐ | High | Conflict resolution UX |
+| 11 | Service worker via vite-plugin-pwa: app-shell precache | ☐ | Medium | Cold-load offline reliability |
+| 12 | UX indicators: cloud-with-slash icon + offline banner + "Send now" affordance + sync-state metadata | ☐ | Medium | Krug-aligned visibility |
+| 13 | Mid-save connection-loss handling: retry-with-If-Match; idempotency | ☐ | Medium | Edge case correctness |
+| 14 | Storage quota warning at 80% | ☐ | Low | Operator UX |
+| 15 | Audit integration: `metadata.replayed: true` + `queuedAt` + `replayedAt` | ☐ | Low | Composes with audit foundation |
+| 16 | Docs + first-run author guide | ☐ | Low | User-facing |
+
+## Per-cut scope
+
+### Cut 1: Dependencies
+
+**Files modified:**
+- `apps/admin/package.json` — add `idb`, `@tanstack/vue-query`, `@tanstack/query-async-storage-persister`, `vite-plugin-pwa`
+
+**Tests:** install + build
+
+### Cut 2: `IndexedDBCache`
+
+**Files added:**
+- `apps/admin/src/client/cache/indexeddb-cache.ts` — implements `AdminCache` from `gazetta` package
+
+**Tests:** `adminCacheContractTests` from `gazetta/testing` runs against this provider
+
+### Cut 3: Provider selection
+
+**Files added:**
+- `apps/admin/src/client/cache/provider-selector.ts` — boot-time probe; falls back to MemoryCache + warning banner
+
+**Tests:** IndexedDB unavailable → MemoryCache returned + banner emitted
+
+### Cut 4: BroadcastChannel
+
+**Files modified:**
+- `apps/admin/src/client/cache/indexeddb-cache.ts` — broadcast on invalidate; subscribe handler invalidates local in-memory mirror
+
+**Tests:** two tabs simulated; invalidation propagates
+
+### Cut 5: Vue Query setup + persister bridge
+
+**Files added:**
+- `apps/admin/src/client/queries/client.ts` — `QueryClient` with `IndexedDBPersister` adapter
+- `apps/admin/src/client/queries/persister.ts` — bridges Vue Query to `IndexedDBCache`
+
+**Tests:** Vue Query state rehydrates from IndexedDB at boot
+
+### Cut 6: Connection state store
+
+**Files added:**
+- `apps/admin/src/client/stores/connectionState.ts` — Pinia store; 5 states; navigator.onLine + heartbeat hybrid; subscribes Vue Query's onlineManager
+
+**Tests:** state transitions on simulated connection events
+
+### Cut 7: Health endpoint
+
+**Files added:**
+- `packages/gazetta/src/admin-api/routes/system.ts` — `GET /api/health` (extends from cache stats route)
+
+**Tests:** returns `{ ok: true, timestamp }`
+
+### Cut 8: Pending-edits store migration
+
+**Files modified:**
+- `apps/admin/src/client/stores/editing.ts` — persist `editorContent`, `editorStash`, `editorStructural` to IndexedDB; hydrate on boot
+
+**Tests:** browser reload preserves pending edits across navigation
+
+### Cut 9: Save queue (highest risk cut)
+
+**Files added:**
+- `apps/admin/src/client/queries/save-queue.ts` — client-generated UUIDs; chained If-Match projections; sequential replay on reconnect
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/pages.ts` — return `etag: <content-hash>` on read; honor `If-Match` on write; return `409 STALE` with current version metadata on mismatch
+
+**Tests:** offline saves chain correctly; replay produces sequential success; conflict on first save pauses subsequent
+
+### Cut 10: Conflict UX
+
+**Files added:**
+- `apps/admin/src/client/components/ConflictBanner.vue` — Show diff / Discard actions
+- `apps/admin/src/client/components/DiffView.vue` — field-by-field semantic diff
+
+**Tests:** 409 STALE response triggers banner; "Discard" reverts pending edits; "Show diff" navigates to diff view
+
+### Cut 11: Service worker
+
+**Files modified:**
+- `apps/admin/vite.config.ts` — add `vite-plugin-pwa` with `injectManifest` strategy
+- `apps/admin/src/client/sw.ts` (NEW) — service worker source; precache app shell
+
+**Tests:** SW registers in production build; cold-load offline serves from cache
+
+### Cut 12: UX indicators
+
+**Files added/modified:**
+- `apps/admin/src/client/components/SyncStatusIndicator.vue` — cloud-with-slash icon component
+- `apps/admin/src/client/components/OfflineBanner.vue` — global banner per connection state
+
+**Tests:** indicator only shows when relevant (Krug "absence is a state")
+
+### Cut 13: Mid-save connection-loss
+
+**Files modified:**
+- `apps/admin/src/client/queries/save-queue.ts` — handle in-flight save when connection drops; retry with same If-Match for idempotency
+
+**Tests:** simulated mid-save drop → retry succeeds with idempotent server response
+
+### Cut 14: Storage quota warning
+
+**Files added:**
+- `apps/admin/src/client/composables/useStorageQuota.ts` — `navigator.storage.estimate()` polling; warning at 80%
+
+**Tests:** simulated 80% quota → banner visible
+
+### Cut 15: Audit integration
+
+**Files modified:**
+- `packages/gazetta/src/audit/types.ts` — `metadata.replayed: true`, `metadata.queuedAt`, `metadata.replayedAt` field schemas
+- Save handlers — record audit events with replay metadata when If-Match indicates replay
+
+**Tests:** replay events audit with full metadata
+
+### Cut 16: Docs
+
+**Files added/modified:**
+- `docs/offline.md` (NEW) — operator + author guide
+
+## Validation gate (definition of done)
+
+- [ ] All 16 cuts merged
+- [ ] Manual test: edit page offline → close laptop → reopen → edits persist → reconnect → sync invisibly
+- [ ] Conflict scenario test: edit offline + concurrent online edit → reconnect → conflict banner surfaces
+- [ ] Service worker test: cold-load admin offline → SPA loads from cache
+
+## Deferred items
+
+| Item | Trigger to revisit |
+|---|---|
+| Background Sync API (replay with tab closed) | v2 ergonomic improvement |
+| PWA install prompt (`manifest.json`) | Operator opt-in feature |
+| Push notifications | When Notification Provider extension surface ships email/Slack |
+| Three-way merge conflict resolution | Concurrent editing Tier 3 strategic bet |
+| Per-locale comments / per-locale conflict | Concrete demand |
+| OPFS as L6 provider | Site exceeds IndexedDB quota OR worker-thread sync writes needed |
+| `last-cached` failure mode | Concrete demand |
+| Activity feed | Composes from audit log when feed surface exists |
+
+## Open implementation questions
+
+1. **`IndexedDBPersister` debounce**: how often to write Vue Query cache to IndexedDB? Recommend 500ms debounce on changes; trade-off between write frequency and data-loss-on-crash window.
+2. **Service worker update flow**: vite-plugin-pwa supports `skipWaiting` + `clientsClaim`; recommend with toast notification "New version available — refresh." Author dismisses or refreshes; auto-activates on next navigation.
+3. **`If-Match` etag granularity**: per-page-manifest (current sidecar `.{8hex}.hash`) is fine. For inline-component-level conflict detection (future), would need per-component etags; deferred.
+
+## Estimates
+
+| Cut | Estimate |
+|---|---|
+| 1 (Deps) | 0.5 day |
+| 2-4 (IDB cache + selection + BroadcastChannel) | 2 days |
+| 5 (Vue Query) | 1.5 days |
+| 6-7 (Connection + health) | 1 day |
+| 8 (Pending-edits) | 1 day |
+| 9 (Save queue) | 2.5 days |
+| 10 (Conflict UX) | 2 days |
+| 11 (Service worker) | 1.5 days |
+| 12 (UX indicators) | 1.5 days |
+| 13-14 (Mid-save + quota) | 1 day |
+| 15 (Audit) | 0.5 day |
+| 16 (Docs) | 1 day |
+
+**Total: ~16-17 days.** Highest cut count + highest risk pass; budget ~3-4 weeks with iteration.
+
+## SOLID checks per cut
+
+- **Cut 2-4**: SRP per file (cache provider / selector / cross-tab broadcaster). DIP — admin code consumes `AdminCache`.
+- **Cut 5**: Vue Query as separate layer; doesn't blend into AdminCache responsibilities.
+- **Cut 9-10**: save queue + conflict UX are separate modules. Diff view is its own component.
+- **Cut 11**: service worker scope is explicit (app shell only); doesn't touch query / mutation logic.
+- **Cut 12**: indicators consume connection-state store; no business logic in components.

--- a/.claude/rules/design-plugins-implementation.md
+++ b/.claude/rules/design-plugins-implementation.md
@@ -1,0 +1,150 @@
+---
+paths:
+  - "packages/gazetta/src/plugins/**"
+  - "packages/gazetta/src/admin-api/**"
+  - "**/site.config.ts"
+---
+
+# Plugin / extensibility — Implementation
+
+Companion to [design-plugins.md](design-plugins.md). Cut sequence with risk ordering.
+
+See [design-plugins.md](design-plugins.md) for the design itself.
+
+## Cut sequence
+
+**Status legend**: ✓ shipped · ◐ in progress · ☐ pending
+
+Branch: `plugins-v1` off `main`. Sequenced after TS config + Hooks per Phase 1 dependency order. **No backwards compatibility**.
+
+| # | Cut | Status | Risk | Validates |
+|---|---|---|---|---|
+| 1 | `plugins/` infrastructure: types, `Plugin` shape, `PluginAPI` interface | ☐ | Low | Type-only foundation |
+| 2 | Plugin loader: walk `admin.plugins` array; serial async init; `optional()` wrapper | ☐ | Medium | The dispatch core |
+| 3 | `PluginAPI` registration methods: `registerHook` + barrels for existing surfaces | ☐ | Medium | Plugin extension point |
+| 4 | Provider registration: `registerStorageProvider`, `registerCacheProvider`, `registerAuditProvider`, `registerAuthIdentityProvider`, `registerAltTextAdapter`, `registerTransformAdapter`, `registerDeployAdapter`, `registerValidator` | ☐ | Medium | All 11 surfaces wired |
+| 5 | Admin UI registration: `registerEditor` + `registerField` | ☐ | Low | Admin extension surfaces |
+| 6 | Route registration: `registerRoute` with Zod schema + capability gate | ☐ | Medium | Plugin-contributed admin routes |
+| 7 | `RegistrationAfterInitError` enforcement | ☐ | Low | Window-bounded registration |
+| 8 | Versioning: peerDep load-time check with warning | ☐ | Low | Forward-compat |
+| 9 | Service-account capabilities: opt-in elevation for plugin hooks | ☐ | Medium | Plugin trust elevation |
+| 10 | Plugin author docs + example plugin | ☐ | Low | User-facing |
+
+## Per-cut scope
+
+### Cut 1: Infrastructure
+
+**Files added:**
+- `packages/gazetta/src/plugins/types.ts` — `Plugin`, `PluginAPI`, `PluginRegistration`, `PluginLogger`
+- `packages/gazetta/src/plugins/errors.ts` — `PluginConfigurationError`, `RegistrationAfterInitError`
+- `packages/gazetta/src/plugins/index.ts` — barrel; exports `optional` from hooks/
+
+**Tests:** types compile
+
+### Cut 2: Plugin loader
+
+**Files added:**
+- `packages/gazetta/src/plugins/loader.ts` — `loadPlugins(siteConfig)` walks `admin.plugins` array; calls `init(api)` for each; awaits each serially; collects `dispose()` references
+- `packages/gazetta/src/plugins/api-impl.ts` — `PluginAPI` instance per plugin; tracks registration window state
+
+**Tests:** serial init order + async init awaiting + optional plugin failure → log + continue + non-optional plugin failure → boot fails
+
+### Cut 3: Hook registration via `PluginAPI`
+
+**Files modified:**
+- `packages/gazetta/src/plugins/api-impl.ts` — `registerHook(phase, handler, options)` delegates to hooks registry with namespace prefix (`@plugin-name:hookName`)
+
+**Tests:** plugin-supplied hooks land in priority band 100-999 + namespacing prevents collisions
+
+### Cut 4: Provider registration
+
+**Files modified:**
+- `packages/gazetta/src/plugins/api-impl.ts` — 8 register methods for the 8 provider-shaped surfaces
+- Each register method validates the factory + adds to the surface-specific registry
+
+**Tests:** plugin-supplied provider survives operator config selection (`provider: '@my-org/redis'` resolves to plugin's registered factory)
+
+### Cut 5: Admin UI registration
+
+**Files modified:**
+- `packages/gazetta/src/plugins/api-impl.ts` — `registerEditor(name, mount)` + `registerField(name, mount)` extend the existing editor/field registries
+
+**Tests:** plugin-supplied editor mounts in admin shell
+
+### Cut 6: Route registration
+
+**Files added:**
+- `packages/gazetta/src/plugins/route-registry.ts` — `RouteDefinition` + Hono integration; one handler per (method, path) tuple; collision throws
+
+**Files modified:**
+- `packages/gazetta/src/plugins/api-impl.ts` — `registerRoute(definition)` registers Hono route with capability middleware
+
+**Tests:** plugin-supplied route serves under `/api/plugins/{plugin-name}/...` + capability gate enforced + Zod schema validation
+
+### Cut 7: `RegistrationAfterInitError`
+
+**Files modified:**
+- `packages/gazetta/src/plugins/api-impl.ts` — after init resolves, all register methods throw `RegistrationAfterInitError`
+
+**Tests:** registration call after init resolves throws clearly
+
+### Cut 8: Versioning
+
+**Files added:**
+- `packages/gazetta/src/plugins/version-check.ts` — read plugin's `package.json` peerDep on `gazetta`; semver-compare against running version; warn on mismatch (no refuse)
+
+**Tests:** mismatch logs warning + valid range no warning + site-local plugins skip check
+
+### Cut 9: Service-account capabilities
+
+**Files modified:**
+- `packages/gazetta/src/auth/role-resolver.ts` — when hook fires from a plugin with `serviceAccount` config, principal's caps unioned with service account's for hook duration
+- `packages/gazetta/src/audit/types.ts` — extend `metadata` shape to record `serviceAccount` elevation
+
+**Tests:** hook with `serviceAccount: ['read:audit-log']` can read audit even when triggering principal lacks the capability + audit metadata records the elevation
+
+### Cut 10: Docs
+
+**Files added/modified:**
+- `docs/plugins.md` (NEW) — plugin author guide
+- `examples/starter/admin/plugins/local-webhook/` (NEW) — example local plugin
+
+## Validation gate (definition of done)
+
+- [ ] All 10 cuts merged
+- [ ] Existing in-tree provider implementations (R2Storage, AnthropicAltAdapter, etc.) refactored to register via the plugin API at boot — proves the contract works for all 11 surfaces from day one
+- [ ] At least one example local plugin in starter
+
+## Deferred items
+
+| Item | Trigger to revisit |
+|---|---|
+| Plugin marketplace | Out of scope; v1 plugins via npm registry directly |
+| Plugin sandbox / per-plugin permission model | Out of scope; full Node access by design |
+| Plugin hot-reload | v1 requires admin restart |
+| Plugin discovery via `package.json` `gazetta` field | UI hint only; not load-time discovery |
+
+## Open implementation questions
+
+1. **Dynamic import for npm-installed plugins**: standard ESM resolution from `node_modules` works; plugin author's package.json `main` / `exports` field drives entry point.
+2. **`PluginAPI` instance scope**: per-plugin instance or shared with state-track? Per-plugin, with internal state tracking init window per plugin.
+3. **Existing in-tree provider refactor**: do this as part of Cut 4, OR as a separate post-Cut-9 sweep? Recommend within Cut 4 for each surface — proves the contract on real implementations early.
+
+## Estimates
+
+| Cut | Estimate |
+|---|---|
+| 1-2 | 1.5 days |
+| 3-5 | 2 days |
+| 6 | 1.5 days |
+| 7-9 | 1.5 days |
+| 10 | 1 day |
+
+**Total: ~7-8 days.**
+
+## SOLID checks per cut
+
+- **Cut 1-2**: SRP per file. DIP — consumers depend on `Plugin` interface, not loader internals.
+- **Cut 4**: ISP — register methods are typed per surface; each provider factory has its own type. OCP — adding a new surface is a new register method, not a refactor of existing ones.
+- **Cut 6**: SRP — route registry separate from plugin loader.
+- **Cut 9**: composition with auth/RBAC + audit; preserves both layers' contracts.

--- a/.claude/rules/design-validation-implementation.md
+++ b/.claude/rules/design-validation-implementation.md
@@ -12,7 +12,7 @@ Per [team-preferences.md rule 17](team-preferences.md): "Build and validate, don
 
 | Cut | What | Effort | Dependency | Status |
 |---|---|---|---|---|
-| **1** | Validator infrastructure + save-delta | 4 days | None | ◐ |
+| **1** | Validator infrastructure + save-delta | 4 days | None | ✓ |
 | **2** | Background scanner + admin UI surfaces | 4 days | Cut 1 | ☐ |
 | **3** | Render-for-analysis + quality validators (a11y, html-validate) + altRequired | 5 days | Cut 1, Cut 2 | ☐ |
 | **4** | Publish gate + heavy validators (Lighthouse, linkinator) | 5 days | Cut 3 | ☐ |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,8 +7,8 @@ Strategic forward-looking priorities for Gazetta. Captures what's prioritized, w
 ## How to read this
 
 - **Tier 1** = next 4-8 weeks; explicit commitment
-- **Tier 2** = next quarter; planned but not started — includes **foundational design passes** (architectural dimensions every feature must respect) alongside committed implementation work
-- **Tier 3** = strategic bets; implementation work that depends on a foundational design pass being done first
+- **Tier 2** = next quarter; planned but not started — historically included foundational design passes alongside committed implementation work; design corpus is now complete
+- **Tier 3** = phased implementation plan against the complete design corpus; ~7-11 month horizon for Phase 0 + Phase 1 + Phase 2 + Phase 3
 - **Deferred** = real gaps but not the right time
 - **Non-goals** = explicit strategic non-fits — see [`docs/non-goals.md`](docs/non-goals.md)
 
@@ -134,34 +134,97 @@ Operator-facing features that mature production deployments:
 ### Environment-specific content
 - #62 environment-specific content — design pass needed; sized after design
 
-## Tier 3 — strategic bets (implementation pending foundational design)
+## Tier 3 — implementation phases (design corpus complete; building features)
 
-### Themes implementation (4-6 weeks)
-After `design-themes.md` lands. Theme variants for pages/fragments + runtime theme routing + admin theme switcher per active page.
+The 13-dimension foundational design corpus is complete. Implementation is now sequenced as four phases. **No backwards-compatibility constraint** (pre-1.0 product); cutovers are clean. **No external shipping pressure**; architectural correctness prioritized over velocity.
 
-### Auth + RBAC + audit + review implementation (6-10 weeks)
-After `design-auth-rbac.md`, `design-audit.md`, `design-review-workflow.md` all land. The team CMS feature set: roles, authorization gates on every API endpoint, audit log records on every write, per-content review state machine, per-target publish approval.
+Total horizon: ~7-11 months for Phase 0 + Phase 1 + Phase 2 + Phase 3. Tier 3 strategic bets (concurrent editing, etc.) deferred indefinitely.
 
-### Per-field translation (#192)
-After `design-i18n.md` lands. Layered overlay model on top of existing whole-file locale variants.
+### Phase 0 — Implementation planning artifacts (1-2 weeks)
 
-### Real-time presence
-After `design-audit.md` lands (audit log is the event source). Sanity Presence as reference. Real-time transport implementation lands as part of presence (1-2 weeks); presence MVP (presence-only, no concurrent editing): 4 weeks.
+Write 7 missing `design-{feature}-implementation.md` docs:
+- `design-auth-rbac-implementation.md`
+- `design-audit-implementation.md`
+- `design-hooks-implementation.md`
+- `design-plugins-implementation.md`
+- `design-cache-implementation.md`
+- `design-offline-implementation.md`
+- `design-collaboration-implementation.md`
 
-### Hooks implementation
-After `design-hooks.md` lands. Phased cut sequence similar to validation's 6-cut pattern.
+Each defines cut sequence, per-cut scope, files added/modified, tests, integration consumer for validation, and SOLID checks. No migration sections needed (no backwards compat).
 
-### Plugin implementation
-After `design-plugins.md` lands. Unifies existing extension surfaces under one contract.
+Plus: lock the cross-cutting sequencing (TS config affects every consumer; serial), per-foundation test plans, and integration test strategy across foundations.
 
-### Validation Cut 4 (publish gate + heavy validators)
-Per [`design-validation-implementation.md`](.claude/rules/design-validation-implementation.md). Adds Lighthouse via Playwright + linkinator. Operator-controlled strictness at publish time. **Effort**: 5 days.
+### Phase 1 — Foundations (8-12 weeks)
 
-### Validation Cut 5 + 6 (CLI rewrite + template-developer surfaces)
-Per design-validation-implementation. Closes out the validation system.
+Each foundation: code + unit tests + contract tests (where it's an extension surface) + integration tests + at least one consumer integration + user-facing docs. Sequenced to respect cross-cutting dependencies.
 
-### Concurrent editing with OT/CRDT
-Huge investment. After presence-only ships and product positioning is clear. 3-6 months.
+| Foundation | Sequence | Estimate |
+|---|---|---|
+| TS config migration | First (mechanical, affects everything) | 1-2w |
+| AuthIdentity layer | After TS config (Principal extraction; trust modes) | 2w |
+| Component IDs | Independent (structural manifest change) | 1w |
+| AdminCache abstraction | Independent (replaces existing memos) | 1-2w |
+| Audit primitive | After AuthIdentity (records `actor` snapshot) | 1-2w |
+| Hooks lifecycle | After AuthIdentity (`Principal` in HookContext) | 2w |
+| Plugin loader | After TS config + Hooks (factory invocation; PluginAPI) | 1-2w |
+| NotificationProvider (in-admin only) | After Hooks (in-admin via subscribe) | 1w |
+
+### Phase 2 — Features composing against foundations (10-14 weeks)
+
+| Feature | Depends on | Estimate |
+|---|---|---|
+| Validation Cut 2 (background scanner) | AdminCache | 4 days |
+| Validation Cut 3 (render-for-analysis + a11y) | AdminCache + Cut 2 | 5 days |
+| Per-field translation (#192) | i18n design (shipped) + Component IDs | 2-3w |
+| Review workflow MVP | AuthIdentity + Audit + Hooks | 2-3w |
+| Comments-first collaboration v1 | AuthIdentity + Audit + Component IDs + NotificationProvider | 3w |
+| Offline mode v1 | AdminCache + service worker stack (idb + Vue Query + vite-plugin-pwa) | 3w |
+
+### Phase 3 — Polish, parallel tracks, remaining cuts (8-12 weeks)
+
+These can run in parallel with Phase 1-2 since they don't depend on the foundations:
+
+- **Editor papercut cluster** (2-3w; Tier 1 commitment): #103, #104, #105, #82, #45
+- **Onboarding sprint** (3-4w; Tier 1 commitment): #203 deploy adapter contract + 3 priority adapters + #213 container guide + #79 Docker example + #214 first-run UX
+
+After foundations + features land:
+
+- **Validation Cut 4-6** (~3w): publish gate + Lighthouse, CLI rewrite, template-developer surfaces
+- **Static publish fan-out** (#202, 1-2w)
+- **Small content cluster** (1-2w): #61 redirects, #58 RSS/Atom, #57 pagination, #91 connectivity validate
+- **Operability cluster** (2w): #19, #38, #39, #75, #76, #195, #198
+- **MCP server** (#49, 1-2w)
+- **Documentation thorough sweep** (3w; spread across phases)
+- **Examples + gazetta.studio updates** (2w)
+- **Compare polish** (1w): #109, #111
+- **E2e infra** (#184, small)
+- **Image transformations** (#201, sized after design)
+- **Environment-specific content** (#62, design pass first)
+
+### Deferred indefinitely (demand-driven)
+
+| Item | Trigger to revisit |
+|---|---|
+| Real-time presence MVP | Operator demand for live collaboration awareness |
+| Concurrent editing with OT/CRDT (3-6 months investment) | Presence ships first + product positioning clear |
+| AI tag suggestion task | After translation ships |
+| AI image generation | Concrete operator request |
+| Per-locale comments | Concrete demand |
+| Approval-blocking comments | Compliance archetype demand |
+| File attachments on comments | Operator asks |
+| Markdown formatting in comments | Operator asks |
+| Activity feed | Operator asks |
+| Reactions on comments | Operator asks |
+| Email/Slack/Teams/Discord NotificationProviders | Operator demand (expected order locked in `design-collaboration.md` Q3) |
+| Edge SSR for `dynamic` Targets (WinterTC origin) | WASM-compiled templates or framework support catches up |
+
+### Constraints driving this scope
+
+- **No backwards compatibility**: cutovers replace existing code wholesale; no migration tooling required
+- **No shipping pressure**: architectural correctness prioritized; foundations shipped before features
+- **Maintainer attention is finite**: deferred items respect their triggers; don't pre-build for hypothetical demand
+- **Design corpus is cohesive**: cutting features creates incomplete consumer profiles that make foundations look over-designed; we ship the full feature set the design corpus assumes
 
 ## Deferred — real gaps but not now
 


### PR DESCRIPTION
## Summary

Pivots from design to implementation. After 4 grilling rounds locked the planning constraints (no backwards compat, no shipping pressure, foundation-first), wrote the phased plan + all 7 missing implementation docs.

## Plan structure

**Phase 0** (this PR; 1-2 weeks) — Implementation planning artifacts
**Phase 1** (8-12 weeks) — Foundations: TS config → AuthIdentity → Component IDs / AdminCache → Audit → Hooks → Plugin loader → NotificationProvider
**Phase 2** (10-14 weeks) — Features composing against foundations
**Phase 3** (8-12 weeks) — Polish + parallel tracks (Editor papercut + Onboarding sprint can run alongside Phase 1-2)

Total horizon: 7-11 months. Tier 3 strategic bets (real-time presence, concurrent editing, deferred items) demand-driven.

## Implementation docs delivered

7 new docs under `.claude/rules/`:

| Foundation | Cuts | Estimate | Notes |
|---|---|---|---|
| auth-rbac | 11 | ~10-12 days | Sequenced first |
| audit | 10 | ~10-11 days | Extends history-recorder |
| hooks | 10 | ~7-8 days | Composes with auth + audit |
| plugins | 10 | ~7-8 days | Composes with TS config + hooks |
| cache | 11 | ~6-7 days | Replaces existing memos |
| offline | 16 | ~16-17 days | Largest by cut count; highest risk |
| collaboration | 16 | ~16-17 days | Largest by scope; UI-heavy |

Each doc: cut sequence (low-risk-first per [team-preferences rule 17](.claude/rules/team-preferences.md)), per-cut scope, validation gates, deferred items, open implementation questions, estimates, SOLID checks per cut.

## ROADMAP.md update

Tier 3 section rewritten as the phased Phase 0-3 plan. Demand-driven deferrals enumerated. Constraints driving scope documented.

## Validation Cut 1 status correction

Audit revealed Cut 1 was shipped in commit 53e6a9b; flipped `design-validation-implementation.md` status from in-progress to shipped.

## Next step after merge

Phase 1 starts with TS config migration (lowest-risk; mechanical; affects every consumer; required before plugin loader composes). Each foundation gets its own branch + PR sequence following the relevant impl doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)