### PR TITLE
AdminCache Cuts 1-2: types + errors + key encoding + MemoryCache provider + typed admin surface

### DIFF
--- a/packages/gazetta/src/cache/errors.ts
+++ b/packages/gazetta/src/cache/errors.ts
@@ -1,0 +1,46 @@
+/**
+ * `CacheError` taxonomy per `design-cache.md` Gap 5.
+ *
+ * Two leaf classes today; more land as v2 providers ship and
+ * surface their own failure modes (e.g., Redis transport errors,
+ * Azure Service Bus reconnect failures).
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: error classes only. No logging, no retry policy.
+ *   - OCP: new failure classes extend `CacheError`; existing
+ *     handlers continue to catch the base class.
+ *   - LSP: every subclass IS a `CacheError`; `instanceof` checks
+ *     work uniformly.
+ */
+
+/** Base class for all cache errors. */
+export class CacheError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options)
+    this.name = 'CacheError'
+  }
+}
+
+/**
+ * Thrown at admin boot when cache config is invalid (missing env
+ * var for a remote provider, malformed connection string, unknown
+ * provider name). Admin won't start.
+ */
+export class CacheConfigurationError extends CacheError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options)
+    this.name = 'CacheConfigurationError'
+  }
+}
+
+/**
+ * Thrown when a stored value can't be deserialized. Rare; consumers
+ * typically log + return null rather than propagate.
+ */
+export class CacheSchemaError extends CacheError {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options)
+    this.name = 'CacheSchemaError'
+  }
+}

--- a/packages/gazetta/src/cache/keys.ts
+++ b/packages/gazetta/src/cache/keys.ts
@@ -1,0 +1,64 @@
+/**
+ * Cache key encoding per `design-cache.md` Q1.
+ *
+ * Format: colon-separated `{domain}:{op}:{id?}:{dim1}:{dim2}...`
+ *
+ * Components are encoded via `encodeRefName` from `hash.ts` —
+ * slashes become dots, dots in input throw. Same encoding as
+ * sidecar filenames; reusing keeps page names like `blog/[slug]`
+ * round-trip-safe across both surfaces.
+ *
+ * Cut 1 ships the basic encoder. Cut 3 wraps with the Gazetta
+ * major-version prefix and the 255-char overflow-hash policy
+ * (consumer keeps clean keys; provider stores capped form).
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns key encoding. Cut 3's policy layer
+ *     (version prefix, overflow-hash) wraps but doesn't replace.
+ *   - DIP: consumers call `encodeCacheKey(parts)`; the encoding
+ *     mechanism is internal.
+ */
+import { encodeRefName } from '../hash.js'
+
+/**
+ * Encode an array of components into a colon-separated cache key.
+ *
+ * Each component is passed through `encodeRefName`:
+ *   - `/` becomes `.` (path-style components round-trip)
+ *   - `.` in input throws (dot is reserved for the slash encoding)
+ *
+ * Examples:
+ *   encodeCacheKey(['pages', 'detail', 'home']) → 'pages:detail:home'
+ *   encodeCacheKey(['pages', 'detail', 'blog/[slug]']) → 'pages:detail:blog.[slug]'
+ *   encodeCacheKey(['pages', 'has.dot']) throws
+ */
+export function encodeCacheKey(parts: readonly string[]): string {
+  if (parts.length === 0) {
+    throw new Error('encodeCacheKey requires at least one component')
+  }
+  return parts.map(encodeRefName).join(':')
+}
+
+/**
+ * Extract the prefix portion of a key for `invalidatePrefix()`
+ * convenience. Returns the first N components joined by `:`.
+ *
+ * Examples:
+ *   prefixOf('pages:detail:home', 1) → 'pages:'
+ *   prefixOf('pages:detail:home', 2) → 'pages:detail:'
+ *
+ * The trailing colon is included so prefix matches don't accidentally
+ * include `pagesx:...` style siblings — `'pages:'` matches `'pages:detail:home'`
+ * but not `'pages-archived:home'`.
+ */
+export function prefixOf(key: string, components: number): string {
+  if (components <= 0) {
+    throw new Error('prefixOf requires components >= 1')
+  }
+  const parts = key.split(':')
+  if (components >= parts.length) {
+    return `${key}:`
+  }
+  return `${parts.slice(0, components).join(':')}:`
+}

