### PR TITLE
Cache foundation: AdminCache + MemoryCache + SSE invalidation broadcast

### DIFF
--- a/.claude/rules/design-cache-implementation.md
+++ b/.claude/rules/design-cache-implementation.md
@@ -18,15 +18,15 @@ Branch: `cache-v1` off `main`. **No backwards compatibility** — replaces exist
 
 | # | Cut | Status | Risk | Validates |
 |---|---|---|---|---|
-| 1 | `cache/` infrastructure: types, errors, key conventions | ☐ | Low | Type-only foundation |
-| 2 | `AdminCache` interface + `MemoryCache` provider with bounded LRU eviction | ☐ | Medium | The seam + v1 default |
-| 3 | Key conventions: colon-separated, automatic Gazetta-major-version prefix, 255-char overflow-hash | ☐ | Low | Key-handling utility |
+| 1 | `cache/` infrastructure: types, errors, key conventions | ✓ | Low | Type-only foundation (shipped pre-Path-X-Phase-3) |
+| 2 | `AdminCache` interface + `MemoryCache` provider with bounded LRU eviction | ✓ | Medium | The seam + v1 default (shipped pre-Path-X-Phase-3) |
+| 3 | Key conventions: colon-separated, automatic Gazetta-major-version prefix, 255-char overflow-hash | ✓ | Low | Key-handling utility |
 | 4 | SSE invalidation broadcast + `subscribe()` method | ☐ | Medium | Cross-instance coordination primitive |
-| 5 | Sweep existing memos: `findDependentsFromSidecars`, template-scan cache, locale-cache → migrate to `AdminCache.MemoryCache` | ☐ | Medium | Real consumers; replaces ad-hoc memos |
-| 6 | Save handler invalidation: `cache.invalidatePrefix('pages:')` etc. on save / publish | ☐ | Low-medium | Explicit per-feature invalidation |
+| 5 | First real consumer (/api/pages summary) + paired save invalidation | ✓ | Medium | The contract works on real consumers; folds in the original Cut 6 (split shipped a regression). See "Per-cut scope" Cut 5 below for the audit findings on memos that don't migrate. |
+| 6 | _(folded into Cut 5 — see Per-cut scope)_ | ✓ | — | Save handler invalidation paired with read-side caching to avoid shipping a stale-cache regression. |
 | 7 | Stats: hit / miss / size / errors counters + structured log every 5 min + `GET /api/system/cache/stats` | ☐ | Low | Observability |
-| 8 | `CacheError` taxonomy: `CacheConfigurationError`, `CacheSchemaError` | ☐ | Low | Error contracts |
-| 9 | Per-site cache instance + per-site key auto-prefix | ☐ | Medium | Multi-site isolation |
+| 8 | `CacheError` taxonomy: `CacheConfigurationError`, `CacheSchemaError` | ✓ | Low | Error contracts (shipped pre-Path-X-Phase-3) |
+| 9 | Per-site cache instance + per-site key auto-prefix | ✓ | Medium | Multi-site isolation |
 | 10 | `adminCacheContractTests` test helper exported from `gazetta/testing` | ☐ | Low | Plugin author validation surface |
 | 11 | Docs + operator config examples | ☐ | Low | User-facing |
 
@@ -73,25 +73,65 @@ Branch: `cache-v1` off `main`. **No backwards compatibility** — replaces exist
 
 **Tests:** invalidation broadcasts + subscribers receive events + auto-reconnect with backoff (single-process; trivial case)
 
-### Cut 5: Sweep existing memos
+### Cut 5: First real consumer + save invalidation (paired)
 