--- a/packages/gazetta/src/cache/memory.ts
+++ b/packages/gazetta/src/cache/memory.ts
@@ -1,0 +1,157 @@
+/**
+ * `MemoryCache` — process-internal `AdminCache` provider. v1 default.
+ *
+ * Per-instance scope; multi-instance-correct via independence (each
+ * instance receives SSE invalidation for its own writes via Cut 4's
+ * bridge). LRU eviction at configured caps; stats track operational
+ * counters.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns the in-memory provider. Stats, LRU,
+ *     subscribe handling all live here because they're one cohesive
+ *     "memory cache" concern; splitting would fragment.
+ *   - LSP: substitutable for any future `AdminCache` provider via
+ *     the contract test helper (Cut 10).
+ *   - DIP: consumers depend on `AdminCache`, not `createMemoryCache`.
+ *
+ * # subscribe() in Cut 2 (no-op honest semantics)
+ *
+ * The contract is "events from other instances." Cut 2 ships
+ * single-instance MemoryCache with no SSE bridge — there ARE no
+ * other instances, so handlers register but no events fire. Cut 4
+ * modifies this file to wire EventEmitter for the SSE bridge to
+ * deliver cross-instance events.
+ *
+ * This is honest behavior, not a stub-throwing-not-implemented:
+ *   - subscribe() returns a working disposer
+ *   - handlers ARE in the registered set
+ *   - events would fire if any source emitted them
+ *   - it's just that v1 single-instance has no source
+ */
+import type { MemoryCacheConfig } from '../types.js'
+import type { AdminCache, CacheStats, InvalidationEvent } from './types.js'
+
+/** Default cap when operator config doesn't override. */
+const DEFAULT_MAX_ENTRIES = 10_000
+/** Default cap when operator config doesn't override. */
+const DEFAULT_MAX_BYTES = 50 * 1024 * 1024 // 50 MB
+
+interface CacheEntry {
+  value: unknown
+  /** Approximate byte size — `JSON.stringify(value).length`. */
+  bytes: number
+}
+
+/**
+ * Build a `MemoryCache` from operator config. Reads
+ * `admin.cache.memory.{maxEntries, maxBytes}` per `design-cache.md`
+ * Gap 1; falls back to `DEFAULT_MAX_*` when fields absent.
+ *
+ * `MemoryCacheConfig` is the typed shape — operators set it via the
+ * loose `admin.cache: z.record(...)` block in `site.config.ts`; the
+ * runtime cast in `config/loader.ts` aligns shapes.
+ */
+export function createMemoryCache(config: MemoryCacheConfig = {}): AdminCache {
+  const maxEntries = config.maxEntries ?? DEFAULT_MAX_ENTRIES
+  const maxBytes = config.maxBytes ?? DEFAULT_MAX_BYTES
+
+  // Map insertion order is the LRU order; access touches it via
+  // delete+set on hit (Map.set on existing key preserves order, so
+  // the explicit delete-then-set is required to bump recency).
+  const entries = new Map<string, CacheEntry>()
+  let totalBytes = 0
+
+  // Cross-instance event subscribers. Cut 2 never invokes these
+  // (no SSE bridge yet); Cut 4 wires emit on incoming SSE messages.
+  const subscribers = new Set<(event: InvalidationEvent) => void>()
+
+  // Operational counters surfaced via stats() per design-cache.md Q5.
+  let hits = 0
+  let misses = 0
+  let evictions = 0
+  let lastInvalidation: { prefix: string; at: string; source: string } | undefined
+
+  function evictOldestIfOverCap(): void {
+    while (entries.size > maxEntries || totalBytes > maxBytes) {
+      const oldestKey = entries.keys().next().value
+      if (oldestKey === undefined) return
+      const entry = entries.get(oldestKey)
+      entries.delete(oldestKey)
+      if (entry) totalBytes -= entry.bytes
+      evictions++
+    }
+  }
+
+  return {
+    async get<T>(key: string): Promise<T | null> {
+      const entry = entries.get(key)
+      if (!entry) {
+        misses++
+        return null
+      }
+      // LRU touch — delete + re-insert moves to end (most recent).
+      entries.delete(key)
+      entries.set(key, entry)
+      hits++
+      return entry.value as T
+    },
+
+    async set<T>(key: string, value: T, _opts?: { ttl?: number }): Promise<void> {
+      // TTL is part of the AdminCache contract but MemoryCache v1
+      // doesn't honor it — eviction is LRU-only. A future TTL pass
+      // (or a TTL-aware provider) handles expiry.
+      const bytes = JSON.stringify(value).length
+      const existing = entries.get(key)
+      if (existing) {
+        totalBytes -= existing.bytes
+        entries.delete(key)
+      }
+      entries.set(key, { value, bytes })
+      totalBytes += bytes
+      evictOldestIfOverCap()
+    },
+
+    async invalidate(key: string): Promise<void> {
+      const entry = entries.get(key)
+      if (!entry) return
+      entries.delete(key)
+      totalBytes -= entry.bytes
+    },
+
+    async invalidatePrefix(prefix: string): Promise<number> {
+      let cleared = 0
+      for (const [key, entry] of entries) {
+        if (key.startsWith(prefix)) {
+          entries.delete(key)
+          totalBytes -= entry.bytes
+          cleared++
+        }
+      }
+      lastInvalidation = {
+        prefix,
+        at: new Date().toISOString(),
+        source: 'local',
+      }
+      return cleared
+    },
+
+    subscribe(handler: (event: InvalidationEvent) => void): () => void {
+      subscribers.add(handler)
+      return () => {
+        subscribers.delete(handler)
+      }
+    },
+
+    async stats(): Promise<CacheStats> {
+      return {
+        hits,
+        misses,
+        size: entries.size,
+        evictions,
+        bytesApproximate: totalBytes,
+        lastInvalidation,
+      }
+    },
+  }
+}