-**Files modified:**
-- `packages/gazetta/src/admin-api/index.ts` — `cachedScan` (template scan via `memoizeAsync`) → migrate to `AdminCache`
-- `packages/gazetta/src/admin-api/routes/publish.ts` — `fragmentDepsBackfill` Map (per-source in-flight memo for `/api/dependents`) → migrate to `AdminCache`
-- `packages/gazetta/src/admin-api/source-context.ts` — per-source `Map<string, SourceContext>` cache → migrate to `AdminCache`
-- Other ad-hoc memos identified during cut (the codebase isn't memo-heavy; expected sweep is small)
+**Reshaped from the original Cut 5 + Cut 6 plan.** The pre-implementation
+draft listed three "sweep targets" — `cachedScan`, `fragmentDepsBackfill`,
+the `registrySourceResolver` SourceContext map. Audit found none of them
+fit the `AdminCache` contract:
 
-**Note**: a previous draft of this section listed `source-sidecars.ts`, `locale.ts`, and `manifest.ts` as sweep targets. `source-sidecars.ts` was deleted in commit `7d61ce5` (Media v1 step 13c — drop forward sidecars + `SourceSidecarWriter`); `locale.ts` and `manifest.ts` carry no caches. The actual cache-pattern callers above replace that stale list.
+| Candidate | Why not |
+|---|---|
+| `cachedScan` (template scan, `memoizeAsync` wrapper) | Singleflight semantics — concurrent misses share one in-flight Promise. `AdminCache.get/set` doesn't provide thundering-herd protection; migrating would regress 5 concurrent template scans on cold start. `memoizeAsync` is a published primitive (`concurrency.ts`), not ad-hoc. Stays. |
+| `fragmentDepsBackfill: Map<string, Promise<void>>` | Same singleflight pattern; in-flight memo of a side-effecting build (`rebuildDepIndex`). No cached value to return. Stays. |
+| `registrySourceResolver` Map | Caches `SourceContext` instances carrying function refs (`history.recordWrite`) and class instances. Violates the locked invariant "Cached values MUST be JSON-serializable" (`design-cache.md` offline composition). Stays. |
 
-**Tests:** equivalence tests confirm cache hits return same shapes as pre-migration
+The codebase is genuinely not memo-heavy as the draft anticipated.
+The right Cut 5 is: pick a real consumer that benefits from JSON-
+serializable cached results and wire it through, paired with the save
+invalidation Cut 6 originally separated. Splitting them ships a
+regression (cache shows stale data until next save) — same lesson
+called out in `design-config-implementation.md` Cut 5/Cut 10 reshuffle.
 
-### Cut 6: Save handler invalidation
+**What shipped (paired Cut 5 + Cut 6):**
 
-**Files modified:**
-- `packages/gazetta/src/admin-api/routes/pages.ts` — explicit `cache.invalidatePrefix('pages:')` on save; sidecar-driven cascade invalidates dependent pages
-- Similar in `fragments.ts`, `assets.ts`, `publish.ts`
+Files modified:
+- `packages/gazetta/src/admin-api/source-context.ts` — `SourceContext`
+  gains a `cache: AdminCache` field. `createSourceContext` lazily
+  builds a `MemoryCache` (and wraps with `forSite()`) when the caller
+  doesn't supply one. The cache lives at SourceContext lifetime, so
+  every `loadSiteFromSource(source)` returns a `Site` whose `cache`
+  is the same instance — entries persist across requests.
+- `packages/gazetta/src/site-loader.ts` — `LoadSiteOptions.cache`
+  added; when supplied, used verbatim (already site-scoped).
+  Fallback path (CLI, tests) builds a fresh wrapped cache per call.
+- `packages/gazetta/src/admin-api/routes/pages.ts` — `GET /api/pages`
+  reads `pages:summary` from `source.cache`, computes on miss, sets.
+  Save handlers (`POST/PUT/DELETE`) call
+  `source.cache.invalidatePrefix('pages:')` before returning.
+- `packages/gazetta/src/admin-api/routes/fragments.ts` — same shape
+  for `GET /api/fragments` (`fragments:summary`). Fragment writes
+  also invalidate `pages:` because page summaries reflect fragment
+  references resolvable through the loader.
+- `packages/gazetta/src/admin-api/routes/history.ts` — undo and
+  restore invalidate `pages:` + `fragments:` when the target is the
+  source target (the common case; restoring on a non-source target
+  doesn't affect this source's cache).
 
-**Tests:** save invalidates correct prefix; sidecar cascade invalidates dependents
+**Not invalidated (deliberately, to keep the diff small):**
+- Asset writes — the cached page/fragment summary doesn't include
+  asset refs (just `name/route/template/locales`); rename/replace/
+  delete don't dirty the summary.
+- Publish — writes to target storage, not source content; source
+  cache stays valid.
+
+**Tests:** existing `admin-api.test.ts` POST→GET round-trips already
+exercise the contract end-to-end (creating a page then listing must
+return the new page); they were failing under read-only Cut 5 and
+now pass with the paired invalidation. No new test files needed —
+the cache primitives are unit-tested in `cache-keys`/`cache-memory`/
+`cache-per-site`; the integration is exercised via the admin-api
+suite.
 
 ### Cut 7: Stats
 

--- a/.claude/rules/design-cache-implementation.md
+++ b/.claude/rules/design-cache-implementation.md
@@ -21,7 +21,7 @@ Branch: `cache-v1` off `main`. **No backwards compatibility** — replaces exist
 | 1 | `cache/` infrastructure: types, errors, key conventions | ✓ | Low | Type-only foundation (shipped pre-Path-X-Phase-3) |
 | 2 | `AdminCache` interface + `MemoryCache` provider with bounded LRU eviction | ✓ | Medium | The seam + v1 default (shipped pre-Path-X-Phase-3) |
 | 3 | Key conventions: colon-separated, automatic Gazetta-major-version prefix, 255-char overflow-hash | ✓ | Low | Key-handling utility |
-| 4 | SSE invalidation broadcast + `subscribe()` method | ☐ | Medium | Cross-instance coordination primitive |
+| 4 | SSE invalidation broadcast + `subscribe()` method | ✓ | Medium | Cross-instance coordination primitive |
 | 5 | First real consumer (/api/pages summary) + paired save invalidation | ✓ | Medium | The contract works on real consumers; folds in the original Cut 6 (split shipped a regression). See "Per-cut scope" Cut 5 below for the audit findings on memos that don't migrate. |
 | 6 | _(folded into Cut 5 — see Per-cut scope)_ | ✓ | — | Save handler invalidation paired with read-side caching to avoid shipping a stale-cache regression. |
 | 7 | Stats: hit / miss / size / errors counters + structured log every 5 min + `GET /api/system/cache/stats` | ✓ | Low | Observability |
@@ -64,14 +64,22 @@ Branch: `cache-v1` off `main`. **No backwards compatibility** — replaces exist
 
 ### Cut 4: SSE invalidation broadcast
 
-**Files added:**
-- `packages/gazetta/src/cache/sse.ts` — server-side broadcast on invalidate / invalidatePrefix
+**Contract evolution from the Q2 lock.** The original framing was "events from other instances" with single-instance providers as honest no-ops. Implementation surfaced that the L4→L6 server-to-browser cascade is the load-bearing consumer: from the browser's POV the server IS another instance, so the right contract is "events from any source." Updated `design-cache.md`'s subscribe section accordingly.
 
 **Files modified:**
-- `packages/gazetta/src/cache/memory.ts` — replace Cut 2's no-op `subscribe()` with Node EventEmitter wiring; SSE listener calls handler set via emit
-- SSE channel location TBD when Cut 4 starts. Existing dev-server reload SSE lives at [`cli/index.ts`](../../packages/gazetta/src/cli/index.ts) (`/__reload`, line 1536); Cut 4 either extends it or adds a new admin-api SSE route alongside the existing `streamSSE` use in `admin-api/routes/publish.ts:522`. No `admin-api/middleware/sse.ts` exists today.
+- `packages/gazetta/src/cache/memory.ts` — `MemoryCache` now fires `subscribers` on every local `invalidate` and `invalidatePrefix`. Event payload carries the consumer-facing prefix (the form passed to the method) — the `applyKeyPolicy` version prefix and overflow-hash are storage encoding details that don't leak into events. Subscriber faults isolated via try/catch; one failing subscriber doesn't prevent siblings from firing. New `instance?: string` option lets operators override the auto-generated 8-char hex ID (matches Kubernetes pod / Cloud Run revision conventions per `design-logging.md`).
+- `packages/gazetta/src/cache/types.ts` — JSDoc updated to document the "events from any source" contract and the consumer-facing-prefix invariant.
+- `packages/gazetta/src/admin-api/routes/system.ts` — `GET /api/system/cache/invalidations` SSE endpoint added next to `/stats`. Subscribes to the resolved source's cache; buffers events; writes them as SSE frames. `stream.onAbort` disposes the subscriber so we don't leak between connections.
 
-**Tests:** invalidation broadcasts + subscribers receive events + auto-reconnect with backoff (single-process; trivial case)
+**Tests:**
+- `cache-memory.test.ts` — local emission, prefix carries consumer form (no `:` leak from version prefix), invalidate(missing) no-fire, invalidatePrefix-no-match still emits (browser's L6 may hold what L4 evicted), instance ID stability + override, subscriber fault isolation
+- `cache-per-site.test.ts` — round-trip through forSite + MemoryCache delivers consumer prefix; cross-site events filtered (site A invalidations don't fire site B's subscriber)
+- `admin-api.test.ts` — SSE smoke: open connection, trigger save in background, assert `event: invalidation` arrives with `data: {"prefix":"pages:",...}`. Bounded with `setTimeout` race so a regression doesn't hang the suite.
+
+**Deferred from Cut 4:**
+- Auto-reconnect with backoff on the SSE consumer side — implementation lives in the browser-side `IndexedDBCache` provider when offline mode ships (`design-offline.md` Cut 4). v1 SSE endpoint just streams; clients reconnect on their own.
+- `subscribeReconnects` stat — same — populated by the browser-side cache when reconnect logic lands.
+- Strict-mode boot blocking on subscribe — Gap 4 reserved for compliance contexts; not v1.
 
 ### Cut 5: First real consumer + save invalidation (paired)
 

--- a/.claude/rules/design-cache-implementation.md
+++ b/.claude/rules/design-cache-implementation.md
@@ -24,7 +24,7 @@ Branch: `cache-v1` off `main`. **No backwards compatibility** — replaces exist
 | 4 | SSE invalidation broadcast + `subscribe()` method | ☐ | Medium | Cross-instance coordination primitive |
 | 5 | First real consumer (/api/pages summary) + paired save invalidation | ✓ | Medium | The contract works on real consumers; folds in the original Cut 6 (split shipped a regression). See "Per-cut scope" Cut 5 below for the audit findings on memos that don't migrate. |
 | 6 | _(folded into Cut 5 — see Per-cut scope)_ | ✓ | — | Save handler invalidation paired with read-side caching to avoid shipping a stale-cache regression. |
-| 7 | Stats: hit / miss / size / errors counters + structured log every 5 min + `GET /api/system/cache/stats` | ☐ | Low | Observability |
+| 7 | Stats: hit / miss / size / errors counters + structured log every 5 min + `GET /api/system/cache/stats` | ✓ | Low | Observability |
 | 8 | `CacheError` taxonomy: `CacheConfigurationError`, `CacheSchemaError` | ✓ | Low | Error contracts (shipped pre-Path-X-Phase-3) |
 | 9 | Per-site cache instance + per-site key auto-prefix | ✓ | Medium | Multi-site isolation |
 | 10 | `adminCacheContractTests` test helper exported from `gazetta/testing` | ☐ | Low | Plugin author validation surface |

--- a/.claude/rules/design-cache-implementation.md
+++ b/.claude/rules/design-cache-implementation.md
@@ -27,8 +27,8 @@ Branch: `cache-v1` off `main`. **No backwards compatibility** — replaces exist
 | 7 | Stats: hit / miss / size / errors counters + structured log every 5 min + `GET /api/system/cache/stats` | ✓ | Low | Observability |
 | 8 | `CacheError` taxonomy: `CacheConfigurationError`, `CacheSchemaError` | ✓ | Low | Error contracts (shipped pre-Path-X-Phase-3) |
 | 9 | Per-site cache instance + per-site key auto-prefix | ✓ | Medium | Multi-site isolation |
-| 10 | `adminCacheContractTests` test helper exported from `gazetta/testing` | ☐ | Low | Plugin author validation surface |
-| 11 | Docs + operator config examples | ☐ | Low | User-facing |
+| 10 | `adminCacheContractTests` test helper exported from `gazetta/testing` | ✓ | Low | Plugin author validation surface |
+| 11 | Docs + operator config examples | ✓ | Low | User-facing |
 
 ## Per-cut scope
 

--- a/.claude/rules/design-cache.md
+++ b/.claude/rules/design-cache.md
@@ -70,14 +70,18 @@ This pushes the discipline to cache CONSUMERS (write deterministic functions of 
 
 **Generic dependency-aware invalidation rejected**: tracking dependencies in the cache layer requires reverse-dep graphs that must be coordinated across instances OR rebuilt per-instance (which defeats the cache). Sidecars already solve this at L5 — explicit per-feature invalidation at L4 reads sidecars to compute the affected set, no cache-layer dep graph needed.
 
-**SSE broadcast for cross-instance coordination (Q2 lock):**
+**Subscribe contract — events from any source (Q2 lock + Cut 4 evolution):**
 
-Each provider implements `subscribe(handler)` per its coordination mechanism:
-- `MemoryCache` — process-internal `EventEmitter`
-- `RedisCache` — Redis pub/sub
-- `AzureCache` — Azure Service Bus or Redis pub/sub
+`subscribe(handler)` fires on **every** invalidation regardless of origin: local invalidations on this provider AND cross-instance invalidations delivered via the provider's coordination mechanism. Subscribers discriminate via `event.source.instance` if they only care about cross-instance events.
 
-Save flow: write manifest → write sidecars → invalidate L4 entries → SSE broadcast → other instances invalidate L4 → connected browsers invalidate L6.
+The original Q2 framing was "events from OTHER instances" with single-instance providers as honest no-ops. Cut 4 implementation surfaced that the L4→L6 server-to-browser cascade is the load-bearing consumer: from the browser's POV the server IS another instance, so the right contract is "events from any source." Locking that as the contract avoids two coexisting subscribe semantics across providers.
+
+Per provider:
+- `MemoryCache` — emits on every local invalidation (Cut 4); cross-instance events arrive via SSE bridge when a peer subscriber exists (future Redis or browser admin)
+- `RedisCache` — Redis pub/sub fans out to all subscribers including the local one; same "any source" semantics
+- `AzureCache` — Azure Service Bus or Redis pub/sub; same shape
+
+Save flow: write manifest → write sidecars → invalidate L4 entries → subscribers fire (local SSE bridge forwards to browsers; future shared-backing providers fan out to peer instances) → connected browsers invalidate L6.
 
 **Best-effort invalidation atomicity** (Q2 lock):
 

--- a/.claude/rules/design-cache.md
+++ b/.claude/rules/design-cache.md
@@ -122,7 +122,12 @@ export interface AdminCache {
   invalidate(key: string): Promise<void>
   /** Invalidate all keys matching a prefix. Returns count cleared. */
   invalidatePrefix(prefix: string): Promise<number>
-  /** Subscribe to invalidation events from other instances. Returns disposer. */
+  /**
+   * Subscribe to invalidation events from any source — local
+   * invalidations on this provider AND cross-instance invalidations
+   * delivered via the provider's coordination mechanism. Returns
+   * disposer. Discriminate via `event.source.instance`.
+   */
   subscribe(handler: (event: InvalidationEvent) => void): () => void
   /** Stats for diagnostics — hit rate, size, age distribution. Optional. */
   stats?(): Promise<CacheStats>
@@ -137,6 +142,8 @@ export interface CacheStats {
   hits: number
   misses: number
   size: number
+  /** Identity of the reporting instance — same value as InvalidationEvent.source.instance. */
+  instance?: string
   // Provider-specific extras allowed
 }
 ```
@@ -266,6 +273,7 @@ interface CacheStats {
   misses: number
   size: number               // entry count
   errors: number             // transport failures since last reset
+  instance?: string          // identity of the reporting instance
   // Optional richer fields (provider-supported)
   bytesApproximate?: number
   evictions?: number

--- a/.claude/rules/design-logging.md
+++ b/.claude/rules/design-logging.md
@@ -129,9 +129,11 @@ Logs from multiple admin instances (Cloud Run / Kubernetes deployments) merge in
 Operators searching `module:cache.* AND instance:pod-abc-123` see one instance's cache behavior; without `instance` filter, see all instances merged.
 
 `instance` is set automatically from environment:
-- Cloud Run: `K_REVISION` env
-- Kubernetes: `HOSTNAME` env
-- Otherwise: `os.hostname()` fallback
+- Cloud Run: `K_REVISION` env (per-revision, NOT per-instance — pods scaled from the same revision share this ID; for per-pod identity, operators override the cache instance ID explicitly from the metadata server)
+- Otherwise: `os.hostname()` — returns the pod name on K8s default config, the machine hostname elsewhere
+- Last resort: a random 8-char hex (only when `os.hostname()` returns empty)
+
+`process.env.HOSTNAME` is NOT in the chain. Linux containers usually have it via the shell, but Node processes exec'd directly (e.g., `CMD ["node", "..."]` in a Dockerfile) don't inherit shell environment, so `HOSTNAME` may be undefined on K8s pods. `os.hostname()` calls `gethostname(2)` directly and is reliable across runtimes.
 
 ## Logger interface
 

--- a/apps/admin/tests/api.test.ts
+++ b/apps/admin/tests/api.test.ts
@@ -18,7 +18,7 @@ beforeAll(async () => {
   if (!loaded) throw new Error(`No site.config.ts at ${projectSiteDir}`)
   const manifest = siteConfigToManifest(loaded.config)
   const source = createSourceContext({ storage, siteDir: '', projectSiteDir, manifest })
-  app = createAdminApp({ source, siteDir: projectSiteDir, templatesDir })
+  app = createAdminApp({ source, siteDir: projectSiteDir, templatesDir, disableCacheStatsLogger: true })
 })
 
 afterAll(async () => {

--- a/apps/admin/tests/history.test.ts
+++ b/apps/admin/tests/history.test.ts
@@ -60,6 +60,7 @@ describe('History on save', () => {
       templatesDir,
       targets: new Map([['local', storage]]),
       targetConfigs: { local: { storage: { type: 'filesystem' }, environment: 'local', editable: true } },
+      disableCacheStatsLogger: true,
     })
   })
 
@@ -157,7 +158,7 @@ describe('History disabled on save', () => {
     // No history provider → source.history is undefined → no revisions.
     const manifest = await getManifest()
     const source = createSourceContext({ storage, siteDir: '', projectSiteDir: starterSiteDir, manifest })
-    app = createAdminApp({ source, siteDir: starterSiteDir, templatesDir })
+    app = createAdminApp({ source, siteDir: starterSiteDir, templatesDir, disableCacheStatsLogger: true })
   })
 
   afterAll(async () => {
@@ -187,7 +188,7 @@ describe('Retention', () => {
     const history = createHistoryProvider({ storage, retention: 2 })
     const manifest = await getManifest()
     const source = createSourceContext({ storage, siteDir: '', projectSiteDir: starterSiteDir, history, manifest })
-    app = createAdminApp({ source, siteDir: starterSiteDir, templatesDir })
+    app = createAdminApp({ source, siteDir: starterSiteDir, templatesDir, disableCacheStatsLogger: true })
   })
 
   afterAll(async () => {
@@ -230,6 +231,7 @@ describe('History HTTP endpoints', () => {
       templatesDir,
       targets: new Map([['local', storage]]),
       targetConfigs: { local: { storage: { type: 'filesystem' }, environment: 'local', editable: true } },
+      disableCacheStatsLogger: true,
     })
   })
 
@@ -324,6 +326,7 @@ describe('History HTTP endpoints', () => {
         templatesDir,
         targets: new Map([['local', storage]]),
         targetConfigs: { local: { storage: { type: 'filesystem' }, environment: 'local', editable: true } },
+        disableCacheStatsLogger: true,
       })
       const res = await freshApp.request('/api/history/undo?target=local', { method: 'POST' })
       expect(res.status).toBe(409)

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -49,16 +49,44 @@ export default defineSite({
 
 ## Multi-instance deployments
 
-Each admin instance gets its own `MemoryCache` — eventual consistency
-across instances is acceptable because each handles its own writes
-and invalidations on its own cache. Authors editing on one instance
-see fresh data on the next read against THAT instance.
+Most v1 deployments are single-instance: `gazetta serve` on one VPS,
+one Cloud Run revision with min-instances=1, one container. With
+sticky sessions enabled (Cloud Run's default, Kubernetes
+`sessionAffinity: ClientIP`), a multi-instance setup is also fine —
+each author's browser sticks to one admin instance for the editing
+session, and that instance's cache stays consistent with their saves.
 
-If your deployment runs N admin instances behind a round-robin load
-balancer (Cloud Run, Kubernetes), the cache hit rate per instance is
-reduced because each warms independently. This is fine at the
-documented operating envelope (~5000 pages); shared providers (Redis,
-Azure Cache) reserved for v2 when concrete operator demand surfaces.
+### Without sticky sessions
+
+A round-robin load balancer in front of N admin instances creates a
+correctness gap. Concretely:
+
+1. Author saves a page. Request lands on instance A.
+2. A invalidates A's `MemoryCache` and broadcasts the invalidation
+   to browsers connected to A via SSE (see "Subscribing to
+   invalidations" below).
+3. Author refreshes. Request lands on instance B.
+4. B's `MemoryCache` still holds the stale `pages:summary`. B serves
+   stale.
+5. The stale entry stays until B's LRU evicts it (capacity pressure)
+   or B restarts.
+
+With v1 ('s `MemoryCache` provider), there's no server-to-server
+coordination — invalidations on A don't reach B's cache. **For low-
+write CMS workloads, that means hours of staleness on the silent
+instance is possible.** Mitigations, ranked by what operators
+typically do:
+
+| Mitigation | Tradeoff |
+|---|---|
+| **Configure sticky sessions** | Standard answer; supported by every major load balancer. The author always hits the same instance during their editing session. |
+| **Run a single instance** | Simplest. Works at the documented operating envelope (~5000 pages). |
+| **Disable the cache** | Pass `cache: memoryCache({ maxEntries: 0 })` to bypass — every read recomputes from disk. Correct, slower. Last resort. |
+
+A shared backing provider (RedisCache) reserved for v2. The
+`AdminCache.subscribe()` contract is already shaped for it — Redis
+pub/sub fans out invalidations across instances; consumers don't
+change. Ships when concrete operator demand surfaces.
 
 ## Per-site key isolation
 
@@ -88,6 +116,7 @@ different caches.
   "hits": 142,
   "misses": 17,
   "size": 8,
+  "instance": "pod-abc-123",
   "evictions": 0,
   "bytesApproximate": 1834,
   "lastInvalidation": {
@@ -99,7 +128,13 @@ different caches.
 ```
 
 `hits` / `misses` / `size` are guaranteed by the contract. Optional
-fields surface when the underlying provider tracks them.
+fields (including `instance`) surface when the underlying provider
+tracks them.
+
+The `instance` field is critical in multi-instance deployments: with
+a round-robin load balancer, two consecutive `curl` calls to this
+endpoint may hit different pods and return different counter values.
+Read `instance` to know which pod answered.
 
 ### Periodic structured log
 
@@ -110,10 +145,15 @@ The admin process emits a structured log entry every 5 minutes:
   "timestamp": "2026-05-06T11:45:00.000Z",
   "level": "info",
   "module": "cache.stats",
+  "instance": "pod-abc-123",
   "message": "cache stats",
-  "stats": { "hits": 142, "misses": 17, "size": 8, ... }
+  "stats": { "hits": 142, "misses": 17, "size": 8, "instance": "pod-abc-123", ... }
 }
 ```
+
+`instance` is hoisted to a top-level field so log aggregators can
+filter on `module:cache.* AND instance:pod-abc-123` to see one pod's
+behavior in isolation.
 
 Pipe stdout to your log aggregator (Datadog, Loki, journalctl) and
 filter on `module:cache.stats`. Cadence isn't tunable; operators with
@@ -122,6 +162,55 @@ stricter monitoring polls `/api/system/cache/stats` directly.
 To suppress the periodic log entirely (e.g., in development), pass
 `disableCacheStatsLogger: true` to `createAdminApp()`. The stats
 endpoint still works.
+
+## Subscribing to invalidations
+
+The admin server exposes a Server-Sent Events stream of cache
+invalidations:
+
+```
+GET /api/system/cache/invalidations
+```
+
+The stream sends one `event: ready` frame on connection, then one
+`event: invalidation` frame per cache invalidation thereafter.
+Browsers subscribe via `EventSource`; the canonical consumer is the
+browser-side L6 cache (when offline mode ships) which uses these
+events to invalidate its own IndexedDB-backed entries.
+
+Frame shape:
+
+```
+event: invalidation
+data: {"prefix":"pages:","source":{"instance":"pod-abc-123","timestamp":"2026-05-06T11:42:00.000Z"}}
+```
+
+`prefix` is consumer-facing (the form passed to `cache.invalidatePrefix`,
+not the internal storage form). `source.instance` identifies which
+admin pod fired the event.
+
+### Scope: server-to-browser only in v1
+
+The stream covers invalidations on whichever instance the browser is
+connected to. With v1's `MemoryCache` provider, there's no server-to-
+server fan-out: invalidations on instance A don't reach browsers
+connected to instance B. See "Without sticky sessions" above.
+
+When `RedisCache` (or any shared-backing provider) ships, its
+`subscribe()` delivers cross-instance events via Redis pub/sub. The
+SSE endpoint doesn't change; the provider handles fan-out.
+
+### Reconnect: clients must reset their cache
+
+The stream doesn't emit event IDs. If a client's connection drops
+and reconnects, the server has no way to replay missed events — the
+client must treat reconnect as "I may have missed any invalidation
+that happened during the gap" and reset its own cache state.
+
+Per [`design-offline.md`](../.claude/rules/design-offline.md)'s
+reconnect strategy: full local cache reset on reconnect. Cache
+divergence during disconnected windows is hard to detect surgically;
+full reset is the simplest correctness mechanism.
 
 ## Plugin-contributed providers
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,0 +1,189 @@
+## Cache
+
+How Gazetta caches admin reads — what the default does, when to swap
+providers, and how to monitor cache health.
+
+For the design model and `AdminCache` interface contract, see
+[`.claude/rules/design-cache.md`](../.claude/rules/design-cache.md).
+
+## What's cached
+
+The admin server caches summary listings that are expensive to recompute
+on every request:
+
+| Surface | Cache key | Invalidated on |
+|---|---|---|
+| `GET /api/pages` summary | `pages:summary` | page save / delete / fragment edit / history restore |
+| `GET /api/fragments` summary | `fragments:summary` | fragment save / delete / history restore |
+
+Detail endpoints (`GET /api/pages/:name`, `GET /api/fragments/:name`)
+read from disk per request — caching them adds invalidation surface
+without much speedup.
+
+## Default: `MemoryCache`
+
+If you don't declare a cache, Gazetta uses an in-process `MemoryCache`
+with these defaults:
+
+| Knob | Default | Tunable via |
+|---|---|---|
+| Max entries | 10,000 | `memoryCache({ maxEntries: N })` |
+| Approximate max bytes | 50 MB | `memoryCache({ maxBytes: N })` |
+| Eviction | LRU on overflow | not tunable |
+| TTL | none (LRU-only) | `set(..., { ttl })` accepted but ignored in v1 |
+
+This is the right choice for single-process deployments
+(`gazetta dev`, `gazetta serve`, single-container hosts). Keys live in
+RAM; nothing to install.
+
+```ts
+// site.config.ts
+import { defineSite, memoryCache } from 'gazetta'
+
+export default defineSite({
+  // Optional — `MemoryCache()` is the implicit default.
+  cache: memoryCache({ maxEntries: 5000 }),
+  // ... rest of config
+})
+```
+
+## Multi-instance deployments
+
+Each admin instance gets its own `MemoryCache` — eventual consistency
+across instances is acceptable because each handles its own writes
+and invalidations on its own cache. Authors editing on one instance
+see fresh data on the next read against THAT instance.
+
+If your deployment runs N admin instances behind a round-robin load
+balancer (Cloud Run, Kubernetes), the cache hit rate per instance is
+reduced because each warms independently. This is fine at the
+documented operating envelope (~5000 pages); shared providers (Redis,
+Azure Cache) reserved for v2 when concrete operator demand surfaces.
+
+## Per-site key isolation
+
+Every cache instance is wrapped per-site — keys transparently get a
+`site:{name}:` prefix before reaching the underlying provider. Two
+sites sharing a backing service (future Redis cluster) don't collide
+on `pages:summary`.
+
+You don't write the prefix yourself; the wrapping happens at admin
+boot. Plugin authors writing custom providers see only the wrapped
+keys.
+
+## Monitoring
+
+### On-demand snapshot
+
+```
+GET /api/system/cache/stats
+```
+
+Returns the current cache stats for the resolved source. Honors
+`?target=...` like every other admin route — different targets have
+different caches.
+
+```json
+{
+  "hits": 142,
+  "misses": 17,
+  "size": 8,
+  "evictions": 0,
+  "bytesApproximate": 1834,
+  "lastInvalidation": {
+    "prefix": "pages:",
+    "at": "2026-05-06T11:42:00.000Z",
+    "source": "local"
+  }
+}
+```
+
+`hits` / `misses` / `size` are guaranteed by the contract. Optional
+fields surface when the underlying provider tracks them.
+
+### Periodic structured log
+
+The admin process emits a structured log entry every 5 minutes:
+
+```json
+{
+  "timestamp": "2026-05-06T11:45:00.000Z",
+  "level": "info",
+  "module": "cache.stats",
+  "message": "cache stats",
+  "stats": { "hits": 142, "misses": 17, "size": 8, ... }
+}
+```
+
+Pipe stdout to your log aggregator (Datadog, Loki, journalctl) and
+filter on `module:cache.stats`. Cadence isn't tunable; operators with
+stricter monitoring polls `/api/system/cache/stats` directly.
+
+To suppress the periodic log entirely (e.g., in development), pass
+`disableCacheStatsLogger: true` to `createAdminApp()`. The stats
+endpoint still works.
+
+## Plugin-contributed providers
+
+Per [`design-cache.md`](../.claude/rules/design-cache.md) plugin-promotion
+rules, providers like Redis and Azure Cache will ship in-tree when
+3+ operators ask. Until then, plugin authors export a factory that
+returns an `AdminCache`:
+
+```ts
+// In @example/redis-cache
+import type { AdminCache } from 'gazetta'
+
+export function redisCache(opts: { url: string }): AdminCache {
+  // ... build a provider satisfying AdminCache
+}
+```
+
+Operators import and invoke directly:
+
+```ts
+import { defineSite } from 'gazetta'
+import { redisCache } from '@example/redis-cache'
+
+export default defineSite({
+  cache: redisCache({ url: process.env.REDIS_URL! }),
+})
+```
+
+### Validating a custom provider
+
+Plugin authors run the contract test helper to confirm baseline LSP
+correctness:
+
+```ts
+// In your provider's test suite
+import { describe } from 'vitest'
+import { adminCacheContractTests } from 'gazetta/testing'
+import { redisCache } from '../src'
+
+describe('redisCache satisfies the AdminCache contract', () => {
+  adminCacheContractTests(
+    () => redisCache({ url: 'redis://localhost:6379/15' }),
+    {
+      supportsTtl: true,
+      supportsCrossInstanceSubscribe: true,
+      supportsTransportFailureSimulation: true,
+    },
+  )
+})
+```
+
+The capability flags gate the optional test blocks. Providers that
+don't honor TTL leave `supportsTtl` false; the suite skips the TTL
+test cleanly.
+
+## Cached values must be JSON-serializable
+
+The `AdminCache` contract requires JSON-serializable values — no
+functions, no Symbols, no top-level Maps or Sets. This holds across
+all providers (in-process and shared) so that future browser-side
+caches (`IndexedDBCache`, etc.) can persist the same entries from the
+same consumer code.
+
+If you're caching something that isn't naturally serializable, do the
+serialization in the consumer.

--- a/packages/gazetta/package.json
+++ b/packages/gazetta/package.json
@@ -50,6 +50,10 @@
       "types": "./dist/schema/index.d.ts",
       "import": "./dist/schema/index.js"
     },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "import": "./dist/testing/index.js"
+    },
     "./providers/azure-blob": {
       "types": "./dist/providers/azure-blob.d.ts",
       "import": "./dist/providers/azure-blob.js"

--- a/packages/gazetta/src/admin-api/cache-stats-logger.ts
+++ b/packages/gazetta/src/admin-api/cache-stats-logger.ts
@@ -1,0 +1,129 @@
+/**
+ * Periodic structured logging of `AdminCache` stats per
+ * `design-cache.md` Q5.
+ *
+ * Cadence: 5 minutes — emits ~288 entries/day per cache instance.
+ * Low log volume; fine-grained enough to spot issues. Cadence is
+ * not configurable in v1 (operators with stricter monitoring needs
+ * poll `/api/system/cache/stats`).
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns periodic-stats-logging. Routes own
+ *     on-demand snapshots; the cache provider owns counters; the
+ *     logger orchestrates the timer.
+ *   - DIP: depends on the `AdminCache` interface, not on a specific
+ *     provider.
+ *   - LSP: works with any provider that implements `stats()` (and
+ *     no-ops gracefully when `stats` is absent).
+ *
+ * # Multi-instance discipline
+ *
+ * The logger runs once per admin process, against one cache instance.
+ * Multi-instance deployments emit one log stream per instance —
+ * operators correlate via the structured log fields (notably the
+ * `instance` field that the future structured logger will inject per
+ * `design-logging.md`). Cross-instance aggregation is the log
+ * aggregator's job, not Gazetta's.
+ */
+import type { AdminCache, CacheStats } from '../cache/types.js'
+
+/** Default cadence — 5 minutes. */
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000
+
+export interface StartCacheStatsLoggerOptions {
+  cache: AdminCache
+  /**
+   * Interval between log emissions, in milliseconds. Defaults to 5
+   * minutes. Tests pass a smaller value (or `0` to disable the
+   * background timer entirely and drive emissions manually via
+   * `tick()`).
+   */
+  intervalMs?: number
+  /**
+   * Sink for emitted log entries. Defaults to `console.log` with a
+   * JSON payload — matches `design-logging.md`'s "structured JSON
+   * logs" rule. Tests pass a capture function.
+   */
+  sink?: (entry: CacheStatsLogEntry) => void
+}
+
+export interface CacheStatsLogEntry {
+  /** ISO 8601 with Z suffix; matches the audit-log convention. */
+  timestamp: string
+  /** Always 'info' — periodic stats are healthy operational signal. */
+  level: 'info'
+  /** Module namespace per design-logging.md. */
+  module: 'cache.stats'
+  message: string
+  stats: CacheStats
+}
+
+export interface CacheStatsLogger {
+  /** Stop the periodic timer (does nothing if no timer is running). */
+  dispose(): void
+  /**
+   * Manually emit one entry. Useful for tests or for triggering an
+   * extra emission ahead of a planned rollover.
+   */
+  tick(): Promise<void>
+}
+
+/**
+ * Start the periodic logger. Returns a handle exposing `dispose()`
+ * for clean shutdown (tests, hot reload, graceful exit).
+ *
+ * When `intervalMs` is 0, no timer is scheduled — the caller drives
+ * emissions via `tick()` only. Useful in tests that need
+ * deterministic emit timing without fake timers.
+ */
+export function startCacheStatsLogger(opts: StartCacheStatsLoggerOptions): CacheStatsLogger {
+  const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS
+  const sink = opts.sink ?? defaultSink
+
+  async function tick(): Promise<void> {
+    // stats() is optional on the contract — providers that don't
+    // expose it produce a minimum-floor snapshot so the log entry
+    // shape stays stable across providers.
+    const stats: CacheStats = (await opts.cache.stats?.()) ?? { hits: 0, misses: 0, size: 0 }
+    sink({
+      timestamp: new Date().toISOString(),
+      level: 'info',
+      module: 'cache.stats',
+      message: 'cache stats',
+      stats,
+    })
+  }
+
+  let timer: ReturnType<typeof setInterval> | null = null
+  if (intervalMs > 0) {
+    timer = setInterval(() => {
+      // Don't await — periodic emission must not back up if a sink
+      // is slow. Swallow rejections so a transient failure on one
+      // tick (e.g., provider blip) doesn't propagate to the
+      // unhandled-rejection handler; the next tick fires regardless.
+      tick().catch(() => undefined)
+    }, intervalMs)
+    // Don't keep the event loop alive solely for this timer —
+    // graceful shutdown shouldn't have to remember to dispose this.
+    if (timer && typeof timer.unref === 'function') timer.unref()
+  }
+
+  return {
+    dispose(): void {
+      if (timer) {
+        clearInterval(timer)
+        timer = null
+      }
+    },
+    tick,
+  }
+}
+
+function defaultSink(entry: CacheStatsLogEntry): void {
+  // Matches design-logging.md's "structured JSON logs" rule.
+  // pino integration lands when the logging foundation ships;
+  // until then, stringify so log aggregators tailing stdout see
+  // a parseable line.
+  console.log(JSON.stringify(entry))
+}

--- a/packages/gazetta/src/admin-api/cache-stats-logger.ts
+++ b/packages/gazetta/src/admin-api/cache-stats-logger.ts
@@ -55,6 +55,15 @@ export interface CacheStatsLogEntry {
   level: 'info'
   /** Module namespace per design-logging.md. */
   module: 'cache.stats'
+  /**
+   * Identity of the reporting cache instance — top-level for log-
+   * aggregator filtering (`module:cache.* AND instance:pod-abc`)
+   * per `design-logging.md` Multi-instance correlation. Also nested
+   * inside `stats.instance` for callers that consume the stats blob
+   * directly. Optional because providers may report stats without an
+   * identity field.
+   */
+  instance?: string
   message: string
   stats: CacheStats
 }
@@ -90,6 +99,7 @@ export function startCacheStatsLogger(opts: StartCacheStatsLoggerOptions): Cache
       timestamp: new Date().toISOString(),
       level: 'info',
       module: 'cache.stats',
+      instance: stats.instance,
       message: 'cache stats',
       stats,
     })

--- a/packages/gazetta/src/admin-api/index.ts
+++ b/packages/gazetta/src/admin-api/index.ts
@@ -59,6 +59,18 @@ export interface AdminAppOptions {
 
 type AdminApp = Hono & {
   invalidateTemplatesCache(): void
+  /**
+   * Drop AdminCache entries for content (page + fragment summaries)
+   * across every SourceContext the resolver has built. Called by
+   * `gazetta dev`'s file watcher on out-of-band manifest changes
+   * (git pull, manual edit, e2e wipes) — those bypass the save
+   * handler that would normally invalidate the cache.
+   *
+   * Production (`gazetta serve`) doesn't have a file watcher;
+   * out-of-band changes there are vanishingly rare (manifests are
+   * deployed-once artifacts).
+   */
+  invalidateContentCache(): Promise<void>
 }
 
 /**
@@ -194,6 +206,11 @@ export function createAdminApp(opts: AdminAppOptions): AdminApp {
   // Hono Request interface — the CLI casts the return.
   const appWithInvalidate = app as AdminApp
   appWithInvalidate.invalidateTemplatesCache = () => cachedScan.invalidate()
+  appWithInvalidate.invalidateContentCache = async () => {
+    await resolveSource.forEachBuilt(async ctx => {
+      await Promise.all([ctx.cache.invalidatePrefix('pages:'), ctx.cache.invalidatePrefix('fragments:')])
+    })
+  }
   return appWithInvalidate
 }
 

--- a/packages/gazetta/src/admin-api/index.ts
+++ b/packages/gazetta/src/admin-api/index.ts
@@ -26,6 +26,8 @@ import { compareRoutes } from './routes/compare.js'
 import { fieldRoutes } from './routes/fields.js'
 import { historyRoutes } from './routes/history.js'
 import { assetRoutes } from './routes/assets.js'
+import { systemRoutes } from './routes/system.js'
+import { startCacheStatsLogger } from './cache-stats-logger.js'
 
 export interface AdminAppOptions {
   /**
@@ -47,6 +49,12 @@ export interface AdminAppOptions {
   targets?: Map<string, StorageProvider>
   /** Target configurations — providers are initialized lazily on first publish/fetch/compare. */
   targetConfigs?: Record<string, TargetConfig>
+  /**
+   * Disable the periodic cache-stats logger. Defaults to false (logger
+   * runs every 5 minutes). Tests pass true to avoid background timers
+   * leaking into the test runtime.
+   */
+  disableCacheStatsLogger?: boolean
 }
 
 type AdminApp = Hono & {
@@ -169,6 +177,17 @@ export function createAdminApp(opts: AdminAppOptions): AdminApp {
   app.route('/', fieldRoutes(resolveSource, adminDir))
   app.route('/', historyRoutes(resolveSource, opts.targets, opts.targetConfigs))
   app.route('/', assetRoutes(resolveSource))
+  app.route('/', systemRoutes(resolveSource))
+
+  // Periodic cache stats log — fires every 5 minutes against the
+  // bootstrap source's cache. Runs unobtrusively (timer.unref()
+  // means it never blocks process exit). Tests pass
+  // `disableCacheStatsLogger: true` to avoid background timers; the
+  // route at /api/system/cache/stats still exposes on-demand
+  // snapshots either way.
+  if (!opts.disableCacheStatsLogger) {
+    startCacheStatsLogger({ cache: source.cache })
+  }
 
   // Exposed for the CLI's template file watcher: clears the memoized scan
   // so the next publish/compare picks up template edits. Not part of the

--- a/packages/gazetta/src/admin-api/routes/fragments.ts
+++ b/packages/gazetta/src/admin-api/routes/fragments.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import { loadSiteFromSource } from '../source-context.js'
 import { recordWrite } from '../../history-recorder.js'
 import type { SourceContextResolver } from '../source-context.js'
-import { CreateFragmentRequestSchema } from '../schemas/fragments.js'
+import { CreateFragmentRequestSchema, type FragmentSummary } from '../schemas/fragments.js'
 import { isValidLocale } from '../../locale.js'
 import { rebuildAssetRefs, type ItemRef } from '../../assets/asset-deps.js'
 import { rebuildFragmentDeps } from '../../fragment-deps.js'
@@ -18,8 +18,11 @@ export function fragmentRoutes(resolve: SourceContextResolver, validators: Valid
     const source = await resolve(c.req.query('target'))
     // Empty target → empty list. See pages.ts for rationale.
     try {
+      // Cache the summary list (see pages.ts for the same rationale).
+      const cached = await source.cache.get<FragmentSummary[]>('fragments:summary')
+      if (cached) return c.json(cached)
       const site = await loadSiteFromSource(source)
-      const fragments = [...site.fragments.entries()].map(([name, frag]) => {
+      const fragments: FragmentSummary[] = [...site.fragments.entries()].map(([name, frag]) => {
         const localeEntry = site.fragmentLocales.get(name)
         return {
           name,
@@ -27,6 +30,7 @@ export function fragmentRoutes(resolve: SourceContextResolver, validators: Valid
           locales: localeEntry ? [...localeEntry.locales.keys()] : undefined,
         }
       })
+      await source.cache.set('fragments:summary', fragments)
       return c.json(fragments)
     } catch (err) {
       const msg = (err as Error).message
@@ -69,6 +73,10 @@ export function fragmentRoutes(resolve: SourceContextResolver, validators: Valid
       rebuildAssetRefs(source.contentRoot, item, null, manifest),
       rebuildFragmentDeps(source.contentRoot, item, null, manifest),
     ])
+    // Fragment edits affect both fragments and any pages that
+    // reference them — drop both summaries so /api/pages reflects
+    // any newly-resolvable fragment refs on the next call.
+    await Promise.all([source.cache.invalidatePrefix('fragments:'), source.cache.invalidatePrefix('pages:')])
     return c.json({ ok: true, name: body.name })
   })
 
@@ -162,6 +170,7 @@ export function fragmentRoutes(resolve: SourceContextResolver, validators: Valid
       rebuildAssetRefs(source.contentRoot, item, fragment, manifest),
       rebuildFragmentDeps(source.contentRoot, item, fragment, manifest),
     ])
+    await Promise.all([source.cache.invalidatePrefix('fragments:'), source.cache.invalidatePrefix('pages:')])
     return c.json({ ok: true })
   })
 
@@ -198,6 +207,7 @@ export function fragmentRoutes(resolve: SourceContextResolver, validators: Valid
       )
     }
     await Promise.all(teardowns)
+    await Promise.all([source.cache.invalidatePrefix('fragments:'), source.cache.invalidatePrefix('pages:')])
     return c.json({ ok: true })
   })
 

--- a/packages/gazetta/src/admin-api/routes/fragments.ts
+++ b/packages/gazetta/src/admin-api/routes/fragments.ts
@@ -18,8 +18,11 @@ export function fragmentRoutes(resolve: SourceContextResolver, validators: Valid
     const source = await resolve(c.req.query('target'))
     // Empty target → empty list. See pages.ts for rationale.
     try {
-      // Cache the summary list (see pages.ts for the same rationale).
-      const cached = await source.cache.get<FragmentSummary[]>('fragments:summary')
+      // Cache the summary list (see pages.ts for the rationale + the
+      // target-scoping invariant per design-cache.md Gap 6).
+      const targetKey = source.targetName ?? '__source__'
+      const cacheKey = `fragments:summary:target:${targetKey}`
+      const cached = await source.cache.get<FragmentSummary[]>(cacheKey)
       if (cached) return c.json(cached)
       const site = await loadSiteFromSource(source)
       const fragments: FragmentSummary[] = [...site.fragments.entries()].map(([name, frag]) => {
@@ -30,7 +33,7 @@ export function fragmentRoutes(resolve: SourceContextResolver, validators: Valid
           locales: localeEntry ? [...localeEntry.locales.keys()] : undefined,
         }
       })
-      await source.cache.set('fragments:summary', fragments)
+      await source.cache.set(cacheKey, fragments)
       return c.json(fragments)
     } catch (err) {
       const msg = (err as Error).message

--- a/packages/gazetta/src/admin-api/routes/history.ts
+++ b/packages/gazetta/src/admin-api/routes/history.ts
@@ -128,6 +128,12 @@ export function historyRoutes(
       revisionId: list[1].id,
       message: `Undo ${list[0].operation} (rev ${list[0].id})`,
     })
+    // Restoring on the source target rewrites the manifests we summarize
+    // through `/api/pages` and `/api/fragments`. Other targets share no
+    // cache with this source so they're untouched.
+    if (targetName === source.targetName) {
+      await Promise.all([source.cache.invalidatePrefix('pages:'), source.cache.invalidatePrefix('fragments:')])
+    }
     return c.json({ revision: restored, restoredFrom: list[1].id })
   })
 
@@ -148,6 +154,9 @@ export function historyRoutes(
         revisionId,
         message: `Rollback to ${revisionId}`,
       })
+      if (targetName === source.targetName) {
+        await Promise.all([source.cache.invalidatePrefix('pages:'), source.cache.invalidatePrefix('fragments:')])
+      }
       return c.json({ revision: restored, restoredFrom: revisionId })
     } catch (err) {
       // readRevision throws ENOENT-style errors when the id doesn't

--- a/packages/gazetta/src/admin-api/routes/pages.ts
+++ b/packages/gazetta/src/admin-api/routes/pages.ts
@@ -30,7 +30,17 @@ export function pageRoutes(resolve: SourceContextResolver, validators: Validator
       // (and any future per-prefix entries) with one invalidatePrefix.
       // SourceContext owns the cache, so two requests against the same
       // target reuse the same instance.
-      const cached = await source.cache.get<PageSummary[]>('pages:summary')
+      //
+      // The `:target:{name}` suffix is target-scoping per design-cache.md
+      // Gap 6 ("Target is a first-class dimension in cache keys when
+      // value is target-scoped"). Pages can diverge between targets
+      // (per design-publishing.md "targets can diverge"), so summaries
+      // must too. Without the suffix, two SourceContexts sharing one
+      // backing cache (operator's `gazetta.config.ts defaults.cache`)
+      // would clobber each other's summaries.
+      const targetKey = source.targetName ?? '__source__'
+      const cacheKey = `pages:summary:target:${targetKey}`
+      const cached = await source.cache.get<PageSummary[]>(cacheKey)
       if (cached) return c.json(cached)
       const site = await loadSiteFromSource(source)
       const pages: PageSummary[] = [...site.pages.entries()].map(([name, page]) => {
@@ -42,7 +52,7 @@ export function pageRoutes(resolve: SourceContextResolver, validators: Validator
           locales: localeEntry ? [...localeEntry.locales.keys()] : undefined,
         }
       })
-      await source.cache.set('pages:summary', pages)
+      await source.cache.set(cacheKey, pages)
       return c.json(pages)
     } catch (err) {
       const msg = (err as Error).message
@@ -97,6 +107,16 @@ export function pageRoutes(resolve: SourceContextResolver, validators: Validator
     // The summary list is now stale — drop it so the next /api/pages
     // recomputes from disk. Cheap (single key) and explicit per
     // design-cache.md Q2 (no auto-invalidation; consumers enumerate).
+    //
+    // Note: `pages:` matches all `pages:summary:target:*` entries,
+    // so this over-invalidates other targets when a backing cache is
+    // shared (one cross-target recompute on next read per affected
+    // target). Acceptable trade vs. the alternative — per-target
+    // precision would require the save handler to scope its
+    // invalidation key, but `pages:summary:target:${this}` doesn't
+    // catch hypothetical future per-page entries (e.g.
+    // `pages:detail:home:target:${this}`) without a wildcard the
+    // cache contract doesn't support.
     await source.cache.invalidatePrefix('pages:')
     return c.json({ ok: true, name: body.name })
   })

--- a/packages/gazetta/src/admin-api/routes/pages.ts
+++ b/packages/gazetta/src/admin-api/routes/pages.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import { loadSiteFromSource } from '../source-context.js'
 import { recordWrite } from '../../history-recorder.js'
 import type { SourceContextResolver } from '../source-context.js'
-import { CreatePageRequestSchema } from '../schemas/pages.js'
+import { CreatePageRequestSchema, type PageSummary } from '../schemas/pages.js'
 import { isValidLocale } from '../../locale.js'
 import { rebuildAssetRefs, type ItemRef } from '../../assets/asset-deps.js'
 import { rebuildFragmentDeps } from '../../fragment-deps.js'
@@ -24,8 +24,16 @@ export function pageRoutes(resolve: SourceContextResolver, validators: Validator
     // open" (wrong, reports items as present) and "fail closed" (wrong,
     // hides legitimate targets the user might want to switch to).
     try {
+      // Cache the summary list. Per design-scale.md, /api/pages is a
+      // load-bearing read; per design-cache.md the key includes the
+      // 'pages:' reserved prefix so save handlers can blow this entry
+      // (and any future per-prefix entries) with one invalidatePrefix.
+      // SourceContext owns the cache, so two requests against the same
+      // target reuse the same instance.
+      const cached = await source.cache.get<PageSummary[]>('pages:summary')
+      if (cached) return c.json(cached)
       const site = await loadSiteFromSource(source)
-      const pages = [...site.pages.entries()].map(([name, page]) => {
+      const pages: PageSummary[] = [...site.pages.entries()].map(([name, page]) => {
         const localeEntry = site.pageLocales.get(name)
         return {
           name,
@@ -34,6 +42,7 @@ export function pageRoutes(resolve: SourceContextResolver, validators: Validator
           locales: localeEntry ? [...localeEntry.locales.keys()] : undefined,
         }
       })
+      await source.cache.set('pages:summary', pages)
       return c.json(pages)
     } catch (err) {
       const msg = (err as Error).message
@@ -85,6 +94,10 @@ export function pageRoutes(resolve: SourceContextResolver, validators: Validator
       rebuildAssetRefs(source.contentRoot, item, null, manifest),
       rebuildFragmentDeps(source.contentRoot, item, null, manifest),
     ])
+    // The summary list is now stale — drop it so the next /api/pages
+    // recomputes from disk. Cheap (single key) and explicit per
+    // design-cache.md Q2 (no auto-invalidation; consumers enumerate).
+    await source.cache.invalidatePrefix('pages:')
     return c.json({ ok: true, name: body.name })
   })
 
@@ -197,6 +210,7 @@ export function pageRoutes(resolve: SourceContextResolver, validators: Validator
       rebuildAssetRefs(source.contentRoot, item, page, manifest),
       rebuildFragmentDeps(source.contentRoot, item, page, manifest),
     ])
+    await source.cache.invalidatePrefix('pages:')
     return c.json({ ok: true })
   })
 
@@ -237,6 +251,7 @@ export function pageRoutes(resolve: SourceContextResolver, validators: Validator
       )
     }
     await Promise.all(teardowns)
+    await source.cache.invalidatePrefix('pages:')
     return c.json({ ok: true })
   })
 

--- a/packages/gazetta/src/admin-api/routes/publish.ts
+++ b/packages/gazetta/src/admin-api/routes/publish.ts
@@ -486,6 +486,26 @@ export function publishRoutes(
         const result: PublishResult = { target: targetName, success: true, copiedFiles: totalFiles }
         results.push(result)
         console.log(`    ${targetName}: ${totalFiles} files`)
+
+        // Publish wrote new manifests to the target's storage. Any
+        // SourceContext for that target has a stale cached page /
+        // fragment summary. Resolve the target's SourceContext (if
+        // the resolver has built one) and invalidate. Cheap; covers
+        // the case where the admin UI's active target is the publish
+        // destination and the next /api/pages should reflect the
+        // newly-published items.
+        try {
+          const targetSource = await resolve(targetName)
+          await Promise.all([
+            targetSource.cache.invalidatePrefix('pages:'),
+            targetSource.cache.invalidatePrefix('fragments:'),
+          ])
+        } catch {
+          // Resolver may not know this target (registry not configured;
+          // legacy single-target setup). Cache invalidation is best-
+          // effort; ignore.
+        }
+
         yield { kind: 'target-result', result }
       } catch (err) {
         const error = (err as Error).message

--- a/packages/gazetta/src/admin-api/routes/system.ts
+++ b/packages/gazetta/src/admin-api/routes/system.ts
@@ -1,0 +1,39 @@
+import { Hono } from 'hono'
+import type { CacheStats } from '../../cache/types.js'
+import type { CacheStatsResponse } from '../schemas/system.js'
+import type { SourceContextResolver } from '../source-context.js'
+
+/**
+ * System routes — operational diagnostics for the admin process.
+ *
+ * `GET /api/system/cache/stats` returns the current snapshot of the
+ * resolved source's `AdminCache`. Operators (or external monitoring)
+ * pull this on demand; the periodic structured log emitted from
+ * `admin-api/index.ts` covers passive observability via log
+ * aggregators.
+ *
+ * # Why per-source, not process-global
+ *
+ * Per `design-cache.md` Gap 3, each `SourceContext` carries its own
+ * `AdminCache` instance scoped via `forSite()`. Different targets
+ * (read via `?target=...`) get different caches. The route mirrors
+ * the rest of admin-api: every endpoint resolves a source from the
+ * `?target=` query, so stats follow the same convention. Operators
+ * monitoring "cache health" pick a target the same way they pick
+ * one for `/api/pages`.
+ */
+export function systemRoutes(resolve: SourceContextResolver) {
+  const app = new Hono()
+
+  app.get('/api/system/cache/stats', async c => {
+    const source = await resolve(c.req.query('target'))
+    // `stats()` is optional on the AdminCache contract — providers
+    // that don't expose it return a minimum-floor zero snapshot so
+    // the response shape stays stable across providers.
+    const stats: CacheStats = (await source.cache.stats?.()) ?? { hits: 0, misses: 0, size: 0 }
+    const body: CacheStatsResponse = stats
+    return c.json(body)
+  })
+
+  return app
+}

--- a/packages/gazetta/src/admin-api/routes/system.ts
+++ b/packages/gazetta/src/admin-api/routes/system.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
-import type { CacheStats } from '../../cache/types.js'
+import { streamSSE } from 'hono/streaming'
+import type { CacheStats, InvalidationEvent } from '../../cache/types.js'
 import type { CacheStatsResponse } from '../schemas/system.js'
 import type { SourceContextResolver } from '../source-context.js'
 
@@ -33,6 +34,72 @@ export function systemRoutes(resolve: SourceContextResolver) {
     const stats: CacheStats = (await source.cache.stats?.()) ?? { hits: 0, misses: 0, size: 0 }
     const body: CacheStatsResponse = stats
     return c.json(body)
+  })
+
+  /**
+   * Server-Sent Events stream of cache invalidations on the resolved
+   * source's cache. Powers the L4→L6 cascade per `design-cache.md`'s
+   * "Offline composition" section: server-side L4 invalidations
+   * trigger SSE broadcast; browser-side L6 caches subscribe and
+   * invalidate their entries in response.
+   *
+   * Subscribers receive the consumer-facing prefix (e.g., `pages:`)
+   * — the version-prefix and per-site scope are stripped by the
+   * forSite wrapper before the event reaches the route.
+   *
+   * Cleanup: stream.onAbort fires when the client disconnects (tab
+   * close, navigation, network drop). The subscribe disposer
+   * detaches the handler from the cache so we don't leak between
+   * connections.
+   */
+  app.get('/api/system/cache/invalidations', async c => {
+    const source = await resolve(c.req.query('target'))
+    return streamSSE(c, async stream => {
+      // Buffer events between MemoryCache's synchronous emit and our
+      // async stream.writeSSE. If the client is slow to read, events
+      // accumulate here rather than blocking the invalidation that
+      // triggered them. Unbounded in v1 — admin invalidation volume
+      // is low; bound + drop-oldest lands when concrete pain surfaces.
+      const queue: InvalidationEvent[] = []
+      let resolveWaiter: (() => void) | null = null
+
+      const dispose = source.cache.subscribe(event => {
+        queue.push(event)
+        if (resolveWaiter) {
+          const r = resolveWaiter
+          resolveWaiter = null
+          r()
+        }
+      })
+
+      stream.onAbort(() => {
+        dispose()
+        if (resolveWaiter) {
+          const r = resolveWaiter
+          resolveWaiter = null
+          r()
+        }
+      })
+
+      // Send a comment immediately so the client's EventSource
+      // transitions to OPEN — useful for tests that wait on
+      // readyState before triggering invalidations.
+      await stream.writeSSE({ data: '', event: 'ready' })
+
+      while (!stream.aborted) {
+        if (queue.length === 0) {
+          await new Promise<void>(resolve => {
+            resolveWaiter = resolve
+          })
+          continue
+        }
+        const event = queue.shift()!
+        await stream.writeSSE({
+          event: 'invalidation',
+          data: JSON.stringify(event),
+        })
+      }
+    })
   })
 
   return app

--- a/packages/gazetta/src/admin-api/routes/system.ts
+++ b/packages/gazetta/src/admin-api/routes/system.ts
@@ -51,6 +51,24 @@ export function systemRoutes(resolve: SourceContextResolver) {
    * close, navigation, network drop). The subscribe disposer
    * detaches the handler from the cache so we don't leak between
    * connections.
+   *
+   * # Reconnect contract — clients must reset their cache
+   *
+   * The stream does NOT emit event IDs (`SSEMessage.id`), so the
+   * standard EventSource `Last-Event-ID` reconnect mechanism has
+   * nothing to anchor on. Servers can't replay missed events.
+   * Clients reconnecting must assume "I may have missed any
+   * invalidation that happened during the gap" and reset their own
+   * cache state. Per `design-offline.md`'s reconnect strategy: full
+   * local cache reset is the simplest correctness mechanism.
+   *
+   * # Multi-instance scope (v1)
+   *
+   * The stream forwards invalidations from THIS instance's cache
+   * only. With v1's `MemoryCache`, there's no cross-instance fan-out;
+   * when `RedisCache` ships, its `subscribe()` will deliver cross-
+   * instance events via Redis pub/sub and this route forwards them
+   * unchanged.
    */
   app.get('/api/system/cache/invalidations', async c => {
     const source = await resolve(c.req.query('target'))

--- a/packages/gazetta/src/admin-api/schemas/index.ts
+++ b/packages/gazetta/src/admin-api/schemas/index.ts
@@ -16,6 +16,7 @@
  *   - GET  /api/history + POST /api/history/{undo,restore} (revisions + restore)
  *   - POST /api/fetch (cross-target copy)
  *   - DELETE /api/assets/:name (AssetRef + 409 AssetInUseResponse)
+ *   - GET  /api/system/cache/stats (CacheStats snapshot)
  *
  * Add new endpoint modules here as they move to schema-validated contracts.
  */
@@ -31,3 +32,4 @@ export * from './publish.js'
 export * from './history.js'
 export * from './fetch.js'
 export * from './assets.js'
+export * from './system.js'

--- a/packages/gazetta/src/admin-api/schemas/system.ts
+++ b/packages/gazetta/src/admin-api/schemas/system.ts
@@ -1,0 +1,30 @@
+/**
+ * Zod schema for /api/system/cache/stats — operational diagnostics
+ * for the admin's L4 `AdminCache`.
+ *
+ * Shape mirrors `CacheStats` from `cache/types.ts`. Required floor is
+ * (hits, misses, size); optional fields surface when the underlying
+ * provider tracks them (MemoryCache tracks all; future providers may
+ * not).
+ */
+import { z } from 'zod'
+
+export const CacheStatsResponseSchema = z.object({
+  hits: z.number().int().nonnegative(),
+  misses: z.number().int().nonnegative(),
+  size: z.number().int().nonnegative(),
+  errors: z.number().int().nonnegative().optional(),
+  evictions: z.number().int().nonnegative().optional(),
+  bytesApproximate: z.number().int().nonnegative().optional(),
+  oldestEntryAt: z.string().optional(),
+  lastInvalidation: z
+    .object({
+      prefix: z.string(),
+      at: z.string(),
+      source: z.string(),
+    })
+    .optional(),
+  subscribeReconnects: z.number().int().nonnegative().optional(),
+})
+
+export type CacheStatsResponse = z.infer<typeof CacheStatsResponseSchema>

--- a/packages/gazetta/src/admin-api/schemas/system.ts
+++ b/packages/gazetta/src/admin-api/schemas/system.ts
@@ -13,6 +13,13 @@ export const CacheStatsResponseSchema = z.object({
   hits: z.number().int().nonnegative(),
   misses: z.number().int().nonnegative(),
   size: z.number().int().nonnegative(),
+  /**
+   * Identity of the reporting cache instance. Operators querying
+   * `/api/system/cache/stats` in multi-instance deployments read this
+   * to know which pod / revision answered (the load balancer's choice
+   * can vary between requests).
+   */
+  instance: z.string().optional(),
   errors: z.number().int().nonnegative().optional(),
   evictions: z.number().int().nonnegative().optional(),
   bytesApproximate: z.number().int().nonnegative().optional(),

--- a/packages/gazetta/src/admin-api/source-context.ts
+++ b/packages/gazetta/src/admin-api/source-context.ts
@@ -132,8 +132,18 @@ export function createSourceContext(opts: CreateSourceContextOptions): SourceCon
   // once, here, so every loadSiteFromSource() call shares it. Per the
   // single-Site-per-process invariant, the source's site name is
   // stable for the process lifetime.
+  //
+  // Fallback chain:
+  //   1. opts.cache  — caller owns lifetime explicitly (preferred)
+  //   2. opts.manifest.cache — operator's instance from gazetta.config
+  //      defaults.cache (hoisted into site.cache by applyGazettaDefaults
+  //      in the loader). Without this fallback the operator's tuned
+  //      cache is silently ignored on the registry / direct-loadSite
+  //      paths that pass `manifest` but not `cache`.
+  //   3. fresh memoryCache() — single-Site-per-process invariant means
+  //      each process gets its own; safe default.
   const siteName = opts.siteName ?? opts.manifest?.name ?? 'unnamed'
-  const cache = forSite(opts.cache ?? memoryCache(), siteName)
+  const cache = forSite(opts.cache ?? opts.manifest?.cache ?? memoryCache(), siteName)
   return {
     storage: opts.storage,
     siteDir: opts.siteDir,

--- a/packages/gazetta/src/admin-api/source-context.ts
+++ b/packages/gazetta/src/admin-api/source-context.ts
@@ -224,11 +224,25 @@ export function createSourceContextFromRegistry(opts: SourceContextFromRegistryO
  * The resolver is called once per handler invocation; implementations can
  * memoize where appropriate.
  */
-export type SourceContextResolver = (targetName: string | undefined) => SourceContext | Promise<SourceContext>
+export interface SourceContextResolver {
+  (targetName: string | undefined): SourceContext | Promise<SourceContext>
+  /**
+   * Walk every SourceContext the resolver has memoized. The static
+   * resolver yields its single context; the registry resolver yields
+   * every per-target context built on-demand. Used by `gazetta dev`'s
+   * file watcher to invalidate AdminCache entries on out-of-band
+   * manifest changes (git pull, manual edit, e2e test wipes).
+   */
+  forEachBuilt(fn: (source: SourceContext) => void | Promise<void>): Promise<void>
+}
 
 /** Static resolver — always returns the given SourceContext regardless of requested target. */
 export function staticSourceResolver(source: SourceContext): SourceContextResolver {
-  return () => source
+  const resolve = ((_targetName: string | undefined) => source) as SourceContextResolver
+  resolve.forEachBuilt = async fn => {
+    await fn(source)
+  }
+  return resolve
 }
 
 export interface RegistrySourceResolverOptions {
@@ -266,7 +280,7 @@ export interface RegistrySourceResolverOptions {
  */
 export function registrySourceResolver(opts: RegistrySourceResolverOptions): SourceContextResolver {
   const cache = new Map<string, SourceContext>()
-  return async (targetName: string | undefined) => {
+  const resolve = (async (targetName: string | undefined) => {
     const name = targetName ?? opts.registry.defaultEditable()
     const cached = cache.get(name)
     if (cached) return cached
@@ -294,5 +308,11 @@ export function registrySourceResolver(opts: RegistrySourceResolverOptions): Sou
     })
     cache.set(name, ctx)
     return ctx
+  }) as SourceContextResolver
+  resolve.forEachBuilt = async fn => {
+    for (const ctx of cache.values()) {
+      await fn(ctx)
+    }
   }
+  return resolve
 }

--- a/packages/gazetta/src/admin-api/source-context.ts
+++ b/packages/gazetta/src/admin-api/source-context.ts
@@ -10,6 +10,9 @@
  */
 
 import type { GazettaManifest, StorageProvider, SiteManifest } from '../types.js'
+import { memoryCache } from '../cache/factories.js'
+import { forSite } from '../cache/per-site.js'
+import type { AdminCache } from '../cache/types.js'
 import { createContentRoot, type ContentRoot } from '../content-root.js'
 import { loadSite, type Site, type LoadSiteOptions } from '../site-loader.js'
 import type { TargetRegistry } from '../targets.js'
@@ -63,14 +66,35 @@ export interface SourceContext {
    * (gazetta → site → target). Absent when no `gazetta.config.ts` exists.
    */
   readonly gazettaManifest?: GazettaManifest
+  /**
+   * Per-source `AdminCache` instance — already wrapped via `forSite()`
+   * so keys are scoped to this source's site name. Always present;
+   * `createSourceContext` lazily builds a `MemoryCache` when the caller
+   * doesn't supply one.
+   *
+   * Routes that read site-derived data (page summaries, fragment lists,
+   * dependents) read this cache through `loadSiteFromSource` — every
+   * load of the same source returns a `Site` whose `cache` field is the
+   * same instance, so consumers share entries across requests.
+   *
+   * Save handlers invalidate via `source.cache.invalidatePrefix('pages:')`
+   * etc. on writes (Cut 4).
+   */
+  readonly cache: AdminCache
 }
 
 /**
  * Load a site from a SourceContext. Passes the project-level manifest
- * so loadSite doesn't need a target-level site config file.
+ * so loadSite doesn't need a target-level site config file. Forwards
+ * the source's per-site cache so every load shares one cache instance.
  */
 export function loadSiteFromSource(source: SourceContext, opts?: Partial<LoadSiteOptions>): Promise<Site> {
-  return loadSite({ contentRoot: source.contentRoot, manifest: source.manifest, ...opts })
+  return loadSite({
+    contentRoot: source.contentRoot,
+    manifest: source.manifest,
+    cache: source.cache,
+    ...opts,
+  })
 }
 
 export interface CreateSourceContextOptions {
@@ -84,9 +108,32 @@ export interface CreateSourceContextOptions {
   manifest?: SiteManifest
   /** Optional gazetta-level manifest; first rung of the three-rung config chain. */
   gazettaManifest?: GazettaManifest
+  /**
+   * Pre-built unscoped `AdminCache` — typically the operator's
+   * gazetta.config.ts default or per-site override (Path X). When
+   * provided, `createSourceContext` wraps it with `forSite()` using
+   * the manifest's site name. When absent, a fresh `MemoryCache()`
+   * is built and wrapped.
+   *
+   * The wrapping happens here (not at every loadSite call) so all
+   * loads of the same source share one site-scoped cache instance.
+   */
+  cache?: AdminCache
+  /**
+   * Site name used for `forSite()` key scoping. Defaults to
+   * `manifest.name`. Required when `manifest` is absent and the
+   * caller still wants a site-scoped cache.
+   */
+  siteName?: string
 }
 
 export function createSourceContext(opts: CreateSourceContextOptions): SourceContext {
+  // Site-scoped cache: wrap the operator-supplied (or fresh) instance
+  // once, here, so every loadSiteFromSource() call shares it. Per the
+  // single-Site-per-process invariant, the source's site name is
+  // stable for the process lifetime.
+  const siteName = opts.siteName ?? opts.manifest?.name ?? 'unnamed'
+  const cache = forSite(opts.cache ?? memoryCache(), siteName)
   return {
     storage: opts.storage,
     siteDir: opts.siteDir,
@@ -95,6 +142,7 @@ export function createSourceContext(opts: CreateSourceContextOptions): SourceCon
     history: opts.history,
     manifest: opts.manifest,
     gazettaManifest: opts.gazettaManifest,
+    cache,
   }
 }
 

--- a/packages/gazetta/src/cache/keys.ts
+++ b/packages/gazetta/src/cache/keys.ts
@@ -1,25 +1,54 @@
 /**
- * Cache key encoding per `design-cache.md` Q1.
+ * Cache key encoding per `design-cache.md` Q1 + Gap 2.
  *
- * Format: colon-separated `{domain}:{op}:{id?}:{dim1}:{dim2}...`
- *
- * Components are encoded via `encodeRefName` from `hash.ts` —
- * slashes become dots, dots in input throw. Same encoding as
- * sidecar filenames; reusing keeps page names like `blog/[slug]`
- * round-trip-safe across both surfaces.
- *
- * Cut 1 ships the basic encoder. Cut 3 wraps with the Gazetta
- * major-version prefix and the 255-char overflow-hash policy
- * (consumer keeps clean keys; provider stores capped form).
+ * Two layers:
+ *   1. Consumer-facing encoder (`encodeCacheKey`): colon-separated
+ *      `{domain}:{op}:{id?}:{dim1}:{dim2}...` with components passed
+ *      through `encodeRefName` (slashes → dots; dots in input throw).
+ *      Same encoding as sidecar filenames; page names like
+ *      `blog/[slug]` round-trip across both surfaces.
+ *   2. Provider-internal policy (`applyKeyPolicy`): prepends the
+ *      cache schema version and caps total length at 255 chars,
+ *      replacing the overflow tail with an 8-char sha256 hash so
+ *      prefix-invalidation still works when the prefix is below the
+ *      cap. Consumers never see the policy-wrapped form.
  *
  * # SOLID lenses
  *
- *   - SRP: this module owns key encoding. Cut 3's policy layer
- *     (version prefix, overflow-hash) wraps but doesn't replace.
- *   - DIP: consumers call `encodeCacheKey(parts)`; the encoding
- *     mechanism is internal.
+ *   - SRP: encoder owns "consumer key shape"; policy owns "what the
+ *     provider stores." Two concerns, two functions.
+ *   - DIP: consumers call `encodeCacheKey(parts)`; providers call
+ *     `applyKeyPolicy(key)` internally before storing/looking up.
+ *     Neither leaks the version-prefix mechanism to callers.
+ *
+ * # Schema versioning
+ *
+ * `CACHE_SCHEMA_VERSION` is bumped manually when the on-the-wire
+ * shape of cached values changes in a way that makes old entries
+ * unreadable (e.g., a field removed from a summary type). NOT tied
+ * to the package version — patch releases can ship cache-shape
+ * changes; minor releases can be cache-compatible. Manual bumping
+ * keeps the trigger explicit.
  */
+import { createHash } from 'node:crypto'
 import { encodeRefName } from '../hash.js'
+
+/**
+ * Bump when the shape of cached values changes incompatibly. Old
+ * entries with a mismatched prefix are inaccessible and eventually
+ * evicted by LRU.
+ */
+export const CACHE_SCHEMA_VERSION = 1
+
+/**
+ * Maximum stored key length. 255 matches filesystem-provider key-as-
+ * filename ergonomics for future `FileCache` providers; safely under
+ * Redis's 512MB cap and Azure's 250-char path limits.
+ */
+const MAX_KEY_LENGTH = 255
+
+/** sha256 hex prefix length used for overflow hashing. */
+const OVERFLOW_HASH_LENGTH = 8
 
 /**
  * Encode an array of components into a colon-separated cache key.
@@ -61,4 +90,64 @@ export function prefixOf(key: string, components: number): string {
     return `${key}:`
   }
   return `${parts.slice(0, components).join(':')}:`
+}
+
+/**
+ * Apply the version + overflow-hash policy to a consumer-encoded key.
+ * Provider-internal — consumers don't see the result; they pass clean
+ * keys to `cache.get/set/invalidate`, and the provider wraps before
+ * storing or looking up.
+ *
+ * Two transforms:
+ *   1. Prepend `{CACHE_SCHEMA_VERSION}:` so a schema bump invalidates
+ *      every entry across the process atomically.
+ *   2. If the wrapped key exceeds `MAX_KEY_LENGTH`, keep everything up
+ *      to the last `:` boundary that fits in `MAX_KEY_LENGTH - 9`
+ *      chars, then append `:{8-char-sha256}`. Prefix-invalidation
+ *      still works on the kept prefix; only the tail is opaque.
+ *
+ * Examples:
+ *   applyKeyPolicy('pages:detail:home') → '1:pages:detail:home'
+ *   applyKeyPolicy(very-long-key) →
+ *     '1:pages:detail:long-prefix-portion:{hash8}'
+ */
+export function applyKeyPolicy(consumerKey: string): string {
+  const versioned = `${CACHE_SCHEMA_VERSION}:${consumerKey}`
+  if (versioned.length <= MAX_KEY_LENGTH) return versioned
+
+  // Need to overflow. Reserve OVERFLOW_HASH_LENGTH + 1 (for the
+  // ':' separator) at the tail; cut the prefix at the last ':' that
+  // fits in the remaining budget.
+  const reserve = OVERFLOW_HASH_LENGTH + 1
+  const budget = MAX_KEY_LENGTH - reserve
+
+  // Find the last ':' at or before `budget` so prefix matches still
+  // align with consumer-visible component boundaries.
+  let cut = versioned.lastIndexOf(':', budget)
+  // Always at least the version prefix is present (`1:`); cut > 0
+  // here because versioned.length > MAX_KEY_LENGTH > budget > 1.
+  if (cut <= 0) {
+    // Pathological: no ':' in budget. Hard-cut at budget. Prefix
+    // invalidation degrades to "first N chars" rather than aligning
+    // to component boundaries, but keys this dense are unusual.
+    cut = budget
+  }
+
+  const kept = versioned.slice(0, cut)
+  const tail = versioned.slice(cut)
+  const hash = createHash('sha256').update(tail).digest('hex').slice(0, OVERFLOW_HASH_LENGTH)
+  return `${kept}:${hash}`
+}
+
+/**
+ * Apply the version prefix to a `invalidatePrefix()` argument.
+ * Provider-internal. Distinct from `applyKeyPolicy` because prefixes
+ * are not capped or hashed — `invalidatePrefix('pages:')` should
+ * match every stored `'1:pages:...'` key, not just keys that happen
+ * to fit under `MAX_KEY_LENGTH`. The cap-and-hash policy on `set/get`
+ * keeps long keys lookupable; prefix invalidation operates on the
+ * first chars, which the policy preserves verbatim up to the cap.
+ */
+export function applyPrefixPolicy(consumerPrefix: string): string {
+  return `${CACHE_SCHEMA_VERSION}:${consumerPrefix}`
 }

--- a/packages/gazetta/src/cache/memory.ts
+++ b/packages/gazetta/src/cache/memory.ts
@@ -29,6 +29,7 @@
  *   - events would fire if any source emitted them
  *   - it's just that v1 single-instance has no source
  */
+import { applyKeyPolicy, applyPrefixPolicy } from './keys.js'
 import type { AdminCache, CacheStats, InvalidationEvent } from './types.js'
 
 /**
@@ -97,14 +98,15 @@ export function createMemoryCache(config: MemoryCacheOptions = {}): AdminCache {
 
   return {
     async get<T>(key: string): Promise<T | null> {
-      const entry = entries.get(key)
+      const wrapped = applyKeyPolicy(key)
+      const entry = entries.get(wrapped)
       if (!entry) {
         misses++
         return null
       }
       // LRU touch — delete + re-insert moves to end (most recent).
-      entries.delete(key)
-      entries.set(key, entry)
+      entries.delete(wrapped)
+      entries.set(wrapped, entry)
       hits++
       return entry.value as T
     },
@@ -113,28 +115,31 @@ export function createMemoryCache(config: MemoryCacheOptions = {}): AdminCache {
       // TTL is part of the AdminCache contract but MemoryCache v1
       // doesn't honor it — eviction is LRU-only. A future TTL pass
       // (or a TTL-aware provider) handles expiry.
+      const wrapped = applyKeyPolicy(key)
       const bytes = JSON.stringify(value).length
-      const existing = entries.get(key)
+      const existing = entries.get(wrapped)
       if (existing) {
         totalBytes -= existing.bytes
-        entries.delete(key)
+        entries.delete(wrapped)
       }
-      entries.set(key, { value, bytes })
+      entries.set(wrapped, { value, bytes })
       totalBytes += bytes
       evictOldestIfOverCap()
     },
 
     async invalidate(key: string): Promise<void> {
-      const entry = entries.get(key)
+      const wrapped = applyKeyPolicy(key)
+      const entry = entries.get(wrapped)
       if (!entry) return
-      entries.delete(key)
+      entries.delete(wrapped)
       totalBytes -= entry.bytes
     },
 
     async invalidatePrefix(prefix: string): Promise<number> {
+      const wrapped = applyPrefixPolicy(prefix)
       let cleared = 0
       for (const [key, entry] of entries) {
-        if (key.startsWith(prefix)) {
+        if (key.startsWith(wrapped)) {
           entries.delete(key)
           totalBytes -= entry.bytes
           cleared++

--- a/packages/gazetta/src/cache/memory.ts
+++ b/packages/gazetta/src/cache/memory.ts
@@ -37,6 +37,7 @@
  * sees consumer-facing prefixes.
  */
 import { randomBytes } from 'node:crypto'
+import { hostname } from 'node:os'
 import { applyKeyPolicy, applyPrefixPolicy } from './keys.js'
 import type { AdminCache, CacheStats, InvalidationEvent } from './types.js'
 
@@ -56,11 +57,39 @@ export interface MemoryCacheOptions {
   maxBytes?: number
   /**
    * Stable identifier emitted on `InvalidationEvent.source.instance`.
-   * Defaults to a random 8-char hex generated once per construction.
-   * Plays the same role as Kubernetes pod / Cloud Run revision IDs in
-   * future shared-backing providers (per `design-logging.md`).
+   * When omitted, resolved from the environment (per
+   * `design-logging.md`):
+   *
+   *   1. `process.env.K_REVISION` — Cloud Run revision name. Per-
+   *      revision, NOT per-instance: pods scaled from the same
+   *      revision share this ID. Useful for revision-level log
+   *      filtering; for per-pod identity on Cloud Run, override
+   *      explicitly via this field from the metadata server.
+   *   2. `os.hostname()` — pod name on K8s (default config), machine
+   *      hostname elsewhere. Reliable across container runtimes
+   *      regardless of whether `process.env.HOSTNAME` is populated.
+   *   3. Random 8-char hex — only reached when hostname returns an
+   *      empty string (rare on real systems).
+   *
+   * Plugin authors writing shared-backing providers (Redis, Azure)
+   * should accept the same option and use the same resolution chain
+   * so log correlation across providers works uniformly.
    */
   instance?: string
+}
+
+/**
+ * Resolve the instance ID from the environment when the operator
+ * doesn't supply one. Exported for tests; callers should pass through
+ * `MemoryCacheOptions.instance`.
+ */
+export function resolveInstanceId(override?: string): string {
+  if (override) return override
+  const k = process.env.K_REVISION
+  if (k) return k
+  const h = hostname()
+  if (h) return h
+  return randomBytes(4).toString('hex')
 }
 
 /** Default cap when operator config doesn't override. */
@@ -83,7 +112,7 @@ interface CacheEntry {
 export function createMemoryCache(config: MemoryCacheOptions = {}): AdminCache {
   const maxEntries = config.maxEntries ?? DEFAULT_MAX_ENTRIES
   const maxBytes = config.maxBytes ?? DEFAULT_MAX_BYTES
-  const instance = config.instance ?? randomBytes(4).toString('hex')
+  const instance = resolveInstanceId(config.instance)
 
   // Map insertion order is the LRU order; access touches it via
   // delete+set on hit (Map.set on existing key preserves order, so
@@ -214,6 +243,7 @@ export function createMemoryCache(config: MemoryCacheOptions = {}): AdminCache {
         hits,
         misses,
         size: entries.size,
+        instance,
         evictions,
         bytesApproximate: totalBytes,
         lastInvalidation,

--- a/packages/gazetta/src/cache/memory.ts
+++ b/packages/gazetta/src/cache/memory.ts
@@ -15,25 +15,33 @@
  *     the contract test helper (Cut 10).
  *   - DIP: consumers depend on `AdminCache`, not `createMemoryCache`.
  *
- * # subscribe() in Cut 2 (no-op honest semantics)
+ * # subscribe() — local emission per Cut 4
  *
- * The contract is "events from other instances." Cut 2 ships
- * single-instance MemoryCache with no SSE bridge — there ARE no
- * other instances, so handlers register but no events fire. Cut 4
- * modifies this file to wire EventEmitter for the SSE bridge to
- * deliver cross-instance events.
+ * The contract evolved during Cut 4. The original framing was "events
+ * from other instances," with single-instance providers as honest
+ * no-ops. Real consumers (the L4→L6 server-to-browser cascade per
+ * `design-cache.md` "Offline composition") need server-side L4
+ * invalidations to reach browser-side L6 caches. From the browser's
+ * POV the server IS another instance, so the right contract is
+ * "events from any source" — including local ones.
  *
- * This is honest behavior, not a stub-throwing-not-implemented:
- *   - subscribe() returns a working disposer
- *   - handlers ARE in the registered set
- *   - events would fire if any source emitted them
- *   - it's just that v1 single-instance has no source
+ * `invalidate()` and `invalidatePrefix()` fire to subscribers with
+ * the **input** key/prefix (the consumer-facing form passed to the
+ * method). The `applyKeyPolicy` version prefix and overflow-hash are
+ * provider-internal storage details — they don't leak to event
+ * payloads.
+ *
+ * `forSite()` filters events whose prefix doesn't belong to the
+ * wrapping site (cross-site events from a future shared backing
+ * service); the SSE bridge subscribes to the forSite wrapper and
+ * sees consumer-facing prefixes.
  */
+import { randomBytes } from 'node:crypto'
 import { applyKeyPolicy, applyPrefixPolicy } from './keys.js'
 import type { AdminCache, CacheStats, InvalidationEvent } from './types.js'
 
 /**
- * Options for constructing an in-process `MemoryCache`. Both fields
+ * Options for constructing an in-process `MemoryCache`. All fields
  * optional; defaults are 10,000 entries and 50 MB approximate.
  *
  * Lives on the factory signature (rather than as a separate `*Config`
@@ -46,6 +54,13 @@ export interface MemoryCacheOptions {
   maxEntries?: number
   /** Approximate max bytes before LRU eviction kicks in. Default 50 MB. */
   maxBytes?: number
+  /**
+   * Stable identifier emitted on `InvalidationEvent.source.instance`.
+   * Defaults to a random 8-char hex generated once per construction.
+   * Plays the same role as Kubernetes pod / Cloud Run revision IDs in
+   * future shared-backing providers (per `design-logging.md`).
+   */
+  instance?: string
 }
 
 /** Default cap when operator config doesn't override. */
@@ -68,6 +83,7 @@ interface CacheEntry {
 export function createMemoryCache(config: MemoryCacheOptions = {}): AdminCache {
   const maxEntries = config.maxEntries ?? DEFAULT_MAX_ENTRIES
   const maxBytes = config.maxBytes ?? DEFAULT_MAX_BYTES
+  const instance = config.instance ?? randomBytes(4).toString('hex')
 
   // Map insertion order is the LRU order; access touches it via
   // delete+set on hit (Map.set on existing key preserves order, so
@@ -93,6 +109,33 @@ export function createMemoryCache(config: MemoryCacheOptions = {}): AdminCache {
       entries.delete(oldestKey)
       if (entry) totalBytes -= entry.bytes
       evictions++
+    }
+  }
+
+  /**
+   * Notify subscribers of an invalidation. `prefix` is the **input**
+   * form (what the consumer passed to invalidate / invalidatePrefix);
+   * the version-prefix + overflow-hash applied by `applyKeyPolicy` is
+   * a storage encoding detail and never reaches event payloads.
+   *
+   * Subscribers that throw shouldn't poison sibling subscribers —
+   * each notification is wrapped in a try/catch. The error is
+   * swallowed (subscribe is observational; failing-open keeps the
+   * invalidation honest from the caller's POV).
+   */
+  function emit(prefix: string): void {
+    if (subscribers.size === 0) return
+    const event: InvalidationEvent = {
+      prefix,
+      source: { instance, timestamp: new Date().toISOString() },
+    }
+    for (const handler of subscribers) {
+      try {
+        handler(event)
+      } catch {
+        // Subscriber faults must not interfere with the
+        // invalidation that triggered them. Silently swallow.
+      }
     }
   }
 
@@ -133,6 +176,7 @@ export function createMemoryCache(config: MemoryCacheOptions = {}): AdminCache {
       if (!entry) return
       entries.delete(wrapped)
       totalBytes -= entry.bytes
+      emit(key)
     },
 
     async invalidatePrefix(prefix: string): Promise<number> {
@@ -150,6 +194,11 @@ export function createMemoryCache(config: MemoryCacheOptions = {}): AdminCache {
         at: new Date().toISOString(),
         source: 'local',
       }
+      // Emit even when cleared === 0 — subscribers (notably the
+      // L4→L6 SSE bridge) want every invalidation intent, not just
+      // those that hit something locally. A consumer's L6 cache may
+      // hold an entry the server's L4 already evicted via LRU.
+      emit(prefix)
       return cleared
     },
 

--- a/packages/gazetta/src/cache/per-site.ts
+++ b/packages/gazetta/src/cache/per-site.ts
@@ -1,0 +1,122 @@
+/**
+ * Per-site cache scoping per `design-cache.md` Gap 3.
+ *
+ * Wraps an `AdminCache` instance with a site-name prefix on every
+ * key. Two motivations:
+ *
+ *   1. **Future shared backing services** (Redis, Azure cache when
+ *      they ship) — a single Redis cluster shared across N Site
+ *      processes needs key isolation so site A's cache writes don't
+ *      collide with site B's. Per-site key prefix solves this at the
+ *      wrapper layer; the backing provider is unaware.
+ *
+ *   2. **Multi-site deployments evolving over time** — pre-1.0
+ *      Gazetta locks single-Site-per-process, so today there's no
+ *      collision risk in-process. But a future configuration could
+ *      legitimately host two Sites in one process; `forSite` makes
+ *      that change additive.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns "scope an AdminCache to a site name."
+ *     Provider mechanics live in `memory.ts`; key encoding lives in
+ *     `keys.ts`. Three concerns, three files.
+ *   - OCP: a future `forPlugin(cache, pluginName)` wrapper composes
+ *     identically; no change to consumers.
+ *   - LSP: `forSite(cache, name)` returns an `AdminCache`. Any
+ *     caller depending on the interface keeps working.
+ *   - ISP: consumers see `AdminCache`, never the wrapping mechanism.
+ *   - DIP: `loadSite()` wraps once at construction; consumers depend
+ *     on `site.cache: AdminCache`.
+ */
+import { encodeRefName } from '../hash.js'
+import type { AdminCache, CacheStats, InvalidationEvent } from './types.js'
+
+/**
+ * Reserved prefix for the per-site key namespace. Documented as
+ * a built-in per `design-cache.md` Q1's "Reserved prefixes" rule —
+ * plugins must not write keys under `site:`.
+ */
+const SITE_NAMESPACE = 'site'
+
+/**
+ * Wrap an `AdminCache` with per-site key scoping. Every key written,
+ * read, or invalidated through the returned cache is transparently
+ * prefixed with `site:{encoded-name}:`.
+ *
+ * Examples (with siteName = 'main'):
+ *   inner.set('site:main:pages:home', value)  ← stored
+ *   wrapped.set('pages:home', value)          ← what consumers see
+ *
+ * Prefix invalidation works through the wrapping uniformly:
+ *   wrapped.invalidatePrefix('pages:')        ← consumer call
+ *   inner.invalidatePrefix('site:main:pages:') ← actual mechanism
+ *
+ * The `subscribe()` handler receives events with the unwrapped
+ * (consumer-facing) prefix. Events for OTHER sites' invalidations
+ * reaching the same backing service are filtered out (they have a
+ * different `site:{other}:` prefix); cross-site events would be a
+ * leak otherwise.
+ */
+export function forSite(inner: AdminCache, siteName: string): AdminCache {
+  if (!siteName) {
+    throw new Error('forSite: siteName must be a non-empty string')
+  }
+  const encodedName = encodeRefName(siteName)
+  const sitePrefix = `${SITE_NAMESPACE}:${encodedName}:`
+
+  function wrap(key: string): string {
+    return `${sitePrefix}${key}`
+  }
+
+  /**
+   * Strip the `site:{name}:` prefix from a stored key for handoff to
+   * a consumer subscriber. Returns null when the key isn't owned by
+   * this site (shared backing service receiving another site's event).
+   */
+  function unwrap(key: string): string | null {
+    if (!key.startsWith(sitePrefix)) return null
+    return key.slice(sitePrefix.length)
+  }
+
+  return {
+    async get<T>(key: string): Promise<T | null> {
+      return inner.get<T>(wrap(key))
+    },
+
+    async set<T>(key: string, value: T, opts?: { ttl?: number }): Promise<void> {
+      return inner.set(wrap(key), value, opts)
+    },
+
+    async invalidate(key: string): Promise<void> {
+      return inner.invalidate(wrap(key))
+    },
+
+    async invalidatePrefix(prefix: string): Promise<number> {
+      return inner.invalidatePrefix(wrap(prefix))
+    },
+
+    subscribe(handler: (event: InvalidationEvent) => void): () => void {
+      // Forward only events that belong to this site; rewrite the
+      // prefix to the consumer-facing form before firing the handler.
+      return inner.subscribe(event => {
+        const unwrapped = unwrap(event.prefix)
+        if (unwrapped === null) return
+        handler({ ...event, prefix: unwrapped })
+      })
+    },
+
+    async stats(): Promise<CacheStats> {
+      // Stats are global to the underlying provider — there's no
+      // honest way to slice them per-site without scanning every
+      // entry, which defeats the cache. Surface the inner stats
+      // verbatim; operators interpret them with the knowledge that
+      // shared backing services pool stats across all sites.
+      const innerStats = inner.stats
+      if (!innerStats) {
+        return { hits: 0, misses: 0, size: 0 }
+      }
+      return innerStats.call(inner)
+    },
+  }
+}

--- a/packages/gazetta/src/cache/types.ts
+++ b/packages/gazetta/src/cache/types.ts
@@ -100,6 +100,16 @@ export interface CacheStats {
   misses: number
   /** Entry count. */
   size: number
+  /**
+   * Identity of the reporting cache instance — same value as
+   * `InvalidationEvent.source.instance` for events emitted by this
+   * provider. Operators querying `/api/system/cache/stats` in
+   * multi-instance deployments use this to know which pod / revision
+   * answered (the load balancer's choice can vary between requests).
+   * Optional because some providers may not have a meaningful
+   * identity (e.g., a no-op stub).
+   */
+  instance?: string
   // Provider-specific extras allowed.
   errors?: number
   evictions?: number

--- a/packages/gazetta/src/cache/types.ts
+++ b/packages/gazetta/src/cache/types.ts
@@ -21,11 +21,10 @@
  *   - Cached values MUST be JSON-serializable (no functions, no
  *     Symbols, no top-level Maps/Sets) — required for L4 → L6
  *     handoff via IndexedDB / localStorage.
- *   - `subscribe()` delivers events from OTHER instances, not from
- *     local invalidations. Single-instance providers (MemoryCache
- *     in single-process deployments) register handlers but never
- *     fire events; multi-instance deployments wire the SSE bridge
- *     in Cut 4.
+ *   - `subscribe()` delivers invalidation events from any source
+ *     (local OR cross-instance — Cut 4 contract evolution). The
+ *     `event.source.instance` field discriminates origin so
+ *     subscribers can filter as needed.
  *   - `invalidatePrefix()` is best-effort with a time cap (~100ms
  *     default per design-cache.md PWA-responsiveness principle);
  *     un-cleared entries clear at TTL or on next invalidation.
@@ -49,12 +48,26 @@ export interface AdminCache {
   /** Invalidate all keys matching a prefix. Returns count cleared. */
   invalidatePrefix(prefix: string): Promise<number>
   /**
-   * Subscribe to invalidation events from other instances. Returns
-   * disposer.
+   * Subscribe to invalidation events from any source. Returns disposer.
    *
-   * Single-instance providers (MemoryCache in single-process)
-   * register handlers but no events fire — the cross-instance SSE
-   * bridge that drives this lands in Cut 4.
+   * Local invalidations (this instance's `invalidate` /
+   * `invalidatePrefix` calls) AND cross-instance invalidations
+   * (delivered via SSE bridge or shared backing service) both fire
+   * the handler. Discriminate via `event.source.instance` —
+   * subscribers that only care about cross-instance events can filter
+   * out their own.
+   *
+   * The L4→L6 server-to-browser cascade is the load-bearing consumer:
+   * server-side `invalidatePrefix('pages:')` fires to a subscribed
+   * SSE route, which forwards the event to connected browser admin
+   * clients, which invalidate their L6 caches. From the browser's
+   * POV the server IS another instance, so "events from any source"
+   * is the right contract.
+   *
+   * Event payloads carry the **consumer-facing** prefix (the form
+   * passed to the invalidate call). Provider-internal storage
+   * details (version prefix, overflow hash, per-site scope) don't
+   * leak into the event.
    */
   subscribe(handler: (event: InvalidationEvent) => void): () => void
   /** Stats for diagnostics. Optional — not every provider exposes. */

--- a/packages/gazetta/src/cache/types.ts
+++ b/packages/gazetta/src/cache/types.ts
@@ -76,6 +76,14 @@ export interface AdminCache {
    * potentially stale and reset (re-fetch from source). The L6 admin
    * cache (`design-offline.md`) follows this rule via full reset on
    * reconnect.
+   *
+   * **Handlers should be synchronous.** Providers fire subscribers
+   * with `handler(event)` — without `await`. TypeScript's `void`
+   * return type accepts async handlers for ergonomic reasons, but
+   * the cache won't await them; rejections from a returned Promise
+   * become unhandled. Subscribers needing async work should enqueue
+   * synchronously and process asynchronously elsewhere (e.g., the
+   * SSE bridge pushes to a buffer + drains from a stream loop).
    */
   subscribe(handler: (event: InvalidationEvent) => void): () => void
   /** Stats for diagnostics. Optional — not every provider exposes. */

--- a/packages/gazetta/src/cache/types.ts
+++ b/packages/gazetta/src/cache/types.ts
@@ -68,6 +68,14 @@ export interface AdminCache {
    * passed to the invalidate call). Provider-internal storage
    * details (version prefix, overflow hash, per-site scope) don't
    * leak into the event.
+   *
+   * **No replay on reconnect.** Subscribers (notably the SSE bridge
+   * forwarding to browsers) that lose their connection get no
+   * server-side replay of events they missed during the gap. The
+   * contract: on reconnect, treat your own cached state as
+   * potentially stale and reset (re-fetch from source). The L6 admin
+   * cache (`design-offline.md`) follows this rule via full reset on
+   * reconnect.
    */
   subscribe(handler: (event: InvalidationEvent) => void): () => void
   /** Stats for diagnostics. Optional — not every provider exposes. */

--- a/packages/gazetta/src/cli/index.ts
+++ b/packages/gazetta/src/cli/index.ts
@@ -1649,6 +1649,7 @@ async function runDev(siteDir: string, port: number) {
   let cmsApp:
     | (Hono & {
         invalidateTemplatesCache(): void
+        invalidateContentCache(): Promise<void>
       })
     | null = null
   if (isDevMode) {
@@ -1893,6 +1894,12 @@ async function runDev(siteDir: string, port: number) {
     if (filename.endsWith('.json') || filename.endsWith('.yaml')) {
       console.log(`  Manifest changed: ${filename}`)
       invalidateAllTemplates()
+      // Out-of-band manifest changes (git pull, manual edit, e2e
+      // test wipes) bypass the admin-api save handler that would
+      // otherwise invalidate the AdminCache. Drop content-summary
+      // entries so the next /api/pages or /api/fragments rebuilds
+      // from disk. Best-effort; the void promise is fire-and-forget.
+      void cmsApp?.invalidateContentCache()
       notifyReload()
     }
   })
@@ -1950,6 +1957,7 @@ async function setupCmsApi(
 ): Promise<
   Hono & {
     invalidateTemplatesCache(): void
+    invalidateContentCache(): Promise<void>
   }
 > {
   const cmsApp = createAdminApp({ source, siteDir, templatesDir, adminDir, targetConfigs })

--- a/packages/gazetta/src/compare.ts
+++ b/packages/gazetta/src/compare.ts
@@ -1,4 +1,6 @@
 import { join } from 'node:path'
+import { memoryCache } from './cache/factories.js'
+import { forSite } from './cache/per-site.js'
 import { loadSite } from './site-loader.js'
 import { hashManifest } from './hash.js'
 import { scanTemplates, templateHashesFrom, type TemplateInfo } from './templates-scan.js'
@@ -88,6 +90,10 @@ export async function compareTargets(opts: CompareOptions): Promise<CompareResul
       storage: sourceRoot.storage,
       siteDir: sourceRoot.rootPath,
       templatesDir: opts.templatesDir,
+      // Fresh per-empty-site cache; not shared. Compare doesn't read
+      // through this cache, but the Site type now requires the field
+      // (Cut 2). forSite-wrapped to keep the contract uniform.
+      cache: forSite(memoryCache(), '(empty)'),
     }
   }
   // Hash fragments first (they don't depend on page hashes). Static-mode

--- a/packages/gazetta/src/site-loader.ts
+++ b/packages/gazetta/src/site-loader.ts
@@ -1,4 +1,7 @@
 import { join } from 'node:path'
+import { memoryCache } from './cache/factories.js'
+import { forSite } from './cache/per-site.js'
+import type { AdminCache } from './cache/types.js'
 import type { SiteConfig } from './config/types.js'
 import { siteConfigToManifest } from './config/loader.js'
 import { mapLimit } from './concurrency.js'
@@ -77,6 +80,19 @@ export interface Site {
   siteDir: string
   /** Directory containing template packages. Project-level, separate from content rooting. */
   templatesDir: string
+  /**
+   * AdminCache instance for L4 admin / origin-server caching. Always
+   * present — `loadSite` either wires the operator-supplied instance
+   * from `manifest.cache` (Path X — gazetta.config.ts defaults or per-
+   * site override) or falls back to a fresh `memoryCache()`.
+   *
+   * Per-site key scoping is automatic via `forSite()` — consumers call
+   * `site.cache.get('pages:home')` and the wrapper transparently
+   * prefixes with `site:{name}:` before hitting the underlying provider.
+   * Future shared backing services (Redis, Azure) inherit isolation
+   * for free.
+   */
+  cache: AdminCache
 }
 
 interface DiscoverPagesResult {
@@ -272,6 +288,15 @@ export async function loadSite(opts: LoadSiteOptions): Promise<Site> {
     console.warn(`  Warning: no pages found in ${contentRoot.path('pages')}`)
   }
 
+  // Per-site cache: use the operator-supplied instance from
+  // manifest.cache (Path X — set via gazetta.config.ts defaults or
+  // per-site override). When absent (most CLI / test paths) fall back
+  // to a fresh MemoryCache so consumers always have a cache to use.
+  // Wrap with forSite() so future shared providers (Redis, Azure)
+  // get key isolation across sites.
+  const baseCache: AdminCache = manifest.cache ?? memoryCache()
+  const cache = forSite(baseCache, manifest.name)
+
   return {
     manifest,
     pages,
@@ -279,6 +304,7 @@ export async function loadSite(opts: LoadSiteOptions): Promise<Site> {
     fragments,
     fragmentLocales,
     contentRoot,
+    cache,
     // backward-compat fields
     siteDir,
     templatesDir,

--- a/packages/gazetta/src/site-loader.ts
+++ b/packages/gazetta/src/site-loader.ts
@@ -234,6 +234,18 @@ export interface LoadSiteOptions {
    * Mutually exclusive with `manifest`.
    */
   config?: SiteConfig
+  /**
+   * Pre-built per-site `AdminCache` — used when the caller owns the
+   * cache lifetime (typically the admin-api boot, which builds one per
+   * SourceContext so every load of the same source shares one cache).
+   *
+   * When provided, `loadSite` assumes the cache is already site-scoped
+   * and uses it verbatim. When absent, falls back to constructing one
+   * from `manifest.cache` (operator-supplied via Path X) or a fresh
+   * `memoryCache()`, wrapped with `forSite()` per call. The fallback
+   * suits CLI and tests where loadSite is called once.
+   */
+  cache?: AdminCache
 }
 
 /**
@@ -288,14 +300,18 @@ export async function loadSite(opts: LoadSiteOptions): Promise<Site> {
     console.warn(`  Warning: no pages found in ${contentRoot.path('pages')}`)
   }
 
-  // Per-site cache: use the operator-supplied instance from
-  // manifest.cache (Path X — set via gazetta.config.ts defaults or
-  // per-site override). When absent (most CLI / test paths) fall back
-  // to a fresh MemoryCache so consumers always have a cache to use.
-  // Wrap with forSite() so future shared providers (Redis, Azure)
-  // get key isolation across sites.
-  const baseCache: AdminCache = manifest.cache ?? memoryCache()
-  const cache = forSite(baseCache, manifest.name)
+  // Per-site cache resolution:
+  //   1. If the caller owns the cache lifetime (admin-api boot via
+  //      SourceContext), use the supplied instance verbatim — it's
+  //      already site-scoped.
+  //   2. Else use the operator-supplied instance from manifest.cache
+  //      (Path X — set via gazetta.config.ts defaults or per-site
+  //      override), wrapped with forSite() per call.
+  //   3. Else fall back to a fresh MemoryCache (CLI, tests) wrapped
+  //      with forSite(). Each loadSite() call gets its own — fine for
+  //      one-shot uses; the admin-api path takes (1) to share across
+  //      requests.
+  const cache: AdminCache = opts.cache ?? forSite(manifest.cache ?? memoryCache(), manifest.name)
 
   return {
     manifest,

--- a/packages/gazetta/src/testing/admin-cache-contract.ts
+++ b/packages/gazetta/src/testing/admin-cache-contract.ts
@@ -1,0 +1,258 @@
+/**
+ * Contract tests for `AdminCache` providers, exported from
+ * `gazetta/testing`.
+ *
+ * Plugin authors and future built-in providers (RedisCache,
+ * AzureCache, FileCache, IndexedDBCache, etc.) run this suite
+ * against their implementation. The helper proves baseline LSP
+ * correctness — every provider must round-trip values, isolate
+ * keys, support prefix invalidation, and report honest stats.
+ *
+ * Capability-specific behaviors (TTL expiry, cross-instance
+ * subscribe, transport fail-open) are gated by per-test opt-ins on
+ * the options object. Providers that don't support a capability skip
+ * those tests cleanly — no LSP lies.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns "test the AdminCache contract." Provider
+ *     mechanics live with each provider; this helper exercises the
+ *     interface uniformly.
+ *   - LSP: every provider that opts in to the helper passes the same
+ *     baseline. Failures here mean the provider violates the contract,
+ *     not that the test is wrong.
+ *   - OCP: adding a new capability check (e.g., `etag` support when
+ *     `EtagCapableCache` ships) is one new option + one new test
+ *     block; no rewrite of existing tests.
+ *   - DIP: the helper depends on the `AdminCache` interface, not on
+ *     any specific provider.
+ *
+ * # Why this isn't a vitest snapshot test
+ *
+ * Cache stats are non-deterministic over time and providers vary in
+ * which optional fields they track. Snapshot tests would create a
+ * brittle coupling between every provider's stats() shape and a
+ * shared snapshot. Behavior assertions ("hits incremented after a
+ * get-hit") are stable across providers.
+ */
+import { describe, expect, it } from 'vitest'
+import type { AdminCache } from '../cache/types.js'
+
+/**
+ * Factory shape — each test gets a fresh provider instance. Providers
+ * with module-level state should construct fresh per call so tests
+ * don't leak across each other.
+ */
+export type AdminCacheFactory = () => AdminCache | Promise<AdminCache>
+
+export interface AdminCacheContractOptions {
+  /**
+   * Whether the provider honors TTL on `set(key, value, { ttl })`.
+   * Default false (matches `MemoryCache` v1's LRU-only eviction).
+   * When true, the suite includes a TTL-expiry test that waits for
+   * the configured `ttlSeconds` to elapse.
+   */
+  supportsTtl?: boolean
+  /**
+   * TTL in seconds used by the TTL test. Default 1 second — long
+   * enough to be observable, short enough to keep the test fast.
+   * Only consulted when `supportsTtl` is true.
+   */
+  ttlSeconds?: number
+  /**
+   * Whether `subscribe()` delivers events from a sibling instance
+   * (true for shared-backing providers like RedisCache after Cut 4
+   * of cache-impl ships SSE; false for single-instance MemoryCache
+   * v1). When true, the suite includes a cross-instance notification
+   * test.
+   */
+  supportsCrossInstanceSubscribe?: boolean
+  /**
+   * Whether the provider fails open on transport errors per Universal
+   * Provider Requirement #5. Tests a synthetic transport failure
+   * surfaced via a wrapper; only meaningful for providers that have
+   * a transport layer (Redis, Azure). MemoryCache has no transport.
+   */
+  supportsTransportFailureSimulation?: boolean
+}
+
+/**
+ * Run the contract suite against a provider factory. Call from a
+ * `describe` block in the provider's own test file:
+ *
+ *   import { adminCacheContractTests } from 'gazetta/testing'
+ *
+ *   describe('RedisCache', () => {
+ *     adminCacheContractTests(
+ *       () => createRedisCache({ url: 'redis://localhost:6379' }),
+ *       { supportsTtl: true, supportsCrossInstanceSubscribe: true },
+ *     )
+ *   })
+ */
+export function adminCacheContractTests(factory: AdminCacheFactory, options: AdminCacheContractOptions = {}): void {
+  describe('AdminCache contract — get/set/invalidate', () => {
+    it('round-trips a value through get/set', async () => {
+      const cache = await factory()
+      await cache.set('item:home', { title: 'Home' })
+      expect(await cache.get('item:home')).toEqual({ title: 'Home' })
+    })
+
+    it('returns null on a miss', async () => {
+      const cache = await factory()
+      expect(await cache.get('item:never-set')).toBeNull()
+    })
+
+    it('preserves the JSON-serializable contract — strings round-trip', async () => {
+      const cache = await factory()
+      await cache.set('item:str', 'hello')
+      expect(await cache.get('item:str')).toBe('hello')
+    })
+
+    it('preserves arrays and nested objects', async () => {
+      const cache = await factory()
+      const value = { items: [1, 2, 3], nested: { a: { b: 'c' } } }
+      await cache.set('item:complex', value)
+      expect(await cache.get('item:complex')).toEqual(value)
+    })
+
+    it('overwrites an existing value', async () => {
+      const cache = await factory()
+      await cache.set('item:k', 'first')
+      await cache.set('item:k', 'second')
+      expect(await cache.get('item:k')).toBe('second')
+    })
+
+    it('invalidate removes a single key', async () => {
+      const cache = await factory()
+      await cache.set('item:a', 1)
+      await cache.set('item:b', 2)
+      await cache.invalidate('item:a')
+      expect(await cache.get('item:a')).toBeNull()
+      expect(await cache.get('item:b')).toBe(2)
+    })
+
+    it('invalidate is a no-op on a missing key', async () => {
+      const cache = await factory()
+      await expect(cache.invalidate('item:never-set')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('AdminCache contract — invalidatePrefix', () => {
+    it('removes all keys matching the prefix', async () => {
+      const cache = await factory()
+      await cache.set('group-a:home', 1)
+      await cache.set('group-a:about', 2)
+      await cache.set('group-b:home', 3)
+      const cleared = await cache.invalidatePrefix('group-a:')
+      expect(cleared).toBe(2)
+      expect(await cache.get('group-a:home')).toBeNull()
+      expect(await cache.get('group-a:about')).toBeNull()
+      expect(await cache.get('group-b:home')).toBe(3)
+    })
+
+    it('returns 0 when no keys match', async () => {
+      const cache = await factory()
+      await cache.set('group-a:home', 1)
+      const cleared = await cache.invalidatePrefix('group-c:')
+      expect(cleared).toBe(0)
+    })
+
+    it('does not match sibling prefixes (trailing colon discipline)', async () => {
+      // `'pages:'` should NOT match `'pages-archived:'` — the trailing
+      // colon prevents that. Consumers that omit the trailing colon
+      // are responsible for the consequences.
+      const cache = await factory()
+      await cache.set('pages:home', 1)
+      await cache.set('pages-archived:home', 2)
+      const cleared = await cache.invalidatePrefix('pages:')
+      expect(cleared).toBe(1)
+      expect(await cache.get('pages-archived:home')).toBe(2)
+    })
+  })
+
+  describe('AdminCache contract — subscribe', () => {
+    it('returns a disposer that does not throw when called', async () => {
+      const cache = await factory()
+      const disposer = cache.subscribe(() => undefined)
+      expect(() => disposer()).not.toThrow()
+    })
+
+    it('disposer is idempotent', async () => {
+      const cache = await factory()
+      const disposer = cache.subscribe(() => undefined)
+      disposer()
+      expect(() => disposer()).not.toThrow()
+    })
+  })
+
+  describe('AdminCache contract — stats', () => {
+    it('returns the required floor when stats() is implemented', async () => {
+      const cache = await factory()
+      // stats is optional on the contract — providers that don't
+      // expose it skip this test entirely.
+      if (!cache.stats) return
+      const result = await cache.stats()
+      expect(result).toMatchObject({
+        hits: expect.any(Number),
+        misses: expect.any(Number),
+        size: expect.any(Number),
+      })
+    })
+
+    it('size reflects the number of stored entries', async () => {
+      const cache = await factory()
+      if (!cache.stats) return
+      await cache.set('item:a', 1)
+      await cache.set('item:b', 2)
+      const result = await cache.stats()
+      expect(result.size).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  if (options.supportsTtl) {
+    const ttlSeconds = options.ttlSeconds ?? 1
+    describe('AdminCache contract — TTL', () => {
+      it(`expires entries after ${ttlSeconds}s`, async () => {
+        const cache = await factory()
+        await cache.set('item:ttl', 'value', { ttl: ttlSeconds })
+        // Wait slightly past the TTL boundary.
+        await new Promise(r => setTimeout(r, (ttlSeconds + 0.2) * 1000))
+        expect(await cache.get('item:ttl')).toBeNull()
+      })
+    })
+  }
+
+  if (options.supportsCrossInstanceSubscribe) {
+    describe('AdminCache contract — cross-instance subscribe', () => {
+      it('delivers invalidation events from a sibling instance', async () => {
+        const a = await factory()
+        const b = await factory()
+        const events: Array<{ prefix: string }> = []
+        b.subscribe(event => events.push({ prefix: event.prefix }))
+
+        await a.set('shared:k', 1)
+        await a.invalidatePrefix('shared:')
+
+        // Allow async fan-out (provider-specific transport latency).
+        await new Promise(r => setTimeout(r, 100))
+        expect(events.some(e => e.prefix.includes('shared:'))).toBe(true)
+      })
+    })
+  }
+
+  if (options.supportsTransportFailureSimulation) {
+    describe('AdminCache contract — fail-open', () => {
+      it('treats transport failure on get as a miss (returns null, no throw)', async () => {
+        // Providers that opt in must expose a way to inject a
+        // transport failure. The contract assertion: under failure,
+        // get must NOT throw and must return null. Providers
+        // implement the injection mechanism in their own test setup.
+        const cache = await factory()
+        // The factory closure is the operator's hook — opt-in
+        // providers wire the failure into the returned instance and
+        // the test exercises whatever the provider's docs say.
+        await expect(cache.get('item:transport-failure')).resolves.not.toThrow()
+      })
+    })
+  }
+}

--- a/packages/gazetta/src/testing/index.ts
+++ b/packages/gazetta/src/testing/index.ts
@@ -1,0 +1,14 @@
+/**
+ * `gazetta/testing` — test helpers for plugin authors and contributors.
+ *
+ * Imports here pull in `vitest` as a peer dependency. Plugin authors
+ * who use this barrel must have vitest in their devDependencies.
+ *
+ * Why a separate subpath: keeps vitest off the main `gazetta` import
+ * graph, so production deployments never bundle test-only code.
+ */
+export {
+  adminCacheContractTests,
+  type AdminCacheContractOptions,
+  type AdminCacheFactory,
+} from './admin-cache-contract.js'

--- a/packages/gazetta/tests/admin-api.test.ts
+++ b/packages/gazetta/tests/admin-api.test.ts
@@ -42,6 +42,7 @@ beforeAll(async () => {
     siteDir: projectSiteDir, // used for templatesDir/adminDir defaults
     templatesDir: resolve(projectRoot, 'templates'),
     adminDir: resolve(projectRoot, 'admin'),
+    disableCacheStatsLogger: true,
   })
 })
 
@@ -64,6 +65,24 @@ describe('GET /api/site', () => {
     const { status, body } = await get('/api/site')
     expect(status).toBe(200)
     expect(body.name).toBe('Gazetta Starter')
+  })
+})
+
+describe('GET /api/system/cache/stats', () => {
+  it('returns the source cache snapshot', async () => {
+    // Hit /api/pages first so the cache has something to report —
+    // the stats() shape is provider-defined but the floor (hits,
+    // misses, size) is required by the AdminCache contract.
+    await get('/api/pages')
+    const { status, body } = await get('/api/system/cache/stats')
+    expect(status).toBe(200)
+    expect(body).toMatchObject({
+      hits: expect.any(Number),
+      misses: expect.any(Number),
+      size: expect.any(Number),
+    })
+    // /api/pages writes to the cache on miss → at least one entry.
+    expect(body.size).toBeGreaterThanOrEqual(1)
   })
 })
 

--- a/packages/gazetta/tests/admin-api.test.ts
+++ b/packages/gazetta/tests/admin-api.test.ts
@@ -86,6 +86,66 @@ describe('GET /api/system/cache/stats', () => {
   })
 })
 
+describe('GET /api/system/cache/invalidations (SSE)', () => {
+  it('opens an SSE stream and emits an invalidation event on save', async () => {
+    // Use AbortController so we can cleanly close the long-lived
+    // stream after asserting. Without it the test runtime would
+    // hang waiting on a never-closing connection.
+    const ctrl = new AbortController()
+    const res = await app.request('/api/system/cache/invalidations', { signal: ctrl.signal })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toMatch(/text\/event-stream/)
+    expect(res.body).toBeTruthy()
+
+    // Read the stream incrementally. After the initial 'ready' event,
+    // trigger a save via /api/pages and assert that an invalidation
+    // event arrives in a bounded window.
+    const reader = res.body!.getReader()
+    const decoder = new TextDecoder()
+    const collected: string[] = []
+    let saveTriggered = false
+
+    const readPromise = (async () => {
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) return
+        collected.push(decoder.decode(value, { stream: true }))
+        // After the first chunk lands ('ready' event) trigger a save.
+        if (!saveTriggered) {
+          saveTriggered = true
+          // Don't await — the save's response cycle is independent
+          // of this stream; we just want the invalidation it triggers.
+          void app.request('/api/pages', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: 'sse-cache-test', template: 'page-default' }),
+          })
+        }
+        // Stop reading once an invalidation event arrives.
+        if (collected.join('').includes('event: invalidation')) return
+      }
+    })()
+
+    // Bound the wait so a regression doesn't hang the suite.
+    const timeoutPromise = new Promise<void>(resolve => setTimeout(resolve, 5000))
+    await Promise.race([readPromise, timeoutPromise])
+    ctrl.abort()
+    try {
+      reader.cancel()
+    } catch {
+      // already aborted
+    }
+
+    const text = collected.join('')
+    expect(text).toContain('event: ready')
+    expect(text).toContain('event: invalidation')
+    expect(text).toMatch(/data: \{[^}]*"prefix":"pages:"/)
+
+    // Cleanup the page we created.
+    await rm(resolve(localTargetDir, 'pages/sse-cache-test'), { recursive: true, force: true })
+  }, 15_000)
+})
+
 describe('GET /api/pages', () => {
   it('returns all pages', async () => {
     const { status, body } = await get('/api/pages')

--- a/packages/gazetta/tests/admin-api.test.ts
+++ b/packages/gazetta/tests/admin-api.test.ts
@@ -84,6 +84,16 @@ describe('GET /api/system/cache/stats', () => {
     // /api/pages writes to the cache on miss → at least one entry.
     expect(body.size).toBeGreaterThanOrEqual(1)
   })
+
+  it('includes the instance field for multi-instance correlation (Gap 1)', async () => {
+    const { body } = await get('/api/system/cache/stats')
+    // Instance is resolved from K_REVISION → os.hostname() → random hex.
+    // We don't pin a specific value — only that the field is present
+    // and non-empty. Operators in multi-instance deployments use this
+    // to know which pod / revision answered.
+    expect(typeof body.instance).toBe('string')
+    expect(body.instance.length).toBeGreaterThan(0)
+  })
 })
 
 describe('GET /api/system/cache/invalidations (SSE)', () => {

--- a/packages/gazetta/tests/admin-cache-contract.test.ts
+++ b/packages/gazetta/tests/admin-cache-contract.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Run the `adminCacheContractTests` helper against the in-tree
+ * `MemoryCache` provider.
+ *
+ * Two purposes:
+ *   1. Proves the helper itself is correct — if MemoryCache fails
+ *      the contract, either the helper or the provider is wrong.
+ *   2. Acts as the reference example for plugin authors — copy this
+ *      file, swap the factory, point at your provider.
+ *
+ * MemoryCache opts in to none of the capability flags:
+ *   - supportsTtl: false (LRU-only eviction in v1; design-cache.md
+ *     Cut 2 doc explicitly notes this)
+ *   - supportsCrossInstanceSubscribe: false (single-instance until
+ *     Cut 4 ships SSE)
+ *   - supportsTransportFailureSimulation: false (no transport)
+ */
+import { describe } from 'vitest'
+import { createMemoryCache } from '../src/cache/memory.js'
+import { adminCacheContractTests } from '../src/testing/admin-cache-contract.js'
+
+describe('MemoryCache satisfies the AdminCache contract', () => {
+  adminCacheContractTests(() => createMemoryCache())
+})

--- a/packages/gazetta/tests/cache-keys.test.ts
+++ b/packages/gazetta/tests/cache-keys.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { encodeCacheKey, prefixOf } from '../src/cache/keys.js'
+import { CACHE_SCHEMA_VERSION, applyKeyPolicy, applyPrefixPolicy, encodeCacheKey, prefixOf } from '../src/cache/keys.js'
 
 describe('encodeCacheKey', () => {
   it('joins components with colon', () => {
@@ -51,5 +51,68 @@ describe('prefixOf', () => {
   it('throws when components is zero or negative', () => {
     expect(() => prefixOf('pages:home', 0)).toThrow()
     expect(() => prefixOf('pages:home', -1)).toThrow()
+  })
+})
+
+describe('applyKeyPolicy', () => {
+  it('prepends the cache schema version', () => {
+    expect(applyKeyPolicy('pages:detail:home')).toBe(`${CACHE_SCHEMA_VERSION}:pages:detail:home`)
+  })
+
+  it('leaves short keys unchanged beyond the version prefix', () => {
+    const wrapped = applyKeyPolicy('a:b:c')
+    expect(wrapped.length).toBeLessThanOrEqual(255)
+    expect(wrapped).toMatch(/^\d+:a:b:c$/)
+  })
+
+  it('hashes the overflow tail when the wrapped key exceeds 255 chars', () => {
+    // Build a key just over the cap so we can verify the cut point.
+    const big = encodeCacheKey(['pages', 'detail', 'a'.repeat(300)])
+    const wrapped = applyKeyPolicy(big)
+    expect(wrapped.length).toBeLessThanOrEqual(255)
+    // Tail is an 8-char hex hash separated by ':'
+    expect(wrapped).toMatch(/:[0-9a-f]{8}$/)
+  })
+
+  it('preserves the prefix up to the last colon boundary that fits', () => {
+    // A key with multiple short components followed by one long
+    // component. Prefix-invalidation on `pages:detail:` must still
+    // work, so the kept prefix must include those components in full.
+    const big = encodeCacheKey(['pages', 'detail', 'b'.repeat(300)])
+    const wrapped = applyKeyPolicy(big)
+    expect(wrapped.startsWith(`${CACHE_SCHEMA_VERSION}:pages:detail:`)).toBe(true)
+  })
+
+  it('produces stable output for the same input', () => {
+    const k = encodeCacheKey(['pages', 'detail', 'c'.repeat(300)])
+    expect(applyKeyPolicy(k)).toBe(applyKeyPolicy(k))
+  })
+
+  it('produces different outputs for different long inputs', () => {
+    const a = encodeCacheKey(['pages', 'detail', 'd'.repeat(300)])
+    const b = encodeCacheKey(['pages', 'detail', 'e'.repeat(300)])
+    expect(applyKeyPolicy(a)).not.toBe(applyKeyPolicy(b))
+  })
+})
+
+describe('applyPrefixPolicy', () => {
+  it('prepends the cache schema version without hashing', () => {
+    expect(applyPrefixPolicy('pages:')).toBe(`${CACHE_SCHEMA_VERSION}:pages:`)
+  })
+
+  it('matches what applyKeyPolicy produces for keys under the cap', () => {
+    // Critical contract: invalidatePrefix('pages:') must match every
+    // stored entry under that consumer prefix. Verify by hand-computing
+    // the wrapped prefix and asserting that wrapped keys start with it.
+    const wrappedPrefix = applyPrefixPolicy('pages:')
+    const wrappedKey = applyKeyPolicy('pages:detail:home')
+    expect(wrappedKey.startsWith(wrappedPrefix)).toBe(true)
+  })
+
+  it('matches long-key prefixes when the prefix is short', () => {
+    const wrappedPrefix = applyPrefixPolicy('pages:detail:')
+    const big = encodeCacheKey(['pages', 'detail', 'f'.repeat(300)])
+    const wrappedKey = applyKeyPolicy(big)
+    expect(wrappedKey.startsWith(wrappedPrefix)).toBe(true)
   })
 })

--- a/packages/gazetta/tests/cache-memory.test.ts
+++ b/packages/gazetta/tests/cache-memory.test.ts
@@ -115,7 +115,7 @@ describe('MemoryCache invalidatePrefix', () => {
   })
 })
 
-describe('MemoryCache subscribe (Cut 2 — no-op semantics)', () => {
+describe('MemoryCache subscribe (Cut 4 — local emission)', () => {
   it('registers handler and returns disposer', () => {
     const cache = createMemoryCache()
     const events: InvalidationEvent[] = []
@@ -124,17 +124,90 @@ describe('MemoryCache subscribe (Cut 2 — no-op semantics)', () => {
     disposer()
   })
 
-  it('does not fire events on local invalidate (cross-instance only)', async () => {
-    // Cut 2 ships subscribe() registering in a Set; Cut 4 wires the
-    // SSE bridge that delivers events. Local invalidations don't
-    // emit because the contract is "events from OTHER instances."
+  it('fires on local invalidate with the consumer-facing key', async () => {
     const cache = createMemoryCache()
     const events: InvalidationEvent[] = []
     cache.subscribe(e => events.push(e))
     await cache.set('k', 1)
     await cache.invalidate('k')
-    await cache.invalidatePrefix('p')
+    expect(events).toHaveLength(1)
+    expect(events[0]?.prefix).toBe('k')
+    // The version prefix and overflow-hash applied by applyKeyPolicy
+    // are storage encoding details — they don't leak into event
+    // payloads.
+    expect(events[0]?.prefix).not.toContain(':')
+  })
+
+  it('fires on invalidatePrefix with the consumer-facing prefix', async () => {
+    const cache = createMemoryCache()
+    const events: InvalidationEvent[] = []
+    cache.subscribe(e => events.push(e))
+    await cache.invalidatePrefix('pages:')
+    expect(events).toHaveLength(1)
+    expect(events[0]?.prefix).toBe('pages:')
+  })
+
+  it('fires on invalidatePrefix even when nothing matched', async () => {
+    // Subscribers (notably the L4→L6 SSE bridge) want every invalidation
+    // intent — a consumer's L6 cache may hold an entry the server's L4
+    // already evicted via LRU.
+    const cache = createMemoryCache()
+    const events: InvalidationEvent[] = []
+    cache.subscribe(e => events.push(e))
+    await cache.invalidatePrefix('never-set:')
+    expect(events).toHaveLength(1)
+  })
+
+  it('does not fire on get/set/miss (only invalidations are events)', async () => {
+    const cache = createMemoryCache()
+    const events: InvalidationEvent[] = []
+    cache.subscribe(e => events.push(e))
+    await cache.set('k', 1)
+    await cache.get('k')
+    await cache.get('missing')
     expect(events).toEqual([])
+  })
+
+  it('does not fire on invalidate(missing key) — nothing to invalidate', async () => {
+    // Distinct from invalidatePrefix's "always emit" rule: invalidate(key)
+    // is a single-key delete; if the key doesn't exist there's no state
+    // change worth notifying about. Browsers re-issuing the invalidate
+    // would just no-op anyway.
+    const cache = createMemoryCache()
+    const events: InvalidationEvent[] = []
+    cache.subscribe(e => events.push(e))
+    await cache.invalidate('never-set')
+    expect(events).toEqual([])
+  })
+
+  it('fires every event with the same instance id', async () => {
+    const cache = createMemoryCache()
+    const events: InvalidationEvent[] = []
+    cache.subscribe(e => events.push(e))
+    await cache.invalidatePrefix('a:')
+    await cache.invalidatePrefix('b:')
+    expect(events).toHaveLength(2)
+    expect(events[0]?.source.instance).toBe(events[1]?.source.instance)
+  })
+
+  it('honors operator-supplied instance id', async () => {
+    const cache = createMemoryCache({ instance: 'pod-abc' })
+    const events: InvalidationEvent[] = []
+    cache.subscribe(e => events.push(e))
+    await cache.invalidatePrefix('a:')
+    expect(events[0]?.source.instance).toBe('pod-abc')
+  })
+
+  it('isolates subscriber failures from sibling subscribers', async () => {
+    const cache = createMemoryCache()
+    const seen: string[] = []
+    cache.subscribe(() => {
+      throw new Error('first subscriber boom')
+    })
+    cache.subscribe(e => seen.push(`second:${e.prefix}`))
+    await cache.invalidatePrefix('k:')
+    // Sibling subscriber still fired even though the first threw.
+    expect(seen).toEqual(['second:k:'])
   })
 
   it('disposer removes handler from registered set', () => {

--- a/packages/gazetta/tests/cache-memory.test.ts
+++ b/packages/gazetta/tests/cache-memory.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { createMemoryCache } from '../src/cache/memory.js'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createMemoryCache, resolveInstanceId } from '../src/cache/memory.js'
 import type { InvalidationEvent } from '../src/cache/types.js'
 
 describe('MemoryCache get/set/invalidate', () => {
@@ -286,5 +286,57 @@ describe('MemoryCache key policy (Cut 1)', () => {
     await cache.set(longKey, 'value')
     await cache.invalidate(longKey)
     expect(await cache.get(longKey)).toBeNull()
+  })
+})
+
+describe('resolveInstanceId chain (Gap 7)', () => {
+  let savedKRevision: string | undefined
+
+  beforeEach(() => {
+    savedKRevision = process.env.K_REVISION
+    delete process.env.K_REVISION
+  })
+
+  afterEach(() => {
+    if (savedKRevision === undefined) delete process.env.K_REVISION
+    else process.env.K_REVISION = savedKRevision
+  })
+
+  it('honors an explicit override above all env signals', () => {
+    process.env.K_REVISION = 'cloud-run-revision-1'
+    expect(resolveInstanceId('explicit-id')).toBe('explicit-id')
+  })
+
+  it('uses K_REVISION when set and no override given', () => {
+    process.env.K_REVISION = 'service-rev-7'
+    expect(resolveInstanceId()).toBe('service-rev-7')
+  })
+
+  it('falls back to a non-empty string when K_REVISION is unset', () => {
+    // os.hostname() varies across CI runners; we don't assert a
+    // specific value, only that the fallback returned something
+    // useful (non-empty). The random-hex tail of the chain only
+    // fires when os.hostname() returns empty, which doesn't happen
+    // on real systems.
+    const id = resolveInstanceId()
+    expect(typeof id).toBe('string')
+    expect(id.length).toBeGreaterThan(0)
+  })
+})
+
+describe('MemoryCache stats (Gap 1)', () => {
+  it('includes the instance field on stats output', async () => {
+    const cache = createMemoryCache({ instance: 'pod-stats-test' })
+    const stats = await cache.stats?.()
+    expect(stats?.instance).toBe('pod-stats-test')
+  })
+
+  it('stats.instance matches the source.instance on emitted events', async () => {
+    const cache = createMemoryCache({ instance: 'pod-event-test' })
+    const events: InvalidationEvent[] = []
+    cache.subscribe(e => events.push(e))
+    await cache.invalidatePrefix('a:')
+    const stats = await cache.stats?.()
+    expect(stats?.instance).toBe(events[0]?.source.instance)
   })
 })

--- a/packages/gazetta/tests/cache-memory.test.ts
+++ b/packages/gazetta/tests/cache-memory.test.ts
@@ -168,3 +168,50 @@ describe('MemoryCache stats', () => {
     expect(stats?.size).toBe(2)
   })
 })
+
+describe('MemoryCache key policy (Cut 1)', () => {
+  it('round-trips values keyed by very long consumer keys', async () => {
+    // Long keys force the overflow-hash path inside applyKeyPolicy.
+    // The provider must be consistent: set under a long consumer key,
+    // get under the same long consumer key, and read the value back.
+    const cache = createMemoryCache()
+    const longKey = `pages:detail:${'x'.repeat(300)}`
+    await cache.set(longKey, { title: 'long' })
+    expect(await cache.get(longKey)).toEqual({ title: 'long' })
+  })
+
+  it('distinguishes two different long keys via the overflow hash', async () => {
+    // Two long keys differing only in the overflow tail must NOT
+    // collide — overflow hash is what makes them distinct.
+    const cache = createMemoryCache()
+    const a = `pages:detail:${'a'.repeat(300)}`
+    const b = `pages:detail:${'b'.repeat(300)}`
+    await cache.set(a, 'A')
+    await cache.set(b, 'B')
+    expect(await cache.get(a)).toBe('A')
+    expect(await cache.get(b)).toBe('B')
+  })
+
+  it('invalidatePrefix matches long-keyed entries when the prefix is short', async () => {
+    // Critical contract from design-cache.md Gap 2: prefix invalidation
+    // works regardless of how long the full key is, as long as the
+    // prefix is short enough to be preserved verbatim by applyKeyPolicy.
+    const cache = createMemoryCache()
+    await cache.set(`pages:detail:${'a'.repeat(300)}`, 1)
+    await cache.set(`pages:detail:${'b'.repeat(300)}`, 2)
+    await cache.set('fragments:detail:header', 3)
+    const cleared = await cache.invalidatePrefix('pages:')
+    expect(cleared).toBe(2)
+    expect(await cache.get(`pages:detail:${'a'.repeat(300)}`)).toBeNull()
+    expect(await cache.get(`pages:detail:${'b'.repeat(300)}`)).toBeNull()
+    expect(await cache.get('fragments:detail:header')).toBe(3)
+  })
+
+  it('invalidate removes a long-keyed entry', async () => {
+    const cache = createMemoryCache()
+    const longKey = `pages:detail:${'z'.repeat(300)}`
+    await cache.set(longKey, 'value')
+    await cache.invalidate(longKey)
+    expect(await cache.get(longKey)).toBeNull()
+  })
+})

--- a/packages/gazetta/tests/cache-per-site.test.ts
+++ b/packages/gazetta/tests/cache-per-site.test.ts
@@ -138,4 +138,36 @@ describe('forSite subscribe filtering', () => {
     expect(() => disposer()).not.toThrow()
     expect(() => disposer()).not.toThrow() // idempotent
   })
+
+  it('forwards consumer-facing prefix on real local invalidations (Cut 4)', async () => {
+    // End-to-end: an invalidatePrefix call through the wrapper reaches
+    // the inner MemoryCache (which now emits local events per Cut 4),
+    // bubbles back through forSite's subscribe (which strips the
+    // site:{name}: scope), and lands at the consumer subscriber with
+    // the consumer-facing prefix.
+    const inner = createMemoryCache()
+    const cache = forSite(inner, 'main')
+    const received: InvalidationEvent[] = []
+    cache.subscribe(e => received.push(e))
+    await cache.invalidatePrefix('pages:')
+    expect(received).toHaveLength(1)
+    expect(received[0]?.prefix).toBe('pages:')
+  })
+
+  it('invalidations on one site do not reach the other site', async () => {
+    // Two sites sharing the inner provider — each subscribes through
+    // its own forSite wrapper. Site A's invalidations must NOT fire
+    // site B's subscriber (the unwrap filter rejects events whose key
+    // doesn't carry site B's scope).
+    const inner = createMemoryCache()
+    const a = forSite(inner, 'site-a')
+    const b = forSite(inner, 'site-b')
+    const aEvents: InvalidationEvent[] = []
+    const bEvents: InvalidationEvent[] = []
+    a.subscribe(e => aEvents.push(e))
+    b.subscribe(e => bEvents.push(e))
+    await a.invalidatePrefix('pages:')
+    expect(aEvents).toHaveLength(1)
+    expect(bEvents).toHaveLength(0)
+  })
 })

--- a/packages/gazetta/tests/cache-per-site.test.ts
+++ b/packages/gazetta/tests/cache-per-site.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+import { createMemoryCache } from '../src/cache/memory.js'
+import { forSite } from '../src/cache/per-site.js'
+import type { InvalidationEvent } from '../src/cache/types.js'
+
+describe('forSite key scoping', () => {
+  it('round-trips through the wrapper transparently', async () => {
+    const inner = createMemoryCache()
+    const cache = forSite(inner, 'main')
+    await cache.set('pages:home', { title: 'Home' })
+    expect(await cache.get('pages:home')).toEqual({ title: 'Home' })
+  })
+
+  it('isolates two sites sharing the same backing provider', async () => {
+    const inner = createMemoryCache()
+    const a = forSite(inner, 'site-a')
+    const b = forSite(inner, 'site-b')
+    await a.set('pages:home', 'A')
+    await b.set('pages:home', 'B')
+    expect(await a.get('pages:home')).toBe('A')
+    expect(await b.get('pages:home')).toBe('B')
+  })
+
+  it('one site cannot read another site by guessing its key', async () => {
+    const inner = createMemoryCache()
+    const a = forSite(inner, 'site-a')
+    const b = forSite(inner, 'site-b')
+    await a.set('pages:home', 'A')
+    // 'site:site-a:pages:home' is what's actually stored, but b is
+    // scoped to 'site:site-b:' so the lookup goes through that prefix.
+    expect(await b.get('pages:home')).toBeNull()
+    expect(await b.get('site:site-a:pages:home')).toBeNull()
+  })
+
+  it('invalidatePrefix scopes to the calling site', async () => {
+    const inner = createMemoryCache()
+    const a = forSite(inner, 'site-a')
+    const b = forSite(inner, 'site-b')
+    await a.set('pages:home', 1)
+    await a.set('pages:about', 2)
+    await b.set('pages:home', 3) // sibling site, same consumer key
+    const cleared = await a.invalidatePrefix('pages:')
+    expect(cleared).toBe(2)
+    // Site B's entry must survive site A's invalidation.
+    expect(await b.get('pages:home')).toBe(3)
+    expect(await a.get('pages:home')).toBeNull()
+  })
+
+  it('invalidate removes a single key from the calling site only', async () => {
+    const inner = createMemoryCache()
+    const a = forSite(inner, 'site-a')
+    const b = forSite(inner, 'site-b')
+    await a.set('pages:home', 1)
+    await b.set('pages:home', 2)
+    await a.invalidate('pages:home')
+    expect(await a.get('pages:home')).toBeNull()
+    expect(await b.get('pages:home')).toBe(2)
+  })
+
+  it('encodes site names with reserved characters (slash → dot)', async () => {
+    const inner = createMemoryCache()
+    // A site name with a slash should still scope correctly through
+    // the existing encodeRefName slash-to-dot rule.
+    const cache = forSite(inner, 'studio/main')
+    await cache.set('k', 'v')
+    expect(await cache.get('k')).toBe('v')
+  })
+
+  it('throws when siteName is empty', () => {
+    const inner = createMemoryCache()
+    expect(() => forSite(inner, '')).toThrow(/non-empty/)
+  })
+
+  it('stats are passed through from the inner provider', async () => {
+    const inner = createMemoryCache()
+    const cache = forSite(inner, 'main')
+    await cache.set('k', 1)
+    await cache.get('k') // hit
+    await cache.get('missing') // miss
+    const stats = await cache.stats?.()
+    // Inner is a fresh MemoryCache — its hit/miss counts came entirely
+    // from the wrapper's calls. (Stats are global to the underlying
+    // provider; in shared-backing scenarios they pool across sites,
+    // which is the documented behavior.)
+    expect(stats?.hits).toBe(1)
+    expect(stats?.misses).toBe(1)
+    expect(stats?.size).toBe(1)
+  })
+})
+
+describe('forSite subscribe filtering', () => {
+  it('filters out events from other sites sharing the same provider', () => {
+    // The wrapper's subscribe() handler should only fire for events
+    // whose underlying key starts with this site's prefix. Cut 4
+    // (SSE bridge) is what would emit cross-site events; here we
+    // simulate by reaching into the inner provider's subscribe
+    // mechanism via the wrapper.
+    const inner = createMemoryCache()
+
+    // Capture the inner subscribe handler so we can drive synthetic
+    // events through it.
+    let innerHandler: ((event: InvalidationEvent) => void) | null = null
+    const wrappedInner = {
+      ...inner,
+      subscribe(handler: (event: InvalidationEvent) => void) {
+        innerHandler = handler
+        return () => {
+          innerHandler = null
+        }
+      },
+    }
+
+    const cache = forSite(wrappedInner, 'site-a')
+    const received: InvalidationEvent[] = []
+    cache.subscribe(e => received.push(e))
+
+    // Synthetic event from another site — must NOT reach the handler.
+    innerHandler?.({
+      prefix: 'site:site-b:pages:home',
+      source: { instance: 'remote', timestamp: '2026-05-06T00:00:00Z' },
+    })
+
+    // Synthetic event from this site — must reach the handler with
+    // the prefix unwrapped (consumer-facing form).
+    innerHandler?.({
+      prefix: 'site:site-a:pages:home',
+      source: { instance: 'remote', timestamp: '2026-05-06T00:00:01Z' },
+    })
+
+    expect(received).toHaveLength(1)
+    expect(received[0]?.prefix).toBe('pages:home')
+  })
+
+  it('disposer detaches the handler from the inner provider', () => {
+    const inner = createMemoryCache()
+    const cache = forSite(inner, 'site-a')
+    const disposer = cache.subscribe(() => undefined)
+    expect(() => disposer()).not.toThrow()
+    expect(() => disposer()).not.toThrow() // idempotent
+  })
+})

--- a/packages/gazetta/tests/cache-stats-logger.test.ts
+++ b/packages/gazetta/tests/cache-stats-logger.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest'
+import { startCacheStatsLogger, type CacheStatsLogEntry } from '../src/admin-api/cache-stats-logger.js'
+import { createMemoryCache } from '../src/cache/memory.js'
+
+describe('startCacheStatsLogger', () => {
+  it('emits a structured entry on tick()', async () => {
+    const cache = createMemoryCache()
+    await cache.set('k', 1)
+    await cache.get('k') // hit
+    await cache.get('missing') // miss
+
+    const entries: CacheStatsLogEntry[] = []
+    const logger = startCacheStatsLogger({
+      cache,
+      intervalMs: 0, // no timer; manual tick only
+      sink: e => entries.push(e),
+    })
+
+    await logger.tick()
+    logger.dispose()
+
+    expect(entries).toHaveLength(1)
+    const entry = entries[0]
+    expect(entry?.level).toBe('info')
+    expect(entry?.module).toBe('cache.stats')
+    expect(entry?.stats.hits).toBe(1)
+    expect(entry?.stats.misses).toBe(1)
+    expect(entry?.stats.size).toBe(1)
+    // ISO 8601 with Z suffix
+    expect(entry?.timestamp).toMatch(/Z$/)
+  })
+
+  it('falls back to a zero snapshot when the provider has no stats()', async () => {
+    // Construct a minimal AdminCache that omits the optional stats()
+    // method — exercises the fallback path.
+    const cache = {
+      async get<T>() {
+        return null as T | null
+      },
+      async set() {},
+      async invalidate() {},
+      async invalidatePrefix() {
+        return 0
+      },
+      subscribe() {
+        return () => undefined
+      },
+    }
+
+    const entries: CacheStatsLogEntry[] = []
+    const logger = startCacheStatsLogger({
+      cache,
+      intervalMs: 0,
+      sink: e => entries.push(e),
+    })
+
+    await logger.tick()
+    logger.dispose()
+
+    expect(entries[0]?.stats).toEqual({ hits: 0, misses: 0, size: 0 })
+  })
+
+  it('schedules a periodic timer when intervalMs > 0', async () => {
+    vi.useFakeTimers()
+    try {
+      const cache = createMemoryCache()
+      const entries: CacheStatsLogEntry[] = []
+      const logger = startCacheStatsLogger({
+        cache,
+        intervalMs: 1000,
+        sink: e => entries.push(e),
+      })
+
+      // Tick the timer twice — async sink, so flush microtasks.
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(1000)
+      logger.dispose()
+
+      expect(entries.length).toBeGreaterThanOrEqual(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('dispose() stops the timer', async () => {
+    vi.useFakeTimers()
+    try {
+      const cache = createMemoryCache()
+      const entries: CacheStatsLogEntry[] = []
+      const logger = startCacheStatsLogger({
+        cache,
+        intervalMs: 1000,
+        sink: e => entries.push(e),
+      })
+
+      await vi.advanceTimersByTimeAsync(1000)
+      const after1 = entries.length
+      logger.dispose()
+      await vi.advanceTimersByTimeAsync(5000)
+      // No new emissions after dispose.
+      expect(entries.length).toBe(after1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('continues ticking even when an earlier tick rejects', async () => {
+    vi.useFakeTimers()
+    try {
+      let calls = 0
+      const cache = {
+        async get<T>() {
+          return null as T | null
+        },
+        async set() {},
+        async invalidate() {},
+        async invalidatePrefix() {
+          return 0
+        },
+        subscribe() {
+          return () => undefined
+        },
+        async stats() {
+          calls++
+          if (calls === 1) throw new Error('transient')
+          return { hits: calls, misses: 0, size: 0 }
+        },
+      }
+      const entries: CacheStatsLogEntry[] = []
+      const logger = startCacheStatsLogger({
+        cache,
+        intervalMs: 1000,
+        sink: e => entries.push(e),
+      })
+
+      await vi.advanceTimersByTimeAsync(1000) // tick 1 — rejects
+      await vi.advanceTimersByTimeAsync(1000) // tick 2 — succeeds
+      logger.dispose()
+
+      // First tick emitted nothing (sink only fires when the stats
+      // promise resolves); second tick succeeded and emitted.
+      expect(entries.length).toBe(1)
+      expect(entries[0]?.stats.hits).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/gazetta/tests/cache-stats-logger.test.ts
+++ b/packages/gazetta/tests/cache-stats-logger.test.ts
@@ -30,6 +30,23 @@ describe('startCacheStatsLogger', () => {
     expect(entry?.timestamp).toMatch(/Z$/)
   })
 
+  it('hoists instance to a top-level field for log-aggregator filtering (Gap 2)', async () => {
+    const cache = createMemoryCache({ instance: 'pod-log-test' })
+    const entries: CacheStatsLogEntry[] = []
+    const logger = startCacheStatsLogger({
+      cache,
+      intervalMs: 0,
+      sink: e => entries.push(e),
+    })
+    await logger.tick()
+    logger.dispose()
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.instance).toBe('pod-log-test')
+    // Also nested inside stats for direct-stats consumers.
+    expect(entries[0]?.stats.instance).toBe('pod-log-test')
+  })
+
   it('falls back to a zero snapshot when the provider has no stats()', async () => {
     // Construct a minimal AdminCache that omits the optional stats()
     // method — exercises the fallback path.

--- a/packages/gazetta/tests/cache-target-scope.test.ts
+++ b/packages/gazetta/tests/cache-target-scope.test.ts
@@ -38,12 +38,20 @@ function mockProvider(): StorageProvider {
 }
 
 describe('cache target-scope contract', () => {
-  it('two SourceContexts sharing one backing cache write to the SAME key without target dimension', async () => {
-    // This test pins the bug shape — confirms that without target in
-    // the key, a write via local is visible to production. If this
-    // test ever PASSES (returns null instead of local data), it means
-    // forSite or createSourceContext started doing per-target scoping
-    // at the wrapper level, which would indicate a contract change.
+  it('forSite isolates by site name only — NOT by target name', async () => {
+    // Pins the wrapper-level contract. Two SourceContexts in the
+    // same site (different targets) share scope under forSite —
+    // a key written without target dimension is visible across
+    // both wrappers when they share a backing.
+    //
+    // The right place for target-scoping is the consumer (key
+    // shape), not the wrapper. The other tests in this file
+    // demonstrate the consumer-level fix (`:target:{name}` suffix).
+    //
+    // If THIS test ever fails — production.get returning null — it
+    // means forSite or createSourceContext started doing per-target
+    // scoping at the wrapper level, indicating a contract change
+    // worth grilling.
     const sharedBacking = createMemoryCache({ instance: 'shared' })
     const manifest: SiteManifest = { name: 'main', cache: sharedBacking }
 

--- a/packages/gazetta/tests/cache-target-scope.test.ts
+++ b/packages/gazetta/tests/cache-target-scope.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression test for Gap 11: cross-target cache pollution under a
+ * shared backing provider.
+ *
+ * Background: when an operator sets `gazetta.config.ts defaults.cache:
+ * memoryCache(...)`, that single instance is shared across every
+ * SourceContext built for the process. Each SourceContext wraps it
+ * via `forSite(manifest.name)` — but the wrapper scope is the SITE
+ * name, not the TARGET name. Two targets in the same site (local +
+ * production) wrap the same backing with the same scope. If consumers
+ * (admin-api routes) use a target-agnostic cache key like
+ * `pages:summary`, they collide on the same stored key, and a write
+ * via target=local is read back via target=production.
+ *
+ * Fix per `design-cache.md` Gap 6: target is a first-class dimension
+ * in cache keys for target-scoped values. Consumers (routes) include
+ * `:target:{name}` in the key shape.
+ *
+ * This test pins the contract that route consumers must follow. If a
+ * future consumer caches target-scoped data without including target
+ * in the key, the failure mode is silent stale reads — not what we
+ * want. Test fails loudly when the contract is violated.
+ */
+import { describe, expect, it } from 'vitest'
+import { createMemoryCache } from '../src/cache/memory.js'
+import { createSourceContext } from '../src/admin-api/source-context.js'
+import type { SiteManifest, StorageProvider } from '../src/types.js'
+
+function mockProvider(): StorageProvider {
+  return {
+    readFile: async () => '',
+    writeFile: async () => {},
+    readDir: async () => [],
+    exists: async () => false,
+    mkdir: async () => {},
+    rm: async () => {},
+  }
+}
+
+describe('cache target-scope contract', () => {
+  it('two SourceContexts sharing one backing cache write to the SAME key without target dimension', async () => {
+    // This test pins the bug shape — confirms that without target in
+    // the key, a write via local is visible to production. If this
+    // test ever PASSES (returns null instead of local data), it means
+    // forSite or createSourceContext started doing per-target scoping
+    // at the wrapper level, which would indicate a contract change.
+    const sharedBacking = createMemoryCache({ instance: 'shared' })
+    const manifest: SiteManifest = { name: 'main', cache: sharedBacking }
+
+    const local = {
+      ...createSourceContext({ storage: mockProvider(), siteDir: '', manifest }),
+      targetName: 'local',
+    }
+    const production = {
+      ...createSourceContext({ storage: mockProvider(), siteDir: '', manifest }),
+      targetName: 'production',
+    }
+
+    await local.cache.set('shared-key', 'value-from-local')
+    expect(await production.cache.get('shared-key')).toBe('value-from-local')
+  })
+
+  it('target-scoped keys (per design-cache.md Gap 6) prevent cross-target pollution', async () => {
+    const sharedBacking = createMemoryCache({ instance: 'shared' })
+    const manifest: SiteManifest = { name: 'main', cache: sharedBacking }
+
+    const local = {
+      ...createSourceContext({ storage: mockProvider(), siteDir: '', manifest }),
+      targetName: 'local',
+    }
+    const production = {
+      ...createSourceContext({ storage: mockProvider(), siteDir: '', manifest }),
+      targetName: 'production',
+    }
+
+    // Mirror the route-level keying convention.
+    const keyFor = (s: { targetName?: string }) => `pages:summary:target:${s.targetName ?? '__source__'}`
+
+    await local.cache.set(keyFor(local), [{ name: 'page-on-local' }])
+    await production.cache.set(keyFor(production), [{ name: 'page-on-prod' }])
+
+    expect(await local.cache.get(keyFor(local))).toEqual([{ name: 'page-on-local' }])
+    expect(await production.cache.get(keyFor(production))).toEqual([{ name: 'page-on-prod' }])
+
+    // Cross-read using the OTHER target's key still works (same
+    // backing) — proves the isolation comes from the key dimension,
+    // not the wrapper.
+    expect(await local.cache.get(keyFor(production))).toEqual([{ name: 'page-on-prod' }])
+  })
+
+  it('save invalidatePrefix("pages:") clears all targets — documented over-invalidation', async () => {
+    // The route-level save handler uses `invalidatePrefix('pages:')`
+    // for cheapness + future-proofing (catches future per-page
+    // entries). When a backing cache is shared across targets, this
+    // blows the other targets' summaries too. Documented trade-off
+    // in pages.ts; this test pins the behavior.
+    const sharedBacking = createMemoryCache({ instance: 'shared' })
+    const manifest: SiteManifest = { name: 'main', cache: sharedBacking }
+
+    const local = {
+      ...createSourceContext({ storage: mockProvider(), siteDir: '', manifest }),
+      targetName: 'local',
+    }
+    const production = {
+      ...createSourceContext({ storage: mockProvider(), siteDir: '', manifest }),
+      targetName: 'production',
+    }
+
+    const keyFor = (s: { targetName?: string }) => `pages:summary:target:${s.targetName ?? '__source__'}`
+
+    await local.cache.set(keyFor(local), [{ name: 'p' }])
+    await production.cache.set(keyFor(production), [{ name: 'q' }])
+
+    // Save on local: invalidates all `pages:` entries, including
+    // production's.
+    await local.cache.invalidatePrefix('pages:')
+
+    expect(await local.cache.get(keyFor(local))).toBeNull()
+    expect(await production.cache.get(keyFor(production))).toBeNull()
+  })
+})

--- a/packages/gazetta/tests/source-context.test.ts
+++ b/packages/gazetta/tests/source-context.test.ts
@@ -44,6 +44,43 @@ describe('createSourceContext', () => {
     // Content paths are target-relative
     expect(source.contentRoot.path('pages', 'home')).toBe('pages/home')
   })
+
+  it('honors manifest.cache when no explicit cache option is supplied (Gap 8)', async () => {
+    // Operator's tuned cache lives on `manifest.cache` after the
+    // config loader's `applyGazettaDefaults` hoists it from
+    // `gazetta.config.ts defaults.cache`. Without this fallback it
+    // would be silently ignored at the SourceContext seam — operator
+    // config that does nothing.
+    const { createMemoryCache } = await import('../src/cache/memory.js')
+    const operatorCache = createMemoryCache({ instance: 'operator-tuned' })
+    const storage = mockProvider()
+    const source = createSourceContext({
+      storage,
+      siteDir: '',
+      projectSiteDir: '/abs/project/sites/main',
+      manifest: { name: 'main', cache: operatorCache },
+    })
+    // forSite wraps with site:{name}: scope; the inner stats() call
+    // passes through unchanged, so we read the operator's instance ID.
+    const stats = await source.cache.stats?.()
+    expect(stats?.instance).toBe('operator-tuned')
+  })
+
+  it('explicit opts.cache overrides manifest.cache', async () => {
+    const { createMemoryCache } = await import('../src/cache/memory.js')
+    const explicit = createMemoryCache({ instance: 'explicit-instance' })
+    const fromManifest = createMemoryCache({ instance: 'from-manifest' })
+    const storage = mockProvider()
+    const source = createSourceContext({
+      storage,
+      siteDir: '',
+      projectSiteDir: '/abs/project/sites/main',
+      manifest: { name: 'main', cache: fromManifest },
+      cache: explicit,
+    })
+    const stats = await source.cache.stats?.()
+    expect(stats?.instance).toBe('explicit-instance')
+  })
 })
 
 describe('createSourceContextFromRegistry', () => {


### PR DESCRIPTION
Ships the L4 cache foundation per [`design-cache.md`](.claude/rules/design-cache.md). 11 cuts shipped + 3 cleanup commits surfacing real bugs found during multi-instance gap analysis.

## What ships

| Cut | What |
|---|---|
| 1-2, 8-9 | `AdminCache` interface + `MemoryCache` provider with bounded LRU, key versioning + 255-char overflow-hash, per-site key auto-prefix via `forSite()`, `CacheError` taxonomy. (Cuts 1+2+8+9 collapsed: most landed during Path X Phase 3; this PR finishes them.) |
| 3 | Key conventions (versioning + overflow-hash) |
| 4 | SSE invalidation broadcast — `GET /api/system/cache/invalidations` streams events to connected browsers for the L4→L6 cascade |
| 5+6 (folded) | First real consumer (`/api/pages` + `/api/fragments` summary) paired with save invalidation — splitting them ships a regression |
| 7 | `GET /api/system/cache/stats` + periodic 5-min structured log |
| 10 | `adminCacheContractTests` helper from `gazetta/testing` for plugin authors |
| 11 | Operator-facing `docs/cache.md` |

## Cleanup commits

Multi-instance gap analysis surfaced four real bugs after the foundation shipped, all fixed in this PR:

- **Gap 8**: operator's `gazetta.config.ts defaults.cache` was silently ignored at the SourceContext seam. One-line fix: `forSite(opts.cache ?? opts.manifest?.cache ?? memoryCache(), siteName)`.
- **Gap 7**: `MemoryCache` instance ID was random hex per construction. Now derives from environment: `config.instance ?? K_REVISION ?? os.hostname() ?? randomBytes(4)`. Updated `design-logging.md` to match (drops `HOSTNAME` from chain — unreliable on K8s when Node is exec'd directly).
- **Gaps 1+2**: stats response and periodic log entries didn't carry instance ID. Operators in multi-instance deployments couldn't tell which pod answered. Added optional `instance` field to both surfaces.
- **Gap 11**: cross-target cache pollution under shared backing — bug reproduced empirically, fixed by adding target dimension to summary cache keys per `design-cache.md` Gap 6 lock. Save invalidations stay broad (`pages:` matches all targets) — over-invalidates by one recompute per affected target on next read; documented trade.

## Multi-instance scope

v1 ships server→browser SSE invalidation. **Server↔server fan-out reserved for v2 RedisCache** when concrete operator demand surfaces. The `subscribe()` contract ("events from any source") is designed for that v2 — the route doesn't change; the provider does the fan-out.

The single biggest operator-facing footgun is documented in `docs/cache.md` "Without sticky sessions": multi-instance deployments without session affinity get correctness drift (saves on instance A invisible to readers on instance B until LRU evicts). Three mitigations ranked by what real operators do: sticky sessions / single instance / disabled cache.

## Test plan

- [x] Cache primitives: `cache-keys`, `cache-memory`, `cache-per-site`, `cache-stats-logger`, `cache-target-scope`, `admin-cache-contract` (all pass)
- [x] Admin API: `/api/system/cache/stats`, `/api/system/cache/invalidations` SSE smoke
- [x] Regression test for Gap 11 cross-target pollution (3 tests pin the contract)
- [x] All 1533 gazetta tests + 520 admin tests pass locally
- [ ] CI verification across Linux + macOS + Windows pack-and-smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)