--- a/packages/gazetta/src/cache/types.ts
+++ b/packages/gazetta/src/cache/types.ts
@@ -1,0 +1,97 @@
+/**
+ * `AdminCache` — provider-substitutable interface for the L4 cache
+ * tier (admin / origin server). One concrete implementation ships in
+ * v1: `MemoryCache` (Cut 2). Reserved for v2: `RedisCache`,
+ * `AzureCache`, `FileCache`.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns the cache contract (interface, stats,
+ *     invalidation event). Nothing else lives here.
+ *   - OCP: new providers implement `AdminCache` and slot into the
+ *     factory (Cut 9). No existing module changes.
+ *   - LSP: every provider honors the same contract. Substitutable
+ *     in tests via the `adminCacheContractTests` helper (Cut 10).
+ *   - ISP: callers depend on this interface, not on a specific
+ *     provider's mechanism (Map, Redis pub/sub, Service Bus).
+ *   - DIP: feature code calls `cache.get(key)` etc.; the seam to
+ *     concrete providers is the factory.
+ *
+ * Locked invariants per `design-cache.md`:
+ *   - Cached values MUST be JSON-serializable (no functions, no
+ *     Symbols, no top-level Maps/Sets) — required for L4 → L6
+ *     handoff via IndexedDB / localStorage.
+ *   - `subscribe()` delivers events from OTHER instances, not from
+ *     local invalidations. Single-instance providers (MemoryCache
+ *     in single-process deployments) register handlers but never
+ *     fire events; multi-instance deployments wire the SSE bridge
+ *     in Cut 4.
+ *   - `invalidatePrefix()` is best-effort with a time cap (~100ms
+ *     default per design-cache.md PWA-responsiveness principle);
+ *     un-cleared entries clear at TTL or on next invalidation.
+ */
+
+/**
+ * The cache contract. All providers implement this; consumers depend
+ * only on the interface.
+ */
+export interface AdminCache {
+  /** Get cached value or null on miss. */
+  get<T>(key: string): Promise<T | null>
+  /**
+   * Set value with optional TTL (seconds). Provider may ignore TTL
+   * if it doesn't support expiry; `MemoryCache` ignores TTL in v1
+   * (LRU-only eviction).
+   */
+  set<T>(key: string, value: T, opts?: { ttl?: number }): Promise<void>
+  /** Invalidate one key. */
+  invalidate(key: string): Promise<void>
+  /** Invalidate all keys matching a prefix. Returns count cleared. */
+  invalidatePrefix(prefix: string): Promise<number>
+  /**
+   * Subscribe to invalidation events from other instances. Returns
+   * disposer.
+   *
+   * Single-instance providers (MemoryCache in single-process)
+   * register handlers but no events fire — the cross-instance SSE
+   * bridge that drives this lands in Cut 4.
+   */
+  subscribe(handler: (event: InvalidationEvent) => void): () => void
+  /** Stats for diagnostics. Optional — not every provider exposes. */
+  stats?(): Promise<CacheStats>
+}
+
+/**
+ * Event delivered to `subscribe()` handlers when another instance
+ * invalidates a cache prefix. Source identifies the originating
+ * instance for cross-instance correlation.
+ */
+export interface InvalidationEvent {
+  /** Key or prefix that was invalidated. */
+  prefix: string
+  /** Originating instance + wall-clock timestamp (ISO 8601). */
+  source: { instance: string; timestamp: string }
+}
+
+/**
+ * Cache stats — minimum required + provider-specific extras allowed.
+ *
+ * The required floor (hits, misses, size) lets the
+ * `/api/system/cache/stats` route (Cut 7) report a useful baseline
+ * across all providers. Optional fields (errors, evictions,
+ * bytesApproximate, oldestEntryAt, lastInvalidation,
+ * subscribeReconnects) ship as the relevant provider tracks them.
+ */
+export interface CacheStats {
+  hits: number
+  misses: number
+  /** Entry count. */
+  size: number
+  // Provider-specific extras allowed.
+  errors?: number
+  evictions?: number
+  bytesApproximate?: number
+  oldestEntryAt?: string
+  lastInvalidation?: { prefix: string; at: string; source: string }
+  subscribeReconnects?: number
+}

--- a/packages/gazetta/src/types.ts
+++ b/packages/gazetta/src/types.ts
@@ -445,6 +445,61 @@ export interface ThemesConfig {
   default?: string
 }
 
+/**
+ * `MemoryCache`-specific config block. Lives at
+ * `siteManifest.admin.cache.memory.{maxEntries, maxBytes}` per
+ * `design-cache.md` Gap 1. Both fields optional; defaults are
+ * 10,000 entries and 50 MB.
+ */
+export interface MemoryCacheConfig {
+  /** Max entry count before LRU eviction kicks in. Default 10,000. */
+  maxEntries?: number
+  /** Approximate max bytes before LRU eviction kicks in. Default 50 MB. */
+  maxBytes?: number
+}
+
+/**
+ * `AdminCache` provider config. The `provider` field discriminates
+ * which provider builds at admin boot; provider-specific fields
+ * live alongside in their own namespace (e.g., `memory: {...}` for
+ * `MemoryCache`, `redis: {...}` for a future RedisCache). Plugin
+ * providers choose their own field shape.
+ */
+export interface CacheSiteConfig {
+  /** Provider name. v1 ships `memory`. v2 reserves `redis`, `azure`, `file`, `distributed`. */
+  provider?: 'memory' | string
+  /** `MemoryCache`-specific fields. */
+  memory?: MemoryCacheConfig
+  /**
+   * Strict-mode opt-in (per `design-cache.md` Gap 4). Blocks admin
+   * boot until the cache provider's `subscribe()` is established.
+   * Used in compliance contexts where eventual consistency during
+   * the boot window is unacceptable. Default `false`.
+   */
+  requireSubscribeOnBoot?: boolean
+}
+
+/**
+ * Admin-runtime config — distinct from content/render dimensions
+ * (`locales`, `themes`, `ai`) which live at `SiteManifest` top level.
+ * Foundational extension surfaces (cache today; auth, audit, hooks,
+ * notifications, offline as their cuts ship) attach here.
+ *
+ * Mirrors the `admin` block in `site.config.ts` per
+ * `design-config.md`; the runtime-cast bridge in
+ * `config/loader.ts` (`siteConfigToManifest`) casts the loose
+ * `Record<string, unknown>` schema field to this typed shape.
+ */
+export interface AdminConfig {
+  cache?: CacheSiteConfig
+  // Future foundations extend AdminConfig with their own optional fields:
+  //   auth?: AuthConfig
+  //   audit?: AuditConfig
+  //   hooks?: HooksConfig
+  //   notifications?: NotificationsConfig
+  //   offline?: OfflineConfig
+}
+
 /** Site manifest — runtime shape derived from site.config.ts */
 export interface SiteManifest {
   name: string
@@ -480,6 +535,13 @@ export interface SiteManifest {
   altText?: AltTextSiteConfig
   systemPages?: string[]
   targets?: Record<string, TargetConfig>
+  /**
+   * Admin-runtime concerns (cache, auth, audit, hooks, notifications,
+   * offline). Distinct from content/render dimensions above; mirrors
+   * the `admin` block in `site.config.ts`. First foundation to use
+   * this surface is the L4 cache (`admin.cache`).
+   */
+  admin?: AdminConfig
 }
 
 /** Directory entry returned by StorageProvider.readDir */

--- a/packages/gazetta/tests/cache-keys.test.ts
+++ b/packages/gazetta/tests/cache-keys.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { encodeCacheKey, prefixOf } from '../src/cache/keys.js'
+
+describe('encodeCacheKey', () => {
+  it('joins components with colon', () => {
+    expect(encodeCacheKey(['pages', 'detail', 'home'])).toBe('pages:detail:home')
+  })
+
+  it('encodes slashes as dots (per encodeRefName)', () => {
+    // Page names with subfolders ('blog/[slug]') round-trip safely
+    // because encodeRefName converts '/' to '.'.
+    expect(encodeCacheKey(['pages', 'detail', 'blog/[slug]'])).toBe('pages:detail:blog.[slug]')
+  })
+
+  it('encodes scoped npm-style names', () => {
+    // Plugin keys use the package name as a prefix per design-cache.md.
+    expect(encodeCacheKey(['@gazetta/slack-notify', 'state'])).toBe('@gazetta.slack-notify:state')
+  })
+
+  it('throws when a component contains a dot', () => {
+    // Dot is reserved for the slash encoding; encodeRefName rejects.
+    expect(() => encodeCacheKey(['pages', 'has.dot'])).toThrow(/dot is reserved/)
+  })
+
+  it('throws on empty input', () => {
+    expect(() => encodeCacheKey([])).toThrow(/at least one component/)
+  })
+
+  it('preserves hyphens, brackets, underscores, locale codes', () => {
+    expect(encodeCacheKey(['pages', 'detail', 'home', 'en-US', 'role_editor', '[draft]'])).toBe(
+      'pages:detail:home:en-US:role_editor:[draft]',
+    )
+  })
+})
+
+describe('prefixOf', () => {
+  it('returns the first N components with trailing colon', () => {
+    expect(prefixOf('pages:detail:home', 1)).toBe('pages:')
+    expect(prefixOf('pages:detail:home', 2)).toBe('pages:detail:')
+  })
+
+  it('appends trailing colon to prevent sibling-prefix collisions', () => {
+    // `'pages:'` matches `'pages:detail:home'` but not `'pages-archived:home'`.
+    expect(prefixOf('pages:detail:home', 1)).toBe('pages:')
+  })
+
+  it('returns the full key plus colon when components exceeds key depth', () => {
+    expect(prefixOf('pages:home', 5)).toBe('pages:home:')
+  })
+
+  it('throws when components is zero or negative', () => {
+    expect(() => prefixOf('pages:home', 0)).toThrow()
+    expect(() => prefixOf('pages:home', -1)).toThrow()
+  })
+})

--- a/packages/gazetta/tests/cache-memory.test.ts
+++ b/packages/gazetta/tests/cache-memory.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest'
+import { createMemoryCache } from '../src/cache/memory.js'
+import type { InvalidationEvent } from '../src/cache/types.js'
+
+describe('MemoryCache get/set/invalidate', () => {
+  it('round-trips values through get/set', async () => {
+    const cache = createMemoryCache()
+    await cache.set('pages:home', { title: 'Home' })
+    expect(await cache.get('pages:home')).toEqual({ title: 'Home' })
+  })
+
+  it('returns null on miss', async () => {
+    const cache = createMemoryCache()
+    expect(await cache.get('pages:nope')).toBeNull()
+  })
+
+  it('invalidate removes a single key', async () => {
+    const cache = createMemoryCache()
+    await cache.set('a', 1)
+    await cache.set('b', 2)
+    await cache.invalidate('a')
+    expect(await cache.get('a')).toBeNull()
+    expect(await cache.get('b')).toBe(2)
+  })
+
+  it('invalidate is no-op on missing key', async () => {
+    const cache = createMemoryCache()
+    await expect(cache.invalidate('never-set')).resolves.toBeUndefined()
+  })
+
+  it('set overwrites existing value', async () => {
+    const cache = createMemoryCache()
+    await cache.set('k', 'first')
+    await cache.set('k', 'second')
+    expect(await cache.get('k')).toBe('second')
+  })
+})
+
+describe('MemoryCache LRU eviction', () => {
+  it('evicts oldest entry when maxEntries exceeded', async () => {
+    const cache = createMemoryCache({ maxEntries: 3 })
+    await cache.set('a', 1)
+    await cache.set('b', 2)
+    await cache.set('c', 3)
+    await cache.set('d', 4) // evicts 'a' (oldest)
+    expect(await cache.get('a')).toBeNull()
+    expect(await cache.get('b')).toBe(2)
+    expect(await cache.get('c')).toBe(3)
+    expect(await cache.get('d')).toBe(4)
+  })
+
+  it('get touches recency — accessed entry survives eviction', async () => {
+    const cache = createMemoryCache({ maxEntries: 3 })
+    await cache.set('a', 1)
+    await cache.set('b', 2)
+    await cache.set('c', 3)
+    await cache.get('a') // touches 'a' — moves to end
+    await cache.set('d', 4) // evicts 'b' (now oldest)
+    expect(await cache.get('a')).toBe(1)
+    expect(await cache.get('b')).toBeNull()
+  })
+
+  it('evicts on byte cap', async () => {
+    // Each value JSON.stringify's to a known size; cap forces eviction.
+    // 'aaa' → 5 bytes (with quotes). Three entries = 15 bytes.
+    const cache = createMemoryCache({ maxBytes: 12, maxEntries: 1000 })
+    await cache.set('k1', 'aaa')
+    await cache.set('k2', 'aaa')
+    await cache.set('k3', 'aaa') // total 15 bytes; evicts oldest
+    const stats = await cache.stats?.()
+    expect(stats?.evictions).toBeGreaterThan(0)
+    expect(stats?.bytesApproximate).toBeLessThanOrEqual(12)
+  })
+
+  it('overwriting a key updates byte total', async () => {
+    const cache = createMemoryCache({ maxBytes: 100, maxEntries: 100 })
+    await cache.set('k', 'small')
+    const before = (await cache.stats?.())?.bytesApproximate ?? 0
+    await cache.set('k', 'much-longer-string')
+    const after = (await cache.stats?.())?.bytesApproximate ?? 0
+    expect(after).toBeGreaterThan(before)
+    // Size stays at 1 entry — overwrite, not new entry.
+    expect((await cache.stats?.())?.size).toBe(1)
+  })
+})
+
+describe('MemoryCache invalidatePrefix', () => {
+  it('clears all entries matching prefix; returns count', async () => {
+    const cache = createMemoryCache()
+    await cache.set('pages:home', 1)
+    await cache.set('pages:about', 2)
+    await cache.set('fragments:header', 3)
+    const cleared = await cache.invalidatePrefix('pages:')
+    expect(cleared).toBe(2)
+    expect(await cache.get('pages:home')).toBeNull()
+    expect(await cache.get('pages:about')).toBeNull()
+    expect(await cache.get('fragments:header')).toBe(3)
+  })
+
+  it('returns 0 when no keys match', async () => {
+    const cache = createMemoryCache()
+    await cache.set('pages:home', 1)
+    expect(await cache.invalidatePrefix('fragments:')).toBe(0)
+  })
+
+  it('records lastInvalidation in stats', async () => {
+    const cache = createMemoryCache()
+    await cache.set('pages:home', 1)
+    await cache.invalidatePrefix('pages:')
+    const stats = await cache.stats?.()
+    expect(stats?.lastInvalidation?.prefix).toBe('pages:')
+    expect(stats?.lastInvalidation?.source).toBe('local')
+    // ISO 8601 timestamp; verify shape, not exact value
+    expect(stats?.lastInvalidation?.at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+})
+
+describe('MemoryCache subscribe (Cut 2 — no-op semantics)', () => {
+  it('registers handler and returns disposer', () => {
+    const cache = createMemoryCache()
+    const events: InvalidationEvent[] = []
+    const disposer = cache.subscribe(e => events.push(e))
+    expect(typeof disposer).toBe('function')
+    disposer()
+  })
+
+  it('does not fire events on local invalidate (cross-instance only)', async () => {
+    // Cut 2 ships subscribe() registering in a Set; Cut 4 wires the
+    // SSE bridge that delivers events. Local invalidations don't
+    // emit because the contract is "events from OTHER instances."
+    const cache = createMemoryCache()
+    const events: InvalidationEvent[] = []
+    cache.subscribe(e => events.push(e))
+    await cache.set('k', 1)
+    await cache.invalidate('k')
+    await cache.invalidatePrefix('p')
+    expect(events).toEqual([])
+  })
+
+  it('disposer removes handler from registered set', () => {
+    // Indirect verification: dispose, then no path can reach the
+    // handler. (Cut 4 will add a real test of this once events fire.)
+    const cache = createMemoryCache()
+    const handler = () => undefined
+    const disposer = cache.subscribe(handler)
+    disposer() // should not throw; should be idempotent if called twice
+    disposer()
+  })
+})
+
+describe('MemoryCache stats', () => {
+  it('counts hits and misses', async () => {
+    const cache = createMemoryCache()
+    await cache.set('k', 1)
+    await cache.get('k') // hit
+    await cache.get('k') // hit
+    await cache.get('missing') // miss
+    const stats = await cache.stats?.()
+    expect(stats?.hits).toBe(2)
+    expect(stats?.misses).toBe(1)
+  })
+
+  it('reports current size', async () => {
+    const cache = createMemoryCache()
+    await cache.set('a', 1)
+    await cache.set('b', 2)
+    const stats = await cache.stats?.()
+    expect(stats?.size).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 1 second foundation, scoped to the first two cuts of the AdminCache implementation plan ([`design-cache-implementation.md`](.claude/rules/design-cache-implementation.md)). Unblocks Validation Cut 2 (which depends on AdminCache per the Phase 2 sequencing table).

**Cut 1** — type-only foundation; no runtime behavior. Three files under `packages/gazetta/src/cache/`:
- `types.ts` — `AdminCache` interface, `CacheStats`, `InvalidationEvent`. Locked invariants: cached values JSON-serializable; `subscribe()` delivers cross-instance events only; `invalidatePrefix()` is best-effort with time cap.
- `errors.ts` — `CacheError` base + `CacheConfigurationError` + `CacheSchemaError` per `design-cache.md` Gap 5.
- `keys.ts` — `encodeCacheKey(parts)` reusing `encodeRefName` from `hash.ts` (slashes → dots, dots in input throw — same encoding as sidecar filenames so page names like `blog/[slug]` round-trip safely). `prefixOf(key, components)` for `invalidatePrefix()` convenience.

**Cut 2** — the seam + v1 default. Single-instance LRU cache implementing the Cut 1 contract:
- `cache/memory.ts` — `createMemoryCache(config)` factory matches existing foundation pattern (`createAnthropicAltAdapter`, etc.). Map insertion-order LRU with delete-then-set on hit (required because `Map.set` on existing key preserves order). Defaults 10K entries, 50 MB. `subscribe()` no-op honest semantics — handlers stored, disposer returned; no events fire because the contract is "events from other instances" and Cut 2 single-instance has no source. Cut 4 modifies this file to wire EventEmitter for the SSE bridge.
- `types.ts` additions: `MemoryCacheConfig`, `CacheSiteConfig`, `AdminConfig`, `SiteManifest.admin?: AdminConfig`. First foundation to use the typed admin-runtime surface; mirrors the existing `altText` pattern (loose Zod in `config/schemas.ts`; typed interface in `types.ts`; cast bridges in `siteConfigToManifest`).

**Test coverage**: 27 new unit tests total (10 keys + 17 memory). Plain unit tests over property-based for the keys module — `encodeRefName` already has thorough PBT coverage in `hash-sidecar-names.test.ts`; the wrapper just needs targeted unit tests.

## Why now

Pre-flight against shipped code surfaced doc gaps + the Phase 2 dependency on AdminCache. PR #248 fixed the docs; this PR ships the foundation those docs describe. Validation Cut 2 (background scanner) depends on `AdminCache.MemoryCache` per the Phase 2 table; landing Cuts 1-2 unblocks it as a clean composition consumer rather than an ad-hoc memo that gets rewritten.

## Test plan

- [x] `npm test` passes (520 admin + 569+ gazetta tests, including the new 27)
- [x] `npm run format` clean
- [x] Type-check clean (`tsc --noEmit` in `packages/gazetta`)
- [ ] Manual review of `subscribe()` no-op contract — confirm reading the impl doc Cut 4 line "modifies cache/memory.ts to add subscribe() via Node EventEmitter" is consistent with this commit's design
- [ ] Spot-check the LRU `delete + re-insert` pattern for correctness against the byte-eviction loop