### PR TITLE
Offline mode v1 — admin works through transient connectivity loss

### DIFF
--- a/.claude/rules/design-offline-implementation.md
+++ b/.claude/rules/design-offline-implementation.md
@@ -31,7 +31,7 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 | 8b | Pending-edits store migration — `editorStash` + `editorContent` (closure-rebuild flow) | ☐ | Medium | Content edits survive reload (deferred from original Cut 8) |
 | 9 | Save-etag plumbing: server `ETag` + `If-Match` + 409 STALE + client `StaleSaveError` + `getPageWithEtag` / `updatePage(..., ifMatch)` | ✓ | High | Conflict-detection contract |
 | 9b | Save queue Pinia store: per-item chain projection + Vue Query mutation queue integration (deferred from Cut 9) | ☐ | High | Conflict-on-replay machinery |
-| 10 | Conflict UX: `StaleSaveError` → field-by-field semantic diff banner; Show / Discard actions | ☐ | High | Conflict resolution UX |
+| 10 | Conflict UX: useSaveConflictsStore + ConflictBanner.vue + ConflictDiffView.vue (Show / Discard actions; no overwrite per Krug lock) | ✓ | High | Conflict resolution UX |
 | 11 | Service worker via vite-plugin-pwa: app-shell precache | ☐ | Medium | Cold-load offline reliability |
 | 12 | UX indicators: cloud-with-slash icon + offline banner + "Send now" affordance + sync-state metadata | ☐ | Medium | Krug-aligned visibility |
 | 13 | Mid-save connection-loss handling: retry-with-If-Match; idempotency | ☐ | Medium | Edge case correctness |

--- a/.claude/rules/design-offline-implementation.md
+++ b/.claude/rules/design-offline-implementation.md
@@ -33,8 +33,8 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 | 9b | useEditorEtags Pinia store + useEditorActions integration (selection.ts If-Match plumbing, updateManifest helper, EditorPanel ConflictBanner wiring) | ✓ | High | End-to-end save-conflict flow |
 | 10 | Conflict UX: useSaveConflictsStore + ConflictBanner.vue + ConflictDiffView.vue (Show / Discard actions; no overwrite per Krug lock) | ✓ | High | Conflict resolution UX |
 | 11 | Service worker via vite-plugin-pwa (injectManifest): app-shell precache + skipWaiting handshake + Refresh-toast update flow | ✓ | Medium | Cold-load offline reliability |
-| 12 | UX indicators: cloud-with-slash icon + offline banner + "Send now" affordance + sync-state metadata | ☐ | Medium | Krug-aligned visibility |
-| 13 | Mid-save connection-loss handling: retry-with-If-Match; idempotency | ☐ | Medium | Edge case correctness |
+| 12 | OfflineBanner global visibility + Send now + reconnect toast (per-item cloud-slash icons defer to Cut 13's queue) | ✓ | Medium | Krug-aligned visibility |
+| 13 | Mid-save connection-loss reconcile: detect TypeError → GET-and-compare → silent success or surface StaleSaveError | ✓ | Medium | Edge case correctness |
 | 14 | Storage quota warning at 80% | ☐ | Low | Operator UX |
 | 15 | Audit integration: `metadata.replayed: true` + `queuedAt` + `replayedAt` | ☐ | Low | Composes with audit foundation |
 | 16 | Docs + first-run author guide | ☐ | Low | User-facing |

--- a/.claude/rules/design-offline-implementation.md
+++ b/.claude/rules/design-offline-implementation.md
@@ -35,7 +35,7 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 | 11 | Service worker via vite-plugin-pwa (injectManifest): app-shell precache + skipWaiting handshake + Refresh-toast update flow | ✓ | Medium | Cold-load offline reliability |
 | 12 | OfflineBanner global visibility + Send now + reconnect toast (per-item cloud-slash icons defer to Cut 13's queue) | ✓ | Medium | Krug-aligned visibility |
 | 13 | Mid-save connection-loss reconcile: detect TypeError → GET-and-compare → silent success or surface StaleSaveError | ✓ | Medium | Edge case correctness |
-| 14 | Storage quota warning at 80% | ☐ | Low | Operator UX |
+| 14 | useStorageQuota composable + StorageQuotaBanner (80% threshold; per-tab-session dismiss-once UX) | ✓ | Low | Operator UX |
 | 15 | Audit integration: `metadata.replayed: true` + `queuedAt` + `replayedAt` | ☐ | Low | Composes with audit foundation |
 | 16 | Docs + first-run author guide | ☐ | Low | User-facing |
 

--- a/.claude/rules/design-offline-implementation.md
+++ b/.claude/rules/design-offline-implementation.md
@@ -30,7 +30,7 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 | 8a | Pending-edits store migration — `editorStructural` only (pure-data subset) | ✓ | Medium | Structural edits survive reload |
 | 8b | Pending-edits store migration — `editorStash` + `editorContent` (closure-rebuild flow) | ☐ | Medium | Content edits survive reload (deferred from original Cut 8) |
 | 9 | Save-etag plumbing: server `ETag` + `If-Match` + 409 STALE + client `StaleSaveError` + `getPageWithEtag` / `updatePage(..., ifMatch)` | ✓ | High | Conflict-detection contract |
-| 9b | Save queue Pinia store: per-item chain projection + Vue Query mutation queue integration (deferred from Cut 9) | ☐ | High | Conflict-on-replay machinery |
+| 9b | useEditorEtags Pinia store + useEditorActions integration (selection.ts If-Match plumbing, updateManifest helper, EditorPanel ConflictBanner wiring) | ✓ | High | End-to-end save-conflict flow |
 | 10 | Conflict UX: useSaveConflictsStore + ConflictBanner.vue + ConflictDiffView.vue (Show / Discard actions; no overwrite per Krug lock) | ✓ | High | Conflict resolution UX |
 | 11 | Service worker via vite-plugin-pwa: app-shell precache | ☐ | Medium | Cold-load offline reliability |
 | 12 | UX indicators: cloud-with-slash icon + offline banner + "Send now" affordance + sync-state metadata | ☐ | Medium | Krug-aligned visibility |

--- a/.claude/rules/design-offline-implementation.md
+++ b/.claude/rules/design-offline-implementation.md
@@ -20,14 +20,15 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 
 | # | Cut | Status | Risk | Validates |
 |---|---|---|---|---|
-| 1 | npm dependencies + setup: `idb`, `@tanstack/vue-query`, `@tanstack/query-async-storage-persister`, `vite-plugin-pwa` | ☐ | Low | Tooling foundation |
-| 2 | `IndexedDBCache` provider (browser-side `AdminCache`) using `idb` | ☐ | Medium | The L6 cache primitive |
-| 3 | Provider selection: `IndexedDBCache` primary; `MemoryCache` fallback when IndexedDB unavailable | ☐ | Low | Graceful degradation |
-| 4 | BroadcastChannel cross-tab invalidation | ☐ | Low | Multi-tab coordination |
-| 5 | Vue Query setup + `IndexedDBPersister` bridge to L6 | ☐ | Medium | Query/mutation cache + offline queue |
-| 6 | Connection state Pinia store: hybrid `navigator.onLine` + heartbeat to `/api/health` | ☐ | Medium | 5-state model |
-| 7 | Health endpoint `GET /api/health` | ☐ | Low | Server-side support |
-| 8 | Pending-edits store migration: persist to IndexedDB; survive reload | ☐ | Medium | Editor state persistence |
+| 1 | npm dependencies + setup: `idb`, `@tanstack/vue-query`, `@tanstack/query-async-storage-persister`, `vite-plugin-pwa` | ✓ | Low | Tooling foundation |
+| 2 | `IndexedDBCache` provider (browser-side `AdminCache`) using `idb` | ✓ | Medium | The L6 cache primitive |
+| 3 | Provider selection: `IndexedDBCache` primary; `MemoryCache` fallback when IndexedDB unavailable | ✓ | Low | Graceful degradation |
+| 4 | BroadcastChannel cross-tab invalidation | ✓ | Low | Multi-tab coordination |
+| 5 | Vue Query setup + `IndexedDBPersister` bridge to L6 | ✓ | Medium | Query/mutation cache + offline queue |
+| 6 | Connection state Pinia store: hybrid `navigator.onLine` + heartbeat to `/api/health` | ✓ | Medium | 5-state model |
+| 7 | Health endpoint `GET /api/health` | ✓ | Low | Server-side support |
+| 8a | Pending-edits store migration — `editorStructural` only (pure-data subset) | ✓ | Medium | Structural edits survive reload |
+| 8b | Pending-edits store migration — `editorStash` + `editorContent` (closure-rebuild flow) | ☐ | Medium | Content edits survive reload (deferred from original Cut 8) |
 | 9 | Save queue: client-generated thread IDs + chained If-Match etag projections | ☐ | High | Conflict-on-replay machinery |
 | 10 | Conflict UX: 409 STALE handling; field-by-field semantic diff banner; Show / Discard actions | ☐ | High | Conflict resolution UX |
 | 11 | Service worker via vite-plugin-pwa: app-shell precache | ☐ | Medium | Cold-load offline reliability |
@@ -89,12 +90,29 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 
 **Tests:** returns `{ ok: true, timestamp }`
 
-### Cut 8: Pending-edits store migration
+### Cut 8a: Pending-edits store migration — structural only (shipped)
+
+**Files added:**
+- `apps/admin/src/client/stores/_pendingEditsPersistence.ts` — coordinator; deep-watches `editorStructural.entries`, debounce-writes a JSON-shaped snapshot to the cache, hydrates at boot
+- `apps/admin/tests/pendingEditsPersistence.test.ts` — coordinator contract tests
 
 **Files modified:**
-- `apps/admin/src/client/stores/editing.ts` — persist `editorContent`, `editorStash`, `editorStructural` to IndexedDB; hydrate on boot
+- `apps/admin/src/client/stores/editorStructural.ts` — adds internal `_hydrateFromSnapshot` method (leading underscore) so persistence can restore `original` + `pending` as-is without re-recording the discard baseline through the intent-named mutators
+- `apps/admin/src/client/main.ts` — attaches persistence after Pinia install + before mount; awaits initial hydration
 
-**Tests:** browser reload preserves pending edits across navigation
+**Tests:** hydration from a previously-persisted snapshot; debounced write on mutation (~300ms default); cache invalidation on empty store; debounce coalesces rapid mutations; preserves discard baseline across reload; wrong-version snapshots ignored; dispose() stops the watcher
+
+**Why structural-only:** pure data — no closures, no transient mounts. Reorders are also higher-friction for an author to redo than re-typing a field, making them the highest-value persistence target for this cut. `editorStash` + `editorContent` defer to Cut 8b because both stores carry an `EditingTarget` with a `save` closure bound to the page's selection state; the closure-rebuild flow on rehydration deserves its own focused cut.
+
+### Cut 8b: Pending-edits store migration — content + stash (deferred)
+
+**Files modified:**
+- `apps/admin/src/client/stores/_pendingEditsPersistence.ts` — extend with `attachStashPersistence` + `attachContentPersistence`
+- `apps/admin/src/client/composables/useEditorActions.ts` — navigate flow consults persisted content; `EditingTarget` rebuild on hydration
+
+**Tricky bit — closure rebuild on rehydration:** `EditingTarget.save` is `buildSaveFn(namePath)` (page selection state captured at navigate time). Persisted entries carry a "data-only snapshot" (no closure). On `navigate(path)`, the action checks the persisted entry and rebuilds the `save` closure from the freshly-fetched manifest's selection context.
+
+**Tests:** browser reload preserves stashed edits across pages; current-page dirty state restored on reload via navigate flow; stash restore picks up persisted dirty content during multi-page-edit scenario.
 
 ### Cut 9: Save queue (highest risk cut)
 
@@ -159,7 +177,7 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 
 ## Validation gate (definition of done)
 
-- [ ] All 16 cuts merged
+- [ ] All 17 cuts merged (1-7, 8a, 8b, 9-16)
 - [ ] Manual test: edit page offline → close laptop → reopen → edits persist → reconnect → sync invisibly
 - [ ] Conflict scenario test: edit offline + concurrent online edit → reconnect → conflict banner surfaces
 - [ ] Service worker test: cold-load admin offline → SPA loads from cache
@@ -191,7 +209,8 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 | 2-4 (IDB cache + selection + BroadcastChannel) | 2 days |
 | 5 (Vue Query) | 1.5 days |
 | 6-7 (Connection + health) | 1 day |
-| 8 (Pending-edits) | 1 day |
+| 8a (Structural pending-edits) | 0.5 day |
+| 8b (Stash + content pending-edits, with closure rebuild) | 1.5 days |
 | 9 (Save queue) | 2.5 days |
 | 10 (Conflict UX) | 2 days |
 | 11 (Service worker) | 1.5 days |
@@ -200,7 +219,7 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 | 15 (Audit) | 0.5 day |
 | 16 (Docs) | 1 day |
 
-**Total: ~16-17 days.** Highest cut count + highest risk pass; budget ~3-4 weeks with iteration.
+**Total: ~16-18 days** (8 split into 8a/8b). Highest cut count + highest risk pass; budget ~3-4 weeks with iteration.
 
 ## SOLID checks per cut
 

--- a/.claude/rules/design-offline-implementation.md
+++ b/.claude/rules/design-offline-implementation.md
@@ -28,7 +28,7 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 | 6 | Connection state Pinia store: hybrid `navigator.onLine` + heartbeat to `/api/health` | ✓ | Medium | 5-state model |
 | 7 | Health endpoint `GET /api/health` | ✓ | Low | Server-side support |
 | 8a | Pending-edits store migration — `editorStructural` only (pure-data subset) | ✓ | Medium | Structural edits survive reload |
-| 8b | Pending-edits store migration — `editorStash` + `editorContent` (closure-rebuild flow) | ☐ | Medium | Content edits survive reload (deferred from original Cut 8) |
+| 8b | usePersistedEditsStore (cross-page key) + auto-mirror on markDirty/stashCurrent + navigate seam rebuilds target via buildTarget + clear-on-save | ✓ | Medium | Content edits survive reload |
 | 9 | Save-etag plumbing: server `ETag` + `If-Match` + 409 STALE + client `StaleSaveError` + `getPageWithEtag` / `updatePage(..., ifMatch)` | ✓ | High | Conflict-detection contract |
 | 9b | useEditorEtags Pinia store + useEditorActions integration (selection.ts If-Match plumbing, updateManifest helper, EditorPanel ConflictBanner wiring) | ✓ | High | End-to-end save-conflict flow |
 | 10 | Conflict UX: useSaveConflictsStore + ConflictBanner.vue + ConflictDiffView.vue (Show / Discard actions; no overwrite per Krug lock) | ✓ | High | Conflict resolution UX |

--- a/.claude/rules/design-offline-implementation.md
+++ b/.claude/rules/design-offline-implementation.md
@@ -37,7 +37,7 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 | 13 | Mid-save connection-loss reconcile: detect TypeError → GET-and-compare → silent success or surface StaleSaveError | ✓ | Medium | Edge case correctness |
 | 14 | useStorageQuota composable + StorageQuotaBanner (80% threshold; per-tab-session dismiss-once UX) | ✓ | Low | Operator UX |
 | 15 | Audit integration: `metadata.replayed: true` + `queuedAt` + `replayedAt` | ☐ | Low | Composes with audit foundation |
-| 16 | Docs + first-run author guide | ☐ | Low | User-facing |
+| 16 | docs/offline.md author + operator guide; CLAUDE.md listing updated | ✓ | Low | User-facing |
 
 ## Per-cut scope
 

--- a/.claude/rules/design-offline-implementation.md
+++ b/.claude/rules/design-offline-implementation.md
@@ -32,7 +32,7 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 | 9 | Save-etag plumbing: server `ETag` + `If-Match` + 409 STALE + client `StaleSaveError` + `getPageWithEtag` / `updatePage(..., ifMatch)` | ✓ | High | Conflict-detection contract |
 | 9b | useEditorEtags Pinia store + useEditorActions integration (selection.ts If-Match plumbing, updateManifest helper, EditorPanel ConflictBanner wiring) | ✓ | High | End-to-end save-conflict flow |
 | 10 | Conflict UX: useSaveConflictsStore + ConflictBanner.vue + ConflictDiffView.vue (Show / Discard actions; no overwrite per Krug lock) | ✓ | High | Conflict resolution UX |
-| 11 | Service worker via vite-plugin-pwa: app-shell precache | ☐ | Medium | Cold-load offline reliability |
+| 11 | Service worker via vite-plugin-pwa (injectManifest): app-shell precache + skipWaiting handshake + Refresh-toast update flow | ✓ | Medium | Cold-load offline reliability |
 | 12 | UX indicators: cloud-with-slash icon + offline banner + "Send now" affordance + sync-state metadata | ☐ | Medium | Krug-aligned visibility |
 | 13 | Mid-save connection-loss handling: retry-with-If-Match; idempotency | ☐ | Medium | Edge case correctness |
 | 14 | Storage quota warning at 80% | ☐ | Low | Operator UX |

--- a/.claude/rules/design-offline-implementation.md
+++ b/.claude/rules/design-offline-implementation.md
@@ -29,8 +29,9 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 | 7 | Health endpoint `GET /api/health` | ✓ | Low | Server-side support |
 | 8a | Pending-edits store migration — `editorStructural` only (pure-data subset) | ✓ | Medium | Structural edits survive reload |
 | 8b | Pending-edits store migration — `editorStash` + `editorContent` (closure-rebuild flow) | ☐ | Medium | Content edits survive reload (deferred from original Cut 8) |
-| 9 | Save queue: client-generated thread IDs + chained If-Match etag projections | ☐ | High | Conflict-on-replay machinery |
-| 10 | Conflict UX: 409 STALE handling; field-by-field semantic diff banner; Show / Discard actions | ☐ | High | Conflict resolution UX |
+| 9 | Save-etag plumbing: server `ETag` + `If-Match` + 409 STALE + client `StaleSaveError` + `getPageWithEtag` / `updatePage(..., ifMatch)` | ✓ | High | Conflict-detection contract |
+| 9b | Save queue Pinia store: per-item chain projection + Vue Query mutation queue integration (deferred from Cut 9) | ☐ | High | Conflict-on-replay machinery |
+| 10 | Conflict UX: `StaleSaveError` → field-by-field semantic diff banner; Show / Discard actions | ☐ | High | Conflict resolution UX |
 | 11 | Service worker via vite-plugin-pwa: app-shell precache | ☐ | Medium | Cold-load offline reliability |
 | 12 | UX indicators: cloud-with-slash icon + offline banner + "Send now" affordance + sync-state metadata | ☐ | Medium | Krug-aligned visibility |
 | 13 | Mid-save connection-loss handling: retry-with-If-Match; idempotency | ☐ | Medium | Edge case correctness |
@@ -114,7 +115,29 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 
 **Tests:** browser reload preserves stashed edits across pages; current-page dirty state restored on reload via navigate flow; stash restore picks up persisted dirty content during multi-page-edit scenario.
 
-### Cut 9: Save queue (highest risk cut)
+### Cut 9: Save-etag plumbing (shipped)
+
+**Files added:**
+- `packages/gazetta/src/save-etag.ts` — shared `computeSaveEtag(manifest)`. SHA-256 truncated to 16 hex over canonical manifest JSON. Web Crypto API; works in Node 18+ AND browsers. Exposed via `gazetta/save-etag` subpath so the client can import without pulling in `node:crypto`-flavored modules.
+- `packages/gazetta/tests/save-etag.test.ts` — 12 unit tests pin determinism + field coverage + canonical-key ordering + null vs undefined.
+- `apps/admin/tests/api-save-etag.test.ts` — 11 client tests via mocked fetch.
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/pages.ts` — GET sets `ETag` header; PUT honors `If-Match` and returns 409 STALE with `current` manifest body + `currentEtag` on mismatch; success echoes the new etag both as response header AND as `etag` field in body so chain projection works without a follow-up GET. The echo shape includes `route` so it matches the next GET.
+- `packages/gazetta/src/admin-api/routes/fragments.ts` — same shape (without `route`/`metadata` fields since fragments don't carry them).
+- `packages/gazetta/tests/admin-api.test.ts` — 7 new tests pin: header round-trip on pages + fragments, optional If-Match (last-write-wins), stale 409 with current body, chained projection for offline replay.
+- `apps/admin/src/client/api/client.ts` — new `StaleSaveError` peer to `ValidationFailedError`; `requestWithEtag<T>` helper; `getPageWithEtag` / `getFragmentWithEtag`; `updatePage` / `updateFragment` extend opts with `ifMatch?: string`.
+- `packages/gazetta/package.json` — `gazetta/save-etag` subpath export.
+
+**Why two etags coexist:** the publish-state `.{8hex}.hash` includes template + fragment hashes (drives publish/cache invalidation: a template change must invalidate every dependent page). The save etag is pure manifest content (the browser can't access template/fragment hashes; mixing them would force false 409s on every author after a template edit). Two etags, two semantics, two consumers.
+
+**Why SHA-256 truncated to 16 hex (not MD5 truncated to 8):** save etags collide more often than publish hashes (every save is a new etag candidate; many saves per page over a long offline session). 8 hex = 4B keyspace; tens of thousands of saves would hit the birthday bound. 16 hex = 18.4 quintillion keyspace.
+
+**Tests:** see file references above. All tests green; no regressions on existing `VALIDATION_FAILED` 409 path.
+
+**Why Cut 9 is split into 9 + 9b:** the server contract + client API plumbing (this cut) is sufficient for any consumer that tracks the etag itself. The full save-queue Pinia store with Vue Query mutation-queue integration + per-item chain state machine is a separate surface area that would bloat this commit. Cut 9b lands when concrete consumer demand surfaces (likely with `useEditorActions` integration when Cut 8b's content-edit persistence ships).
+
+### Cut 9b: Save queue (deferred)
 
 **Files added:**
 - `apps/admin/src/client/queries/save-queue.ts` — client-generated UUIDs; chained If-Match projections; sequential replay on reconnect
@@ -177,7 +200,7 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 
 ## Validation gate (definition of done)
 
-- [ ] All 17 cuts merged (1-7, 8a, 8b, 9-16)
+- [ ] All 18 cuts merged (1-7, 8a, 8b, 9, 9b, 10-16)
 - [ ] Manual test: edit page offline → close laptop → reopen → edits persist → reconnect → sync invisibly
 - [ ] Conflict scenario test: edit offline + concurrent online edit → reconnect → conflict banner surfaces
 - [ ] Service worker test: cold-load admin offline → SPA loads from cache
@@ -211,7 +234,8 @@ Branch: `offline-v1` off `main`. Sequenced after AdminCache (depends on `AdminCa
 | 6-7 (Connection + health) | 1 day |
 | 8a (Structural pending-edits) | 0.5 day |
 | 8b (Stash + content pending-edits, with closure rebuild) | 1.5 days |
-| 9 (Save queue) | 2.5 days |
+| 9 (Save-etag plumbing) | 1 day |
+| 9b (Save queue + Vue Query integration) | 1.5 days |
 | 10 (Conflict UX) | 2 days |
 | 11 (Service worker) | 1.5 days |
 | 12 (UX indicators) | 1.5 days |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,8 @@ Stateless CMS that structures websites as composable fragments. All state lives 
 - `docs/content-assets.md` — Content author guide for the asset library
 - `docs/migration.md` — Migrating templates from `z.string()` URLs to `embeddedAsset()` references
 - `docs/transform-adapters.md` — Per-target image delivery strategies
+- `docs/cache.md` — Admin read-side cache configuration + monitoring
+- `docs/offline.md` — Offline mode (cold-load reliability, save conflicts, browser support)
 
 ## Design docs (auto-loaded by Claude)
 

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -13,9 +13,12 @@
   "dependencies": {
     "@hono/node-server": "^2.0.1",
     "@primeuix/themes": "^2.0.3",
+    "@tanstack/query-async-storage-persister": "^5.100.9",
+    "@tanstack/vue-query": "^5.100.9",
     "@vueuse/core": "^14.3.0",
     "gazetta": "*",
     "hono": "^4.12.16",
+    "idb": "^8.0.3",
     "morphdom": "^2.7.8",
     "pinia": "^3.0.0",
     "primeicons": "^7.0.0",
@@ -34,6 +37,7 @@
     "tsx": "^4.21.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.10",
+    "vite-plugin-pwa": "^1.3.0",
     "vitest": "^4.1.5"
   }
 }

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -32,6 +32,7 @@
     "@types/node": "^25.6.0",
     "@vitejs/plugin-vue": "^6.0.6",
     "@vue/test-utils": "^2.4.10",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.0.2",
     "testcontainers": "^11.13.0",
     "tsx": "^4.21.0",

--- a/apps/admin/src/client/App.vue
+++ b/apps/admin/src/client/App.vue
@@ -13,6 +13,7 @@ import UnsavedDialog from './components/UnsavedDialog.vue'
 import AssetLibrary from './components/AssetLibrary.vue'
 import AssetPicker from './components/AssetPicker.vue'
 import AssetDeleteConfirm from './components/AssetDeleteConfirm.vue'
+import OfflineBanner from './components/OfflineBanner.vue'
 
 const site = useSiteStore()
 const theme = useThemeStore()
@@ -75,6 +76,7 @@ onMounted(() => {
 <template>
   <div class="cms-app">
     <Toolbar />
+    <OfflineBanner />
     <div v-if="site.error" class="cms-error">{{ site.error }}</div>
     <!-- Only block on the first load. Subsequent reloads (e.g., on
          active-target switch) keep the router-view mounted so the

--- a/apps/admin/src/client/App.vue
+++ b/apps/admin/src/client/App.vue
@@ -14,6 +14,7 @@ import AssetLibrary from './components/AssetLibrary.vue'
 import AssetPicker from './components/AssetPicker.vue'
 import AssetDeleteConfirm from './components/AssetDeleteConfirm.vue'
 import OfflineBanner from './components/OfflineBanner.vue'
+import StorageQuotaBanner from './components/StorageQuotaBanner.vue'
 
 const site = useSiteStore()
 const theme = useThemeStore()
@@ -77,6 +78,7 @@ onMounted(() => {
   <div class="cms-app">
     <Toolbar />
     <OfflineBanner />
+    <StorageQuotaBanner />
     <div v-if="site.error" class="cms-error">{{ site.error }}</div>
     <!-- Only block on the first load. Subsequent reloads (e.g., on
          active-target switch) keep the router-view mounted so the

--- a/apps/admin/src/client/api/client.ts
+++ b/apps/admin/src/client/api/client.ts
@@ -33,6 +33,28 @@ export class ValidationFailedError extends Error {
   }
 }
 
+/**
+ * Thrown when a save / fragment-update returns 409 with code STALE — the
+ * server's etag changed between the client's read and write per
+ * `design-offline.md` Q3. Carries the server's CURRENT manifest so the
+ * conflict UX (Cut 10) can surface a field-by-field diff banner.
+ *
+ * `currentEtag` is the server's post-mismatch etag — the client uses it
+ * to retry by either rebasing the local edit on top of the new manifest
+ * or discarding the local edit.
+ */
+export class StaleSaveError extends Error {
+  readonly code = 'STALE' as const
+  readonly current: Record<string, unknown>
+  readonly currentEtag: string
+  constructor(current: Record<string, unknown>, currentEtag: string) {
+    super('Save failed: the server has a newer version of this content')
+    this.name = 'StaleSaveError'
+    this.current = current
+    this.currentEtag = currentEtag
+  }
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   const res = await fetch(apiUrl(path), {
     ...options,
@@ -40,12 +62,41 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   })
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: res.statusText }))
-    if (res.status === 409 && body && typeof body === 'object' && body.code === 'VALIDATION_FAILED') {
-      throw new ValidationFailedError(body.issues ?? [])
+    if (res.status === 409 && body && typeof body === 'object') {
+      if (body.code === 'VALIDATION_FAILED') throw new ValidationFailedError(body.issues ?? [])
+      if (body.code === 'STALE') throw new StaleSaveError(body.current ?? {}, body.currentEtag ?? '')
     }
     throw new Error(body.error ?? `Request failed: ${res.status}`)
   }
   return res.json()
+}
+
+/**
+ * `request<T>` for endpoints that return the save-concurrency `ETag`
+ * header (per design-offline.md Q3). Returns the parsed body plus the
+ * unquoted etag value when present. Used by `getPageWithEtag` /
+ * `getFragmentWithEtag` so offline-aware save flows can echo the etag
+ * back as `If-Match` on the next save.
+ */
+async function requestWithEtag<T>(path: string, options?: RequestInit): Promise<{ data: T; etag: string | null }> {
+  const res = await fetch(apiUrl(path), {
+    ...options,
+    headers: authHeaders({ 'Content-Type': 'application/json', ...(options?.headers as Record<string, string>) }),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText }))
+    if (res.status === 409 && body && typeof body === 'object') {
+      if (body.code === 'VALIDATION_FAILED') throw new ValidationFailedError(body.issues ?? [])
+      if (body.code === 'STALE') throw new StaleSaveError(body.current ?? {}, body.currentEtag ?? '')
+    }
+    throw new Error(body.error ?? `Request failed: ${res.status}`)
+  }
+  const data = (await res.json()) as T
+  // RFC-7232 wraps the etag value in quotes; strip them for the typed
+  // value the consumer stores. Re-quoted at If-Match send time.
+  const raw = res.headers.get('ETag')
+  const etag = raw ? raw.replace(/^"(.*)"$/, '$1') : null
+  return { data, etag }
 }
 
 /**
@@ -206,12 +257,28 @@ export const api = {
     const path = options?.locale ? `/pages/${name}?locale=${encodeURIComponent(options.locale)}` : `/pages/${name}`
     return request<PageDetail>(path, options)
   },
+  /**
+   * Same as `getPage` but also returns the server's save-etag (the
+   * `ETag` response header per design-offline.md Q3). Offline-aware
+   * save flows store this and echo it as `If-Match` on the next save
+   * to detect mid-edit drift.
+   */
+  getPageWithEtag: (name: string, options?: RequestInit & { locale?: string }) => {
+    const path = options?.locale ? `/pages/${name}?locale=${encodeURIComponent(options.locale)}` : `/pages/${name}`
+    return requestWithEtag<PageDetail>(path, options)
+  },
   createPage: (data: CreatePageRequest) =>
     request<CreatePageResponse>('/pages', { method: 'POST', body: JSON.stringify(data) }),
   deletePage: (name: string) => request<{ ok: boolean }>(`/pages/${name}`, { method: 'DELETE' }),
-  updatePage: (name: string, data: Partial<PageDetail>, opts?: { locale?: string }) => {
+  updatePage: (name: string, data: Partial<PageDetail>, opts?: { locale?: string; ifMatch?: string }) => {
     const qs = opts?.locale ? `?locale=${encodeURIComponent(opts.locale)}` : ''
-    return request<{ ok: boolean }>(`/pages/${name}${qs}`, { method: 'PUT', body: JSON.stringify(data) })
+    const headers: Record<string, string> = {}
+    if (opts?.ifMatch) headers['If-Match'] = `"${opts.ifMatch}"`
+    return request<{ ok: boolean; etag?: string }>(`/pages/${name}${qs}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+      headers,
+    })
   },
   /** List fragments. See getPages for the `target` option. */
   getFragments: (opts?: { target?: string }) =>
@@ -222,12 +289,28 @@ export const api = {
       : `/fragments/${name}`
     return request<FragmentDetail>(path, options)
   },
+  /**
+   * Same as `getFragment` but also returns the server's save-etag.
+   * See `getPageWithEtag` for the rationale.
+   */
+  getFragmentWithEtag: (name: string, options?: RequestInit & { locale?: string }) => {
+    const path = options?.locale
+      ? `/fragments/${name}?locale=${encodeURIComponent(options.locale)}`
+      : `/fragments/${name}`
+    return requestWithEtag<FragmentDetail>(path, options)
+  },
   createFragment: (data: CreateFragmentRequest) =>
     request<CreateFragmentResponse>('/fragments', { method: 'POST', body: JSON.stringify(data) }),
   deleteFragment: (name: string) => request<{ ok: boolean }>(`/fragments/${name}`, { method: 'DELETE' }),
-  updateFragment: (name: string, data: Partial<FragmentDetail>, opts?: { locale?: string }) => {
+  updateFragment: (name: string, data: Partial<FragmentDetail>, opts?: { locale?: string; ifMatch?: string }) => {
     const qs = opts?.locale ? `?locale=${encodeURIComponent(opts.locale)}` : ''
-    return request<{ ok: boolean }>(`/fragments/${name}${qs}`, { method: 'PUT', body: JSON.stringify(data) })
+    const headers: Record<string, string> = {}
+    if (opts?.ifMatch) headers['If-Match'] = `"${opts.ifMatch}"`
+    return request<{ ok: boolean; etag?: string }>(`/fragments/${name}${qs}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+      headers,
+    })
   },
   getTemplates: () => request<TemplateSummary[]>('/templates'),
   getTemplateSchema: (name: string, options?: RequestInit) =>

--- a/apps/admin/src/client/cache/indexeddb-cache.ts
+++ b/apps/admin/src/client/cache/indexeddb-cache.ts
@@ -262,10 +262,27 @@ export async function createIndexedDBCache(opts: IndexedDBCacheOptions = {}): Pr
       // TTL is part of the AdminCache contract but IndexedDBCache
       // ignores it — eviction is LRS-only. A future TTL pass would
       // add a `ttlAt` field and a periodic sweep.
+      //
+      // # Why we round-trip through JSON, not store the raw value
+      //
+      // `db.put` requires structured-cloneable values. Vue's
+      // reactive Proxies fail structured clone with:
+      //   "Failed to execute 'put' on 'IDBObjectStore':
+      //    #<Object> could not be cloned."
+      // Persistence callers commonly snapshot Pinia state (which
+      // wraps everything in Proxies). The cache provider sanitizes
+      // so any caller can pass any JSON-serializable value (the
+      // AdminCache contract requires values be JSON-serializable
+      // per `design-cache.md` "Offline composition") and storage
+      // works without each caller having to deep-clone first.
+      //
+      // Reuses the JSON we're already computing for byte
+      // accounting — single serialize, double duty.
       const serialized = JSON.stringify(value)
+      const cloneable = JSON.parse(serialized) as T
       const row: CacheRow = {
         key,
-        value,
+        value: cloneable,
         setAt: Date.now(),
         bytes: serialized.length,
       }

--- a/apps/admin/src/client/cache/indexeddb-cache.ts
+++ b/apps/admin/src/client/cache/indexeddb-cache.ts
@@ -1,0 +1,289 @@
+/**
+ * `IndexedDBCache` — browser-side `AdminCache` provider per
+ * `design-offline.md`. Persists cache entries across page reloads;
+ * survives browser sessions; the L6 layer in the L4→L6 cascade
+ * powering offline mode.
+ *
+ * Implements the same `AdminCache` contract as the server-side
+ * `MemoryCache`. The contract is shared via the `gazetta` package's
+ * type exports so consumers (Vue Query bridge, route helpers) can
+ * depend on the interface without knowing whether they're talking to
+ * the server-side or browser-side provider.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns the IndexedDB-backed provider. Provider
+ *     selection, BroadcastChannel cross-tab fan-out, and Vue Query
+ *     bridging live in sibling files.
+ *   - LSP: substitutable for any other `AdminCache` provider; passes
+ *     `adminCacheContractTests` from `gazetta/testing`.
+ *   - DIP: callers depend on the `AdminCache` interface, not on this
+ *     concrete class.
+ *
+ * # Differences from `MemoryCache`
+ *
+ * - **LRS, not LRU**: tracks Least Recently Set rather than Least
+ *   Recently Used. LRU would require a write on every read (to bump
+ *   recency); LRS only writes on `set`. The browser's typical
+ *   eviction pressure is "drop the oldest write," which LRS captures
+ *   correctly without doubling write volume.
+ *
+ * - **Stats are in-memory only**: hit / miss counters live on the
+ *   provider instance and reset on tab reload. Persisting them would
+ *   make every `get` a write — kills the point of caching. Operators
+ *   reading the structured stats log get per-tab-session counts.
+ *
+ * - **No `applyKeyPolicy`**: the server-side provider applies a
+ *   version prefix and overflow-hash before storing. The browser-
+ *   side provider stores keys as received. The L4↔L6 sync still
+ *   works because both providers expose the same consumer-facing
+ *   API; their internal storage encoding doesn't have to match.
+ *
+ * - **Subscribers are local-only in this cut**: same as `MemoryCache`
+ *   pre-Cut-4. BroadcastChannel cross-tab fan-out lands in offline
+ *   Cut 4.
+ */
+import { type IDBPDatabase, openDB } from 'idb'
+import type { AdminCache, CacheStats, InvalidationEvent } from 'gazetta'
+
+/** Default cap. Matches MemoryCache so operators get consistent behavior. */
+const DEFAULT_MAX_ENTRIES = 10_000
+/** Default cap. Matches MemoryCache so operators get consistent behavior. */
+const DEFAULT_MAX_BYTES = 50 * 1024 * 1024 // 50 MB
+
+const DB_NAME = 'gazetta-cache'
+const DB_VERSION = 1
+const STORE_NAME = 'cache'
+const SET_AT_INDEX = 'setAt'
+
+interface CacheRow {
+  /** The cache key (primary key on the store). */
+  key: string
+  /** The cached value — JSON-serializable per `AdminCache` contract. */
+  value: unknown
+  /**
+   * Wall-clock millis when this entry was written. Drives LRS
+   * eviction; not load-bearing for correctness (entries don't expire
+   * by age in v1).
+   */
+  setAt: number
+  /** Approximate byte size — `JSON.stringify(value).length`. */
+  bytes: number
+}
+
+export interface IndexedDBCacheOptions {
+  /** Max entry count before LRS eviction kicks in. Default 10,000. */
+  maxEntries?: number
+  /** Approximate max bytes before LRS eviction kicks in. Default 50 MB. */
+  maxBytes?: number
+  /**
+   * Stable identifier for this provider instance, emitted on
+   * `InvalidationEvent.source.instance` and `CacheStats.instance`.
+   * Defaults to a random 8-char hex generated at construction —
+   * scoped to the tab session.
+   */
+  instance?: string
+  /**
+   * Override the database name. Defaults to `gazetta-cache`. Tests
+   * pass a unique name per test to avoid cross-test contamination
+   * since IndexedDB is browser-global.
+   */
+  dbName?: string
+}
+
+/**
+ * Build an `IndexedDBCache` provider. Returns a Promise because the
+ * IndexedDB connection is async — `openDB()` resolves once the
+ * upgrade callback finishes.
+ *
+ * The returned provider keeps the connection open for its lifetime;
+ * it doesn't expose a `close()` method. Browser tab close releases
+ * the connection. Tests that need clean teardown can `db.close()` on
+ * the underlying DB before the next test, or use unique `dbName`
+ * options.
+ */
+export async function createIndexedDBCache(opts: IndexedDBCacheOptions = {}): Promise<AdminCache & { close(): void }> {
+  const maxEntries = opts.maxEntries ?? DEFAULT_MAX_ENTRIES
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES
+  const instance = opts.instance ?? randomHex(4)
+  const dbName = opts.dbName ?? DB_NAME
+
+  const db: IDBPDatabase = await openDB(dbName, DB_VERSION, {
+    upgrade(database) {
+      // Only one store; keys are arbitrary strings; setAt index for
+      // LRS eviction sweeps.
+      const store = database.createObjectStore(STORE_NAME, { keyPath: 'key' })
+      store.createIndex(SET_AT_INDEX, 'setAt')
+    },
+  })
+
+  const subscribers = new Set<(event: InvalidationEvent) => void>()
+  let hits = 0
+  let misses = 0
+  let evictions = 0
+  let lastInvalidation: { prefix: string; at: string; source: string } | undefined
+
+  function emit(prefix: string): void {
+    if (subscribers.size === 0) return
+    const event: InvalidationEvent = {
+      prefix,
+      source: { instance, timestamp: new Date().toISOString() },
+    }
+    for (const handler of subscribers) {
+      try {
+        handler(event)
+      } catch {
+        // Subscriber faults must not interfere with the
+        // invalidation that triggered them. Silently swallow.
+      }
+    }
+  }
+
+  /**
+   * Sum bytes across every entry. Cursor-walk; one transaction. Used
+   * by `evictUntilUnderCap` and `stats`. Both callers tolerate the
+   * O(N) scan because:
+   *   - eviction only runs after writes when caps may be exceeded;
+   *   - stats() is called at observation cadence (5-min log), not
+   *     hot-path. Operators with byte-cap concerns at envelope have
+   *     a small enough cache that this is microseconds.
+   */
+  async function totalByteSum(): Promise<number> {
+    let total = 0
+    const tx = db.transaction(STORE_NAME, 'readonly')
+    let cursor = await tx.store.openCursor()
+    while (cursor) {
+      total += (cursor.value as CacheRow).bytes
+      cursor = await cursor.continue()
+    }
+    await tx.done
+    return total
+  }
+
+  /**
+   * Walk the setAt index from oldest forward, deleting entries until
+   * the store is back under both caps. Two transactions:
+   *   1. Read current size + bytes (skip if already under caps)
+   *   2. Eviction sweep
+   * Splitting avoids holding a write lock during the cheap-path
+   * "no eviction needed" case.
+   */
+  async function evictUntilUnderCap(): Promise<void> {
+    const initialSize = await db.count(STORE_NAME)
+    const initialBytes = initialSize > 0 ? await totalByteSum() : 0
+    if (initialSize <= maxEntries && initialBytes <= maxBytes) return
+
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    const index = tx.store.index(SET_AT_INDEX)
+    let size = initialSize
+    let totalBytes = initialBytes
+    let cursor = await index.openCursor()
+    while (cursor && (size > maxEntries || totalBytes > maxBytes)) {
+      const row = cursor.value as CacheRow
+      totalBytes -= row.bytes
+      size -= 1
+      await cursor.delete()
+      evictions += 1
+      cursor = await cursor.continue()
+    }
+    await tx.done
+  }
+
+  return {
+    async get<T>(key: string): Promise<T | null> {
+      const row = (await db.get(STORE_NAME, key)) as CacheRow | undefined
+      if (!row) {
+        misses += 1
+        return null
+      }
+      hits += 1
+      return row.value as T
+    },
+
+    async set<T>(key: string, value: T, _opts?: { ttl?: number }): Promise<void> {
+      // TTL is part of the AdminCache contract but IndexedDBCache
+      // ignores it — eviction is LRS-only. A future TTL pass would
+      // add a `ttlAt` field and a periodic sweep.
+      const serialized = JSON.stringify(value)
+      const row: CacheRow = {
+        key,
+        value,
+        setAt: Date.now(),
+        bytes: serialized.length,
+      }
+      await db.put(STORE_NAME, row)
+      await evictUntilUnderCap()
+    },
+
+    async invalidate(key: string): Promise<void> {
+      const existed = (await db.get(STORE_NAME, key)) !== undefined
+      if (!existed) return
+      await db.delete(STORE_NAME, key)
+      emit(key)
+    },
+
+    async invalidatePrefix(prefix: string): Promise<number> {
+      // Cursor-walk over the keypath; delete every row whose key
+      // starts with prefix. `￿` is the highest BMP code point —
+      // any string starting with `prefix` sorts strictly less.
+      // (Our keys are colon-separated ASCII, so BMP coverage is fine.)
+      const range = IDBKeyRange.bound(prefix, prefix + '￿', false, true)
+      const tx = db.transaction(STORE_NAME, 'readwrite')
+      let cleared = 0
+      let cursor = await tx.store.openCursor(range)
+      while (cursor) {
+        await cursor.delete()
+        cleared += 1
+        cursor = await cursor.continue()
+      }
+      await tx.done
+      lastInvalidation = {
+        prefix,
+        at: new Date().toISOString(),
+        source: 'local',
+      }
+      // Emit even when cleared === 0 — same rule as MemoryCache:
+      // subscribers (cross-tab BroadcastChannel in Cut 4) want every
+      // invalidation intent, not just those that hit something locally.
+      emit(prefix)
+      return cleared
+    },
+
+    subscribe(handler: (event: InvalidationEvent) => void): () => void {
+      subscribers.add(handler)
+      return () => {
+        subscribers.delete(handler)
+      }
+    },
+
+    async stats(): Promise<CacheStats> {
+      const size = await db.count(STORE_NAME)
+      const bytesApproximate = size > 0 ? await totalByteSum() : 0
+      return {
+        hits,
+        misses,
+        size,
+        instance,
+        evictions,
+        bytesApproximate,
+        lastInvalidation,
+      }
+    },
+
+    /**
+     * Close the underlying IndexedDB connection. Tests use this to
+     * release the database between runs so version-bumps in upgrade
+     * don't get blocked. Production code doesn't call this — the
+     * connection lives for the tab session.
+     */
+    close(): void {
+      db.close()
+    },
+  }
+}
+
+function randomHex(bytes: number): string {
+  const arr = new Uint8Array(bytes)
+  crypto.getRandomValues(arr)
+  return Array.from(arr, b => b.toString(16).padStart(2, '0')).join('')
+}

--- a/apps/admin/src/client/cache/indexeddb-cache.ts
+++ b/apps/admin/src/client/cache/indexeddb-cache.ts
@@ -39,9 +39,12 @@
  *   works because both providers expose the same consumer-facing
  *   API; their internal storage encoding doesn't have to match.
  *
- * - **Subscribers are local-only in this cut**: same as `MemoryCache`
- *   pre-Cut-4. BroadcastChannel cross-tab fan-out lands in offline
- *   Cut 4.
+ * - **Cross-tab fan-out via BroadcastChannel**: `subscribe()` fires
+ *   for events from any source — local invalidations on this provider
+ *   AND invalidations from peer tabs in the same origin. Matches the
+ *   server-side `MemoryCache` contract evolution ("events from any
+ *   source"). Peer events skip the originator's own subscribers via
+ *   instance-ID comparison; no infinite loop on rebroadcast.
  */
 import { type IDBPDatabase, openDB } from 'idb'
 import type { AdminCache, CacheStats, InvalidationEvent } from 'gazetta'
@@ -55,6 +58,13 @@ const DB_NAME = 'gazetta-cache'
 const DB_VERSION = 1
 const STORE_NAME = 'cache'
 const SET_AT_INDEX = 'setAt'
+
+/**
+ * BroadcastChannel name prefix. Suffixed by `dbName` so different
+ * cache databases in the same origin (tests, future per-site DB names)
+ * don't cross-talk.
+ */
+const BROADCAST_CHANNEL_PREFIX = 'gazetta-cache:'
 
 interface CacheRow {
   /** The cache key (primary key on the store). */
@@ -123,18 +133,66 @@ export async function createIndexedDBCache(opts: IndexedDBCacheOptions = {}): Pr
   let evictions = 0
   let lastInvalidation: { prefix: string; at: string; source: string } | undefined
 
-  function emit(prefix: string): void {
-    if (subscribers.size === 0) return
-    const event: InvalidationEvent = {
-      prefix,
-      source: { instance, timestamp: new Date().toISOString() },
-    }
+  // Cross-tab fan-out via BroadcastChannel. Same-origin tabs share
+  // IndexedDB storage, so an invalidation in tab A means tab B's
+  // cached read result is now stale; the channel notifies peers so
+  // their local subscribers (Vue Query bridge, validation drawer,
+  // etc.) can react. The underlying storage is already shared — we're
+  // not syncing state, just notifying that state changed.
+  //
+  // BroadcastChannel can be undefined in older test runners or
+  // sandboxed contexts; fall back to a no-op so cross-tab degrades
+  // gracefully without breaking single-tab usage.
+  const channel: BroadcastChannel | null =
+    typeof BroadcastChannel !== 'undefined' ? new BroadcastChannel(`${BROADCAST_CHANNEL_PREFIX}${dbName}`) : null
+
+  function fireSubscribers(event: InvalidationEvent): void {
     for (const handler of subscribers) {
       try {
         handler(event)
       } catch {
-        // Subscriber faults must not interfere with the
-        // invalidation that triggered them. Silently swallow.
+        // Subscriber faults must not interfere with the invalidation
+        // that triggered them. Silently swallow.
+      }
+    }
+  }
+
+  if (channel) {
+    channel.onmessage = (msgEvent: MessageEvent) => {
+      const event = msgEvent.data as InvalidationEvent | undefined
+      // Defensive: ignore messages we can't parse. BroadcastChannel
+      // only delivers structured-clone-able payloads, so malformed
+      // events shouldn't happen — but a future contract change in a
+      // peer tab shouldn't crash this tab.
+      if (!event || typeof event !== 'object' || typeof event.prefix !== 'string') return
+      // Loop guard. The originating tab's local emit() already fired
+      // its own subscribers; receiving the rebroadcast and firing
+      // again would double-fire on the originator.
+      if (event.source?.instance === instance) return
+      fireSubscribers(event)
+    }
+  }
+
+  /**
+   * Build the invalidation event, fire local subscribers, then
+   * broadcast to peer tabs. Local-fire-first ordering matches the
+   * server-side `MemoryCache` contract: subscribers see the event in
+   * the same order regardless of cross-tab semantics.
+   */
+  function emit(prefix: string): void {
+    const event: InvalidationEvent = {
+      prefix,
+      source: { instance, timestamp: new Date().toISOString() },
+    }
+    fireSubscribers(event)
+    if (channel) {
+      try {
+        channel.postMessage(event)
+      } catch {
+        // postMessage can throw on closed channels (test teardown
+        // race) or when the payload isn't structured-cloneable. The
+        // payload is plain JSON — clone failures shouldn't happen —
+        // but we still don't want to corrupt the local invalidation.
       }
     }
   }
@@ -271,12 +329,15 @@ export async function createIndexedDBCache(opts: IndexedDBCacheOptions = {}): Pr
     },
 
     /**
-     * Close the underlying IndexedDB connection. Tests use this to
-     * release the database between runs so version-bumps in upgrade
-     * don't get blocked. Production code doesn't call this — the
-     * connection lives for the tab session.
+     * Close the underlying IndexedDB connection AND the
+     * BroadcastChannel. Tests use this to release the database
+     * between runs so version-bumps in upgrade don't get blocked,
+     * and to avoid leaking channel listeners across tests. Production
+     * code doesn't call this — the connection + channel live for the
+     * tab session.
      */
     close(): void {
+      channel?.close()
       db.close()
     },
   }

--- a/apps/admin/src/client/cache/memory-cache.ts
+++ b/apps/admin/src/client/cache/memory-cache.ts
@@ -1,0 +1,186 @@
+/**
+ * Browser-side in-memory `AdminCache` provider.
+ *
+ * Used as the IndexedDB-fallback path per `design-offline.md`'s
+ * "Provider selection logic": when IndexedDB is unavailable
+ * (private-mode browsers, embedded contexts), this provider keeps
+ * offline UX functional in-memory only. No persistence; tab close
+ * loses everything. The Vue layer surfaces a banner via the
+ * `degraded` flag from `provider-selector.ts`.
+ *
+ * Mirrors the server-side `MemoryCache` from the gazetta package
+ * but doesn't import it — the server-side version pulls in
+ * `node:crypto` and `node:os` for env-aware instance ID resolution
+ * (Cloud Run's K_REVISION, K8s hostname). Browser doesn't need
+ * those; a tab-session-scoped random hex is the right identity.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns the browser-memory provider. Selector,
+ *     IndexedDB provider, and Vue-layer banner are siblings.
+ *   - LSP: passes `adminCacheContractTests` from `gazetta/testing`.
+ *   - DIP: callers depend on `AdminCache`, not on this constructor.
+ *
+ * # Differences from server-side `MemoryCache`
+ *
+ * Same contract; same caps (10K entries / 50MB); same LRU eviction
+ * via `Map` insertion-order touch on hit. Two surface differences:
+ *
+ *  - Instance ID is `crypto.getRandomValues`-derived (browser-native);
+ *    no env-var fallback chain.
+ *  - No `applyKeyPolicy`: the server-side provider applies a version
+ *    prefix and overflow-hash before storing. Browser-side stores
+ *    keys as received. Same justification as `IndexedDBCache` —
+ *    consumers see the same public API; provider internals diverge.
+ */
+import type { AdminCache, CacheStats, InvalidationEvent } from 'gazetta'
+
+const DEFAULT_MAX_ENTRIES = 10_000
+const DEFAULT_MAX_BYTES = 50 * 1024 * 1024 // 50 MB
+
+interface CacheEntry {
+  value: unknown
+  /** Approximate byte size — `JSON.stringify(value).length`. */
+  bytes: number
+}
+
+export interface BrowserMemoryCacheOptions {
+  /** Max entry count before LRU eviction kicks in. Default 10,000. */
+  maxEntries?: number
+  /** Approximate max bytes before LRU eviction kicks in. Default 50 MB. */
+  maxBytes?: number
+  /**
+   * Stable identifier emitted on `InvalidationEvent.source.instance`
+   * and `CacheStats.instance`. Defaults to a random 8-char hex
+   * generated at construction — scoped to the tab session.
+   */
+  instance?: string
+}
+
+export function createBrowserMemoryCache(opts: BrowserMemoryCacheOptions = {}): AdminCache {
+  const maxEntries = opts.maxEntries ?? DEFAULT_MAX_ENTRIES
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES
+  const instance = opts.instance ?? randomHex(4)
+
+  // Map insertion order is the LRU order; access touches it via
+  // delete+set on hit (Map.set on existing key preserves order, so
+  // the explicit delete-then-set is required to bump recency).
+  const entries = new Map<string, CacheEntry>()
+  let totalBytes = 0
+
+  const subscribers = new Set<(event: InvalidationEvent) => void>()
+  let hits = 0
+  let misses = 0
+  let evictions = 0
+  let lastInvalidation: { prefix: string; at: string; source: string } | undefined
+
+  function evictOldestIfOverCap(): void {
+    while (entries.size > maxEntries || totalBytes > maxBytes) {
+      const oldestKey = entries.keys().next().value
+      if (oldestKey === undefined) return
+      const entry = entries.get(oldestKey)
+      entries.delete(oldestKey)
+      if (entry) totalBytes -= entry.bytes
+      evictions += 1
+    }
+  }
+
+  function emit(prefix: string): void {
+    if (subscribers.size === 0) return
+    const event: InvalidationEvent = {
+      prefix,
+      source: { instance, timestamp: new Date().toISOString() },
+    }
+    for (const handler of subscribers) {
+      try {
+        handler(event)
+      } catch {
+        // Subscriber faults must not interfere with the
+        // invalidation that triggered them. Silently swallow.
+      }
+    }
+  }
+
+  return {
+    async get<T>(key: string): Promise<T | null> {
+      const entry = entries.get(key)
+      if (!entry) {
+        misses += 1
+        return null
+      }
+      // LRU touch — delete + re-insert moves to end (most recent).
+      entries.delete(key)
+      entries.set(key, entry)
+      hits += 1
+      return entry.value as T
+    },
+
+    async set<T>(key: string, value: T, _opts?: { ttl?: number }): Promise<void> {
+      // TTL is part of the AdminCache contract but this provider
+      // ignores it — eviction is LRU-only.
+      const bytes = JSON.stringify(value).length
+      const existing = entries.get(key)
+      if (existing) {
+        totalBytes -= existing.bytes
+        entries.delete(key)
+      }
+      entries.set(key, { value, bytes })
+      totalBytes += bytes
+      evictOldestIfOverCap()
+    },
+
+    async invalidate(key: string): Promise<void> {
+      const entry = entries.get(key)
+      if (!entry) return
+      entries.delete(key)
+      totalBytes -= entry.bytes
+      emit(key)
+    },
+
+    async invalidatePrefix(prefix: string): Promise<number> {
+      let cleared = 0
+      for (const [key, entry] of entries) {
+        if (key.startsWith(prefix)) {
+          entries.delete(key)
+          totalBytes -= entry.bytes
+          cleared += 1
+        }
+      }
+      lastInvalidation = {
+        prefix,
+        at: new Date().toISOString(),
+        source: 'local',
+      }
+      // Emit even when cleared === 0 — same rule as server-side
+      // MemoryCache: cross-tab BroadcastChannel subscribers (Cut 4)
+      // want every invalidation intent.
+      emit(prefix)
+      return cleared
+    },
+
+    subscribe(handler: (event: InvalidationEvent) => void): () => void {
+      subscribers.add(handler)
+      return () => {
+        subscribers.delete(handler)
+      }
+    },
+
+    async stats(): Promise<CacheStats> {
+      return {
+        hits,
+        misses,
+        size: entries.size,
+        instance,
+        evictions,
+        bytesApproximate: totalBytes,
+        lastInvalidation,
+      }
+    },
+  }
+}
+
+function randomHex(bytes: number): string {
+  const arr = new Uint8Array(bytes)
+  crypto.getRandomValues(arr)
+  return Array.from(arr, b => b.toString(16).padStart(2, '0')).join('')
+}

--- a/apps/admin/src/client/cache/provider-selector.ts
+++ b/apps/admin/src/client/cache/provider-selector.ts
@@ -1,0 +1,132 @@
+/**
+ * Boot-time browser cache provider selection per `design-offline.md`
+ * "Provider selection logic":
+ *
+ *   if (await indexedDBProbe()) return IndexedDBCache
+ *   else                       return MemoryCache + warning
+ *
+ * Some browsers (notably Safari private mode) report IndexedDB
+ * available but throw on actual use. The probe opens a real database
+ * + does a smoke transaction; only providers that pass the probe are
+ * trusted to persist.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns "pick the right browser cache provider."
+ *     Provider implementations are siblings; UX banner is rendered
+ *     by Vue components reading the `degraded` flag on the result.
+ *   - DIP: callers depend on `AdminCache` and the result envelope;
+ *     they don't know which provider they got.
+ *   - OCP: future providers (LocalStorageCache, OPFSCache) slot in
+ *     by extending the probe-and-pick chain; existing branches
+ *     unchanged.
+ */
+import type { AdminCache } from 'gazetta'
+import { createIndexedDBCache } from './indexeddb-cache.js'
+import { createBrowserMemoryCache } from './memory-cache.js'
+
+export interface SelectedProvider {
+  /** The chosen `AdminCache` instance — ready to use. */
+  cache: AdminCache
+  /**
+   * Identifier of the chosen provider for diagnostics + UX. Operators
+   * see this on the cache stats endpoint; the offline UX banner
+   * branches on `degraded` to decide whether to warn the user.
+   */
+  kind: 'indexed-db' | 'memory'
+  /**
+   * True when persistence is unavailable (IndexedDB probe failed).
+   * Vue layer renders a one-time banner: "Offline persistence
+   * unavailable — your edits will be lost on reload." Per
+   * `design-offline.md` Q1 lock.
+   */
+  degraded: boolean
+  /**
+   * When `degraded`, the reason the probe failed. Logged for
+   * operator diagnosis; not surfaced to authors.
+   */
+  reason?: string
+}
+
+const PROBE_DB_NAME = '__gazetta_probe__'
+
+/**
+ * Probe IndexedDB by opening a tiny database and performing a
+ * read-write smoke transaction. This catches:
+ *   - IndexedDB undefined entirely (very old browsers)
+ *   - `indexedDB.open()` throws (some embedded contexts)
+ *   - `open()` succeeds but transactions throw (Safari private mode
+ *     in older Safari builds)
+ *
+ * The probe DB is closed and deleted after the smoke test so it
+ * doesn't leak into the user's storage budget. Failures during
+ * cleanup are swallowed — the probe's verdict is what matters.
+ */
+async function indexedDBProbe(): Promise<{ ok: true } | { ok: false; reason: string }> {
+  if (typeof indexedDB === 'undefined') {
+    return { ok: false, reason: 'IndexedDB API is not defined in this browser' }
+  }
+  try {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open(PROBE_DB_NAME, 1)
+      req.onupgradeneeded = () => req.result.createObjectStore('probe')
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error ?? new Error('open() failed'))
+      req.onblocked = () => reject(new Error('open() blocked'))
+    })
+
+    // Smoke transaction — write + read + delete. Some private-mode
+    // browsers fail here even when open() succeeded.
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction('probe', 'readwrite')
+        tx.oncomplete = () => resolve()
+        tx.onerror = () => reject(tx.error ?? new Error('transaction failed'))
+        tx.onabort = () => reject(tx.error ?? new Error('transaction aborted'))
+        const store = tx.objectStore('probe')
+        store.put('ok', 'probe-key')
+      })
+    } finally {
+      db.close()
+    }
+
+    // Best-effort cleanup. If this fails, the probe DB stays around
+    // — small, but un-tidy. Not worth surfacing to callers.
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const req = indexedDB.deleteDatabase(PROBE_DB_NAME)
+        req.onsuccess = () => resolve()
+        req.onerror = () => reject(req.error ?? new Error('deleteDatabase failed'))
+      })
+    } catch {
+      // ignore
+    }
+
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, reason: (err as Error).message }
+  }
+}
+
+/**
+ * Pick the browser cache provider for this admin session. Call once
+ * at admin boot; cache the result for the session. Returns the
+ * chosen provider plus a `degraded` flag the UX layer reads to
+ * surface the persistence-unavailable banner.
+ */
+export async function selectBrowserCacheProvider(): Promise<SelectedProvider> {
+  const probe = await indexedDBProbe()
+  if (probe.ok) {
+    return {
+      cache: await createIndexedDBCache(),
+      kind: 'indexed-db',
+      degraded: false,
+    }
+  }
+  return {
+    cache: createBrowserMemoryCache(),
+    kind: 'memory',
+    degraded: true,
+    reason: probe.reason,
+  }
+}

--- a/apps/admin/src/client/components/ConflictBanner.vue
+++ b/apps/admin/src/client/components/ConflictBanner.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+/**
+ * Save-conflict banner per `design-offline.md` Q3 + Q4. Surfaces when
+ * the active item has a conflict (the server's etag changed between
+ * the author's read and write — typically because someone else saved,
+ * or the file was edited out-of-band).
+ *
+ * Two actions per the locked Krug-aligned UX:
+ *
+ *   - "Show what changed" → opens the diff view (ConflictDiffView)
+ *   - "Discard my changes" → drops local pending edits + clears the
+ *                            conflict; banner closes; editor reloads
+ *                            the server's current version
+ *
+ * **No "Save anyway / Overwrite" action** per design-offline.md Q3:
+ * authors who genuinely want to overwrite specific changes manually
+ * port their edits onto the new version. Overwrite-without-review
+ * is a footgun.
+ *
+ * Plain language: "Was edited by someone else" — not "STALE" or
+ * "etag mismatch." Author-facing copy stays Krug-clean.
+ */
+import { computed, ref } from 'vue'
+import Button from 'primevue/button'
+import { useSaveConflictsStore } from '../stores/saveConflicts.js'
+import ConflictDiffView from './ConflictDiffView.vue'
+
+const props = defineProps<{
+  /**
+   * Manifest path the editor is currently viewing. Banner shows only
+   * when this path has a conflict registered.
+   */
+  itemPath: string
+}>()
+
+const emit = defineEmits<{
+  /** Author chose "Discard my changes." Editor should reload from
+   *  the server's current. The parent owns the reload mechanics. */
+  discard: []
+}>()
+
+const conflicts = useSaveConflictsStore()
+const conflict = computed(() => conflicts.get(props.itemPath))
+
+const showingDiff = ref(false)
+
+function showDiff(): void {
+  showingDiff.value = true
+}
+
+function hideDiff(): void {
+  showingDiff.value = false
+}
+
+function discard(): void {
+  conflicts.clear(props.itemPath)
+  emit('discard')
+}
+</script>
+
+<template>
+  <div
+    v-if="conflict"
+    class="conflict-banner"
+    role="alert"
+    data-testid="conflict-banner">
+    <div class="banner-header">
+      <i class="pi pi-exclamation-triangle banner-icon" aria-hidden="true" />
+      <span class="banner-title">Was edited by someone else</span>
+    </div>
+    <p class="banner-body">
+      A newer version of this content is on the server. Your changes
+      weren't saved.
+    </p>
+    <div class="banner-actions">
+      <Button
+        size="small"
+        severity="secondary"
+        label="Show what changed"
+        data-testid="conflict-banner-show-diff"
+        @click="showDiff" />
+      <Button
+        size="small"
+        severity="danger"
+        outlined
+        label="Discard my changes"
+        data-testid="conflict-banner-discard"
+        @click="discard" />
+    </div>
+
+    <ConflictDiffView
+      v-if="showingDiff"
+      :current="conflict.current"
+      :pending="conflict.pending"
+      data-testid="conflict-diff-view"
+      @close="hideDiff" />
+  </div>
+</template>
+
+<style scoped>
+.conflict-banner {
+  background: var(--color-warning-bg);
+  color: var(--color-warning-fg);
+  border: 1px solid var(--color-warning-fg);
+  border-radius: var(--p-border-radius-md);
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+.banner-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+.banner-icon {
+  font-size: 1.1rem;
+}
+.banner-body {
+  margin: 0.5rem 0 0.75rem;
+  font-size: 0.875rem;
+}
+.banner-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+</style>

--- a/apps/admin/src/client/components/ConflictDiffView.vue
+++ b/apps/admin/src/client/components/ConflictDiffView.vue
@@ -1,0 +1,205 @@
+<script setup lang="ts">
+/**
+ * Field-by-field semantic diff for the conflict banner per
+ * `design-offline.md` Q3.
+ *
+ * v1 scope: walk the union of top-level keys; for each, show:
+ *
+ *   - **Primitive** (string/number/bool/null): "Title: 'Mine' vs.
+ *     'Theirs'" — explicit comparison
+ *   - **Object/array** (changed): "(changes inside)" — author opens
+ *     the editor to see details
+ *   - **Only in one side**: "(only in mine)" / "(only in theirs)"
+ *
+ * Recursive deep diff is v1.5 — explicitly deferred per design-offline.md
+ * because for v1 the goal is "author understands at a glance whether
+ * to discard or rebase," not "author resolves field-by-field in
+ * the diff view." Most pages have <5 changed top-level fields; the
+ * shallow view scales fine.
+ *
+ * Modal-y inline panel inside the banner — not a full PrimeVue Dialog
+ * because the banner is already a strong surface and embedding the
+ * diff inside it keeps focus close to the actions.
+ */
+import { computed } from 'vue'
+import Button from 'primevue/button'
+
+const props = defineProps<{
+  current: Record<string, unknown>
+  pending: Record<string, unknown>
+}>()
+
+defineEmits<{
+  close: []
+}>()
+
+interface DiffRow {
+  key: string
+  /**
+   * Label is the field name with humanization for known keys
+   * (`metadata` → "Metadata"; `route` → "Route"). Unknown keys
+   * pass through unchanged.
+   */
+  label: string
+  pending: string
+  current: string
+  /** Same on both sides — informational; not actionable. Hidden
+   *  from the diff view to keep the surface to "what changed." */
+  unchanged: boolean
+}
+
+const KNOWN_FIELDS: Record<string, string> = {
+  template: 'Template',
+  route: 'Route',
+  metadata: 'Metadata',
+  content: 'Content',
+  components: 'Components',
+}
+
+function describeValue(v: unknown): string {
+  if (v === null) return 'null'
+  if (v === undefined) return '(unset)'
+  if (typeof v === 'string') return v.length > 60 ? `${v.slice(0, 57)}…` : v
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+  if (Array.isArray(v)) return `${v.length} item${v.length === 1 ? '' : 's'}`
+  if (typeof v === 'object') {
+    const keys = Object.keys(v as Record<string, unknown>)
+    return keys.length === 0 ? '(empty)' : `${keys.length} field${keys.length === 1 ? '' : 's'}`
+  }
+  return String(v)
+}
+
+function isPrimitive(v: unknown): boolean {
+  return v === null || v === undefined || typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean'
+}
+
+function rowFor(key: string): DiffRow {
+  const inPending = key in props.pending
+  const inCurrent = key in props.current
+  const p = props.pending[key]
+  const c = props.current[key]
+  const label = KNOWN_FIELDS[key] ?? key
+
+  if (!inPending && inCurrent) {
+    return { key, label, pending: '(only in theirs)', current: describeValue(c), unchanged: false }
+  }
+  if (inPending && !inCurrent) {
+    return { key, label, pending: describeValue(p), current: '(only in mine)', unchanged: false }
+  }
+  if (isPrimitive(p) && isPrimitive(c)) {
+    return {
+      key,
+      label,
+      pending: describeValue(p),
+      current: describeValue(c),
+      unchanged: p === c,
+    }
+  }
+  // Both sides are objects/arrays — shallow comparison; if the JSON
+  // canonicalizes the same, treat as unchanged.
+  const pJson = JSON.stringify(p)
+  const cJson = JSON.stringify(c)
+  if (pJson === cJson) {
+    return { key, label, pending: describeValue(p), current: describeValue(c), unchanged: true }
+  }
+  return {
+    key,
+    label,
+    pending: `${describeValue(p)} (changes inside)`,
+    current: `${describeValue(c)} (changes inside)`,
+    unchanged: false,
+  }
+}
+
+const rows = computed<DiffRow[]>(() => {
+  const keys = new Set([...Object.keys(props.pending), ...Object.keys(props.current)])
+  return [...keys].map(rowFor).filter(r => !r.unchanged)
+})
+</script>
+
+<template>
+  <div class="diff-view" data-testid="conflict-diff-view">
+    <div class="diff-header">
+      <strong>What changed</strong>
+      <Button
+        icon="pi pi-times"
+        text
+        rounded
+        size="small"
+        severity="secondary"
+        aria-label="Close diff view"
+        data-testid="conflict-diff-close"
+        @click="$emit('close')" />
+    </div>
+    <p v-if="rows.length === 0" class="diff-empty" data-testid="conflict-diff-empty">
+      No top-level differences detected.
+    </p>
+    <table v-else class="diff-table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Yours</th>
+          <th>Theirs</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="row in rows" :key="row.key" :data-testid="`conflict-diff-row-${row.key}`">
+          <td class="diff-label">{{ row.label }}</td>
+          <td class="diff-cell diff-pending" :data-testid="`conflict-diff-pending-${row.key}`">
+            {{ row.pending }}
+          </td>
+          <td class="diff-cell diff-current" :data-testid="`conflict-diff-current-${row.key}`">
+            {{ row.current }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<style scoped>
+.diff-view {
+  margin-top: 0.75rem;
+  background: var(--color-bg);
+  color: var(--color-fg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--p-border-radius-sm);
+  padding: 0.75rem;
+}
+.diff-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+.diff-empty {
+  margin: 0.25rem 0 0;
+  font-size: 0.875rem;
+  color: var(--color-muted);
+}
+.diff-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+.diff-table th {
+  text-align: start;
+  font-weight: 600;
+  padding: 0.25rem 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+.diff-table td {
+  padding: 0.25rem 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+  vertical-align: top;
+}
+.diff-label {
+  font-weight: 500;
+  white-space: nowrap;
+}
+.diff-cell {
+  font-family: ui-monospace, monospace;
+  font-size: 0.8125rem;
+  word-break: break-word;
+}
+</style>

--- a/apps/admin/src/client/components/EditorPanel.vue
+++ b/apps/admin/src/client/components/EditorPanel.vue
@@ -13,11 +13,17 @@ import type { EditorMount } from 'gazetta/types'
 import FragmentBlastRadius from './FragmentBlastRadius.vue'
 import PageMetadataEditor from './PageMetadataEditor.vue'
 import ValidationBanner from './ValidationBanner.vue'
+import ConflictBanner from './ConflictBanner.vue'
+import { useLocaleStore } from '../stores/locale.js'
+import { useSaveConflictsStore } from '../stores/saveConflicts.js'
+import { manifestPath } from '../stores/editorEtags.js'
 
 const editing = useEditingStore()
 const selection = useSelectionStore()
 const theme = useThemeStore()
 const unsavedGuard = useUnsavedGuardStore()
+const conflicts = useSaveConflictsStore()
+const localeStore = useLocaleStore()
 const route = useRoute()
 const router = useRouter()
 const containerRef = ref<HTMLElement | null>(null)
@@ -85,11 +91,51 @@ onKeyStroke('s', e => {
     if (editing.dirty) editing.save()
   }
 })
+
+// Active manifest path — used by the ConflictBanner. The banner only
+// renders when a conflict exists for THIS path, so a conflict on
+// `pages/home/page.json` doesn't show while the author is editing
+// `pages/about/page.json`. Conflicts persist across navigation per
+// design-offline.md Q4.
+const activeManifestPath = computed<string | null>(() => {
+  if (!selection.selection) return null
+  const kind = selection.type === 'page' ? 'page' : 'fragment'
+  const locale = localeStore.effectiveLocale ?? undefined
+  return manifestPath(kind, selection.selection.name, locale)
+})
+
+const showConflictBanner = computed(() => activeManifestPath.value !== null)
+
+/**
+ * Author chose "Discard my changes" — replace the editor's local
+ * edit with the server's current manifest content + clear the
+ * conflict. The conflict carries the full manifest the server has;
+ * we apply the relevant slice (root content / current path's
+ * component content) to editorContent.
+ *
+ * For the v1 minimum: reload the selection from the server. This
+ * pulls fresh content + a fresh etag in one round-trip and clears
+ * any stale state. Heavier than strictly necessary (the conflict
+ * already has the data) but it guarantees correctness for every
+ * edit context (root, component, fragment) without per-context
+ * orchestration.
+ */
+async function handleConflictDiscard() {
+  if (!activeManifestPath.value) return
+  conflicts.clear(activeManifestPath.value)
+  // Drop local pending; reload from server.
+  editing.discard()
+  await selection.reload()
+}
 </script>
 
 <template>
   <div class="editor-panel" data-testid="editor-panel">
     <ValidationBanner />
+    <ConflictBanner
+      v-if="showConflictBanner && activeManifestPath"
+      :itemPath="activeManifestPath"
+      @discard="handleConflictDiscard" />
     <div v-if="editing.loadError" class="editor-error" data-testid="editor-error">
       <i class="pi pi-exclamation-triangle" />
       <p>{{ editing.loadError }}</p>

--- a/apps/admin/src/client/components/EditorPanel.vue
+++ b/apps/admin/src/client/components/EditorPanel.vue
@@ -15,15 +15,15 @@ import PageMetadataEditor from './PageMetadataEditor.vue'
 import ValidationBanner from './ValidationBanner.vue'
 import ConflictBanner from './ConflictBanner.vue'
 import { useLocaleStore } from '../stores/locale.js'
-import { useSaveConflictsStore } from '../stores/saveConflicts.js'
 import { manifestPath } from '../stores/editorEtags.js'
+import { useConflictDiscard } from '../composables/useConflictDiscard.js'
 
 const editing = useEditingStore()
 const selection = useSelectionStore()
 const theme = useThemeStore()
 const unsavedGuard = useUnsavedGuardStore()
-const conflicts = useSaveConflictsStore()
 const localeStore = useLocaleStore()
+const conflictDiscard = useConflictDiscard()
 const route = useRoute()
 const router = useRouter()
 const containerRef = ref<HTMLElement | null>(null)
@@ -107,25 +107,15 @@ const activeManifestPath = computed<string | null>(() => {
 const showConflictBanner = computed(() => activeManifestPath.value !== null)
 
 /**
- * Author chose "Discard my changes" — replace the editor's local
- * edit with the server's current manifest content + clear the
- * conflict. The conflict carries the full manifest the server has;
- * we apply the relevant slice (root content / current path's
- * component content) to editorContent.
- *
- * For the v1 minimum: reload the selection from the server. This
- * pulls fresh content + a fresh etag in one round-trip and clears
- * any stale state. Heavier than strictly necessary (the conflict
- * already has the data) but it guarantees correctness for every
- * edit context (root, component, fragment) without per-context
- * orchestration.
+ * Author chose "Discard my changes" — delegate to the dedicated
+ * conflict-discard composable. The orchestration (clear conflict
+ * → drop local pending → reload selection) lives there so the
+ * flow is independently testable without mounting the editor's
+ * real-DOM machinery.
  */
 async function handleConflictDiscard() {
   if (!activeManifestPath.value) return
-  conflicts.clear(activeManifestPath.value)
-  // Drop local pending; reload from server.
-  editing.discard()
-  await selection.reload()
+  await conflictDiscard.run(activeManifestPath.value)
 }
 </script>
 

--- a/apps/admin/src/client/components/OfflineBanner.vue
+++ b/apps/admin/src/client/components/OfflineBanner.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+/**
+ * Global offline / connection-state banner per `design-offline.md`
+ * Q4 (Krug-aligned sync-state visibility).
+ *
+ * Renders a thin top-of-app strip when the connection state isn't
+ * `online`. Per the locked Krug UX:
+ *
+ *   - `online`        → no banner (absence is the state)
+ *   - `degraded`      → subtle "Connection unstable" indicator
+ *   - `offline`       → persistent "Offline" banner with "Send now"
+ *   - `reconnecting`  → subtle spinner + "Connection back"
+ *
+ * # Plain language locked
+ *
+ * "Offline" — not "Disconnected" or "STALE." "Send now" — not
+ * "Force sync" or "Retry queue." Author-facing copy stays clean of
+ * the wire layer's vocabulary.
+ *
+ * # Per-item indicators are out of scope here
+ *
+ * The cloud-with-slash icon on individual saved-locally items
+ * requires a per-item save-queue store that doesn't exist yet
+ * (Cut 13's mid-save retry will introduce it). Surfacing the icon
+ * now would be theater — the indicator would never appear because
+ * nothing produces queued state. Cut 13 lights up the per-item
+ * indicators automatically when its queue ships.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this component renders connection-state visibility.
+ *     Connection-state itself lives in `useConnectionState`; the
+ *     transient "Connection back" toast is fired via the existing
+ *     toast store, not state owned here.
+ *   - DIP: depends on `useConnectionState`'s typed API; doesn't
+ *     know how the heartbeat or navigator events drive transitions.
+ *
+ * # Why a single component (not three)
+ *
+ * The four visible states (online, degraded, offline, reconnecting)
+ * share one mounting surface and one DOM region. Rendering each
+ * via a separate component would fragment the styling concern and
+ * push the orchestration into the parent. The `v-if` chain over
+ * connectionState.status keeps the surface narrow.
+ */
+import { onMounted, watch } from 'vue'
+import Button from 'primevue/button'
+import { useConnectionState } from '../stores/connectionState.js'
+import { useToastStore } from '../stores/toast.js'
+
+const connection = useConnectionState()
+const toast = useToastStore()
+
+async function sendNow(): Promise<void> {
+  // "Send now" affordance per design-offline.md "Force-sync
+  // affordance (visible only when relevant)" — fires an immediate
+  // probe + replay attempt regardless of the scheduled cadence.
+  // Useful when the operator knows the network is back; the
+  // connection-state heartbeat may still be backing off.
+  await connection.probeNow()
+}
+
+// Transient "Connection back" toast on `offline → reconnecting | online`
+// transition. Per design-offline.md Q2: "transition to `online`"
+// happens immediately after `reconnecting` in v1 (no save queue
+// yet). The transition is fast enough that watching for
+// `reconnecting` alone misses it; we watch the leading edge of any
+// state-change-from-offline.
+let wasOffline = false
+onMounted(() => {
+  wasOffline = connection.status === 'offline'
+})
+watch(
+  () => connection.status,
+  next => {
+    if (wasOffline && (next === 'online' || next === 'reconnecting')) {
+      // Transient — auto-dismiss. Plain language ("Connection back"),
+      // no jargon ("Reconnected" technically correct but Krug-ier).
+      toast.show('Connection back', { type: 'info', duration: 3000 })
+    }
+    wasOffline = next === 'offline'
+  },
+)
+</script>
+
+<template>
+  <div
+    v-if="connection.status === 'offline'"
+    class="offline-banner offline-banner-offline"
+    role="alert"
+    data-testid="offline-banner"
+    data-state="offline">
+    <i class="pi pi-cloud-slash banner-icon" aria-hidden="true" />
+    <span class="banner-text">Offline</span>
+    <Button
+      size="small"
+      severity="secondary"
+      outlined
+      label="Send now"
+      class="banner-action"
+      data-testid="offline-banner-send-now"
+      @click="sendNow" />
+  </div>
+
+  <div
+    v-else-if="connection.status === 'degraded'"
+    class="offline-banner offline-banner-degraded"
+    role="status"
+    data-testid="offline-banner"
+    data-state="degraded">
+    <i class="pi pi-spin pi-spinner banner-icon" aria-hidden="true" />
+    <span class="banner-text">Connection unstable</span>
+  </div>
+
+  <div
+    v-else-if="connection.status === 'reconnecting'"
+    class="offline-banner offline-banner-reconnecting"
+    role="status"
+    data-testid="offline-banner"
+    data-state="reconnecting">
+    <i class="pi pi-spin pi-spinner banner-icon" aria-hidden="true" />
+    <span class="banner-text">Reconnecting</span>
+  </div>
+</template>
+
+<style scoped>
+.offline-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  border-bottom: 1px solid transparent;
+}
+.offline-banner-offline {
+  background: var(--color-warning-bg);
+  color: var(--color-warning-fg);
+  border-bottom-color: var(--color-warning-fg);
+  font-weight: 600;
+}
+.offline-banner-degraded,
+.offline-banner-reconnecting {
+  background: var(--color-info-bg);
+  color: var(--color-info-fg);
+  border-bottom-color: var(--color-border);
+  font-size: 0.75rem;
+  padding-block: 0.25rem;
+}
+.banner-icon {
+  font-size: 0.875rem;
+}
+.banner-text {
+  flex: 1;
+}
+.banner-action {
+  margin-inline-start: auto;
+}
+</style>

--- a/apps/admin/src/client/components/StorageQuotaBanner.vue
+++ b/apps/admin/src/client/components/StorageQuotaBanner.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+/**
+ * Storage-quota warning banner per `design-offline.md` Q4
+ * "Storage approaching limit." Shows a subtle banner when local
+ * storage usage exceeds 80% of the browser's per-origin cap.
+ *
+ * Plain language locked: "Storage almost full" — not "Quota
+ * exceeded" or "IndexedDB at 80%." Author-facing copy stays Krug-
+ * clean.
+ *
+ * # Dismiss-once UX
+ *
+ * Click the close button → banner hides at the current usage
+ * threshold; reappears only when usage climbs back through that
+ * level. Per-tab-session dismissal — closing + reopening the tab
+ * resurrects the warning if quota is still high.
+ *
+ * # Mounted in App.vue alongside OfflineBanner
+ *
+ * Two thin top-of-app strips can coexist (offline + storage
+ * warning are independent concerns). Order: offline banner first
+ * (more urgent), storage banner second.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this component renders quota visibility. The polling
+ *     + threshold logic lives in `useStorageQuota`; the cache
+ *     LRU eviction at 100% lives in the cache layer.
+ *   - DIP: depends on `useStorageQuota`'s typed API; doesn't know
+ *     how the estimate is sampled.
+ */
+import Button from 'primevue/button'
+import { useStorageQuota } from '../composables/useStorageQuota.js'
+
+const quota = useStorageQuota()
+</script>
+
+<template>
+  <div
+    v-if="quota.showWarning.value"
+    class="storage-quota-banner"
+    role="status"
+    data-testid="storage-quota-banner">
+    <i class="pi pi-database banner-icon" aria-hidden="true" />
+    <span class="banner-text">
+      Storage almost full — please connect to send your saved items.
+    </span>
+    <Button
+      icon="pi pi-times"
+      text
+      rounded
+      size="small"
+      severity="secondary"
+      class="banner-dismiss"
+      aria-label="Dismiss storage warning"
+      data-testid="storage-quota-banner-dismiss"
+      @click="quota.dismiss()" />
+  </div>
+</template>
+
+<style scoped>
+.storage-quota-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  background: var(--color-warning-bg);
+  color: var(--color-warning-fg);
+  border-bottom: 1px solid var(--color-warning-fg);
+}
+.banner-icon {
+  font-size: 0.875rem;
+}
+.banner-text {
+  flex: 1;
+}
+.banner-dismiss {
+  margin-inline-start: auto;
+}
+</style>

--- a/apps/admin/src/client/composables/useConflictDiscard.ts
+++ b/apps/admin/src/client/composables/useConflictDiscard.ts
@@ -1,0 +1,77 @@
+/**
+ * Conflict-discard orchestrator per `design-offline.md` Q3.
+ *
+ * When the author clicks "Discard my changes" on the conflict
+ * banner (Cut 10), three things must happen in order:
+ *
+ *   1. Clear the conflict store entry for the active item — the
+ *      banner closes
+ *   2. Drop the editor's local pending edits — `editing.discard()`
+ *   3. Reload the selection from the server — pulls fresh manifest
+ *      + fresh save-etag in one round trip; clears any stale state
+ *
+ * # Why a composable, not inline in EditorPanel.vue
+ *
+ * The orchestration lives at the composable layer (per
+ * `useEditorActions` precedent); EditorPanel renders the visible
+ * state. Extracting the discard flow as `useConflictDiscard` makes
+ * it independently testable without mounting the editor's
+ * real-DOM machinery (editor-mount.ts, jiti-loaded custom editors,
+ * @rjsf React tree).
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this composable owns "translate a conflict-banner
+ *     discard action into the right side effects." It does NOT
+ *     own the conflict state, the editor state, or the selection
+ *     state — just the orchestration.
+ *   - DIP: callers pass an `itemPath` (already computed by the
+ *     consuming component); the composable depends on the typed
+ *     store APIs.
+ *
+ * # Why reload, not "apply current.content directly"
+ *
+ * The conflict record carries the server's `current` manifest, so
+ * we COULD apply it directly. But:
+ *
+ *   - The current shape may differ from what the editor needs
+ *     (route is derived; component children may have changed)
+ *   - We need a fresh save-etag for the next save attempt; reload
+ *     fetches both manifest + etag in one go
+ *
+ * Reload via `selection.reload()` covers every edit context (root,
+ * component, fragment) uniformly. Cheaper-than-strictly-necessary
+ * but uniformly correct.
+ */
+import { useEditingStore } from '../stores/editing.js'
+import { useSaveConflictsStore } from '../stores/saveConflicts.js'
+import { useSelectionStore } from '../stores/selection.js'
+
+export interface ConflictDiscardHandle {
+  /**
+   * Run the discard flow for `itemPath`. Idempotent: calling on a
+   * path that has no conflict still drops local edits + reloads
+   * (the banner shouldn't be visible in that case, but the action
+   * is safe regardless).
+   */
+  run(itemPath: string): Promise<void>
+}
+
+/**
+ * Composable that returns a `run` function. Production code wires
+ * this to the ConflictBanner's `@discard` event in EditorPanel.vue;
+ * tests construct it with a fresh Pinia and assert the side effects.
+ */
+export function useConflictDiscard(): ConflictDiscardHandle {
+  const conflicts = useSaveConflictsStore()
+  const editing = useEditingStore()
+  const selection = useSelectionStore()
+
+  return {
+    async run(itemPath: string): Promise<void> {
+      conflicts.clear(itemPath)
+      editing.discard()
+      await selection.reload()
+    },
+  }
+}

--- a/apps/admin/src/client/composables/useEditorActions.ts
+++ b/apps/admin/src/client/composables/useEditorActions.ts
@@ -21,6 +21,7 @@ import { api, StaleSaveError, ValidationFailedError } from '../api/client.js'
 import { useLocaleStore } from '../stores/locale.js'
 import { useEditorEtagsStore, manifestPath } from '../stores/editorEtags.js'
 import { useSaveConflictsStore } from '../stores/saveConflicts.js'
+import { persistedEditKey, persistedEditKeyForSelection, usePersistedEditsStore } from '../stores/persistedEdits.js'
 
 const MAX_RETRY_ATTEMPTS = 3
 const BASE_RETRY_DELAY = 3000
@@ -56,11 +57,41 @@ export function useEditorActions() {
     retryAttempt = 0
   }
 
+  // --- Cross-page persisted-edits key helper (Cut 8b) ---
+
+  /**
+   * Build the persisted-edits key for a (selection, target) pair.
+   * Returns null when the active context isn't a persistable target
+   * (no selection, no target, fragment-link host).
+   */
+  function persistedKeyForCurrent(): string | null {
+    const sel = useSelectionStore()
+    if (!sel.selection || !ec.target) return null
+    const kind = sel.selection.type === 'page' ? 'page' : 'fragment'
+    const locale = useLocaleStore().effectiveLocale ?? undefined
+    return persistedEditKey(kind, sel.selection.name, locale, ec.target.path)
+  }
+
+  /** Same shape, but for a stash entry's target.path. */
+  function persistedKeyForStashEntry(targetPath: string): string | null {
+    const sel = useSelectionStore()
+    if (!sel.selection) return null
+    const kind = sel.selection.type === 'page' ? 'page' : 'fragment'
+    const locale = useLocaleStore().effectiveLocale ?? undefined
+    return persistedEditKey(kind, sel.selection.name, locale, targetPath)
+  }
+
   // --- Stash ---
 
   function stashCurrent() {
     if (ec.dirty && ec.target && ec.content) {
       stash.stash(ec.target.path, ec.target, deepClone(ec.content))
+      // Mirror into the cross-page persisted store (Cut 8b) so the
+      // edit survives reload. The in-memory stash is keyed by
+      // target.path which collides across pages; persistedEdits uses
+      // the richer (kind, name, locale, path) tuple.
+      const key = persistedKeyForCurrent()
+      if (key) usePersistedEditsStore().set(key, deepClone(ec.content))
     }
   }
 
@@ -417,7 +448,10 @@ export function useEditorActions() {
       return
     }
 
-    // Check stash before fetching
+    // Check in-memory stash before fetching. The in-memory stash is
+    // intra-selection (keyed by target.path which collides across
+    // pages); it picks up where the author left off within the
+    // current page/fragment.
     const stashKey = selectionToStashKey(sel)
     if (stashKey) {
       const stashed = stash.restore(stashKey)
@@ -437,7 +471,28 @@ export function useEditorActions() {
       const target = await buildTarget(sel, signal)
       persistence.saving = false
       persistence.lastSaveError = null
-      await ec.open(target)
+      // Cut 8b: fall through to the cross-page persisted-edits store
+      // for dirty content that survived a reload. Keys are richer
+      // (kind, name, locale, path) so two pages with the same
+      // component path don't collide. We check AFTER buildTarget
+      // because the persisted entry has data only — the save closure
+      // gets rebuilt by buildTarget; ec.open then overlays the
+      // persisted dirty content onto the freshly-built target.
+      const sl = useSelectionStore()
+      const kind = sl.selection?.type === 'page' ? 'page' : sl.selection?.type === 'fragment' ? 'fragment' : null
+      const name = sl.selection?.name ?? null
+      const localeForKey = useLocaleStore().effectiveLocale ?? undefined
+      const persistedKey = persistedEditKeyForSelection(sel, kind, name, localeForKey)
+      const persisted = persistedKey ? usePersistedEditsStore().get(persistedKey) : null
+      if (persisted) {
+        await ec.open(target, persisted.editedContent)
+        // Promote: the entry is now live in the editor; remove from
+        // the persisted store so a subsequent navigate-away → stash
+        // → restore flow doesn't re-apply the same content twice.
+        usePersistedEditsStore().clear(persistedKey!)
+      } else {
+        await ec.open(target)
+      }
       usePreviewStore().invalidateDraft()
       retryAttempt = 0
     } catch (err) {
@@ -480,10 +535,20 @@ export function useEditorActions() {
   function markDirty(newContent: Record<string, unknown>) {
     ec.markDirty(newContent)
     usePreviewStore().invalidateDraft()
+    // Mirror into the cross-page persisted store (Cut 8b) so the
+    // live edit survives reload. The persistence coordinator
+    // debounces writes to IndexedDB; we just keep the store
+    // up-to-date on every keystroke.
+    const key = persistedKeyForCurrent()
+    if (key) usePersistedEditsStore().set(key, deepClone(newContent))
   }
 
   function revertStashed(componentPath: string) {
     stash.revert(componentPath)
+    // Cut 8b: drop the cross-page persisted mirror for this stash
+    // entry too — author explicitly chose to discard, not keep.
+    const k = persistedKeyForStashEntry(componentPath)
+    if (k) usePersistedEditsStore().clear(k)
     usePreviewStore().invalidateDraft()
   }
 
@@ -527,6 +592,12 @@ export function useEditorActions() {
   function clearEditorForRemovedPath(path: string) {
     if (ec.path === path) ec.clear()
     if (stash.has(path)) stash.revert(path)
+    // Cut 8b: also drop the cross-page persisted mirror for this
+    // path. The component is being removed from the manifest;
+    // re-applying its persisted dirty content after a reload would
+    // resurrect content that no longer has a home.
+    const k = persistedKeyForStashEntry(path)
+    if (k) usePersistedEditsStore().clear(k)
   }
 
   /**
@@ -543,6 +614,11 @@ export function useEditorActions() {
     ec.discard()
     const key = currentManifestKey()
     if (key) structural.discard(key)
+    // Cut 8b: drop the cross-page persisted mirror for the current
+    // edit. The author explicitly reverted; re-applying the dirty
+    // content on reload would undo their intent.
+    const persistedKey = persistedKeyForCurrent()
+    if (persistedKey) usePersistedEditsStore().clear(persistedKey)
     usePreviewStore().invalidateDraft()
   }
 
@@ -604,6 +680,17 @@ export function useEditorActions() {
     const result = await persistence.save(current, stashedEntries, structuralWrites)
     if (result.success) {
       ec.markSaved()
+      // Cut 8b: clear cross-page persisted entries for everything
+      // that just saved successfully. The current edit + all stashed
+      // entries are now on the server; the persisted-edits mirror
+      // for those keys would otherwise re-apply on the next reload.
+      const persistedStore = usePersistedEditsStore()
+      const currentKey = persistedKeyForCurrent()
+      if (currentKey) persistedStore.clear(currentKey)
+      for (const key of stashedKeys) {
+        const k = persistedKeyForStashEntry(key)
+        if (k) persistedStore.clear(k)
+      }
       for (const key of stashedKeys) stash.revert(key)
       structural.clearAll()
       validationStore.clear()

--- a/apps/admin/src/client/composables/useEditorActions.ts
+++ b/apps/admin/src/client/composables/useEditorActions.ts
@@ -17,8 +17,10 @@ import { useEditorPersistenceStore, type StructuralWrite } from '../stores/edito
 import { useEditorContentStore, type EditingTarget } from '../stores/editorContent.js'
 import { useValidationIssuesStore } from '../stores/validationIssues.js'
 import { type EditorSelection, selectionToStashKey, selectionToErrorLabel } from './editorSelection.js'
-import { api, ValidationFailedError } from '../api/client.js'
+import { api, StaleSaveError, ValidationFailedError } from '../api/client.js'
 import { useLocaleStore } from '../stores/locale.js'
+import { useEditorEtagsStore, manifestPath } from '../stores/editorEtags.js'
+import { useSaveConflictsStore } from '../stores/saveConflicts.js'
 
 const MAX_RETRY_ATTEMPTS = 3
 const BASE_RETRY_DELAY = 3000
@@ -102,6 +104,46 @@ export function useEditorActions() {
     return null
   }
 
+  /**
+   * Etag-aware update wrapper. Reads the current If-Match from
+   * `useEditorEtagsStore`, sends it on the PUT, updates the store
+   * from the response on success, pushes to `useSaveConflictsStore`
+   * on 409 STALE per design-offline.md Q3. Used by every save path
+   * (root content, component content, fragment edit, structural).
+   *
+   * Re-throws on conflict so callers can short-circuit; non-conflict
+   * errors propagate untouched.
+   */
+  async function updateManifest(
+    kind: 'page' | 'fragment',
+    name: string,
+    payload: Record<string, unknown>,
+    pendingForConflict: Record<string, unknown>,
+  ): Promise<void> {
+    const locale = useLocaleStore().effectiveLocale ?? undefined
+    const path = manifestPath(kind, name, locale)
+    const etags = useEditorEtagsStore()
+    const ifMatch = etags.get(path) ?? undefined
+    try {
+      const updateFn = kind === 'page' ? api.updatePage : api.updateFragment
+      const result = await updateFn(name, payload, { locale, ifMatch })
+      if (result.etag) etags.set(path, result.etag)
+    } catch (err) {
+      if (err instanceof StaleSaveError) {
+        useSaveConflictsStore().set({
+          itemPath: path,
+          current: err.current,
+          currentEtag: err.currentEtag,
+          pending: pendingForConflict,
+        })
+        // Update etag baseline so the next manual save (after the
+        // author rebases) chains correctly.
+        etags.set(path, err.currentEtag)
+      }
+      throw err
+    }
+  }
+
   function buildSaveFn(namePath: string): (content: Record<string, unknown>) => Promise<void> {
     return async (newContent: Record<string, unknown>) => {
       const sel = useSelectionStore()
@@ -130,12 +172,20 @@ export function useEditorActions() {
         }
       }
 
-      const localeOpts = { locale: useLocaleStore().effectiveLocale ?? undefined }
-      if (sel.selection.type === 'page') {
-        await api.updatePage(sel.selection.name, { components: updatedComponents }, localeOpts)
-      } else {
-        await api.updateFragment(sel.selection.name, { components: updatedComponents }, localeOpts)
+      const kind = sel.selection.type === 'page' ? 'page' : 'fragment'
+      // pendingForConflict is the manifest as the author tried to
+      // save it — used by the conflict diff view to show "yours."
+      const pending: Record<string, unknown> = {
+        template: detail.template,
+        content: detail.content,
+        components: updatedComponents,
       }
+      if (kind === 'page') {
+        const pageDetail = detail as { metadata?: Record<string, unknown>; route?: string }
+        if (pageDetail.metadata) pending.metadata = pageDetail.metadata
+        if (pageDetail.route) pending.route = pageDetail.route
+      }
+      await updateManifest(kind, sel.selection.name, { components: updatedComponents }, pending)
     }
   }
 
@@ -150,20 +200,22 @@ export function useEditorActions() {
         if (!d || !selection) throw new Error('No page/fragment selected')
         const pageContent = (d.content as Record<string, unknown>) ?? {}
         const { schema, hasEditor, editorUrl, fieldsBaseUrl } = await fetchSchema(d.template, signal)
-        const saveFn =
-          selection.type === 'page'
-            ? (c: Record<string, unknown>) =>
-                api
-                  .updatePage(selection.name, { content: c }, { locale: useLocaleStore().effectiveLocale ?? undefined })
-                  .then(() => {})
-            : (c: Record<string, unknown>) =>
-                api
-                  .updateFragment(
-                    selection.name,
-                    { content: c },
-                    { locale: useLocaleStore().effectiveLocale ?? undefined },
-                  )
-                  .then(() => {})
+        const kind = selection.type === 'page' ? ('page' as const) : ('fragment' as const)
+        const saveFn = (c: Record<string, unknown>) => {
+          // pending = the manifest the author tried to save — used
+          // by the conflict diff view to show "yours."
+          const pending: Record<string, unknown> = {
+            template: d.template,
+            content: c,
+            components: d.components,
+          }
+          if (kind === 'page') {
+            const pageDetail = d as { metadata?: Record<string, unknown>; route?: string }
+            if (pageDetail.metadata) pending.metadata = pageDetail.metadata
+            if (pageDetail.route) pending.route = pageDetail.route
+          }
+          return updateManifest(kind, selection.name, { content: c }, pending)
+        }
         return {
           template: d.template,
           path: '_root',
@@ -193,10 +245,13 @@ export function useEditorActions() {
         }
       }
       case 'fragmentEdit': {
-        const frag = await api.getFragment(sel.fragmentName, {
-          signal,
-          locale: useLocaleStore().effectiveLocale ?? undefined,
-        })
+        const locale = useLocaleStore().effectiveLocale ?? undefined
+        // getFragmentWithEtag captures the save-concurrency etag for
+        // the offline save flow per design-offline.md Q3. The
+        // selection store does the same on selectFragment; this path
+        // (direct fragment-edit URL) is the other entry point.
+        const { data: frag, etag } = await api.getFragmentWithEtag(sel.fragmentName, { signal, locale })
+        if (etag) useEditorEtagsStore().set(manifestPath('fragment', sel.fragmentName, locale), etag)
         const fragContent = (frag.content as Record<string, unknown>) ?? {}
         const { schema, hasEditor, editorUrl, fieldsBaseUrl } = await fetchSchema(frag.template, signal)
         return {
@@ -207,14 +262,14 @@ export function useEditorActions() {
           hasEditor,
           editorUrl,
           fieldsBaseUrl,
-          save: c =>
-            api
-              .updateFragment(
-                sel.fragmentName,
-                { content: c },
-                { locale: useLocaleStore().effectiveLocale ?? undefined },
-              )
-              .then(() => {}),
+          save: c => {
+            const pending: Record<string, unknown> = {
+              template: frag.template,
+              content: c,
+              components: frag.components,
+            }
+            return updateManifest('fragment', sel.fragmentName, { content: c }, pending)
+          },
         }
       }
       case 'fragmentLink':
@@ -408,15 +463,13 @@ export function useEditorActions() {
    */
   function buildStructuralWrite(keyString: string, components: unknown[]): StructuralWrite {
     const key = manifestKeyFromString(keyString)
-    const localeOpts = { locale: useLocaleStore().effectiveLocale ?? undefined }
     return {
       label: keyString,
       write: async () => {
-        if (key.kind === 'page') {
-          await api.updatePage(key.name, { components: components as never }, localeOpts)
-        } else {
-          await api.updateFragment(key.name, { components: components as never }, localeOpts)
-        }
+        // pending shape carries the structural change; if a conflict
+        // surfaces, the diff view shows the components count change.
+        const pending: Record<string, unknown> = { components }
+        await updateManifest(key.kind, key.name, { components: components as never }, pending)
       },
     }
   }

--- a/apps/admin/src/client/composables/useEditorActions.ts
+++ b/apps/admin/src/client/composables/useEditorActions.ts
@@ -111,8 +111,33 @@ export function useEditorActions() {
    * on 409 STALE per design-offline.md Q3. Used by every save path
    * (root content, component content, fragment edit, structural).
    *
-   * Re-throws on conflict so callers can short-circuit; non-conflict
-   * errors propagate untouched.
+   * # Mid-save connection-loss handling (Cut 13)
+   *
+   * If the PUT itself fails with a network error (fetch rejects with
+   * TypeError — DNS / refused / aborted), we don't know whether the
+   * server received the save before the connection dropped. Two
+   * possibilities:
+   *
+   *   (a) Server received + processed the save; the response was
+   *       lost in transit. The on-disk manifest matches what we
+   *       tried to save.
+   *   (b) Server didn't receive the save. The on-disk manifest is
+   *       still the pre-save state.
+   *
+   * We reconcile via a single GET-and-compare:
+   *
+   *   - GET the current manifest + etag
+   *   - If GET also fails: surface the original network error;
+   *     editor stays dirty so the author can retry manually
+   *   - If server's current === pending: case (a). Advance the
+   *     etag store; treat as silent success per design-offline.md
+   *     Q4 "handled invisibly"
+   *   - Else: case (b) OR case (a) with a concurrent third-party
+   *     save in between. Surface as `StaleSaveError` so the normal
+   *     conflict flow takes over
+   *
+   * Re-throws on (resolved) conflict + on the original network
+   * error when GET also fails. Silent on case (a).
    */
   async function updateManifest(
     kind: 'page' | 'fragment',
@@ -139,9 +164,104 @@ export function useEditorActions() {
         // Update etag baseline so the next manual save (after the
         // author rebases) chains correctly.
         etags.set(path, err.currentEtag)
+        throw err
+      }
+      // Network error path — try to reconcile via GET-and-compare.
+      // TypeError is fetch's standard network-failure shape; HTTP
+      // errors (4xx / 5xx) come back as `Error` from request<T>
+      // and don't go through reconcile (a 5xx isn't ambiguous in
+      // the same way; the server told us it failed).
+      if (err instanceof TypeError) {
+        await reconcileMidSaveDrop(kind, name, locale, pendingForConflict, path)
+        return
       }
       throw err
     }
+  }
+
+  /**
+   * Mid-save connection-loss reconcile. See updateManifest header
+   * for the rationale. Called when the PUT failed with a network
+   * error; we don't yet know whether the save landed.
+   */
+  async function reconcileMidSaveDrop(
+    kind: 'page' | 'fragment',
+    name: string,
+    locale: string | undefined,
+    pendingForConflict: Record<string, unknown>,
+    path: string,
+  ): Promise<void> {
+    const etags = useEditorEtagsStore()
+    let current: { template?: unknown; content?: unknown; components?: unknown }
+    let currentEtag: string | null
+    try {
+      const fetchFn = kind === 'page' ? api.getPageWithEtag : api.getFragmentWithEtag
+      const result = await fetchFn(name, { locale })
+      current = result.data as { template?: unknown; content?: unknown; components?: unknown }
+      currentEtag = result.etag
+    } catch (getErr) {
+      // GET failed too — surface the network error. The author's
+      // local edits stay dirty (editor unchanged); they can retry
+      // when connection comes back.
+      throw getErr
+    }
+
+    // Compare server's current to the manifest the author tried to
+    // save. Equal = case (a); the save actually landed before the
+    // connection dropped.
+    if (manifestsEquivalent(current, pendingForConflict)) {
+      if (currentEtag) etags.set(path, currentEtag)
+      // Silent success per design-offline.md Q4 "handled invisibly."
+      return
+    }
+
+    // Different = case (b) or a concurrent save by someone else.
+    // Surface as a stale-save conflict; the editor's banner +
+    // diff view take over from here.
+    const fallbackEtag = currentEtag ?? ''
+    useSaveConflictsStore().set({
+      itemPath: path,
+      current: current as Record<string, unknown>,
+      currentEtag: fallbackEtag,
+      pending: pendingForConflict,
+    })
+    if (fallbackEtag) etags.set(path, fallbackEtag)
+    throw new StaleSaveError(current as Record<string, unknown>, fallbackEtag)
+  }
+
+  /**
+   * Compare two manifest snapshots for save-equivalence. Compares
+   * the union of save-relevant fields (template, content,
+   * components, route, metadata) via canonicalized JSON. Same shape
+   * as the server's `computeSaveEtag` canonicalization; if the
+   * server's etag would equal the etag of `pending`, they're
+   * equivalent.
+   *
+   * We could call computeSaveEtag for both sides and compare hashes;
+   * deep-equal via JSON canonicalization is cheaper for small
+   * manifests and avoids the async crypto call on the reconcile
+   * hot path.
+   */
+  function manifestsEquivalent(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+    const fields = ['template', 'content', 'components', 'metadata', 'route'] as const
+    const pickA: Record<string, unknown> = {}
+    const pickB: Record<string, unknown> = {}
+    for (const f of fields) {
+      if (f in a) pickA[f] = a[f]
+      if (f in b) pickB[f] = b[f]
+    }
+    return JSON.stringify(pickA, sortedKeyReplacer) === JSON.stringify(pickB, sortedKeyReplacer)
+  }
+
+  function sortedKeyReplacer(_key: string, value: unknown): unknown {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      const out: Record<string, unknown> = {}
+      for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+        out[k] = (value as Record<string, unknown>)[k]
+      }
+      return out
+    }
+    return value
   }
 
   function buildSaveFn(namePath: string): (content: Record<string, unknown>) => Promise<void> {

--- a/apps/admin/src/client/composables/useServiceWorkerUpdate.ts
+++ b/apps/admin/src/client/composables/useServiceWorkerUpdate.ts
@@ -1,0 +1,95 @@
+/// <reference types="vite-plugin-pwa/client" />
+/**
+ * Service-worker update flow per `design-offline.md` Cut 11
+ * "Update detection UX":
+ *
+ *   - Boot registers the SW (via vite-plugin-pwa's
+ *     `useRegisterSW` virtual module)
+ *   - When a new SW version is detected, show a toast: "New version
+ *     available — Refresh to update"
+ *   - Author clicks "Refresh" → SW activates (skipWaiting) +
+ *     reloads the tab
+ *
+ * The toast uses the existing `useToastStore.show(... { action })`
+ * affordance — same UI surface as the post-save Undo prompt and
+ * the back-to-previous-target after a target switch. Consistent
+ * action affordance, consistent dismiss timing.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this composable owns "update detection → toast prompt
+ *     → activation handshake." It does NOT own the SW source
+ *     (sw.ts) or the toast UI (App.vue / Toast.vue).
+ *   - DIP: depends on the toast store interface, not on a specific
+ *     toast UI component.
+ *
+ * # Why a composable, not a Pinia store
+ *
+ * The state is fundamentally tied to vite-plugin-pwa's reactive
+ * registration object — the `needRefresh` ref is owned by the
+ * plugin. A Pinia store would mirror that ref through another
+ * layer for no benefit. Composable is the right shape: imported
+ * once, runs side effects (register + watch), no consumer reads
+ * its return value.
+ *
+ * # Production-only
+ *
+ * Vite's `useRegisterSW` is a no-op in dev because the SW isn't
+ * built or registered there. Importing this composable in dev is
+ * harmless (no-op subscription) — but the production behavior is
+ * the only behavior we test in CI's prod-build smoke.
+ */
+import { watch } from 'vue'
+import { useRegisterSW } from 'virtual:pwa-register/vue'
+import { useToastStore } from '../stores/toast.js'
+
+/**
+ * Wire up SW registration + update toast. Call once at admin boot
+ * AFTER Pinia is installed (so `useToastStore` is resolvable).
+ */
+export function useServiceWorkerUpdate(): void {
+  const { needRefresh, updateServiceWorker } = useRegisterSW({
+    immediate: true,
+    onRegisteredSW(_swUrl, registration) {
+      // Periodic background check for new versions every hour
+      // (default for long-lived admin tabs is "wait until next page
+      // load" which never happens). 1h cadence gives operators a
+      // reasonable upgrade window without polling aggressively.
+      if (!registration) return
+      setInterval(
+        () => {
+          // Best-effort — failures don't matter; the next interval
+          // will retry. registration.update() returns a Promise we
+          // don't need to await.
+          void registration.update()
+        },
+        60 * 60 * 1000,
+      )
+    },
+  })
+
+  const toast = useToastStore()
+
+  // Watch needRefresh; when it flips true, surface the toast with
+  // a Refresh action that activates + reloads.
+  watch(needRefresh, fresh => {
+    if (!fresh) return
+    toast.show('A new version is available', {
+      type: 'info',
+      action: {
+        label: 'Refresh',
+        handler: async () => {
+          // updateServiceWorker(true) sends SKIP_WAITING to the SW
+          // and reloads the page once the new SW takes control.
+          // Per vite-plugin-pwa v0.13.2+, the boolean arg is unused
+          // (reload always happens) but kept for API stability.
+          await updateServiceWorker(true)
+        },
+      },
+      // Sticky toast — operator may be mid-edit and want to delay
+      // the refresh. The toast hangs around until they click
+      // "Refresh" or dismiss.
+      duration: 0,
+    })
+  })
+}

--- a/apps/admin/src/client/composables/useStorageQuota.ts
+++ b/apps/admin/src/client/composables/useStorageQuota.ts
@@ -1,0 +1,157 @@
+/**
+ * Storage quota monitoring per `design-offline.md` Q4 "Storage
+ * approaching limit":
+ *
+ *   "When local storage approaches the cap (80% of allocated), a
+ *   subtle banner surfaces: 'Storage almost full — please connect
+ *   to send your saved items.' Plain language; actionable; appears
+ *   once until acknowledged or storage frees."
+ *
+ * LRU eviction kicks in only at 100% (per `design-cache.md` Gap 1
+ * lock). The 80% warning gives the author buffer to act.
+ *
+ * # Approach
+ *
+ * Poll `navigator.storage.estimate()` periodically. The estimate
+ * reports total origin storage (IndexedDB + Cache API + service
+ * worker registrations + localStorage) vs. the browser's per-
+ * origin cap. We don't poll aggressively — the cap doesn't change
+ * fast, and user actions that consume storage (saves, autosaves)
+ * are already low-frequency.
+ *
+ * # Dismiss-once UX
+ *
+ * Per the design: "appears once until acknowledged or storage
+ * frees." If the user dismisses at 80%, we stash the dismissal
+ * threshold; the banner re-appears only when usage crosses BACK
+ * UP through that threshold (e.g., user dismisses at 85%, frees
+ * to 70%, climbs back to 85% later → banner re-appears).
+ *
+ * Dismissal is per-tab-session — not persisted across reloads.
+ * If the author closes the tab and reopens at the same quota,
+ * they see the warning again. Honest: the situation hasn't changed.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this composable owns "is local storage approaching the
+ *     cap?". It does NOT know what to do about it (the banner
+ *     component renders the visible state) or how the cache
+ *     evicts (cache layer handles 100% via LRU).
+ *   - DIP: tests inject a fake `estimateFn` so they can drive the
+ *     scenario synchronously without a real navigator.
+ */
+import { computed, onUnmounted, ref, type Ref } from 'vue'
+
+const POLL_INTERVAL_MS = 60_000
+const WARN_THRESHOLD = 0.8
+
+/**
+ * Optional injection seam for tests. Production wires through the
+ * real `navigator.storage.estimate()`.
+ */
+export type StorageEstimateFn = () => Promise<{ usage?: number; quota?: number }>
+
+export interface StorageQuotaOptions {
+  /** Override the polling interval. Tests pass 0 to disable the timer. */
+  pollIntervalMs?: number
+  /** Override the estimate function for tests. */
+  estimateFn?: StorageEstimateFn
+}
+
+export interface StorageQuotaState {
+  /** Latest sampled usage ratio (0..1) or null if unknown. */
+  usageRatio: Ref<number | null>
+  /** True when ratio > 0.8 AND user hasn't dismissed at the
+   *  current threshold band. The banner consumer reads this. */
+  showWarning: Ref<boolean>
+  /** Force an immediate sample. Tests use this to drive transitions. */
+  sample(): Promise<void>
+  /** User dismissed the warning. Re-appears only when usage climbs
+   *  back through the dismissal threshold. */
+  dismiss(): void
+  /** Stop polling + clean up the timer. Auto-called on
+   *  onUnmounted when the composable is consumed in a component. */
+  stop(): void
+}
+
+/**
+ * Wire storage-quota monitoring. Call once at admin boot OR from
+ * a component (the composable cleans up on unmount).
+ *
+ * Returns reactive refs the consumer reads. Production callers
+ * mount once in a long-lived component (e.g., the offline banner's
+ * sibling); tests instantiate per-case with a fake estimateFn.
+ */
+export function useStorageQuota(opts: StorageQuotaOptions = {}): StorageQuotaState {
+  const pollIntervalMs = opts.pollIntervalMs ?? POLL_INTERVAL_MS
+  const estimateFn = opts.estimateFn ?? defaultEstimate
+
+  const usageRatio = ref<number | null>(null)
+  const dismissedAtRatio = ref<number | null>(null)
+
+  const showWarning = computed<boolean>(() => {
+    const r = usageRatio.value
+    if (r === null) return false
+    if (r < WARN_THRESHOLD) return false
+    // If dismissed at a ratio, suppress until usage climbs ABOVE
+    // that point. `<=` not `<`: dismissing at 0.85 should suppress
+    // at 0.85; only re-fires once we hit 0.86+.
+    if (dismissedAtRatio.value !== null && r <= dismissedAtRatio.value) return false
+    return true
+  })
+
+  async function sample(): Promise<void> {
+    try {
+      const est = await estimateFn()
+      const usage = est.usage ?? 0
+      const quota = est.quota ?? 0
+      if (quota === 0) {
+        usageRatio.value = null
+        return
+      }
+      usageRatio.value = usage / quota
+      // If usage drops back below the dismiss threshold, clear it
+      // so a future climb re-fires the warning.
+      if (dismissedAtRatio.value !== null && usageRatio.value < WARN_THRESHOLD) {
+        dismissedAtRatio.value = null
+      }
+    } catch {
+      // navigator.storage.estimate() rejection is rare but possible
+      // (older browsers, sandboxed contexts). Treat as "quota
+      // unknown" — don't surface a banner; don't crash the app.
+      usageRatio.value = null
+    }
+  }
+
+  function dismiss(): void {
+    dismissedAtRatio.value = usageRatio.value
+  }
+
+  let timer: ReturnType<typeof setInterval> | null = null
+  function stop(): void {
+    if (timer !== null) {
+      clearInterval(timer)
+      timer = null
+    }
+  }
+
+  if (pollIntervalMs > 0) {
+    // Kick off an immediate sample; subsequent samples on interval.
+    void sample()
+    timer = setInterval(() => void sample(), pollIntervalMs)
+  }
+
+  // Auto-cleanup when consumed in a component setup.
+  onUnmounted(() => stop())
+
+  return { usageRatio, showWarning, sample, dismiss, stop }
+}
+
+/** Production estimate — reads `navigator.storage.estimate()` if
+ *  the API is available; returns empty estimate otherwise. */
+async function defaultEstimate(): Promise<{ usage?: number; quota?: number }> {
+  if (typeof navigator === 'undefined' || !navigator.storage?.estimate) {
+    return {}
+  }
+  return navigator.storage.estimate()
+}

--- a/apps/admin/src/client/main.ts
+++ b/apps/admin/src/client/main.ts
@@ -10,6 +10,7 @@ import { createAdminQueryClient, createGazettaClientPersister } from './queries/
 import { createGazettaPersister } from './queries/persister.js'
 import { useConnectionState } from './stores/connectionState.js'
 import { attachPendingEditsPersistence } from './stores/_pendingEditsPersistence.js'
+import { useServiceWorkerUpdate } from './composables/useServiceWorkerUpdate.js'
 import './assets/tokens.css'
 
 // Async boot: provider selection probes IndexedDB before constructing
@@ -49,6 +50,11 @@ async function bootstrap(): Promise<void> {
   // + `editorContent` persistence land in Cut 8b.
   const pendingEditsPersistence = attachPendingEditsPersistence(provider.cache)
   await pendingEditsPersistence.hydrated
+
+  // Register the service worker (production builds only; dev no-op).
+  // Surfaces the "new version available" toast when an update lands.
+  // Per Cut 11; SW source lives at src/client/sw.ts.
+  useServiceWorkerUpdate()
 
   app.mount('#app')
 

--- a/apps/admin/src/client/main.ts
+++ b/apps/admin/src/client/main.ts
@@ -2,20 +2,51 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import PrimeVue from 'primevue/config'
 import Aura from '@primeuix/themes/aura'
+import { VueQueryPlugin } from '@tanstack/vue-query'
 import App from './App.vue'
 import { createRouter } from './router.js'
+import { selectBrowserCacheProvider } from './cache/provider-selector.js'
+import { createAdminQueryClient, createGazettaClientPersister } from './queries/client.js'
+import { createGazettaPersister } from './queries/persister.js'
 import './assets/tokens.css'
 
-const app = createApp(App)
-app.use(createPinia())
-app.use(PrimeVue, {
-  theme: {
-    preset: Aura,
-    options: { darkModeSelector: '.dark' },
-  },
-})
-app.use(createRouter())
-app.mount('#app')
+// Async boot: provider selection probes IndexedDB before constructing
+// the L6 cache. Vue's createApp is sync but Vue's plugin install can
+// run after creation, so we resolve the provider first and feed it
+// into the VueQueryPlugin install.
+async function bootstrap(): Promise<void> {
+  const provider = await selectBrowserCacheProvider()
+  const queryClient = createAdminQueryClient()
+  const persister = createGazettaPersister(provider.cache)
+  const clientPersister = createGazettaClientPersister(persister)
+
+  const app = createApp(App)
+  app.use(createPinia())
+  app.use(PrimeVue, {
+    theme: {
+      preset: Aura,
+      options: { darkModeSelector: '.dark' },
+    },
+  })
+  app.use(VueQueryPlugin, {
+    queryClient,
+    clientPersister,
+  })
+  app.use(createRouter())
+  app.mount('#app')
+
+  if (provider.degraded) {
+    // Surface persistence degradation to operators via console for
+    // now; the user-facing banner lands as a Vue component reading
+    // a Pinia flag in a later cut. Reason field carries the probe
+    // failure for diagnostic logs.
+    console.warn(
+      `[gazetta] offline persistence unavailable — using in-memory cache. Reason: ${provider.reason ?? 'unknown'}`,
+    )
+  }
+}
+
+void bootstrap()
 
 // User theme — append AFTER PrimeVue and tokens.css so user declarations
 // win the cascade. PrimeVue injects styles at runtime via app.use(PrimeVue),

--- a/apps/admin/src/client/main.ts
+++ b/apps/admin/src/client/main.ts
@@ -9,7 +9,7 @@ import { selectBrowserCacheProvider } from './cache/provider-selector.js'
 import { createAdminQueryClient, createGazettaClientPersister } from './queries/client.js'
 import { createGazettaPersister } from './queries/persister.js'
 import { useConnectionState } from './stores/connectionState.js'
-import { attachPendingEditsPersistence } from './stores/_pendingEditsPersistence.js'
+import { attachPendingEditsPersistence, attachPersistedEditsPersistence } from './stores/_pendingEditsPersistence.js'
 import { useServiceWorkerUpdate } from './composables/useServiceWorkerUpdate.js'
 import './assets/tokens.css'
 
@@ -43,13 +43,14 @@ async function bootstrap(): Promise<void> {
   // the first render sees a populated state.
   useConnectionState()
 
-  // Wire pending-edits persistence on top of the L6 cache. Awaits
-  // initial hydration so the first render of the editor sees any
-  // structural pending changes that survived a previous session.
-  // Per Cut 8 scope: persists `editorStructural` only; `editorStash`
-  // + `editorContent` persistence land in Cut 8b.
-  const pendingEditsPersistence = attachPendingEditsPersistence(provider.cache)
-  await pendingEditsPersistence.hydrated
+  // Wire pending-edits persistence on top of the L6 cache. Both
+  // coordinators run in parallel — independent stores, independent
+  // cache keys. Await both hydrations so the first editor render
+  // sees structural reorders (Cut 8a) AND restored dirty content
+  // (Cut 8b) that survived a previous session.
+  const structuralPersistence = attachPendingEditsPersistence(provider.cache)
+  const editsPersistence = attachPersistedEditsPersistence(provider.cache)
+  await Promise.all([structuralPersistence.hydrated, editsPersistence.hydrated])
 
   // Register the service worker (production builds only; dev no-op).
   // Surfaces the "new version available" toast when an update lands.

--- a/apps/admin/src/client/main.ts
+++ b/apps/admin/src/client/main.ts
@@ -8,6 +8,7 @@ import { createRouter } from './router.js'
 import { selectBrowserCacheProvider } from './cache/provider-selector.js'
 import { createAdminQueryClient, createGazettaClientPersister } from './queries/client.js'
 import { createGazettaPersister } from './queries/persister.js'
+import { useConnectionState } from './stores/connectionState.js'
 import './assets/tokens.css'
 
 // Async boot: provider selection probes IndexedDB before constructing
@@ -33,6 +34,13 @@ async function bootstrap(): Promise<void> {
     clientPersister,
   })
   app.use(createRouter())
+
+  // Initialize the connection-state store so it auto-attaches
+  // `navigator.onLine` listeners and starts probing /api/health
+  // when degraded. Must run after Pinia install + before mount so
+  // the first render sees a populated state.
+  useConnectionState()
+
   app.mount('#app')
 
   if (provider.degraded) {

--- a/apps/admin/src/client/main.ts
+++ b/apps/admin/src/client/main.ts
@@ -59,6 +59,20 @@ async function bootstrap(): Promise<void> {
 
   app.mount('#app')
 
+  // User theme — append AFTER PrimeVue (which injects styles at runtime
+  // via app.use(PrimeVue)) so user declarations win the cascade. Must be
+  // INSIDE bootstrap and AFTER app.mount() so the order is deterministic
+  // even when bootstrap awaits cache + persistence hydration. A static
+  // <link> at module scope would race with PrimeVue's runtime injection.
+  // The server returns an empty stylesheet when the user has no
+  // admin/theme.css, so no onerror handling needed.
+  {
+    const link = document.createElement('link')
+    link.rel = 'stylesheet'
+    link.href = '/admin/theme.css'
+    document.head.appendChild(link)
+  }
+
   if (provider.degraded) {
     // Surface persistence degradation to operators via console for
     // now; the user-facing banner lands as a Vue component reading
@@ -71,15 +85,3 @@ async function bootstrap(): Promise<void> {
 }
 
 void bootstrap()
-
-// User theme — append AFTER PrimeVue and tokens.css so user declarations
-// win the cascade. PrimeVue injects styles at runtime via app.use(PrimeVue),
-// so a static <link> in index.html would lose to it. The server returns an
-// empty stylesheet when the user has no admin/theme.css, so no onerror
-// handling needed.
-{
-  const link = document.createElement('link')
-  link.rel = 'stylesheet'
-  link.href = '/admin/theme.css'
-  document.head.appendChild(link)
-}

--- a/apps/admin/src/client/main.ts
+++ b/apps/admin/src/client/main.ts
@@ -9,6 +9,7 @@ import { selectBrowserCacheProvider } from './cache/provider-selector.js'
 import { createAdminQueryClient, createGazettaClientPersister } from './queries/client.js'
 import { createGazettaPersister } from './queries/persister.js'
 import { useConnectionState } from './stores/connectionState.js'
+import { attachPendingEditsPersistence } from './stores/_pendingEditsPersistence.js'
 import './assets/tokens.css'
 
 // Async boot: provider selection probes IndexedDB before constructing
@@ -40,6 +41,14 @@ async function bootstrap(): Promise<void> {
   // when degraded. Must run after Pinia install + before mount so
   // the first render sees a populated state.
   useConnectionState()
+
+  // Wire pending-edits persistence on top of the L6 cache. Awaits
+  // initial hydration so the first render of the editor sees any
+  // structural pending changes that survived a previous session.
+  // Per Cut 8 scope: persists `editorStructural` only; `editorStash`
+  // + `editorContent` persistence land in Cut 8b.
+  const pendingEditsPersistence = attachPendingEditsPersistence(provider.cache)
+  await pendingEditsPersistence.hydrated
 
   app.mount('#app')
 

--- a/apps/admin/src/client/queries/client.ts
+++ b/apps/admin/src/client/queries/client.ts
@@ -1,0 +1,87 @@
+/**
+ * `QueryClient` factory + `clientPersister` builder for
+ * `VueQueryPlugin`. Wires the L4↔L6 cascade described in
+ * `design-offline.md`'s architecture diagram:
+ *
+ *   Vue components → useQuery / useMutation
+ *      → in-memory QueryClient (queries + mutations)
+ *         → persistQueryClient (this file)
+ *            → AsyncStorage adapter (storage-adapter.ts)
+ *               → AdminCache (IndexedDB or memory fallback)
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns "build the QueryClient + bind the
+ *     persister to it." The persister itself, the storage adapter,
+ *     and the L6 cache provider are all separate concerns in
+ *     sibling files.
+ *   - DIP: depends on the `Persister` interface and `AdminCache`,
+ *     not on either's concrete implementation.
+ *   - OCP: future fine-tuning (per-query `gcTime`, default `retry`
+ *     policy) belongs on the `QueryClient` config; the persister
+ *     wiring stays unchanged.
+ *
+ * # Default `gcTime` is critical for offline mode
+ *
+ * Vue Query's default `gcTime` is 5 minutes — queries unused for
+ * 5 minutes get garbage-collected from the in-memory cache. The
+ * persister only persists what's currently in the cache, so a
+ * default gcTime would mean "queries the user hasn't viewed in 5
+ * minutes can't survive reload." For an offline-friendly admin we
+ * push gcTime to 24h so the persisted snapshot covers a full
+ * editing session even if specific pages aren't actively viewed.
+ *
+ * `staleTime` stays at 0 — we WANT background refetches when the
+ * user views something. Persisted data unblocks the UI; refetch
+ * brings it current.
+ */
+import { QueryClient } from '@tanstack/vue-query'
+import { persistQueryClient } from '@tanstack/query-persist-client-core'
+import type { Persister } from '@tanstack/query-persist-client-core'
+
+/** 24 hours in ms — long enough to survive a full editing session,
+ *  short enough that genuinely stale entries eventually GC. */
+const OFFLINE_GC_TIME_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Build the admin's `QueryClient` with offline-friendly defaults.
+ * Exported so tests can mount the same shape Vue Query sees in
+ * production.
+ */
+export function createAdminQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: OFFLINE_GC_TIME_MS,
+        // staleTime: 0 — Vue Query default; queries refetch on mount
+        // / focus / reconnect. Persisted data unblocks initial render
+        // while the refetch lands fresh data underneath.
+        // retry behavior unchanged from defaults (3 retries with
+        // exponential backoff). Connection-state Pinia store will
+        // pause queries via onlineManager in Cut 6.
+      },
+      mutations: {
+        // gcTime same shape — keeps offline-queued mutations alive.
+        gcTime: OFFLINE_GC_TIME_MS,
+      },
+    },
+  })
+}
+
+/**
+ * Build the `clientPersister` callback that `VueQueryPlugin` invokes
+ * with the resolved `QueryClient`. Returns the `[unsubscribe, restored]`
+ * tuple `persistQueryClient` produces — Vue Query's plugin contract
+ * passes the same shape through unchanged.
+ *
+ * The `buster` parameter is the cache-reset knob: when the value
+ * changes between sessions, the persister discards the persisted
+ * client and starts fresh. Use it to purge on Gazetta major-version
+ * upgrades.
+ */
+export function createGazettaClientPersister(
+  persister: Persister,
+  buster?: string,
+): (client: QueryClient) => [() => void, Promise<void>] {
+  return (client: QueryClient) => persistQueryClient({ queryClient: client, persister, buster })
+}

--- a/apps/admin/src/client/queries/persister.ts
+++ b/apps/admin/src/client/queries/persister.ts
@@ -1,0 +1,77 @@
+/**
+ * `Persister` factory — wraps `createAsyncStoragePersister` with
+ * Gazetta-specific defaults and our `AdminCache`-backed storage.
+ *
+ * # Why a thin wrapper?
+ *
+ * - **Single-site-per-process invariant** (per `CONTEXT.md`): the
+ *   persister stores one serialized `PersistedClient` per origin.
+ *   Hardcoding the key here keeps callers from picking colliding
+ *   names; one shipping default they don't have to think about.
+ *
+ * - **Throttle**: writes happen on every `QueryCache` event; the
+ *   persister's `throttleTime` debounces them. 500ms balances
+ *   data-loss-on-crash (small window) against IndexedDB write
+ *   pressure during typing-heavy editing flows. Per
+ *   `design-offline-implementation.md` Cut 5 Open Question 1.
+ *
+ * - **buster** for cache-purge on Gazetta major-version upgrades:
+ *   when consumers bump the buster, the persister discards any
+ *   persisted client whose buster doesn't match. Plumbed through
+ *   so the admin SPA can pass `gazetta.version.major` at boot.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns the persister-with-our-defaults concern.
+ *     The QueryClient itself + plugin install live in `client.ts`;
+ *     the storage adapter lives in `storage-adapter.ts`.
+ *   - DIP: takes `AdminCache`; doesn't know which provider it got.
+ */
+import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister'
+import type { Persister } from '@tanstack/query-persist-client-core'
+import type { AdminCache } from 'gazetta'
+import { cacheAsyncStorage } from './storage-adapter.js'
+
+/**
+ * Single fixed key under which the serialized `PersistedClient` is
+ * stored. Hardcoded because there's only ever ONE persisted client
+ * per origin (see "single-site-per-process" rationale above).
+ *
+ * Note: the persister itself adds a `tanstack-query-` prefix
+ * internally (PERSISTER_KEY_PREFIX) — the on-disk key the cache
+ * sees is `tanstack-query-gazetta-vue-query`.
+ */
+const GAZETTA_PERSISTER_KEY = 'gazetta-vue-query'
+
+/**
+ * 500ms — small enough that a crash mid-edit loses at most a half
+ * second of cached query state; large enough that rapid typing
+ * doesn't write to IndexedDB on every keystroke.
+ */
+const DEFAULT_THROTTLE_MS = 500
+
+export interface CreateGazettaPersisterOptions {
+  /**
+   * Cache reset key. When the buster value changes between sessions,
+   * the persister discards the persisted client. Use this to purge
+   * caches on Gazetta major-version upgrades or for one-off resets.
+   */
+  buster?: string
+  /** Override the default throttle interval for tests + power users. */
+  throttleTime?: number
+  /** Override the storage key. Tests use this to isolate runs. */
+  key?: string
+}
+
+/**
+ * Build a `Persister` against the given `AdminCache`. Pass the result
+ * to `persistQueryClient({ persister, queryClient, ... })` or to
+ * `VueQueryPlugin`'s `clientPersister`.
+ */
+export function createGazettaPersister(cache: AdminCache, opts: CreateGazettaPersisterOptions = {}): Persister {
+  return createAsyncStoragePersister({
+    storage: cacheAsyncStorage(cache),
+    key: opts.key ?? GAZETTA_PERSISTER_KEY,
+    throttleTime: opts.throttleTime ?? DEFAULT_THROTTLE_MS,
+  })
+}

--- a/apps/admin/src/client/queries/storage-adapter.ts
+++ b/apps/admin/src/client/queries/storage-adapter.ts
@@ -1,0 +1,70 @@
+/**
+ * Adapter that exposes our `AdminCache` as TanStack's `AsyncStorage<string>`
+ * — the storage interface `createAsyncStoragePersister` expects.
+ *
+ * The persister stores ONE serialized `PersistedClient` (the entire
+ * Vue Query cache + mutation queue) under a single key. The adapter
+ * forwards that key/value through `AdminCache.get/set/invalidate`,
+ * which under the hood lands in the L6 store (IndexedDB or, when
+ * IndexedDB is unavailable, the browser-side MemoryCache fallback).
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns "translate TanStack's storage shape to
+ *     `AdminCache`'s shape." It does not know about the persister
+ *     itself, the QueryClient, or BroadcastChannel — those are
+ *     siblings in `queries/`.
+ *   - DIP: takes any `AdminCache`. The selector picks IndexedDB or
+ *     memory; the adapter doesn't care which. The same Vue Query
+ *     setup works for both.
+ *   - LSP: substitutable for any other `AsyncStorage<string>` —
+ *     conforms to the documented interface from
+ *     `@tanstack/query-async-storage-persister`.
+ *
+ * # What about prefix isolation?
+ *
+ * The persister already prefixes its key (`PERSISTER_KEY_PREFIX` +
+ * the operator-supplied `key`). Adding our own prefix here would
+ * double-prefix and complicate cache-prefix invalidation when the
+ * persister wants to clear its entry. So we pass the key through
+ * verbatim. The single-Site-per-process invariant means we don't
+ * need extra namespacing — one site, one cache, one persisted
+ * client per origin.
+ */
+import type { AdminCache } from 'gazetta'
+
+/**
+ * The minimum subset of TanStack's `AsyncStorage<string>` we need.
+ * Inlined as a type rather than imported from `@tanstack/...` so
+ * this module compiles without pulling TanStack's full type graph
+ * into every consumer.
+ */
+export interface AsyncStringStorage {
+  getItem(key: string): Promise<string | undefined | null>
+  setItem(key: string, value: string): Promise<unknown>
+  removeItem(key: string): Promise<void>
+}
+
+/**
+ * Build an `AsyncStringStorage` adapter over the given `AdminCache`.
+ * Returned object is stateless beyond the closure on `cache`; safe
+ * to construct once at admin boot and reuse.
+ */
+export function cacheAsyncStorage(cache: AdminCache): AsyncStringStorage {
+  return {
+    async getItem(key: string): Promise<string | null> {
+      // AdminCache.get<T>() returns null on miss; that matches the
+      // persister's "no persisted client yet" expectation.
+      return cache.get<string>(key)
+    },
+    async setItem(key: string, value: string): Promise<void> {
+      // No TTL — the persister expects manual eviction via
+      // removeItem, and our LRS / LRU eviction at the cache cap
+      // handles the catastrophic case.
+      await cache.set(key, value)
+    },
+    async removeItem(key: string): Promise<void> {
+      await cache.invalidate(key)
+    },
+  }
+}

--- a/apps/admin/src/client/router.ts
+++ b/apps/admin/src/client/router.ts
@@ -98,7 +98,16 @@ export function createRouter() {
     // Sync active target from URL query param.
     // ?target=staging → switch to staging. No ?target= → use default (first editable).
     // Only non-default targets appear in the URL — keeps default URLs clean.
+    //
+    // Await `ensureLoaded` so the first navigation's `?target=` lookup
+    // finds the named target. App.vue's `onMounted` hook also kicks
+    // off this load; both call sites share one in-flight promise via
+    // single-flight, so awaiting here is cheap on subsequent navigations.
+    // Without this, the first navigation runs before the targets list
+    // is populated, `setActiveTarget(name)` throws, and the catch
+    // clause silently strips `?target=` from the URL.
     const activeTarget = useActiveTargetStore()
+    await activeTarget.ensureLoaded()
     const urlTarget = to.query.target as string | undefined
     if (urlTarget) {
       // Strip ?target= if it's the default — keep URLs clean

--- a/apps/admin/src/client/stores/_pendingEditsPersistence.ts
+++ b/apps/admin/src/client/stores/_pendingEditsPersistence.ts
@@ -1,0 +1,193 @@
+/**
+ * Pending-edits persistence — bridges the in-memory pending-edits
+ * Pinia stores to the L6 `AdminCache` so edits survive browser
+ * reload per `design-offline.md`'s "Pending edits persist across
+ * browser reload" invariant.
+ *
+ * # Cut 8 scope (this module)
+ *
+ * Persists `editorStructural` only. Structural edits (component
+ * reorder / add / remove on a manifest) are pure data — no closures,
+ * no transient mounts. Reorders are also higher-friction for an
+ * author to redo than re-typing a field, so they're the highest-
+ * value persistence target for this cut.
+ *
+ * `editorStash` + `editorContent` persistence is **deferred to Cut
+ * 8b**. Both stores carry an `EditingTarget` with a `save` closure
+ * bound to the page's selection state. Persisting them naively
+ * loses the closure; rehydration needs to rebuild it via the
+ * navigate flow — a non-trivial seam that deserves its own focused
+ * cut rather than being rushed alongside the structural pass.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns the persistence-coordinator concern.
+ *     Stores stay store-shaped (state + mutations); the coordinator
+ *     observes + serializes + hydrates externally.
+ *   - DIP: takes any `AdminCache`. The selector picks IndexedDB or
+ *     memory; this coordinator doesn't care which.
+ *   - OCP: future per-store sub-modules (stash, content) plug in
+ *     through additional `attach...()` calls without changing what's
+ *     here.
+ *
+ * # Cache key conventions
+ *
+ * Per `design-cache.md` Q1, reserved prefix is `pending-edits:`.
+ * One key per persisted store: `pending-edits:structural`. Future
+ * cuts add `pending-edits:stash` + `pending-edits:content`.
+ */
+import { watch } from 'vue'
+import type { AdminCache } from 'gazetta'
+import type { ComponentEntry, ManifestKey } from 'gazetta/types'
+import { manifestKeyFromString } from 'gazetta/types'
+import { useEditorStructuralStore, type StructuralEntry } from './editorStructural.js'
+
+/**
+ * Cache key for `editorStructural` snapshots. v1 stores everything
+ * under one key; if structural state ever grows large enough to
+ * warrant per-manifest-key sharding, that's a forward change.
+ */
+const STRUCTURAL_KEY = 'pending-edits:structural'
+
+/**
+ * Debounce window between mutation and write. Keeps IndexedDB write
+ * pressure low during rapid drag-reorders without losing more than a
+ * fraction of a second on crash.
+ */
+const STRUCTURAL_WRITE_DEBOUNCE_MS = 300
+
+/**
+ * Serializable shape — array of `[manifestKeyString, entry]` tuples.
+ * Mirrors `editorStructural`'s internal Map shape but with plain
+ * arrays for ComponentEntry tuples (already JSON-safe — they're
+ * either strings or InlineComponent objects).
+ */
+interface PersistedStructural {
+  /** Storage-format version for future schema migrations. */
+  version: 1
+  entries: Array<[string, { original: ComponentEntry[]; pending: ComponentEntry[] }]>
+}
+
+export interface PendingEditsPersistenceOptions {
+  /**
+   * Override the debounce interval. Tests pass 0 to flush
+   * synchronously without waiting for real time to pass.
+   */
+  structuralDebounceMs?: number
+}
+
+/**
+ * Result of attaching pending-edits persistence — exposes a
+ * `dispose()` to detach watchers and a `hydrated` promise that
+ * resolves once boot-time hydration completes (so callers can
+ * await before mounting any UI that depends on the store state).
+ */
+export interface PendingEditsPersistenceHandle {
+  /** Resolves once hydration finishes. */
+  hydrated: Promise<void>
+  /** Stop watching + writing. Tests use this for clean teardown. */
+  dispose(): void
+}
+
+/**
+ * Read the persisted structural state from cache and replay every
+ * entry into the store. Idempotent: replaying the same entries on
+ * an empty store reproduces the persisted state; on a non-empty
+ * store it's a no-op for matching keys (Map.set replaces).
+ */
+async function hydrateStructural(cache: AdminCache): Promise<void> {
+  const persisted = await cache.get<PersistedStructural>(STRUCTURAL_KEY)
+  if (!persisted || persisted.version !== 1) return
+  const store = useEditorStructuralStore()
+  for (const [keyString, entry] of persisted.entries) {
+    const key = manifestKeyFromString(keyString)
+    // Restore via the store's hydration primitive so both `original`
+    // (the discard baseline) and `pending` (the user's WIP) come
+    // through as-is. The intent-named mutators would re-record
+    // `original` from the current call site — wrong for restoration.
+    store._hydrateFromSnapshot(key, entry)
+  }
+}
+
+/**
+ * Snapshot the structural store and write it to the cache. Called
+ * from a debounced watcher; never throws on cache failures (the
+ * AdminCache contract is fail-open per `design-cache.md` Q4).
+ */
+async function persistStructural(cache: AdminCache): Promise<void> {
+  const store = useEditorStructuralStore()
+  // The store exposes `entries` as a reactive Map; `allEntries()`
+  // returns a snapshot we can serialize. Each tuple is already
+  // [string, StructuralEntry] — we just project StructuralEntry
+  // into its plain-data shape (slicing readonly to mutable).
+  const entries = store
+    .allEntries()
+    .map<[string, { original: ComponentEntry[]; pending: ComponentEntry[] }]>(
+      ([key, entry]: [string, StructuralEntry]) => [
+        key,
+        {
+          original: entry.original.slice(),
+          pending: entry.pending.slice(),
+        },
+      ],
+    )
+  if (entries.length === 0) {
+    // Empty state — invalidate rather than write `{ entries: [] }`
+    // so the next hydrate is a clean miss.
+    await cache.invalidate(STRUCTURAL_KEY)
+    return
+  }
+  const payload: PersistedStructural = { version: 1, entries }
+  await cache.set(STRUCTURAL_KEY, payload)
+}
+
+/**
+ * Wire pending-edits persistence on top of an `AdminCache`. Call
+ * from admin boot AFTER Pinia is installed; the returned handle's
+ * `hydrated` promise resolves when initial state is loaded so the
+ * caller can await before mounting any UI that reads the store.
+ *
+ * Production code mounts this once per admin session. Tests can
+ * call it with a fresh cache fixture to drive scenarios.
+ */
+export function attachPendingEditsPersistence(
+  cache: AdminCache,
+  opts: PendingEditsPersistenceOptions = {},
+): PendingEditsPersistenceHandle {
+  const debounceMs = opts.structuralDebounceMs ?? STRUCTURAL_WRITE_DEBOUNCE_MS
+  const store = useEditorStructuralStore()
+
+  // Hydrate first — must complete before the watcher is attached
+  // or the empty initial-state write would clobber persisted data.
+  const hydrated = hydrateStructural(cache)
+
+  // Debounced write. Each store mutation kicks the timer forward;
+  // the latest snapshot wins. Deep watch over the entries map so
+  // we catch both shape changes (set/delete) and value-replacements
+  // (setPending replacing the pending array on an existing key).
+  let writeTimer: ReturnType<typeof setTimeout> | null = null
+  const stop = watch(
+    () => Array.from(store.entries.entries()),
+    () => {
+      if (writeTimer !== null) clearTimeout(writeTimer)
+      writeTimer = setTimeout(() => {
+        writeTimer = null
+        // Fire-and-forget — cache failures are logged by the
+        // AdminCache provider, never propagate to the UI.
+        void persistStructural(cache)
+      }, debounceMs)
+    },
+    { deep: true },
+  )
+
+  return {
+    hydrated,
+    dispose() {
+      stop()
+      if (writeTimer !== null) {
+        clearTimeout(writeTimer)
+        writeTimer = null
+      }
+    },
+  }
+}

--- a/apps/admin/src/client/stores/_pendingEditsPersistence.ts
+++ b/apps/admin/src/client/stores/_pendingEditsPersistence.ts
@@ -4,7 +4,7 @@
  * reload per `design-offline.md`'s "Pending edits persist across
  * browser reload" invariant.
  *
- * # Cut 8 scope (this module)
+ * # Cut 8a scope (this module)
  *
  * Persists `editorStructural` only. Structural edits (component
  * reorder / add / remove on a manifest) are pure data — no closures,
@@ -100,7 +100,17 @@ async function hydrateStructural(cache: AdminCache): Promise<void> {
   if (!persisted || persisted.version !== 1) return
   const store = useEditorStructuralStore()
   for (const [keyString, entry] of persisted.entries) {
-    const key = manifestKeyFromString(keyString)
+    let key
+    try {
+      key = manifestKeyFromString(keyString)
+    } catch {
+      // Malformed entry — could happen if a future schema change
+      // wrote a key shape we don't recognize, or storage was
+      // corrupted out-of-band. Skip the bad entry; restore the
+      // valid ones. Better than killing hydration for ALL entries
+      // because of one bad one.
+      continue
+    }
     // Restore via the store's hydration primitive so both `original`
     // (the discard baseline) and `pending` (the user's WIP) come
     // through as-is. The intent-named mutators would re-record

--- a/apps/admin/src/client/stores/_pendingEditsPersistence.ts
+++ b/apps/admin/src/client/stores/_pendingEditsPersistence.ts
@@ -4,43 +4,47 @@
  * reload per `design-offline.md`'s "Pending edits persist across
  * browser reload" invariant.
  *
- * # Cut 8a scope (this module)
+ * # Two coordinators, two stores
  *
- * Persists `editorStructural` only. Structural edits (component
- * reorder / add / remove on a manifest) are pure data — no closures,
- * no transient mounts. Reorders are also higher-friction for an
- * author to redo than re-typing a field, so they're the highest-
- * value persistence target for this cut.
+ * Cut 8a + Cut 8b together cover the three pending-edits stores:
  *
- * `editorStash` + `editorContent` persistence is **deferred to Cut
- * 8b**. Both stores carry an `EditingTarget` with a `save` closure
- * bound to the page's selection state. Persisting them naively
- * loses the closure; rehydration needs to rebuild it via the
- * navigate flow — a non-trivial seam that deserves its own focused
- * cut rather than being rushed alongside the structural pass.
+ *   `attachPendingEditsPersistence` (Cut 8a)
+ *     persists `editorStructural` (component reorder / add / remove)
+ *
+ *   `attachPersistedEditsPersistence` (Cut 8b)
+ *     persists `usePersistedEditsStore` — a cross-page-correct mirror
+ *     of `editorStash` + `editorContent` dirty state, keyed by
+ *     `(kind, name, locale, path)` tuples so two pages with a
+ *     `_root` or `hero` selection don't collide
+ *
+ * Both follow the same shape: hydrate at boot, deep-watch the
+ * source store, debounce-write a JSON snapshot to the cache.
  *
  * # SOLID lenses
  *
- *   - SRP: this module owns the persistence-coordinator concern.
- *     Stores stay store-shaped (state + mutations); the coordinator
- *     observes + serializes + hydrates externally.
- *   - DIP: takes any `AdminCache`. The selector picks IndexedDB or
- *     memory; this coordinator doesn't care which.
- *   - OCP: future per-store sub-modules (stash, content) plug in
- *     through additional `attach...()` calls without changing what's
+ *   - SRP: this module owns persistence-coordination. Stores stay
+ *     store-shaped (state + mutations); the coordinators observe +
+ *     serialize + hydrate externally.
+ *   - DIP: both `attach...` functions take any `AdminCache`. The
+ *     selector picks IndexedDB or memory; the coordinators don't
+ *     care which.
+ *   - OCP: a third store (e.g., a future per-asset upload-queue)
+ *     plugs in via another `attach...()` without changing what's
  *     here.
  *
  * # Cache key conventions
  *
  * Per `design-cache.md` Q1, reserved prefix is `pending-edits:`.
- * One key per persisted store: `pending-edits:structural`. Future
- * cuts add `pending-edits:stash` + `pending-edits:content`.
+ *
+ *   `pending-edits:structural`  — Cut 8a's editorStructural snapshot
+ *   `pending-edits:dirty`       — Cut 8b's usePersistedEdits snapshot
  */
 import { watch } from 'vue'
 import type { AdminCache } from 'gazetta'
 import type { ComponentEntry, ManifestKey } from 'gazetta/types'
 import { manifestKeyFromString } from 'gazetta/types'
 import { useEditorStructuralStore, type StructuralEntry } from './editorStructural.js'
+import { type PersistedEdit, usePersistedEditsStore } from './persistedEdits.js'
 
 /**
  * Cache key for `editorStructural` snapshots. v1 stores everything
@@ -185,6 +189,94 @@ export function attachPendingEditsPersistence(
         // Fire-and-forget — cache failures are logged by the
         // AdminCache provider, never propagate to the UI.
         void persistStructural(cache)
+      }, debounceMs)
+    },
+    { deep: true },
+  )
+
+  return {
+    hydrated,
+    dispose() {
+      stop()
+      if (writeTimer !== null) {
+        clearTimeout(writeTimer)
+        writeTimer = null
+      }
+    },
+  }
+}
+
+// === Cut 8b: persisted dirty + stashed edits ============================
+
+/** Cache key for the cross-page persisted-edits snapshot. */
+const PERSISTED_EDITS_KEY = 'pending-edits:dirty'
+
+/** Default debounce window — slightly slower than structural since
+ *  field edits fire on every keystroke; rapid coalescing avoids
+ *  IndexedDB write thrash during typing. */
+const PERSISTED_EDITS_WRITE_DEBOUNCE_MS = 500
+
+interface PersistedEditsSnapshot {
+  version: 1
+  entries: Array<[string, PersistedEdit]>
+}
+
+async function hydratePersistedEdits(cache: AdminCache): Promise<void> {
+  const persisted = await cache.get<PersistedEditsSnapshot>(PERSISTED_EDITS_KEY)
+  if (!persisted || persisted.version !== 1) return
+  const store = usePersistedEditsStore()
+  // Filter out malformed entries — same defensive posture as Cut 8a's
+  // structural hydration. One bad row shouldn't kill restoration of
+  // the rest.
+  const valid: Array<[string, PersistedEdit]> = []
+  for (const [key, entry] of persisted.entries) {
+    if (typeof key !== 'string' || !entry || typeof entry !== 'object') continue
+    if (typeof entry.editedContent !== 'object' || entry.editedContent === null) continue
+    valid.push([key, entry])
+  }
+  store._hydrateAll(valid)
+}
+
+async function persistPersistedEdits(cache: AdminCache): Promise<void> {
+  const store = usePersistedEditsStore()
+  const entries = [...store.entries.entries()]
+  if (entries.length === 0) {
+    await cache.invalidate(PERSISTED_EDITS_KEY)
+    return
+  }
+  const payload: PersistedEditsSnapshot = { version: 1, entries }
+  await cache.set(PERSISTED_EDITS_KEY, payload)
+}
+
+export interface PersistedEditsPersistenceOptions {
+  /** Override the debounce interval. Tests pass 0 to flush
+   *  synchronously without waiting for real time to pass. */
+  debounceMs?: number
+}
+
+/**
+ * Wire persistence for `usePersistedEditsStore` (the cross-page
+ * dirty + stashed mirror introduced by Cut 8b). Same shape as
+ * `attachPendingEditsPersistence` from Cut 8a; lives in this file
+ * because it's the same persistence-coordinator concern.
+ */
+export function attachPersistedEditsPersistence(
+  cache: AdminCache,
+  opts: PersistedEditsPersistenceOptions = {},
+): PendingEditsPersistenceHandle {
+  const debounceMs = opts.debounceMs ?? PERSISTED_EDITS_WRITE_DEBOUNCE_MS
+  const store = usePersistedEditsStore()
+
+  const hydrated = hydratePersistedEdits(cache)
+
+  let writeTimer: ReturnType<typeof setTimeout> | null = null
+  const stop = watch(
+    () => Array.from(store.entries.entries()),
+    () => {
+      if (writeTimer !== null) clearTimeout(writeTimer)
+      writeTimer = setTimeout(() => {
+        writeTimer = null
+        void persistPersistedEdits(cache)
       }, debounceMs)
     },
     { deep: true },

--- a/apps/admin/src/client/stores/activeTarget.ts
+++ b/apps/admin/src/client/stores/activeTarget.ts
@@ -74,8 +74,25 @@ export const useActiveTargetStore = defineStore('activeTarget', () => {
     return list[0]?.name ?? null
   }
 
+  /**
+   * In-flight `load()` promise — single-flight so the router guard can
+   * await the same promise as App.vue's `onMounted` hook without firing
+   * a second request. Cleared when load() finishes.
+   */
+  let loadPromise: Promise<void> | null = null
+
   /** Load the list of targets and resolve the active target name. */
-  async function load() {
+  async function load(): Promise<void> {
+    if (loadPromise) return loadPromise
+    loadPromise = doLoad()
+    try {
+      await loadPromise
+    } finally {
+      loadPromise = null
+    }
+  }
+
+  async function doLoad(): Promise<void> {
     loading.value = true
     error.value = null
     try {
@@ -91,6 +108,17 @@ export const useActiveTargetStore = defineStore('activeTarget', () => {
     } finally {
       loading.value = false
     }
+  }
+
+  /**
+   * Ensure the target list is loaded before resolving. Idempotent —
+   * concurrent callers share one in-flight request. Used by the router
+   * guard to make `?target=` resolution work on first navigation
+   * (App.vue's `onMounted` may not have fired yet).
+   */
+  async function ensureLoaded(): Promise<void> {
+    if (targets.value.length > 0 && !error.value) return
+    return load()
   }
 
   /** Change the active target. Called by the router guard when ?target= changes. */
@@ -129,6 +157,7 @@ export const useActiveTargetStore = defineStore('activeTarget', () => {
     // actions
     configure,
     load,
+    ensureLoaded,
     setActiveTarget,
     resetToDefault,
     clear,

--- a/apps/admin/src/client/stores/connectionState.ts
+++ b/apps/admin/src/client/stores/connectionState.ts
@@ -1,0 +1,266 @@
+/**
+ * Connection state — 5-state model + hybrid `navigator.onLine` +
+ * heartbeat per `design-offline.md` Q2 lock.
+ *
+ * # States
+ *
+ *   online        — recent successful request; quiet, no heartbeat
+ *   degraded      — `navigator.onLine` false OR a request failed; 5s
+ *                   heartbeat to /api/health; subtle "Connection
+ *                   unstable" indicator
+ *   offline       — N consecutive heartbeat failures; 30s heartbeat;
+ *                   persistent "Offline" banner; Vue Query pauses
+ *   reconnecting  — heartbeat succeeded after offline; queue replay
+ *                   triggers; transition to online
+ *
+ * # Hybrid logic
+ *
+ *   - `navigator.onLine` change events → instant signal, but
+ *     unreliable (browsers report online when network is broken /
+ *     offline when it's fine). Used for instant UX feedback only.
+ *   - GET /api/health heartbeat → confirms / corrects. Probes when
+ *     state is degraded or offline; quiet when online.
+ *
+ * # Vue Query coupling
+ *
+ *   onlineManager.setOnline(state !== 'offline')
+ *
+ * Vue Query treats `true` as "fetch normally, replay mutations,"
+ * `false` as "pause queries, queue mutations." `online` and
+ * `reconnecting` and `degraded` all keep Vue Query active —
+ * `degraded` is a UI hint, not a Vue Query gate. Only `offline`
+ * pauses fetches.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this store owns connection-state machine + heartbeat
+ *     scheduling. Force-sync UI affordance and per-request failure
+ *     reporting are public methods, not separate stores — they're
+ *     two ways to drive the same state, not two distinct concerns.
+ *   - DIP: heartbeat function + onlineManager + clock are injected
+ *     via factory options so tests don't need real timers, real
+ *     fetch, or real Vue Query.
+ *   - OCP: queue replay (Cut 9) hooks via `onReconnect` callback;
+ *     adding it doesn't require touching the state machine.
+ */
+import { defineStore } from 'pinia'
+import { computed, onScopeDispose, ref } from 'vue'
+import { onlineManager } from '@tanstack/vue-query'
+
+/** 5 connection states per `design-offline.md` Q2 lock. */
+export type ConnectionStatus = 'online' | 'degraded' | 'offline' | 'reconnecting'
+
+/** N heartbeat failures in `degraded` before transition to `offline`. */
+const DEGRADED_TO_OFFLINE_THRESHOLD = 3
+/** Heartbeat cadence in degraded mode (ms). */
+const DEGRADED_HEARTBEAT_MS = 5_000
+/** Heartbeat cadence in offline mode (ms). Longer to back off. */
+const OFFLINE_HEARTBEAT_MS = 30_000
+
+/** Health endpoint path. Lives at /api/health per Cut 7. */
+const HEALTH_PATH = '/api/health'
+
+/**
+ * Heartbeat probe contract. Returns true on success, false on
+ * failure. Never throws — failures are signal, not exceptions.
+ */
+export type HeartbeatFn = () => Promise<boolean>
+
+/** Default heartbeat — raw fetch without auth wrappers. */
+async function defaultHeartbeat(): Promise<boolean> {
+  try {
+    // No auth headers — heartbeat must work even when auth is
+    // broken (token expired, etc.) so the user sees "online" rather
+    // than misleading "offline."
+    const res = await fetch(HEALTH_PATH, { method: 'GET', cache: 'no-store' })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+export interface ConnectionStateOptions {
+  /** Override the heartbeat probe. Tests pass a stub. */
+  heartbeatFn?: HeartbeatFn
+  /**
+   * Disable the auto-installed `navigator.onLine` listeners + the
+   * heartbeat scheduler. Tests opt out so they can drive transitions
+   * synchronously via the public methods.
+   */
+  manualMode?: boolean
+}
+
+let optionsCache: ConnectionStateOptions = {}
+
+/**
+ * Configure the store before its first use. Tests call this with
+ * `manualMode: true` to take control of timing. Production code
+ * leaves the default (auto-attached listeners + scheduler).
+ */
+export function configureConnectionState(opts: ConnectionStateOptions): void {
+  optionsCache = opts
+}
+
+export const useConnectionState = defineStore('connectionState', () => {
+  const opts = optionsCache
+  const heartbeat = opts.heartbeatFn ?? defaultHeartbeat
+  const manualMode = opts.manualMode ?? false
+
+  // Status starts at the navigator's reported state. If the browser
+  // says we're offline at boot, jump straight to `degraded` so the
+  // first heartbeat probes immediately rather than waiting for the
+  // first failure to demote us.
+  const status = ref<ConnectionStatus>(typeof navigator !== 'undefined' && !navigator.onLine ? 'degraded' : 'online')
+  const consecutiveFailures = ref(0)
+
+  // Scheduled heartbeat handle. Re-set every transition that needs
+  // a different cadence.
+  let heartbeatHandle: ReturnType<typeof setTimeout> | null = null
+
+  function clearHeartbeat(): void {
+    if (heartbeatHandle !== null) {
+      clearTimeout(heartbeatHandle)
+      heartbeatHandle = null
+    }
+  }
+
+  function syncVueQuery(): void {
+    // Vue Query gate is binary; only `offline` pauses queries.
+    onlineManager.setOnline(status.value !== 'offline')
+  }
+
+  function scheduleHeartbeat(delayMs: number): void {
+    if (manualMode) return
+    clearHeartbeat()
+    heartbeatHandle = setTimeout(() => {
+      void tick()
+    }, delayMs)
+  }
+
+  /**
+   * One heartbeat attempt. Public so tests can drive the scheduler
+   * synchronously without touching real timers.
+   */
+  async function tick(): Promise<void> {
+    const ok = await heartbeat()
+    if (ok) {
+      handleHeartbeatSuccess()
+    } else {
+      handleHeartbeatFailure()
+    }
+  }
+
+  function handleHeartbeatSuccess(): void {
+    consecutiveFailures.value = 0
+    if (status.value === 'offline') {
+      // Cleared offline — flag reconnecting so consumers fire queue
+      // replay. The transition to `online` happens immediately
+      // after; v1 doesn't yet have a queue to drain.
+      status.value = 'reconnecting'
+      syncVueQuery()
+      // Reconnecting → online in the same tick. Cut 9's save queue
+      // hook will introduce an awaitable replay step before this
+      // transition; for now we just go straight through.
+      status.value = 'online'
+      syncVueQuery()
+    } else if (status.value === 'degraded') {
+      // Heartbeat after a transient failure — back to online.
+      status.value = 'online'
+      syncVueQuery()
+    }
+    clearHeartbeat()
+  }
+
+  function handleHeartbeatFailure(): void {
+    consecutiveFailures.value += 1
+    if (status.value === 'online' || status.value === 'reconnecting') {
+      status.value = 'degraded'
+      syncVueQuery()
+    } else if (status.value === 'degraded' && consecutiveFailures.value >= DEGRADED_TO_OFFLINE_THRESHOLD) {
+      status.value = 'offline'
+      syncVueQuery()
+    }
+    // Schedule the next heartbeat at the cadence for the new state.
+    scheduleHeartbeat(status.value === 'offline' ? OFFLINE_HEARTBEAT_MS : DEGRADED_HEARTBEAT_MS)
+  }
+
+  /**
+   * Report a request failure (network error or server unavailable).
+   * Demotes `online` to `degraded` immediately and kicks off a probe.
+   * The save / list / etc. caller is the intended consumer; today
+   * no caller wires this — Cut 9 (save queue) will be the first.
+   */
+  function reportFailure(): void {
+    if (status.value === 'online') {
+      status.value = 'degraded'
+      consecutiveFailures.value = 1
+      syncVueQuery()
+      scheduleHeartbeat(0)
+    }
+  }
+
+  /**
+   * "Send now" affordance from the offline banner. Probes
+   * immediately regardless of the scheduled cadence.
+   */
+  async function probeNow(): Promise<void> {
+    clearHeartbeat()
+    await tick()
+  }
+
+  function onNavigatorOnline(): void {
+    // The browser thinks we're back. Don't trust it blindly — probe
+    // to confirm. Per Q2: navigator.onLine is "instant UX signal,"
+    // not authoritative.
+    if (status.value === 'offline' || status.value === 'degraded') {
+      void probeNow()
+    }
+  }
+
+  function onNavigatorOffline(): void {
+    // The browser says we're offline. Demote immediately so the UI
+    // feels responsive; the heartbeat will confirm.
+    if (status.value === 'online' || status.value === 'reconnecting') {
+      status.value = 'degraded'
+      syncVueQuery()
+      scheduleHeartbeat(0)
+    }
+  }
+
+  // Auto-attach navigator listeners + initial sync unless manualMode.
+  if (!manualMode && typeof window !== 'undefined') {
+    window.addEventListener('online', onNavigatorOnline)
+    window.addEventListener('offline', onNavigatorOffline)
+    // Honor initial offline state: schedule a probe so we discover
+    // recovery without waiting for a navigator event.
+    if (status.value === 'degraded') scheduleHeartbeat(0)
+    // Cleanup when the store's effect scope tears down (e.g.
+    // setActivePinia in tests). Pinia setup stores run inside an
+    // effect scope, so onScopeDispose fires on store disposal.
+    onScopeDispose(() => {
+      window.removeEventListener('online', onNavigatorOnline)
+      window.removeEventListener('offline', onNavigatorOffline)
+      clearHeartbeat()
+    })
+  }
+
+  // Initial Vue Query sync — at boot we're optimistic; if the
+  // navigator already says offline, syncVueQuery() runs again above.
+  syncVueQuery()
+
+  return {
+    status,
+    consecutiveFailures,
+    isOnline: computed(() => status.value === 'online'),
+    isOffline: computed(() => status.value === 'offline'),
+    /** True for any state UI should surface (degraded/offline/reconnecting). */
+    isAttention: computed(() => status.value !== 'online'),
+    tick,
+    reportFailure,
+    probeNow,
+    // Test helpers (intentionally not part of the SRP-clean public
+    // API but harmless on the Pinia store object).
+    _onNavigatorOnline: onNavigatorOnline,
+    _onNavigatorOffline: onNavigatorOffline,
+  }
+})

--- a/apps/admin/src/client/stores/editorEtags.ts
+++ b/apps/admin/src/client/stores/editorEtags.ts
@@ -1,0 +1,75 @@
+/**
+ * Save-concurrency etag tracker per `design-offline.md` Q3.
+ *
+ * Holds the latest server-issued save-etag for each manifest the
+ * client has read or written. The save flow sends the stored value
+ * as `If-Match` and updates it from the server's response on success.
+ * The conflict flow updates it from the 409 STALE response's
+ * `currentEtag` so the next save chains correctly.
+ *
+ * # Shape
+ *
+ * Keyed by manifest path (`pages/home/page.json`, `fragments/header/
+ * fragment.json`, `pages/about/page.fr.json`). Same key shape as
+ * `useSaveConflictsStore` so cross-store coordination is trivial.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this store owns "what's the latest etag for each
+ *     manifest." It does NOT know how saves consume the etag
+ *     (that's useEditorActions) or how conflicts use it (that's
+ *     ConflictBanner).
+ *   - DIP: consumers depend on the typed store API; the underlying
+ *     Map is an implementation detail.
+ *
+ * # Why not bundle on `EditingTarget`
+ *
+ * Two reasons. First, the editor's active target is component-scoped
+ * (`pages/home/hero`); the etag is manifest-scoped (`pages/home/page.json`).
+ * Multiple components in one page share one etag. Second, the stash
+ * stashes the whole `EditingTarget`; tracking the etag separately
+ * means the stash + active editor + future load paths all read from
+ * one source of truth without each carrying its own copy.
+ */
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+/**
+ * Build the manifest path for a (kind, name, locale?) tuple. Same
+ * format as `useSaveConflictsStore` keys.
+ */
+export function manifestPath(kind: 'page' | 'fragment', name: string, locale?: string): string {
+  if (kind === 'page') {
+    return locale ? `pages/${name}/page.${locale}.json` : `pages/${name}/page.json`
+  }
+  return locale ? `fragments/${name}/fragment.${locale}.json` : `fragments/${name}/fragment.json`
+}
+
+export const useEditorEtagsStore = defineStore('editorEtags', () => {
+  const etags = ref<Map<string, string>>(new Map())
+
+  function set(itemPath: string, etag: string): void {
+    const next = new Map(etags.value)
+    next.set(itemPath, etag)
+    etags.value = next
+  }
+
+  function get(itemPath: string): string | null {
+    return etags.value.get(itemPath) ?? null
+  }
+
+  function clear(itemPath: string): void {
+    if (!etags.value.has(itemPath)) return
+    const next = new Map(etags.value)
+    next.delete(itemPath)
+    etags.value = next
+  }
+
+  function clearAll(): void {
+    etags.value = new Map()
+  }
+
+  const count = computed(() => etags.value.size)
+
+  return { etags, count, set, get, clear, clearAll }
+})

--- a/apps/admin/src/client/stores/editorStructural.ts
+++ b/apps/admin/src/client/stores/editorStructural.ts
@@ -92,6 +92,22 @@ export const useEditorStructuralStore = defineStore('editorStructural', () => {
     return entries.get(manifestKeyToString(key))?.pending ?? null
   }
 
+  /**
+   * Hydration primitive — restore a previously-persisted entry with
+   * both `original` and `pending` arrays as-is. Used by the pending-
+   * edits persistence module at admin boot. Leading underscore flags
+   * the method as internal: app code MUST use the intent-named
+   * mutators (move / add / remove / discard) which preserve the
+   * "original captured once" invariant. This bypasses that invariant
+   * because the persisted snapshot IS the prior captured original.
+   */
+  function _hydrateFromSnapshot(key: ManifestKey, entry: StructuralEntry): void {
+    entries.set(manifestKeyToString(key), {
+      original: entry.original,
+      pending: entry.pending,
+    })
+  }
+
   function hasPendingFor(key: ManifestKey): boolean {
     return entries.has(manifestKeyToString(key))
   }
@@ -116,5 +132,6 @@ export const useEditorStructuralStore = defineStore('editorStructural', () => {
     allEntries,
     pendingCount,
     hasPendingEdits,
+    _hydrateFromSnapshot,
   }
 })

--- a/apps/admin/src/client/stores/persistedEdits.ts
+++ b/apps/admin/src/client/stores/persistedEdits.ts
@@ -1,0 +1,155 @@
+/**
+ * Persisted-edits store per `design-offline.md` Cut 8b. Mirrors
+ * the in-memory `editorStash` + the live `editorContent` dirty
+ * state into a cross-reload-survivable bag of pure-data entries.
+ *
+ * # Why a separate store, not extend editorStash
+ *
+ * `editorStash` is intra-selection: keyed by `target.path` (`hero`,
+ * `_root`, `@logo`). Two pages can have a component named `hero`;
+ * the stash key collides. That's fine in-memory because the
+ * stash is conceptually "OTHER things I was editing within this
+ * page" — switching pages clears the home page's relevant context.
+ *
+ * Persistence demands cross-page correctness: dirty content on
+ * `pages/home/_root` must NOT overlay on `pages/about/_root` after
+ * a reload. So this store uses richer keys:
+ *
+ *   page:{name}:{locale?}:{path}
+ *   fragment:{name}:{locale?}:{path}
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this store owns "what dirty/stashed edits exist that
+ *     must survive reload, and where do they belong." It does NOT
+ *     know how the editor consumes them (useEditorActions navigate
+ *     seam) or how they get to disk (_pendingEditsPersistence).
+ *   - DIP: tests + persistence coordinator depend on the typed
+ *     API; the underlying Map is implementation detail.
+ *
+ * # What's persisted
+ *
+ * Only fields that survive serialization. The `EditingTarget`
+ * carries a `save` closure — NOT serializable. We persist the
+ * data the editor needs to recreate the edit:
+ *
+ *   - selectionKey (richer than stash key; survives cross-page)
+ *   - editedContent (the dirty content the user typed)
+ *   - savedBaselineHash (optional; future divergence detection)
+ *
+ * The save closure rebuilds via `useEditorActions.buildTarget(sel)`
+ * on the navigate-back path; that's a pure function over the
+ * fresh selection state.
+ */
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import type { EditorSelection } from '../composables/editorSelection.js'
+
+export interface PersistedEdit {
+  /** Stable cross-page key for the (selection, locale, path) tuple. */
+  key: string
+  /** The author's dirty content. JSON-serializable. */
+  editedContent: Record<string, unknown>
+  /** ISO timestamp when the entry was last touched (for diagnostics). */
+  updatedAt: string
+}
+
+/**
+ * Build the persistence key for a (kind, name, locale, path) tuple.
+ * Same shape as the on-disk format; pure function.
+ *
+ * Examples:
+ *   page:home::_root
+ *   page:home:fr:_root          (French variant of home page root)
+ *   page:home::hero             (hero component on default-locale home)
+ *   fragment:header::logo       (logo component within header fragment)
+ *   fragment:header::@root      (the fragment-edit page root)
+ */
+export function persistedEditKey(
+  kind: 'page' | 'fragment',
+  name: string,
+  locale: string | undefined,
+  path: string,
+): string {
+  return `${kind}:${name}:${locale ?? ''}:${path}`
+}
+
+/**
+ * Build the persistence key from an EditorSelection + (kind, name).
+ * The selection store knows kind+name; the selection knows the
+ * within-target path. Returns null when the selection isn't a
+ * persistable target (`fragmentLink` opens nothing — nothing to
+ * persist).
+ */
+export function persistedEditKeyForSelection(
+  sel: EditorSelection,
+  kind: 'page' | 'fragment' | null,
+  name: string | null,
+  locale: string | undefined,
+): string | null {
+  if (!kind || !name) return null
+  switch (sel.kind) {
+    case 'root':
+      return persistedEditKey(kind, name, locale, '_root')
+    case 'component':
+      return persistedEditKey(kind, name, locale, sel.path)
+    case 'fragmentEdit':
+      return persistedEditKey('fragment', sel.fragmentName, locale, '_root')
+    case 'fragmentLink':
+      return null
+  }
+}
+
+export const usePersistedEditsStore = defineStore('persistedEdits', () => {
+  const entries = ref<Map<string, PersistedEdit>>(new Map())
+
+  function set(key: string, editedContent: Record<string, unknown>): void {
+    const next = new Map(entries.value)
+    next.set(key, { key, editedContent, updatedAt: new Date().toISOString() })
+    entries.value = next
+  }
+
+  function get(key: string): PersistedEdit | null {
+    return entries.value.get(key) ?? null
+  }
+
+  function has(key: string): boolean {
+    return entries.value.has(key)
+  }
+
+  function clear(key: string): void {
+    if (!entries.value.has(key)) return
+    const next = new Map(entries.value)
+    next.delete(key)
+    entries.value = next
+  }
+
+  function clearAll(): void {
+    entries.value = new Map()
+  }
+
+  /**
+   * Internal hydration primitive used by the persistence
+   * coordinator. Replaces the entire entries map atomically (one
+   * reactive trigger) instead of N individual `set`s. App code
+   * uses `set` / `clear`.
+   */
+  function _hydrateAll(replacements: Iterable<[string, PersistedEdit]>): void {
+    entries.value = new Map(replacements)
+  }
+
+  const count = computed(() => entries.value.size)
+  const hasAny = computed(() => entries.value.size > 0)
+
+  return {
+    entries,
+    count,
+    hasAny,
+    set,
+    get,
+    has,
+    clear,
+    clearAll,
+    _hydrateAll,
+  }
+})

--- a/apps/admin/src/client/stores/saveConflicts.ts
+++ b/apps/admin/src/client/stores/saveConflicts.ts
@@ -1,0 +1,105 @@
+/**
+ * Save-conflict state per `design-offline.md` Q3 + Q4.
+ *
+ * Holds conflict snapshots keyed by manifest path (`pages/home/page.json`
+ * | `fragments/header/fragment.json`). When the save flow's
+ * `StaleSaveError` surfaces, the catching layer registers the conflict
+ * here; the banner UI reads it and offers two actions:
+ *
+ *   - "Discard my changes" → clears the conflict + the local pending edit
+ *   - "Show what changed"  → opens the diff view; banner stays until
+ *                            the author finishes acting
+ *
+ * Conflicts persist across navigation (per Q4): an author can navigate
+ * away, come back, and the banner is still there. Per the Krug-aligned
+ * lock there is no explicit "Dismiss" action — dismissing a conflict
+ * without resolving it is a footgun (the next save would still 409).
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this store owns "what conflicts exist right now and on which
+ *     items." It does NOT know how saves produce conflicts (that's
+ *     useEditorActions when 9b ships) or how the banner renders them
+ *     (ConflictBanner.vue).
+ *   - DIP: consumers depend on the store's typed API; the underlying
+ *     `Map<string, ConflictRecord>` is implementation detail.
+ *
+ * # Why keyed by manifest path, not page name
+ *
+ * Two manifests can have the same name across kinds (a page named
+ * "header" + a fragment named "header"). The conflict surface is at
+ * the file boundary, so the path is the correct identity.
+ */
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+export interface ConflictRecord {
+  /**
+   * Manifest path — uniquely identifies the file in conflict.
+   * Examples: `pages/home/page.json`, `fragments/header/fragment.json`,
+   * `pages/about/page.fr.json` (locale variant).
+   */
+  itemPath: string
+  /** The server's current manifest at the time the 409 STALE arrived. */
+  current: Record<string, unknown>
+  /** The server's current save-etag — re-send as If-Match after rebase. */
+  currentEtag: string
+  /**
+   * The author's pending content at the time the save attempt was made.
+   * Frozen at conflict-detection time so subsequent edits don't change
+   * what the diff view shows.
+   */
+  pending: Record<string, unknown>
+  /** ISO timestamp when the conflict was detected. */
+  surfacedAt: string
+}
+
+export const useSaveConflictsStore = defineStore('saveConflicts', () => {
+  const conflicts = ref<Map<string, ConflictRecord>>(new Map())
+
+  /**
+   * Register a new conflict for `itemPath`. Overwrites any existing
+   * conflict on the same path — the freshest 409 is always the one
+   * the author needs to resolve.
+   */
+  function set(record: Omit<ConflictRecord, 'surfacedAt'>): void {
+    const next = new Map(conflicts.value)
+    next.set(record.itemPath, { ...record, surfacedAt: new Date().toISOString() })
+    conflicts.value = next
+  }
+
+  /** Resolve the conflict for `itemPath` (e.g., after Discard). */
+  function clear(itemPath: string): void {
+    if (!conflicts.value.has(itemPath)) return
+    const next = new Map(conflicts.value)
+    next.delete(itemPath)
+    conflicts.value = next
+  }
+
+  /** Drop all conflicts. Used on logout, target-switch, etc. */
+  function clearAll(): void {
+    conflicts.value = new Map()
+  }
+
+  function get(itemPath: string): ConflictRecord | null {
+    return conflicts.value.get(itemPath) ?? null
+  }
+
+  function has(itemPath: string): boolean {
+    return conflicts.value.has(itemPath)
+  }
+
+  const count = computed(() => conflicts.value.size)
+  const hasAny = computed(() => conflicts.value.size > 0)
+
+  return {
+    conflicts,
+    count,
+    hasAny,
+    set,
+    clear,
+    clearAll,
+    get,
+    has,
+  }
+})

--- a/apps/admin/src/client/stores/selection.ts
+++ b/apps/admin/src/client/stores/selection.ts
@@ -5,6 +5,7 @@ import { useToastStore } from './toast.js'
 import { usePreviewStore } from './preview.js'
 import { useSiteStore } from './site.js'
 import { useLocaleStore } from './locale.js'
+import { manifestPath, useEditorEtagsStore } from './editorEtags.js'
 
 export type Selection =
   | { type: 'page'; name: string; detail: PageDetail }
@@ -53,7 +54,12 @@ export const useSelectionStore = defineStore('selection', () => {
     const { signal } = selectController
     try {
       const locale = useLocaleStore().effectiveLocale ?? undefined
-      const detail = await api.getPage(pageName, { signal, locale })
+      // getPageWithEtag captures the save-concurrency etag for the
+      // offline save flow per design-offline.md Q3. Stored under the
+      // manifest path so the save flow + conflict UX share one
+      // source of truth.
+      const { data: detail, etag } = await api.getPageWithEtag(pageName, { signal, locale })
+      if (etag) useEditorEtagsStore().set(manifestPath('page', pageName, locale), etag)
       selection.value = { type: 'page', name: pageName, detail }
       fragmentHostPage.value = null
       usePreviewStore().invalidate()
@@ -69,7 +75,8 @@ export const useSelectionStore = defineStore('selection', () => {
     const { signal } = selectController
     try {
       const locale = useLocaleStore().effectiveLocale ?? undefined
-      const detail = await api.getFragment(fragName, { signal, locale })
+      const { data: detail, etag } = await api.getFragmentWithEtag(fragName, { signal, locale })
+      if (etag) useEditorEtagsStore().set(manifestPath('fragment', fragName, locale), etag)
       selection.value = { type: 'fragment', name: fragName, detail }
       if (!fragmentHostPage.value) resolveDefaultHostPage()
       usePreviewStore().invalidate()
@@ -84,10 +91,12 @@ export const useSelectionStore = defineStore('selection', () => {
     if (!selection.value) return
     try {
       if (selection.value.type === 'page') {
-        const detail = await api.getPage(selection.value.name)
+        const { data: detail, etag } = await api.getPageWithEtag(selection.value.name)
+        if (etag) useEditorEtagsStore().set(manifestPath('page', selection.value.name), etag)
         selection.value = { type: 'page', name: selection.value.name, detail }
       } else {
-        const detail = await api.getFragment(selection.value.name)
+        const { data: detail, etag } = await api.getFragmentWithEtag(selection.value.name)
+        if (etag) useEditorEtagsStore().set(manifestPath('fragment', selection.value.name), etag)
         selection.value = { type: 'fragment', name: selection.value.name, detail }
       }
     } catch (err) {

--- a/apps/admin/src/client/sw.ts
+++ b/apps/admin/src/client/sw.ts
@@ -1,0 +1,83 @@
+/// <reference lib="webworker" />
+/**
+ * Admin service worker — app-shell precache only per
+ * `design-offline.md` Cut 11 scope.
+ *
+ * # What this SW does
+ *
+ *   - Precaches the admin SPA bundle (HTML/JS/CSS chunks listed in
+ *     `self.__WB_MANIFEST` — injected by `vite-plugin-pwa`'s
+ *     injectManifest strategy at build time).
+ *   - Serves precached responses on cold-load when the network is
+ *     unavailable. Without this, an offline cold-load gets "site
+ *     can't be reached"; with this, the SPA bundle loads, the L6
+ *     `IndexedDBCache` hydrates state, and the app renders.
+ *   - Listens for `SKIP_WAITING` messages from the page so the
+ *     update-available toast can activate the new SW immediately
+ *     when the user clicks "Refresh."
+ *
+ * # What this SW does NOT do
+ *
+ *   - Background sync (deferred to v2 — replay queued saves while
+ *     the tab is closed; the design-offline.md trade-off says
+ *     "authors reopen admin to check sync status; replay-on-next-
+ *     open is acceptable v1 UX")
+ *   - Push notifications (deferred until `NotificationProvider`
+ *     extension surface ships per `design-collaboration.md`)
+ *   - Runtime API caching (admin-API responses cache through
+ *     `IndexedDBCache` per Cut 2; SW doesn't intercept /api/*)
+ *   - PWA install prompt (manifest.webmanifest disabled in
+ *     vite.config.ts; v1 is offline-aware, not installable)
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this file owns "precache the app shell + handle update
+ *     activation." Cache providers (IndexedDB, MemoryCache fallback)
+ *     are siblings; the heartbeat + connection state lives in Pinia
+ *     stores; conflict resolution lives in components.
+ *   - Future extension: when v2 background sync ships, it lands as
+ *     a separate fetch handler in this same file; the precache
+ *     plumbing stays.
+ */
+
+import { precacheAndRoute, cleanupOutdatedCaches } from 'workbox-precaching'
+import { clientsClaim } from 'workbox-core'
+
+declare const self: ServiceWorkerGlobalScope
+
+// Precache the app shell. `__WB_MANIFEST` is replaced by
+// vite-plugin-pwa at build time with the build's chunk manifest.
+// In dev mode (where the SW doesn't run), the empty array is the
+// type-correct fallback.
+precacheAndRoute(self.__WB_MANIFEST ?? [])
+
+// Drop precaches from previous SW versions. Without this, every
+// release leaves the prior version's chunks in the user's cache
+// storage indefinitely. cleanupOutdatedCaches reads the precache
+// manifest and removes any cache entry that's not in the current
+// build.
+cleanupOutdatedCaches()
+
+// Take control of any open tabs immediately on activation. Without
+// this, the new SW would only control tabs opened AFTER it activated
+// — existing tabs would keep using the old SW until reload. With
+// it, the user's "Refresh" toast click activates + claims at the
+// same time.
+clientsClaim()
+
+/**
+ * Update flow: the page detects a new SW version (via vite-plugin-pwa
+ * + virtual:pwa-register), shows a toast with a "Refresh" action,
+ * and on click sends `SKIP_WAITING` to this worker. We respond by
+ * skipping the wait phase so the new SW activates immediately.
+ *
+ * Without skipWaiting, the new SW would sit in the `installed` state
+ * until every tab using the old SW closed — which for a long-lived
+ * admin tab is forever. The toast → click → skipWaiting handshake
+ * gives the user explicit control over the activation moment.
+ */
+self.addEventListener('message', event => {
+  if (event.data && (event.data as { type?: string }).type === 'SKIP_WAITING') {
+    self.skipWaiting()
+  }
+})

--- a/apps/admin/tests/ConflictBanner.test.ts
+++ b/apps/admin/tests/ConflictBanner.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Component tests for ConflictBanner.vue.
+ *
+ *   - Hidden when active item has no conflict
+ *   - Renders headline + body + two action buttons when conflict exists
+ *   - "Show what changed" toggles the diff view
+ *   - "Discard my changes" clears the conflict + emits `discard`
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import PrimeVue from 'primevue/config'
+import ConflictBanner from '../src/client/components/ConflictBanner.vue'
+import { useSaveConflictsStore } from '../src/client/stores/saveConflicts.js'
+
+const ITEM_PATH = 'pages/home/page.json'
+const SAMPLE_CONFLICT = {
+  itemPath: ITEM_PATH,
+  current: { template: 'page-default', content: { title: 'Theirs' }, components: [] },
+  currentEtag: 'fresh',
+  pending: { template: 'page-default', content: { title: 'Mine' }, components: [] },
+}
+
+function mountBanner(itemPath = ITEM_PATH) {
+  return mount(ConflictBanner, {
+    props: { itemPath },
+    global: { plugins: [PrimeVue] },
+  })
+}
+
+describe('ConflictBanner', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('renders nothing when no conflict for the active path', () => {
+    const wrapper = mountBanner()
+    expect(wrapper.find('[data-testid="conflict-banner"]').exists()).toBe(false)
+  })
+
+  it('renders the banner when a conflict exists for the active path', () => {
+    const conflicts = useSaveConflictsStore()
+    conflicts.set(SAMPLE_CONFLICT)
+    const wrapper = mountBanner()
+    expect(wrapper.find('[data-testid="conflict-banner"]').exists()).toBe(true)
+    // Plain-language copy per Krug-aligned UX.
+    expect(wrapper.text()).toContain('Was edited by someone else')
+  })
+
+  it('does not render for a different itemPath', () => {
+    const conflicts = useSaveConflictsStore()
+    conflicts.set(SAMPLE_CONFLICT)
+    const wrapper = mountBanner('pages/about/page.json')
+    expect(wrapper.find('[data-testid="conflict-banner"]').exists()).toBe(false)
+  })
+
+  it('"Show what changed" button reveals the diff view; "X" closes it', async () => {
+    const conflicts = useSaveConflictsStore()
+    conflicts.set(SAMPLE_CONFLICT)
+    const wrapper = mountBanner()
+    expect(wrapper.find('[data-testid="conflict-diff-view"]').exists()).toBe(false)
+
+    await wrapper.find('[data-testid="conflict-banner-show-diff"]').trigger('click')
+    expect(wrapper.find('[data-testid="conflict-diff-view"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="conflict-diff-close"]').trigger('click')
+    expect(wrapper.find('[data-testid="conflict-diff-view"]').exists()).toBe(false)
+  })
+
+  it('"Discard my changes" clears the conflict and emits `discard`', async () => {
+    const conflicts = useSaveConflictsStore()
+    conflicts.set(SAMPLE_CONFLICT)
+    const wrapper = mountBanner()
+
+    await wrapper.find('[data-testid="conflict-banner-discard"]').trigger('click')
+
+    expect(conflicts.has(ITEM_PATH)).toBe(false)
+    expect(wrapper.emitted('discard')).toHaveLength(1)
+    // Banner closes once the conflict clears.
+    expect(wrapper.find('[data-testid="conflict-banner"]').exists()).toBe(false)
+  })
+
+  it('does NOT include a "Save anyway / Overwrite" action (Krug lock)', () => {
+    // Pin the design-offline.md Q3 lock: there's no overwrite button.
+    // Authors who genuinely want to overwrite manually port their
+    // edits onto the new version.
+    const conflicts = useSaveConflictsStore()
+    conflicts.set(SAMPLE_CONFLICT)
+    const wrapper = mountBanner()
+
+    const buttonText = wrapper.findAll('button').map(b => b.text().toLowerCase())
+    expect(buttonText.some(t => t.includes('overwrite'))).toBe(false)
+    expect(buttonText.some(t => t.includes('save anyway'))).toBe(false)
+  })
+})

--- a/apps/admin/tests/ConflictDiffView.test.ts
+++ b/apps/admin/tests/ConflictDiffView.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Component tests for ConflictDiffView.vue.
+ *
+ *   - Walks union of top-level keys
+ *   - Renders primitive fields with explicit "Yours" vs "Theirs"
+ *   - Object/array fields render "(changes inside)" placeholder (v1)
+ *   - "Only in mine" / "Only in theirs" labels for one-sided keys
+ *   - Unchanged fields are omitted from the rendered list
+ *   - Empty-state message when no top-level differences
+ *   - Close button emits `close`
+ */
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import ConflictDiffView from '../src/client/components/ConflictDiffView.vue'
+
+function mountDiff(current: Record<string, unknown>, pending: Record<string, unknown>) {
+  return mount(ConflictDiffView, {
+    props: { current, pending },
+    global: { plugins: [PrimeVue] },
+  })
+}
+
+describe('ConflictDiffView', () => {
+  it('renders empty-state when both sides are identical', () => {
+    const wrapper = mountDiff({ template: 't' }, { template: 't' })
+    expect(wrapper.find('[data-testid="conflict-diff-empty"]').exists()).toBe(true)
+  })
+
+  it('shows primitive field diff with humanized label', () => {
+    const wrapper = mountDiff({ template: 'old' }, { template: 'new' })
+    expect(wrapper.find('[data-testid="conflict-diff-row-template"]').exists()).toBe(true)
+    const pendingCell = wrapper.find('[data-testid="conflict-diff-pending-template"]').text()
+    const currentCell = wrapper.find('[data-testid="conflict-diff-current-template"]').text()
+    expect(pendingCell).toBe('new')
+    expect(currentCell).toBe('old')
+  })
+
+  it('omits unchanged fields from the table', () => {
+    // template is changed; route is identical → only template renders
+    const wrapper = mountDiff({ template: 'old', route: '/about' }, { template: 'new', route: '/about' })
+    expect(wrapper.find('[data-testid="conflict-diff-row-template"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="conflict-diff-row-route"]').exists()).toBe(false)
+  })
+
+  it('object/array fields render "(changes inside)" rather than full content', () => {
+    const wrapper = mountDiff(
+      { content: { title: 'Theirs', body: 'long' } },
+      { content: { title: 'Mine', body: 'long' } },
+    )
+    const pendingCell = wrapper.find('[data-testid="conflict-diff-pending-content"]').text()
+    const currentCell = wrapper.find('[data-testid="conflict-diff-current-content"]').text()
+    expect(pendingCell).toContain('changes inside')
+    expect(currentCell).toContain('changes inside')
+  })
+
+  it('"only in mine" when key exists in pending but not current', () => {
+    const wrapper = mountDiff({}, { metadata: { title: 'Mine' } })
+    const currentCell = wrapper.find('[data-testid="conflict-diff-current-metadata"]').text()
+    expect(currentCell).toContain('only in mine')
+  })
+
+  it('"only in theirs" when key exists in current but not pending', () => {
+    const wrapper = mountDiff({ metadata: { title: 'Theirs' } }, {})
+    const pendingCell = wrapper.find('[data-testid="conflict-diff-pending-metadata"]').text()
+    expect(pendingCell).toContain('only in theirs')
+  })
+
+  it('treats deeply-equal object fields as unchanged', () => {
+    // Same object content, different reference — JSON canonicalization
+    // makes them equal.
+    const wrapper = mountDiff(
+      { content: { title: 'Same', tags: ['a', 'b'] } },
+      { content: { title: 'Same', tags: ['a', 'b'] } },
+    )
+    expect(wrapper.find('[data-testid="conflict-diff-row-content"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="conflict-diff-empty"]').exists()).toBe(true)
+  })
+
+  it('humanizes known field names (route → "Route", metadata → "Metadata")', () => {
+    const wrapper = mountDiff({ route: '/old' }, { route: '/new' })
+    expect(wrapper.text()).toContain('Route')
+  })
+
+  it('truncates very long string values', () => {
+    const long = 'x'.repeat(200)
+    // Truncation applies to whichever side carries the long value;
+    // here the SERVER's current is long.
+    const wrapper = mountDiff({ template: long }, { template: 'short' })
+    const currentCell = wrapper.find('[data-testid="conflict-diff-current-template"]').text()
+    expect(currentCell.length).toBeLessThan(long.length)
+    expect(currentCell).toContain('…')
+  })
+
+  it('emits close when close button is clicked', async () => {
+    const wrapper = mountDiff({ template: 'a' }, { template: 'b' })
+    await wrapper.find('[data-testid="conflict-diff-close"]').trigger('click')
+    expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+
+  it('handles array length differences', () => {
+    const wrapper = mountDiff({ components: ['a'] }, { components: ['a', 'b', 'c'] })
+    const pendingCell = wrapper.find('[data-testid="conflict-diff-pending-components"]').text()
+    expect(pendingCell).toContain('3 items')
+  })
+
+  it('handles null vs missing key distinction', () => {
+    // null is a present-with-null-value; missing is absent. Both
+    // sides treat the value as `(only in ...)` only when truly absent.
+    const wrapper = mountDiff({ content: null }, { content: { title: 'Mine' } })
+    expect(wrapper.find('[data-testid="conflict-diff-row-content"]').exists()).toBe(true)
+  })
+})

--- a/apps/admin/tests/OfflineBanner.test.ts
+++ b/apps/admin/tests/OfflineBanner.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Component tests for OfflineBanner.vue per `design-offline.md`
+ * Q4 sync-state visibility.
+ *
+ *   - Hidden when state is `online` (absence is the state)
+ *   - Renders persistent banner when state is `offline`
+ *   - Renders subtle indicator when state is `degraded`
+ *   - Renders subtle indicator when state is `reconnecting`
+ *   - "Send now" button triggers connection probe
+ *   - "Connection back" toast fires on offline → online transition
+ *   - Plain language locked: no jargon ("STALE", "Disconnected", etc.)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import PrimeVue from 'primevue/config'
+import OfflineBanner from '../src/client/components/OfflineBanner.vue'
+import { configureConnectionState, useConnectionState } from '../src/client/stores/connectionState.js'
+import { useToastStore } from '../src/client/stores/toast.js'
+
+afterEach(() => vi.restoreAllMocks())
+
+function mountBanner() {
+  return mount(OfflineBanner, {
+    global: { plugins: [PrimeVue] },
+  })
+}
+
+describe('OfflineBanner — visibility per state', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    configureConnectionState({ manualMode: true, heartbeatFn: async () => true })
+  })
+
+  it('renders nothing when online (absence is the state)', () => {
+    useConnectionState() // online by default
+    const wrapper = mountBanner()
+    expect(wrapper.find('[data-testid="offline-banner"]').exists()).toBe(false)
+  })
+
+  it('renders persistent banner with "Offline" + "Send now" when state is offline', async () => {
+    const connection = useConnectionState()
+    // Drive to offline via 3 consecutive failed heartbeats.
+    configureConnectionState({ manualMode: true, heartbeatFn: async () => false })
+    setActivePinia(createPinia())
+    const c2 = useConnectionState()
+    await c2.tick()
+    await c2.tick()
+    await c2.tick()
+    expect(c2.status).toBe('offline')
+
+    const wrapper = mountBanner()
+    const banner = wrapper.find('[data-testid="offline-banner"]')
+    expect(banner.exists()).toBe(true)
+    expect(banner.attributes('data-state')).toBe('offline')
+    expect(wrapper.text()).toContain('Offline')
+    expect(wrapper.find('[data-testid="offline-banner-send-now"]').exists()).toBe(true)
+    // Suppress unused-var lint
+    void connection
+  })
+
+  it('renders subtle "Connection unstable" when state is degraded', async () => {
+    const connection = useConnectionState()
+    connection.reportFailure()
+    expect(connection.status).toBe('degraded')
+
+    const wrapper = mountBanner()
+    const banner = wrapper.find('[data-testid="offline-banner"]')
+    expect(banner.exists()).toBe(true)
+    expect(banner.attributes('data-state')).toBe('degraded')
+    expect(wrapper.text()).toContain('Connection unstable')
+    // No Send now button on degraded — author isn't blocked yet.
+    expect(wrapper.find('[data-testid="offline-banner-send-now"]').exists()).toBe(false)
+  })
+
+  it('"Send now" button calls connectionState.probeNow', async () => {
+    setActivePinia(createPinia())
+    configureConnectionState({ manualMode: true, heartbeatFn: async () => false })
+    const connection = useConnectionState()
+    await connection.tick()
+    await connection.tick()
+    await connection.tick()
+    expect(connection.status).toBe('offline')
+
+    const probeSpy = vi.spyOn(connection, 'probeNow').mockResolvedValue()
+
+    const wrapper = mountBanner()
+    await wrapper.find('[data-testid="offline-banner-send-now"]').trigger('click')
+
+    expect(probeSpy).toHaveBeenCalledOnce()
+  })
+})
+
+describe('OfflineBanner — reconnect toast', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    // Heartbeat doesn't matter for these tests — we drive `status`
+    // directly via $patch since the watcher just observes the ref.
+    configureConnectionState({ manualMode: true, heartbeatFn: async () => false })
+  })
+
+  it('fires "Connection back" toast on offline → online transition', async () => {
+    const connection = useConnectionState()
+    // Seed offline state. Drive 3 failed ticks; manualMode means
+    // no scheduler runs.
+    await connection.tick()
+    await connection.tick()
+    await connection.tick()
+    expect(connection.status).toBe('offline')
+
+    // Mount AFTER offline so `wasOffline = true` captures correctly
+    // in the component's onMounted hook.
+    const wrapper = mountBanner()
+    const toast = useToastStore()
+    const showSpy = vi.spyOn(toast, 'show')
+
+    // Patch status to online — this is the transition the watcher fires on.
+    connection.$patch({ status: 'online' })
+    await wrapper.vm.$nextTick()
+
+    expect(showSpy).toHaveBeenCalled()
+    const [message, opts] = showSpy.mock.calls[0]
+    expect(message).toBe('Connection back')
+    expect(opts?.type).toBe('info')
+  })
+
+  it('does NOT fire toast on online → degraded (no spurious "back" message)', async () => {
+    const connection = useConnectionState()
+    expect(connection.status).toBe('online')
+
+    const wrapper = mountBanner()
+    const toast = useToastStore()
+    const showSpy = vi.spyOn(toast, 'show')
+
+    connection.reportFailure() // online → degraded
+    await wrapper.vm.$nextTick()
+    expect(showSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('OfflineBanner — plain language lock', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    configureConnectionState({ manualMode: true, heartbeatFn: async () => false })
+  })
+
+  it('does NOT render wire-layer jargon (STALE, Disconnected, etag, etc.)', async () => {
+    const connection = useConnectionState()
+    await connection.tick()
+    await connection.tick()
+    await connection.tick()
+    const wrapper = mountBanner()
+
+    const text = wrapper.text().toLowerCase()
+    expect(text).not.toContain('stale')
+    expect(text).not.toContain('disconnect')
+    expect(text).not.toContain('etag')
+    expect(text).not.toContain('queue')
+    expect(text).not.toContain('retry')
+    expect(text).not.toContain('sync') // "Send now", not "Sync now"
+  })
+})

--- a/apps/admin/tests/_setup/virtual-pwa-register-stub.ts
+++ b/apps/admin/tests/_setup/virtual-pwa-register-stub.ts
@@ -1,0 +1,26 @@
+/**
+ * Stub for `virtual:pwa-register/vue` used during vitest runs.
+ *
+ * vite-plugin-pwa creates the `virtual:pwa-register/vue` module at
+ * build time only — vitest's dev resolver doesn't see it. Aliasing
+ * the module to this stub via `vitest.config.ts resolve.alias`
+ * lets `useServiceWorkerUpdate.ts` import it during tests without
+ * the plugin being active.
+ *
+ * The stub is intentionally minimal: a no-op `useRegisterSW` that
+ * returns reactive shapes matching the real module's contract.
+ * Tests that need to drive the update flow re-mock the module via
+ * `vi.mock('virtual:pwa-register/vue', ...)` to inject behavior;
+ * this stub only handles the "tests that don't care about SW
+ * registration but happen to touch a module that imports it"
+ * case.
+ */
+import { ref } from 'vue'
+
+export function useRegisterSW() {
+  return {
+    needRefresh: ref(false),
+    offlineReady: ref(false),
+    updateServiceWorker: async () => {},
+  }
+}

--- a/apps/admin/tests/activeTarget.test.ts
+++ b/apps/admin/tests/activeTarget.test.ts
@@ -125,4 +125,86 @@ describe('useActiveTargetStore', () => {
     expect(store.activeTargetName).toBe(null)
     expect(store.error).toBe(null)
   })
+
+  // The router guard runs on every navigation, including the first one,
+  // before App.vue's `onMounted` fires `load()`. Without `ensureLoaded`
+  // the guard's `?target=staging` lookup hits an empty `targets.value`
+  // and `setActiveTarget('staging')` throws — the catch clause silently
+  // strips `?target=` from the URL, the indicator stays on `local`, and
+  // the e2e test fails. `ensureLoaded` lets the guard await the load
+  // before checking. Single-flight semantics ensure App.vue's parallel
+  // `load()` doesn't fire a second request.
+  it('ensureLoaded loads when the targets list is empty', async () => {
+    const store = useActiveTargetStore()
+    let calls = 0
+    store.configure({
+      loadTargets: async () => {
+        calls++
+        return TARGETS
+      },
+    })
+    await store.ensureLoaded()
+    expect(store.targets).toHaveLength(3)
+    expect(calls).toBe(1)
+  })
+
+  it('ensureLoaded is a no-op when targets are already loaded', async () => {
+    const store = useActiveTargetStore()
+    let calls = 0
+    store.configure({
+      loadTargets: async () => {
+        calls++
+        return TARGETS
+      },
+    })
+    await store.load()
+    expect(calls).toBe(1)
+    await store.ensureLoaded()
+    expect(calls).toBe(1) // didn't refetch
+  })
+
+  it('ensureLoaded shares one in-flight load across concurrent callers', async () => {
+    const store = useActiveTargetStore()
+    let calls = 0
+    let resolveLoad!: () => void
+    const blocked = new Promise<void>(r => {
+      resolveLoad = r
+    })
+    store.configure({
+      loadTargets: async () => {
+        calls++
+        await blocked
+        return TARGETS
+      },
+    })
+    // Two concurrent ensureLoaded calls — the second must reuse the first's promise.
+    const a = store.ensureLoaded()
+    const b = store.ensureLoaded()
+    resolveLoad()
+    await Promise.all([a, b])
+    expect(calls).toBe(1)
+  })
+
+  it('ensureLoaded retries after a previous failure clears error', async () => {
+    const store = useActiveTargetStore()
+    let attempt = 0
+    store.configure({
+      loadTargets: async () => {
+        attempt++
+        if (attempt === 1) throw new Error('first call fails')
+        return TARGETS
+      },
+    })
+    // First call fails — error set, targets empty.
+    await store.ensureLoaded()
+    expect(store.error).toBe('first call fails')
+    expect(attempt).toBe(1)
+    // Second call must retry because `error` is set (a no-op here
+    // would mean "I tried once, that's enough" — wrong shape for a
+    // guard that runs on every navigation).
+    await store.ensureLoaded()
+    expect(store.error).toBe(null)
+    expect(store.targets).toHaveLength(3)
+    expect(attempt).toBe(2)
+  })
 })

--- a/apps/admin/tests/api-save-etag.test.ts
+++ b/apps/admin/tests/api-save-etag.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Verify the client's save-etag plumbing per `design-offline.md` Q3.
+ *
+ * The server-side contract (ETag header on GET, If-Match on PUT,
+ * 409 STALE response shape) is exercised by gazetta's admin-api
+ * tests. THIS file pins the client-side translation layer:
+ *
+ *   - `getPageWithEtag` / `getFragmentWithEtag` parse the server's
+ *     `ETag` header (RFC-7232 quoted) and expose the unquoted value
+ *   - `updatePage` / `updateFragment` send `If-Match` (re-quoted)
+ *     when the caller passes `ifMatch`
+ *   - 409 STALE responses surface as `StaleSaveError` carrying the
+ *     server's `current` manifest body and `currentEtag`
+ *
+ * Uses `vi.spyOn(global, 'fetch')` to mock the server response so
+ * tests run without a real admin process.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { api, setActiveTargetProvider, StaleSaveError, ValidationFailedError } from '../src/client/api/client.js'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  setActiveTargetProvider(null)
+})
+
+function mockFetch(handler: (input: RequestInfo | URL, init?: RequestInit) => Response): void {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => handler(input, init))
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { 'Content-Type': 'application/json', ...(init.headers as Record<string, string>) },
+  })
+}
+
+describe('getPageWithEtag', () => {
+  it('returns parsed body + unquoted etag from response header', async () => {
+    mockFetch(() =>
+      jsonResponse(
+        { name: 'home', route: '/', template: 'page-default', content: {}, components: [], dir: 'pages/home' },
+        { headers: { ETag: '"abc1234567890def"' } },
+      ),
+    )
+    const result = await api.getPageWithEtag('home')
+    expect(result.data.name).toBe('home')
+    // Quotes stripped — caller stores the raw 16-hex.
+    expect(result.etag).toBe('abc1234567890def')
+  })
+
+  it('returns null etag when server omits the header (e.g., legacy server)', async () => {
+    mockFetch(() =>
+      jsonResponse({
+        name: 'home',
+        route: '/',
+        template: 'page-default',
+        content: {},
+        components: [],
+        dir: 'pages/home',
+      }),
+    )
+    const result = await api.getPageWithEtag('home')
+    expect(result.etag).toBeNull()
+  })
+
+  it('threads the locale option through the URL', async () => {
+    let capturedUrl = ''
+    mockFetch(input => {
+      capturedUrl = input.toString()
+      return jsonResponse(
+        { name: 'home', route: '/', template: 'page-default', content: {}, components: [], dir: 'pages/home' },
+        { headers: { ETag: '"x"' } },
+      )
+    })
+    await api.getPageWithEtag('home', { locale: 'fr' })
+    expect(capturedUrl).toContain('locale=fr')
+  })
+})
+
+describe('getFragmentWithEtag', () => {
+  it('returns parsed body + unquoted etag', async () => {
+    mockFetch(() =>
+      jsonResponse(
+        { name: 'header', template: 'header-layout', content: {}, components: [], dir: 'fragments/header' },
+        { headers: { ETag: '"deadbeef12345678"' } },
+      ),
+    )
+    const result = await api.getFragmentWithEtag('header')
+    expect(result.data.name).toBe('header')
+    expect(result.etag).toBe('deadbeef12345678')
+  })
+})
+
+describe('updatePage with ifMatch', () => {
+  it('re-quotes the ifMatch value into the If-Match header', async () => {
+    let capturedHeaders: Record<string, string> = {}
+    mockFetch((_, init) => {
+      capturedHeaders = (init?.headers as Record<string, string>) ?? {}
+      return jsonResponse({ ok: true, etag: 'new1234567890ab' })
+    })
+    await api.updatePage('home', { content: { title: 'New' } }, { ifMatch: 'old1234567890ab' })
+    expect(capturedHeaders['If-Match']).toBe('"old1234567890ab"')
+  })
+
+  it('omits If-Match header when ifMatch is not supplied', async () => {
+    let capturedHeaders: Record<string, string> = {}
+    mockFetch((_, init) => {
+      capturedHeaders = (init?.headers as Record<string, string>) ?? {}
+      return jsonResponse({ ok: true })
+    })
+    await api.updatePage('home', { content: { title: 'New' } })
+    expect(capturedHeaders['If-Match']).toBeUndefined()
+  })
+
+  it('returns the server-echoed etag for chain projection', async () => {
+    mockFetch(() => jsonResponse({ ok: true, etag: 'projected-etag-x' }))
+    const result = await api.updatePage('home', { content: { title: 'A' } }, { ifMatch: 'baseline' })
+    expect(result.etag).toBe('projected-etag-x')
+  })
+
+  it('throws StaleSaveError on 409 STALE with server current manifest', async () => {
+    mockFetch(() =>
+      jsonResponse(
+        {
+          code: 'STALE',
+          current: { template: 'page-default', content: { title: 'Drift' }, components: [] },
+          currentEtag: 'fresher-etag-x',
+        },
+        { status: 409 },
+      ),
+    )
+    await expect(api.updatePage('home', { content: { title: 'Mine' } }, { ifMatch: 'stale' })).rejects.toThrow(
+      StaleSaveError,
+    )
+  })
+
+  it('StaleSaveError carries the server `current` manifest + currentEtag', async () => {
+    mockFetch(() =>
+      jsonResponse(
+        {
+          code: 'STALE',
+          current: { template: 'page-default', content: { title: 'Drift' }, components: ['a', 'b'] },
+          currentEtag: 'server-fresh-etag',
+        },
+        { status: 409 },
+      ),
+    )
+    try {
+      await api.updatePage('home', { content: { title: 'Mine' } }, { ifMatch: 'stale' })
+      expect.fail('expected StaleSaveError')
+    } catch (err) {
+      expect(err).toBeInstanceOf(StaleSaveError)
+      const stale = err as StaleSaveError
+      expect(stale.code).toBe('STALE')
+      expect((stale.current.content as { title: string }).title).toBe('Drift')
+      expect(stale.currentEtag).toBe('server-fresh-etag')
+    }
+  })
+
+  it('still throws ValidationFailedError on 409 VALIDATION_FAILED (no regression)', async () => {
+    mockFetch(() =>
+      jsonResponse(
+        {
+          code: 'VALIDATION_FAILED',
+          issues: [
+            {
+              validator: 'referenced-asset-exists',
+              severity: 'error',
+              message: 'missing',
+              itemPath: 'pages/home/page.json',
+            },
+          ],
+        },
+        { status: 409 },
+      ),
+    )
+    await expect(api.updatePage('home', { content: {} })).rejects.toThrow(ValidationFailedError)
+  })
+})
+
+describe('updateFragment with ifMatch', () => {
+  it('sends If-Match for fragments and surfaces 409 STALE the same way', async () => {
+    let capturedHeaders: Record<string, string> = {}
+    mockFetch((_, init) => {
+      capturedHeaders = (init?.headers as Record<string, string>) ?? {}
+      return jsonResponse(
+        { code: 'STALE', current: { template: 'header-layout', content: {}, components: [] }, currentEtag: 'fresh' },
+        { status: 409 },
+      )
+    })
+    await expect(api.updateFragment('header', { content: {} }, { ifMatch: 'stale' })).rejects.toThrow(StaleSaveError)
+    expect(capturedHeaders['If-Match']).toBe('"stale"')
+  })
+})

--- a/apps/admin/tests/cache-eviction.test.ts
+++ b/apps/admin/tests/cache-eviction.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Eviction tests for both browser-side cache providers.
+ *
+ * The shared `adminCacheContractTests` suite covers the public API
+ * (get/set/invalidate/subscribe/stats). It does NOT exercise the
+ * size-cap eviction path — providers can advertise eviction limits
+ * but the contract suite stays neutral about WHEN eviction fires.
+ *
+ * Eviction is real correctness logic: cursor walks (IndexedDB),
+ * Map insertion-order tracking (Memory), totalBytes accounting,
+ * the evictions counter on stats. A bug here means caches grow
+ * unbounded or evict the wrong entry first; both are silent
+ * failures the contract suite wouldn't catch.
+ *
+ * # IndexedDBCache: LRS (Least Recently Set)
+ *
+ * Tracks the `setAt` timestamp; oldest writes evict first. Cursor-
+ * walks the `setAt` index in ascending order until back under cap.
+ *
+ * # Browser MemoryCache: LRU (Least Recently Used)
+ *
+ * Touches Map insertion-order on every hit (`delete + set` to bump
+ * recency). Eviction walks `entries.keys().next()` to find the
+ * least-recently-used.
+ */
+import 'fake-indexeddb/auto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { AdminCache } from 'gazetta'
+import { createIndexedDBCache } from '../src/client/cache/indexeddb-cache.js'
+import { createBrowserMemoryCache } from '../src/client/cache/memory-cache.js'
+
+let dbCounter = 0
+
+describe('IndexedDBCache eviction', () => {
+  let cache: (AdminCache & { close(): void }) | null = null
+
+  afterEach(() => {
+    cache?.close()
+    cache = null
+  })
+
+  it('evicts the oldest entry when entry count exceeds maxEntries (LRS)', async () => {
+    cache = await createIndexedDBCache({
+      dbName: `evict-test-${++dbCounter}`,
+      maxEntries: 3,
+    })
+
+    await cache.set('a', 'A')
+    await cache.set('b', 'B')
+    await cache.set('c', 'C')
+    // Cap reached. All three present.
+    expect(await cache.get('a')).toBe('A')
+    expect(await cache.get('b')).toBe('B')
+    expect(await cache.get('c')).toBe('C')
+
+    // Insert a fourth entry; oldest (a) evicts.
+    await cache.set('d', 'D')
+    expect(await cache.get('a')).toBeNull() // evicted
+    expect(await cache.get('b')).toBe('B')
+    expect(await cache.get('c')).toBe('C')
+    expect(await cache.get('d')).toBe('D')
+
+    // Stats reflect the eviction.
+    const stats = await cache.stats!()
+    expect(stats.evictions).toBe(1)
+    expect(stats.size).toBe(3)
+  })
+
+  it('evicts multiple entries when a single set blows past maxEntries', async () => {
+    // Edge: when caller mutates an existing key, totalBytes grows
+    // by delta; size stays. But if we set a NEW key when the cache
+    // was already at exactly maxEntries, size briefly exceeds and
+    // eviction must catch up.
+    cache = await createIndexedDBCache({
+      dbName: `evict-test-${++dbCounter}`,
+      maxEntries: 2,
+    })
+
+    await cache.set('a', 'A')
+    await cache.set('b', 'B')
+    await cache.set('c', 'C')
+
+    expect(await cache.get('a')).toBeNull()
+    expect((await cache.stats!()).size).toBe(2)
+  })
+
+  it('evicts on byte-cap overflow', async () => {
+    // Each value's bytes ≈ JSON.stringify(value).length. Three
+    // 50-byte strings, cap at 80 bytes — only the most-recent
+    // ~80 bytes worth survives.
+    cache = await createIndexedDBCache({
+      dbName: `evict-test-${++dbCounter}`,
+      maxBytes: 80,
+    })
+
+    const big = 'x'.repeat(50)
+    await cache.set('a', big) // ~52 bytes (string + quotes)
+    await cache.set('b', big) // total ~104 — over cap; a evicts
+    expect(await cache.get('a')).toBeNull()
+    expect(await cache.get('b')).toBe(big)
+  })
+
+  it('updating an existing entry does not double-count bytes', async () => {
+    // Earlier `set` should subtract the old entry's bytes before
+    // adding the new entry. Without that, repeated overwrites of
+    // the same key would inflate totalBytes.
+    cache = await createIndexedDBCache({
+      dbName: `evict-test-${++dbCounter}`,
+      maxBytes: 200,
+    })
+
+    const fifty = 'x'.repeat(50) // ~52 bytes
+    for (let i = 0; i < 10; i++) {
+      await cache.set('one-key', fifty)
+    }
+    // After 10 overwrites of the same key, only 1 entry exists.
+    const stats = await cache.stats!()
+    expect(stats.size).toBe(1)
+    // No eviction should have fired (we never exceeded 200 bytes).
+    expect(stats.evictions).toBe(0)
+  })
+
+  it('size and evictions counters are accurate after mixed operations', async () => {
+    cache = await createIndexedDBCache({
+      dbName: `evict-test-${++dbCounter}`,
+      maxEntries: 3,
+    })
+
+    await cache.set('a', 1)
+    await cache.set('b', 2)
+    await cache.set('c', 3)
+    await cache.set('d', 4) // 1 eviction (a)
+    await cache.set('e', 5) // 1 eviction (b)
+    await cache.invalidate('e') // not an eviction; explicit removal
+
+    const stats = await cache.stats!()
+    expect(stats.size).toBe(2) // c, d
+    expect(stats.evictions).toBe(2)
+  })
+})
+
+describe('Browser MemoryCache eviction (LRU)', () => {
+  it('evicts the least-recently-used entry when entry count exceeds maxEntries', () => {
+    const cache = createBrowserMemoryCache({ maxEntries: 3 })
+
+    void cache.set('a', 'A')
+    void cache.set('b', 'B')
+    void cache.set('c', 'C')
+
+    // Cap reached; insert d → oldest (a) evicts.
+    void cache.set('d', 'D')
+    return Promise.all([
+      cache.get('a').then(v => expect(v).toBeNull()),
+      cache.get('b').then(v => expect(v).toBe('B')),
+      cache.get('c').then(v => expect(v).toBe('C')),
+      cache.get('d').then(v => expect(v).toBe('D')),
+    ])
+  })
+
+  it('LRU touch on hit bumps recency (recently-read entry survives eviction)', async () => {
+    const cache = createBrowserMemoryCache({ maxEntries: 3 })
+    await cache.set('a', 'A')
+    await cache.set('b', 'B')
+    await cache.set('c', 'C')
+
+    // Touch `a` via get → it becomes most-recently-used.
+    await cache.get('a')
+
+    // Insert `d` → least-recently-used is now `b`, which evicts.
+    await cache.set('d', 'D')
+    expect(await cache.get('a')).toBe('A') // survived (touched)
+    expect(await cache.get('b')).toBeNull() // evicted
+    expect(await cache.get('c')).toBe('C')
+    expect(await cache.get('d')).toBe('D')
+  })
+
+  it('evicts on byte-cap overflow', async () => {
+    const cache = createBrowserMemoryCache({ maxBytes: 80 })
+    const big = 'x'.repeat(50)
+    await cache.set('a', big)
+    await cache.set('b', big) // exceeds 80; a evicts
+    expect(await cache.get('a')).toBeNull()
+    expect(await cache.get('b')).toBe(big)
+  })
+
+  it('updating an existing entry does not double-count bytes', async () => {
+    const cache = createBrowserMemoryCache({ maxBytes: 200 })
+    const fifty = 'x'.repeat(50)
+    for (let i = 0; i < 10; i++) {
+      await cache.set('one-key', fifty)
+    }
+    const stats = await cache.stats!()
+    expect(stats.size).toBe(1)
+    expect(stats.evictions).toBe(0)
+  })
+
+  it('evictions counter increments per evicted entry', async () => {
+    const cache = createBrowserMemoryCache({ maxEntries: 2 })
+    await cache.set('a', 1)
+    await cache.set('b', 2)
+    await cache.set('c', 3) // 1 eviction
+    await cache.set('d', 4) // 1 eviction
+    await cache.set('e', 5) // 1 eviction
+
+    const stats = await cache.stats!()
+    expect(stats.size).toBe(2)
+    expect(stats.evictions).toBe(3)
+  })
+})

--- a/apps/admin/tests/cache-eviction.test.ts
+++ b/apps/admin/tests/cache-eviction.test.ts
@@ -25,6 +25,7 @@
  */
 import 'fake-indexeddb/auto'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { reactive } from 'vue'
 import type { AdminCache } from 'gazetta'
 import { createIndexedDBCache } from '../src/client/cache/indexeddb-cache.js'
 import { createBrowserMemoryCache } from '../src/client/cache/memory-cache.js'
@@ -205,5 +206,69 @@ describe('Browser MemoryCache eviction (LRU)', () => {
     const stats = await cache.stats!()
     expect(stats.size).toBe(2)
     expect(stats.evictions).toBe(3)
+  })
+})
+
+describe('cache.set sanitizes Vue reactive values (CI regression)', () => {
+  // Real bug caught by CI: IndexedDBCache.set used to store the
+  // value raw via `db.put`. When persistence callers snapshotted
+  // Pinia state — which wraps everything in Vue reactive Proxies —
+  // structured-clone rejected with:
+  //   "Failed to execute 'put' on 'IDBObjectStore':
+  //    #<Object> could not be cloned."
+  // The fix round-trips through JSON before put, stripping Proxies
+  // (and any other non-cloneable wrappers) along the way.
+
+  let cache: (AdminCache & { close(): void }) | null = null
+
+  afterEach(() => {
+    cache?.close()
+    cache = null
+  })
+
+  it('IndexedDBCache.set accepts a Vue reactive object', async () => {
+    cache = await createIndexedDBCache({ dbName: `proxy-test-${Math.random()}` })
+    const reactiveValue = reactive({ title: 'Hello', tags: ['a', 'b'] })
+
+    // Without the JSON sanitize, this throws inside db.put.
+    await cache.set('key', reactiveValue)
+    const got = await cache.get<{ title: string; tags: string[] }>('key')
+    expect(got).toEqual({ title: 'Hello', tags: ['a', 'b'] })
+  })
+
+  it('IndexedDBCache.set accepts a deeply-nested reactive object', async () => {
+    // The Pinia stores the persistence layer snapshots have nested
+    // shapes (entries Map → entry → editedContent → arbitrary
+    // user JSON). Verify the round-trip handles depth.
+    cache = await createIndexedDBCache({ dbName: `proxy-test-${Math.random()}` })
+    const nested = reactive({
+      version: 1 as const,
+      entries: [
+        [
+          'page:home::_root',
+          reactive({ key: 'page:home::_root', editedContent: reactive({ title: 'Mine' }), updatedAt: '' }),
+        ],
+      ],
+    })
+
+    await cache.set('snap', nested)
+    const got = await cache.get<{
+      version: number
+      entries: Array<[string, { key: string; editedContent: { title: string }; updatedAt: string }]>
+    }>('snap')
+    expect(got!.version).toBe(1)
+    expect(got!.entries[0][1].editedContent.title).toBe('Mine')
+  })
+
+  it('Browser MemoryCache.set accepts a Vue reactive object (parity)', async () => {
+    // Memory cache stores in a Map (no structured clone), so this
+    // already works — the regression test pins the parity so a
+    // future refactor that adds clone semantics doesn't break it.
+    const memCache = createBrowserMemoryCache()
+    const reactiveValue = reactive({ title: 'Hello', tags: ['a', 'b'] })
+
+    await memCache.set('key', reactiveValue)
+    const got = await memCache.get<{ title: string; tags: string[] }>('key')
+    expect(got).toEqual({ title: 'Hello', tags: ['a', 'b'] })
   })
 })

--- a/apps/admin/tests/connectionState.test.ts
+++ b/apps/admin/tests/connectionState.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Verify the 5-state model + transitions per `design-offline.md`
+ * Q2 lock. Tests use `manualMode: true` so the scheduler is dormant
+ * and we can drive transitions via `tick()` synchronously — no real
+ * timers, no real fetch.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { onlineManager } from '@tanstack/vue-query'
+import { configureConnectionState, useConnectionState } from '../src/client/stores/connectionState.js'
+
+describe('useConnectionState — 5-state model', () => {
+  let heartbeatResult: boolean
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    heartbeatResult = true
+    configureConnectionState({
+      manualMode: true,
+      heartbeatFn: async () => heartbeatResult,
+    })
+  })
+
+  afterEach(() => {
+    // Reset Vue Query's online flag so tests don't pollute each other.
+    onlineManager.setOnline(true)
+  })
+
+  it('starts in `online` state when navigator.onLine is true', () => {
+    const store = useConnectionState()
+    expect(store.status).toBe('online')
+    expect(onlineManager.isOnline()).toBe(true)
+  })
+
+  it('reportFailure() demotes online → degraded', () => {
+    const store = useConnectionState()
+    store.reportFailure()
+    expect(store.status).toBe('degraded')
+    // Vue Query stays online during degraded — it's a UI hint.
+    expect(onlineManager.isOnline()).toBe(true)
+  })
+
+  it('three consecutive heartbeat failures: online → degraded → offline', async () => {
+    const store = useConnectionState()
+    heartbeatResult = false
+
+    await store.tick()
+    expect(store.status).toBe('degraded')
+    await store.tick()
+    expect(store.status).toBe('degraded')
+    await store.tick()
+    expect(store.status).toBe('offline')
+
+    // Vue Query gates only on offline.
+    expect(onlineManager.isOnline()).toBe(false)
+  })
+
+  it('successful heartbeat from `degraded` returns to `online`', async () => {
+    const store = useConnectionState()
+    heartbeatResult = false
+    await store.tick()
+    expect(store.status).toBe('degraded')
+
+    heartbeatResult = true
+    await store.tick()
+    expect(store.status).toBe('online')
+  })
+
+  it('successful heartbeat from `offline` transitions through reconnecting → online', async () => {
+    const store = useConnectionState()
+    heartbeatResult = false
+    await store.tick()
+    await store.tick()
+    await store.tick()
+    expect(store.status).toBe('offline')
+
+    heartbeatResult = true
+    await store.tick()
+    // V1 has no save queue — reconnecting collapses to online in
+    // the same tick. When Cut 9 ships, this assertion changes.
+    expect(store.status).toBe('online')
+    expect(onlineManager.isOnline()).toBe(true)
+  })
+
+  it('consecutiveFailures resets on successful heartbeat', async () => {
+    const store = useConnectionState()
+    heartbeatResult = false
+    await store.tick()
+    await store.tick()
+    expect(store.consecutiveFailures).toBe(2)
+
+    heartbeatResult = true
+    await store.tick()
+    expect(store.consecutiveFailures).toBe(0)
+  })
+
+  it('reportFailure() is idempotent — multiple calls in degraded stay degraded', () => {
+    const store = useConnectionState()
+    store.reportFailure()
+    store.reportFailure()
+    store.reportFailure()
+    expect(store.status).toBe('degraded')
+    // Doesn't escalate to offline — only consecutive HEARTBEAT
+    // failures do that. reportFailure is a kick, not a counter.
+    expect(store.consecutiveFailures).toBe(1)
+  })
+
+  it('isAttention is true for any non-online state', async () => {
+    const store = useConnectionState()
+    expect(store.isAttention).toBe(false)
+    store.reportFailure()
+    expect(store.isAttention).toBe(true)
+    heartbeatResult = false
+    await store.tick()
+    await store.tick()
+    expect(store.status).toBe('offline')
+    expect(store.isAttention).toBe(true)
+  })
+
+  it('navigator offline event demotes online → degraded immediately', () => {
+    const store = useConnectionState()
+    store._onNavigatorOffline()
+    expect(store.status).toBe('degraded')
+  })
+
+  it('navigator online event from offline triggers a probe', async () => {
+    const store = useConnectionState()
+    heartbeatResult = false
+    await store.tick()
+    await store.tick()
+    await store.tick()
+    expect(store.status).toBe('offline')
+
+    // The navigator event hands off to probeNow() which awaits the
+    // heartbeat. Stub returns success now.
+    heartbeatResult = true
+    await new Promise(resolve => {
+      // probeNow is async; chain a microtask after it resolves.
+      void store.probeNow().then(resolve)
+    })
+    expect(store.status).toBe('online')
+  })
+
+  it('probeNow runs the heartbeat regardless of schedule', async () => {
+    const store = useConnectionState()
+    const heartbeat = vi.fn(async () => true)
+    setActivePinia(createPinia())
+    configureConnectionState({ manualMode: true, heartbeatFn: heartbeat })
+    const store2 = useConnectionState()
+    await store2.probeNow()
+    expect(heartbeat).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/admin/tests/editorEtags.test.ts
+++ b/apps/admin/tests/editorEtags.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Verify the etag store + manifest-path helper.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { manifestPath, useEditorEtagsStore } from '../src/client/stores/editorEtags.js'
+
+describe('manifestPath helper', () => {
+  it('builds the page manifest path without locale', () => {
+    expect(manifestPath('page', 'home')).toBe('pages/home/page.json')
+  })
+
+  it('builds the page manifest path with locale', () => {
+    expect(manifestPath('page', 'home', 'fr')).toBe('pages/home/page.fr.json')
+  })
+
+  it('builds the fragment manifest path without locale', () => {
+    expect(manifestPath('fragment', 'header')).toBe('fragments/header/fragment.json')
+  })
+
+  it('builds the fragment manifest path with locale', () => {
+    expect(manifestPath('fragment', 'header', 'ja')).toBe('fragments/header/fragment.ja.json')
+  })
+
+  it('handles nested page names (subfolders)', () => {
+    expect(manifestPath('page', 'blog/[slug]')).toBe('pages/blog/[slug]/page.json')
+  })
+
+  it('matches the conflict store key shape so cross-store lookup works', () => {
+    // Pin: useEditorEtagsStore + useSaveConflictsStore use the same
+    // key shape for the same item. A future divergence breaks the
+    // discard-flow rebase which reads from the conflict store.
+    const path = manifestPath('page', 'home', 'fr')
+    expect(path).toBe('pages/home/page.fr.json')
+  })
+})
+
+describe('useEditorEtagsStore', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('starts empty', () => {
+    const store = useEditorEtagsStore()
+    expect(store.count).toBe(0)
+    expect(store.get('any')).toBeNull()
+  })
+
+  it('set / get round-trips a value', () => {
+    const store = useEditorEtagsStore()
+    store.set('pages/home/page.json', 'abc123')
+    expect(store.get('pages/home/page.json')).toBe('abc123')
+    expect(store.count).toBe(1)
+  })
+
+  it('set overwrites the existing etag for a path', () => {
+    const store = useEditorEtagsStore()
+    store.set('pages/home/page.json', 'old')
+    store.set('pages/home/page.json', 'new')
+    expect(store.get('pages/home/page.json')).toBe('new')
+    expect(store.count).toBe(1)
+  })
+
+  it('clear removes one entry without touching siblings', () => {
+    const store = useEditorEtagsStore()
+    store.set('pages/home/page.json', 'a')
+    store.set('pages/about/page.json', 'b')
+    store.clear('pages/home/page.json')
+    expect(store.get('pages/home/page.json')).toBeNull()
+    expect(store.get('pages/about/page.json')).toBe('b')
+  })
+
+  it('clearAll empties the store', () => {
+    const store = useEditorEtagsStore()
+    store.set('a', '1')
+    store.set('b', '2')
+    store.clearAll()
+    expect(store.count).toBe(0)
+  })
+})

--- a/apps/admin/tests/indexeddb-cache-broadcast.test.ts
+++ b/apps/admin/tests/indexeddb-cache-broadcast.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Cross-tab invalidation propagation per `design-offline.md`'s
+ * "Storage isolation — Cross-tab sync via native BroadcastChannel."
+ *
+ * Two `IndexedDBCache` providers built against the same database
+ * name simulate two browser tabs in the same origin. An invalidate
+ * in tab A fires tab B's local subscribers via the channel; the loop
+ * guard (instance-ID check) prevents tab A's own subscribers from
+ * double-firing on the rebroadcast.
+ *
+ * jsdom + fake-indexeddb provides a working BroadcastChannel within
+ * the test realm — separate channels with the same name communicate,
+ * matching real-browser semantics. fake-indexeddb's `auto` import
+ * also covers the storage layer.
+ *
+ * Each test uses a unique `dbName` so the BroadcastChannel name
+ * (`gazetta-cache:{dbName}`) is also unique — prevents cross-test
+ * contamination on the channel.
+ */
+import 'fake-indexeddb/auto'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { AdminCache, InvalidationEvent } from 'gazetta'
+import { createIndexedDBCache } from '../src/client/cache/indexeddb-cache.js'
+
+type DisposableCache = AdminCache & { close(): void }
+
+/** Wait until `predicate` is true OR a deadline elapses. Cross-tab
+ *  message delivery is async (microtask-queued); we can't sync-assert. */
+async function waitFor(predicate: () => boolean, timeoutMs = 200): Promise<void> {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error('timed out waiting for cross-tab message')
+    await new Promise(resolve => setTimeout(resolve, 5))
+  }
+}
+
+describe('IndexedDBCache cross-tab BroadcastChannel propagation', () => {
+  let counter = 0
+  const opened: DisposableCache[] = []
+
+  afterEach(() => {
+    for (const cache of opened.splice(0)) cache.close()
+  })
+
+  async function makePeerPair(dbName: string): Promise<[DisposableCache, DisposableCache]> {
+    // Distinct instance IDs so the loop guard can tell them apart.
+    const tabA = (await createIndexedDBCache({ dbName, instance: 'tab-a' })) as DisposableCache
+    const tabB = (await createIndexedDBCache({ dbName, instance: 'tab-b' })) as DisposableCache
+    opened.push(tabA, tabB)
+    return [tabA, tabB]
+  }
+
+  it('invalidate in tab A fires tab B subscribers', async () => {
+    const [tabA, tabB] = await makePeerPair(`gazetta-bc-${++counter}`)
+
+    const eventsOnB: InvalidationEvent[] = []
+    tabB.subscribe(event => eventsOnB.push(event))
+
+    await tabA.set('shared-key', 'value')
+    await tabA.invalidate('shared-key')
+
+    await waitFor(() => eventsOnB.length > 0)
+    expect(eventsOnB[0].prefix).toBe('shared-key')
+    expect(eventsOnB[0].source.instance).toBe('tab-a')
+  })
+
+  it('invalidatePrefix in tab A fires tab B subscribers with the prefix', async () => {
+    const [tabA, tabB] = await makePeerPair(`gazetta-bc-${++counter}`)
+
+    const eventsOnB: InvalidationEvent[] = []
+    tabB.subscribe(event => eventsOnB.push(event))
+
+    await tabA.set('pages:home', 'h')
+    await tabA.set('pages:about', 'a')
+    await tabA.invalidatePrefix('pages:')
+
+    await waitFor(() => eventsOnB.length > 0)
+    expect(eventsOnB.some(e => e.prefix === 'pages:' && e.source.instance === 'tab-a')).toBe(true)
+  })
+
+  it('loop guard: tab A own subscribers fire ONCE per invalidation, not twice', async () => {
+    // Without the instance-ID check in onmessage, tab A's own
+    // BroadcastChannel listener would receive the rebroadcast and
+    // re-fire local subscribers. This test pins the guard.
+    const [tabA] = await makePeerPair(`gazetta-bc-${++counter}`)
+
+    const eventsOnA: InvalidationEvent[] = []
+    tabA.subscribe(event => eventsOnA.push(event))
+
+    await tabA.invalidatePrefix('pages:')
+    // Give the channel a tick to deliver any rebroadcast that would
+    // double-fire if the guard were missing.
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    expect(eventsOnA.length).toBe(1)
+    expect(eventsOnA[0].source.instance).toBe('tab-a')
+  })
+
+  it('invalidations on different dbNames do NOT cross-talk', async () => {
+    // Two databases in the same origin must have isolated channels.
+    // The channel name is suffixed by `dbName`, so two providers on
+    // different DB names won't see each other's events.
+    const [tabA] = await makePeerPair(`gazetta-bc-${++counter}-alpha`)
+    const [tabB] = await makePeerPair(`gazetta-bc-${++counter}-beta`)
+
+    const eventsOnB: InvalidationEvent[] = []
+    tabB.subscribe(event => eventsOnB.push(event))
+
+    await tabA.invalidatePrefix('pages:')
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    expect(eventsOnB.length).toBe(0)
+  })
+
+  it('subscribe disposer stops cross-tab events', async () => {
+    const [tabA, tabB] = await makePeerPair(`gazetta-bc-${++counter}`)
+
+    const eventsOnB: InvalidationEvent[] = []
+    const dispose = tabB.subscribe(event => eventsOnB.push(event))
+
+    await tabA.invalidatePrefix('pages:')
+    await waitFor(() => eventsOnB.length > 0)
+    expect(eventsOnB.length).toBe(1)
+
+    dispose()
+    eventsOnB.length = 0
+    await tabA.invalidatePrefix('fragments:')
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    expect(eventsOnB.length).toBe(0)
+  })
+})

--- a/apps/admin/tests/indexeddb-cache.test.ts
+++ b/apps/admin/tests/indexeddb-cache.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Validate `IndexedDBCache` against the shared `adminCacheContractTests`
+ * suite from `gazetta/testing`. Same baseline contract as the
+ * server-side `MemoryCache` — proves LSP correctness for the L4↔L6
+ * cache architecture.
+ *
+ * vitest's jsdom environment doesn't include IndexedDB, so we
+ * polyfill via `fake-indexeddb/auto`. The `auto` import sets up
+ * `globalThis.indexedDB` and `globalThis.IDBKeyRange` before any
+ * test runs.
+ *
+ * Each contract test gets a fresh database (unique `dbName`) so
+ * tests don't share state. fake-indexeddb stores everything in
+ * memory; cleanup happens implicitly when the provider goes out of
+ * scope.
+ */
+import 'fake-indexeddb/auto'
+import { describe } from 'vitest'
+import { adminCacheContractTests } from 'gazetta/testing'
+import { createIndexedDBCache } from '../src/client/cache/indexeddb-cache.js'
+
+describe('IndexedDBCache satisfies the AdminCache contract', () => {
+  let counter = 0
+  adminCacheContractTests(() => createIndexedDBCache({ dbName: `gazetta-test-${++counter}` }), {
+    // IndexedDBCache evicts via LRS, not TTL — same as MemoryCache.
+    supportsTtl: false,
+    // Cross-tab fan-out via BroadcastChannel lands in offline Cut 4.
+    supportsCrossInstanceSubscribe: false,
+    // No transport — IndexedDB calls go to local storage, no network.
+    supportsTransportFailureSimulation: false,
+  })
+})

--- a/apps/admin/tests/memory-cache.test.ts
+++ b/apps/admin/tests/memory-cache.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Validate `createBrowserMemoryCache` against the shared
+ * `adminCacheContractTests` suite (same baseline contract as the
+ * IndexedDB provider — proves LSP correctness across both
+ * browser-side providers).
+ *
+ * The browser MemoryCache is the IndexedDB-fallback path per Cut 3:
+ * when the IDB probe fails (Safari Lockdown, private mode), the
+ * selector returns this provider. Without direct contract coverage,
+ * a regression in the fallback path could ship silently — caches
+ * still "work" for trivial round-trips but could break invariants
+ * (eviction, subscribe semantics, stats).
+ *
+ * Mirrors the shape of indexeddb-cache.test.ts.
+ */
+import { describe } from 'vitest'
+import { adminCacheContractTests } from 'gazetta/testing'
+import { createBrowserMemoryCache } from '../src/client/cache/memory-cache.js'
+
+describe('createBrowserMemoryCache satisfies the AdminCache contract', () => {
+  adminCacheContractTests(() => Promise.resolve(createBrowserMemoryCache()), {
+    // LRU-only eviction; ignores TTL options just like server-side
+    // MemoryCache.
+    supportsTtl: false,
+    // Browser-side: no cross-instance subscribe; events stay
+    // in-tab. Cross-tab fan-out is IndexedDBCache's territory
+    // (BroadcastChannel, Cut 4).
+    supportsCrossInstanceSubscribe: false,
+    // Pure JS Map under the hood; no transport to fail.
+    supportsTransportFailureSimulation: false,
+  })
+})

--- a/apps/admin/tests/midSaveDropReconcile.test.ts
+++ b/apps/admin/tests/midSaveDropReconcile.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Cut 13 — mid-save connection-loss reconcile per
+ * `design-offline.md` Q4 "handled invisibly."
+ *
+ * When the PUT throws a network error (TypeError from fetch), the
+ * client doesn't know whether the save landed before the drop.
+ * `updateManifest` reconciles via a single GET-and-compare:
+ *
+ *   - Server's current matches what the author tried to save →
+ *     silent success; etag advances; editor goes clean
+ *   - Server's current differs → StaleSaveError; conflict UX takes
+ *     over (banner + diff view from Cut 10)
+ *   - GET also fails → original network error propagates; editor
+ *     stays dirty so the author can retry manually
+ *
+ * Tests exercise the seam through the editor save closure built by
+ * useEditorActions (production path). api.updatePage is stubbed to
+ * throw TypeError; api.getPageWithEtag is stubbed to return
+ * various server states.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { StaleSaveError, api } from '../src/client/api/client.js'
+import { useEditorActions } from '../src/client/composables/useEditorActions.js'
+import { useEditorContentStore } from '../src/client/stores/editorContent.js'
+import { useSelectionStore } from '../src/client/stores/selection.js'
+import { useEditorEtagsStore, manifestPath } from '../src/client/stores/editorEtags.js'
+import { useSaveConflictsStore } from '../src/client/stores/saveConflicts.js'
+
+afterEach(() => vi.restoreAllMocks())
+
+beforeEach(() => setActivePinia(createPinia()))
+
+function seedRootSelection() {
+  const sel = useSelectionStore()
+  sel.$patch({
+    selection: {
+      type: 'page',
+      name: 'home',
+      detail: {
+        name: 'home',
+        route: '/',
+        template: 'page-default',
+        content: {},
+        components: [],
+        dir: 'pages/home',
+      },
+    },
+  })
+}
+
+describe('mid-save connection-loss reconcile', () => {
+  it('silently succeeds when server.current === pending (case a: save landed, response lost)', async () => {
+    const etags = useEditorEtagsStore()
+    const path = manifestPath('page', 'home')
+    etags.set(path, 'baseline-etag')
+
+    // Stub schema fetch (buildTarget calls api.getTemplateSchema).
+    vi.spyOn(api, 'getTemplateSchema').mockResolvedValue({
+      properties: { title: { type: 'string' } },
+    })
+    // Stub PUT to fail with TypeError (network drop).
+    vi.spyOn(api, 'updatePage').mockRejectedValue(new TypeError('Failed to fetch'))
+    // Stub GET to return what the author tried to save — case (a):
+    // the server received + applied the save; only the response was lost.
+    const getSpy = vi.spyOn(api, 'getPageWithEtag').mockResolvedValue({
+      data: {
+        name: 'home',
+        route: '/',
+        template: 'page-default',
+        content: { title: 'My Edit' },
+        components: [],
+        dir: 'pages/home',
+      },
+      etag: 'post-save-etag',
+    })
+
+    seedRootSelection()
+    const actions = useEditorActions()
+    await actions.openPageRoot()
+
+    // Trigger the save closure with the same content the GET will
+    // report — simulates the case where the save landed.
+    const ec = useEditorContentStore()
+    await ec.target!.save({ title: 'My Edit' })
+
+    // Reconcile must have happened: GET was called, etag advanced.
+    expect(getSpy).toHaveBeenCalledOnce()
+    expect(etags.get(path)).toBe('post-save-etag')
+    // No conflict surfaced (silent success).
+    expect(useSaveConflictsStore().hasAny).toBe(false)
+  })
+
+  it('surfaces StaleSaveError when server.current differs from pending (case b: save did not land OR concurrent third-party save)', async () => {
+    const etags = useEditorEtagsStore()
+    const path = manifestPath('page', 'home')
+    etags.set(path, 'baseline-etag')
+
+    vi.spyOn(api, 'getTemplateSchema').mockResolvedValue({
+      properties: { title: { type: 'string' } },
+    })
+    vi.spyOn(api, 'updatePage').mockRejectedValue(new TypeError('Failed to fetch'))
+    // GET returns the pre-save state — server didn't receive the save.
+    vi.spyOn(api, 'getPageWithEtag').mockResolvedValue({
+      data: {
+        name: 'home',
+        route: '/',
+        template: 'page-default',
+        content: { title: 'Untouched' },
+        components: [],
+        dir: 'pages/home',
+      },
+      etag: 'unchanged-etag',
+    })
+
+    seedRootSelection()
+    const actions = useEditorActions()
+    await actions.openPageRoot()
+
+    const ec = useEditorContentStore()
+    await expect(ec.target!.save({ title: 'My Edit' })).rejects.toThrow(StaleSaveError)
+
+    // Conflict surfaced via the existing flow (Cut 10).
+    const conflicts = useSaveConflictsStore()
+    expect(conflicts.has(path)).toBe(true)
+    const record = conflicts.get(path)!
+    expect((record.current.content as { title: string }).title).toBe('Untouched')
+    expect(record.currentEtag).toBe('unchanged-etag')
+    expect((record.pending.content as { title: string }).title).toBe('My Edit')
+    // Etag store advanced to the server's etag for the next save.
+    expect(etags.get(path)).toBe('unchanged-etag')
+  })
+
+  it('propagates the original network error when GET also fails', async () => {
+    const etags = useEditorEtagsStore()
+    const path = manifestPath('page', 'home')
+    etags.set(path, 'baseline-etag')
+
+    vi.spyOn(api, 'getTemplateSchema').mockResolvedValue({
+      properties: { title: { type: 'string' } },
+    })
+    vi.spyOn(api, 'updatePage').mockRejectedValue(new TypeError('Failed to fetch'))
+    // GET also fails — no reconcile possible.
+    vi.spyOn(api, 'getPageWithEtag').mockRejectedValue(new TypeError('Failed to fetch'))
+
+    seedRootSelection()
+    const actions = useEditorActions()
+    await actions.openPageRoot()
+
+    const ec = useEditorContentStore()
+    await expect(ec.target!.save({ title: 'My Edit' })).rejects.toThrow(TypeError)
+
+    // No conflict surfaced (we don't know what the server has).
+    expect(useSaveConflictsStore().hasAny).toBe(false)
+    // Etag store unchanged — the author's pending edits stay dirty
+    // and they can retry when connection comes back.
+    expect(etags.get(path)).toBe('baseline-etag')
+  })
+
+  it('does NOT reconcile on HTTP errors (only on TypeError network failures)', async () => {
+    const etags = useEditorEtagsStore()
+    const path = manifestPath('page', 'home')
+    etags.set(path, 'baseline-etag')
+
+    vi.spyOn(api, 'getTemplateSchema').mockResolvedValue({
+      properties: { title: { type: 'string' } },
+    })
+    // Stub PUT with a regular Error (e.g., 500 from the server) —
+    // not ambiguous; the server told us it failed.
+    vi.spyOn(api, 'updatePage').mockRejectedValue(new Error('Request failed: 500'))
+    const getSpy = vi.spyOn(api, 'getPageWithEtag')
+
+    seedRootSelection()
+    const actions = useEditorActions()
+    await actions.openPageRoot()
+
+    const ec = useEditorContentStore()
+    await expect(ec.target!.save({ title: 'My Edit' })).rejects.toThrow('Request failed: 500')
+
+    // No reconcile attempt — GET wasn't called.
+    expect(getSpy).not.toHaveBeenCalled()
+    // No conflict surfaced.
+    expect(useSaveConflictsStore().hasAny).toBe(false)
+  })
+
+  it('still surfaces 409 STALE on PUT directly (no reconcile path; the original conflict flow takes over)', async () => {
+    const etags = useEditorEtagsStore()
+    const path = manifestPath('page', 'home')
+    etags.set(path, 'stale-etag')
+
+    vi.spyOn(api, 'getTemplateSchema').mockResolvedValue({
+      properties: { title: { type: 'string' } },
+    })
+    // Stub PUT to throw a normal StaleSaveError (server sent 409).
+    vi.spyOn(api, 'updatePage').mockRejectedValue(
+      new StaleSaveError({ template: 'page-default', content: { title: 'Theirs' }, components: [] }, 'fresh-etag'),
+    )
+    const getSpy = vi.spyOn(api, 'getPageWithEtag')
+
+    seedRootSelection()
+    const actions = useEditorActions()
+    await actions.openPageRoot()
+
+    const ec = useEditorContentStore()
+    await expect(ec.target!.save({ title: 'Mine' })).rejects.toThrow(StaleSaveError)
+
+    // GET wasn't called — the 409 already had the server state.
+    expect(getSpy).not.toHaveBeenCalled()
+    // Standard conflict flow surfaced.
+    expect(useSaveConflictsStore().has(path)).toBe(true)
+  })
+})

--- a/apps/admin/tests/pendingEditsPersistence.test.ts
+++ b/apps/admin/tests/pendingEditsPersistence.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Verify the pending-edits persistence coordinator wires the
+ * editorStructural Pinia store to an `AdminCache` correctly:
+ *
+ *   - On attach: hydrates the store from any previously-persisted
+ *     snapshot
+ *   - On mutation: debounce-writes a fresh snapshot
+ *   - On empty: invalidates the cache key (no zombie empty payload)
+ *
+ * Uses an in-memory fake `AdminCache` so the test exercises the
+ * coordinator's contract without dragging in `fake-indexeddb`. The
+ * cache contract is already validated against `IndexedDBCache` via
+ * the contract suite in indexeddb-cache.test.ts.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import type { AdminCache, CacheStats, InvalidationEvent } from 'gazetta'
+import type { ComponentEntry } from 'gazetta/types'
+import { useEditorStructuralStore } from '../src/client/stores/editorStructural.js'
+import {
+  attachPendingEditsPersistence,
+  type PendingEditsPersistenceHandle,
+} from '../src/client/stores/_pendingEditsPersistence.js'
+
+interface PersistedStructural {
+  version: 1
+  entries: Array<[string, { original: ComponentEntry[]; pending: ComponentEntry[] }]>
+}
+
+function fakeAdminCache(): AdminCache & { _store: Map<string, unknown> } {
+  const store = new Map<string, unknown>()
+  return {
+    _store: store,
+    async get<T>(key: string): Promise<T | null> {
+      const v = store.get(key)
+      return v === undefined ? null : (v as T)
+    },
+    async set<T>(key: string, value: T): Promise<void> {
+      store.set(key, value)
+    },
+    async invalidate(key: string): Promise<void> {
+      store.delete(key)
+    },
+    async invalidatePrefix(prefix: string): Promise<number> {
+      let cleared = 0
+      for (const key of store.keys()) {
+        if (key.startsWith(prefix)) {
+          store.delete(key)
+          cleared += 1
+        }
+      }
+      return cleared
+    },
+    subscribe(_handler: (event: InvalidationEvent) => void): () => void {
+      return () => {}
+    },
+    async stats(): Promise<CacheStats> {
+      return { hits: 0, misses: 0, size: store.size, evictions: 0 }
+    },
+  }
+}
+
+/** Settle pending microtasks + Vue's reactivity scheduler. */
+async function settle(): Promise<void> {
+  // Vue's watch callbacks run on the next microtask after a reactive
+  // mutation; awaiting one tick is enough.
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+describe('attachPendingEditsPersistence — editorStructural', () => {
+  let handle: PendingEditsPersistenceHandle | null = null
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    handle?.dispose()
+    handle = null
+  })
+
+  it('hydrates the store from a previously-persisted snapshot', async () => {
+    const cache = fakeAdminCache()
+    const persisted: PersistedStructural = {
+      version: 1,
+      entries: [
+        [
+          'page:home',
+          {
+            original: ['hero', 'features'],
+            pending: ['features', 'hero'],
+          },
+        ],
+      ],
+    }
+    cache._store.set('pending-edits:structural', persisted)
+
+    handle = attachPendingEditsPersistence(cache, { structuralDebounceMs: 0 })
+    await handle.hydrated
+
+    const store = useEditorStructuralStore()
+    expect(store.pendingFor({ kind: 'page', name: 'home' })).toEqual(['features', 'hero'])
+    expect(store.pendingCount).toBe(1)
+  })
+
+  it('writes a snapshot to the cache after a mutation (debounced)', async () => {
+    const cache = fakeAdminCache()
+    handle = attachPendingEditsPersistence(cache, { structuralDebounceMs: 0 })
+    await handle.hydrated
+
+    const store = useEditorStructuralStore()
+    store.moveComponent({ kind: 'page', name: 'home' }, ['a', 'b', 'c'], 0, 2)
+
+    // Debounce 0 + Vue's tick + the setTimeout(0) inside the watcher.
+    // Two ticks for safety.
+    await settle()
+    await settle()
+
+    const persisted = cache._store.get('pending-edits:structural') as PersistedStructural | undefined
+    expect(persisted).toBeDefined()
+    expect(persisted?.version).toBe(1)
+    expect(persisted?.entries).toHaveLength(1)
+    expect(persisted?.entries[0][0]).toBe('page:home')
+    expect(persisted?.entries[0][1].pending).toEqual(['b', 'c', 'a'])
+  })
+
+  it('invalidates the cache key when the store empties out', async () => {
+    const cache = fakeAdminCache()
+    // Pre-seed cache so we can verify it gets cleared.
+    cache._store.set('pending-edits:structural', {
+      version: 1,
+      entries: [['page:home', { original: ['a'], pending: ['b'] }]],
+    })
+
+    handle = attachPendingEditsPersistence(cache, { structuralDebounceMs: 0 })
+    await handle.hydrated
+
+    const store = useEditorStructuralStore()
+    expect(store.pendingCount).toBe(1)
+
+    store.discard({ kind: 'page', name: 'home' })
+
+    await settle()
+    await settle()
+
+    expect(cache._store.has('pending-edits:structural')).toBe(false)
+  })
+
+  it('debounces multiple mutations into one write', async () => {
+    const cache = fakeAdminCache()
+    const setSpy = vi.spyOn(cache, 'set')
+    handle = attachPendingEditsPersistence(cache, { structuralDebounceMs: 50 })
+    await handle.hydrated
+    setSpy.mockClear()
+
+    const store = useEditorStructuralStore()
+    const key = { kind: 'page' as const, name: 'home' }
+    store.addComponent(key, [], 'hero')
+    store.addComponent(key, ['hero'], 'features')
+    store.addComponent(key, ['hero', 'features'], 'footer')
+
+    // No write yet — debounce hasn't fired.
+    await settle()
+    expect(setSpy).not.toHaveBeenCalled()
+
+    // After the debounce window, exactly one write captures the
+    // final state.
+    await new Promise(resolve => setTimeout(resolve, 80))
+    expect(setSpy).toHaveBeenCalledTimes(1)
+    const written = setSpy.mock.calls[0][1] as PersistedStructural
+    expect(written.entries[0][1].pending).toEqual(['hero', 'features', 'footer'])
+  })
+
+  it('hydration on empty cache is a no-op', async () => {
+    const cache = fakeAdminCache()
+    handle = attachPendingEditsPersistence(cache, { structuralDebounceMs: 0 })
+    await handle.hydrated
+
+    const store = useEditorStructuralStore()
+    expect(store.pendingCount).toBe(0)
+  })
+
+  it('hydration ignores wrong-version snapshots', async () => {
+    const cache = fakeAdminCache()
+    cache._store.set('pending-edits:structural', {
+      version: 99,
+      entries: [['page:home', { original: [], pending: [] }]],
+    })
+
+    handle = attachPendingEditsPersistence(cache, { structuralDebounceMs: 0 })
+    await handle.hydrated
+
+    const store = useEditorStructuralStore()
+    expect(store.pendingCount).toBe(0)
+  })
+
+  it('preserves the discard baseline across hydration', async () => {
+    // Pin: hydration restores `original` (the discard baseline) AS-IS,
+    // not as a copy of `pending`. Without _hydrateFromSnapshot using the
+    // intent-named mutators would re-record original from the call site,
+    // breaking discard.
+    const cache = fakeAdminCache()
+    const persisted: PersistedStructural = {
+      version: 1,
+      entries: [
+        [
+          'page:home',
+          {
+            original: ['original-1', 'original-2'],
+            pending: ['changed-order', 'original-1'],
+          },
+        ],
+      ],
+    }
+    cache._store.set('pending-edits:structural', persisted)
+
+    handle = attachPendingEditsPersistence(cache, { structuralDebounceMs: 0 })
+    await handle.hydrated
+
+    const store = useEditorStructuralStore()
+    const key = { kind: 'page' as const, name: 'home' }
+
+    // Now discard — should revert to the original baseline.
+    store.discard(key)
+    expect(store.pendingFor(key)).toBeNull()
+  })
+
+  it('dispose() stops the watcher', async () => {
+    const cache = fakeAdminCache()
+    const setSpy = vi.spyOn(cache, 'set')
+    handle = attachPendingEditsPersistence(cache, { structuralDebounceMs: 0 })
+    await handle.hydrated
+    setSpy.mockClear()
+
+    handle.dispose()
+    handle = null
+
+    const store = useEditorStructuralStore()
+    store.addComponent({ kind: 'page', name: 'home' }, [], 'hero')
+
+    await settle()
+    await settle()
+
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/admin/tests/pendingEditsPersistence.test.ts
+++ b/apps/admin/tests/pendingEditsPersistence.test.ts
@@ -180,6 +180,27 @@ describe('attachPendingEditsPersistence — editorStructural', () => {
     expect(store.pendingCount).toBe(0)
   })
 
+  it('hydration skips malformed keys but keeps valid entries', async () => {
+    // Defensive: a future schema migration or out-of-band storage
+    // corruption could write a key we can't parse. One bad entry
+    // shouldn't kill hydration for valid entries.
+    const cache = fakeAdminCache()
+    cache._store.set('pending-edits:structural', {
+      version: 1,
+      entries: [
+        ['malformed-no-colon', { original: ['x'], pending: ['y'] }],
+        ['page:home', { original: ['a'], pending: ['b'] }],
+      ],
+    })
+
+    handle = attachPendingEditsPersistence(cache, { structuralDebounceMs: 0 })
+    await handle.hydrated
+
+    const store = useEditorStructuralStore()
+    expect(store.pendingFor({ kind: 'page', name: 'home' })).toEqual(['b'])
+    expect(store.pendingCount).toBe(1)
+  })
+
   it('hydration ignores wrong-version snapshots', async () => {
     const cache = fakeAdminCache()
     cache._store.set('pending-edits:structural', {

--- a/apps/admin/tests/persistedEdits.test.ts
+++ b/apps/admin/tests/persistedEdits.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for the persisted-edits store + key helpers per
+ * `design-offline.md` Cut 8b.
+ *
+ * Pure-data store tests; the integration with useEditorActions
+ * navigate / save lives in persistedEditsIntegration.test.ts.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import {
+  persistedEditKey,
+  persistedEditKeyForSelection,
+  usePersistedEditsStore,
+} from '../src/client/stores/persistedEdits.js'
+import type { EditorSelection } from '../src/client/composables/editorSelection.js'
+
+describe('persistedEditKey', () => {
+  it('builds the key for a default-locale page', () => {
+    expect(persistedEditKey('page', 'home', undefined, '_root')).toBe('page:home::_root')
+  })
+
+  it('includes the locale segment', () => {
+    expect(persistedEditKey('page', 'home', 'fr', '_root')).toBe('page:home:fr:_root')
+  })
+
+  it('builds component-level keys', () => {
+    expect(persistedEditKey('page', 'home', undefined, 'hero')).toBe('page:home::hero')
+  })
+
+  it('builds fragment keys', () => {
+    expect(persistedEditKey('fragment', 'header', undefined, 'logo')).toBe('fragment:header::logo')
+  })
+
+  it('keys for the same component path on DIFFERENT pages do NOT collide', () => {
+    // The Cut 8b motivating case: pages/home and pages/about both
+    // have a _root selection; the in-memory stash collides on the
+    // path-only key but persistedEdits must not.
+    const home = persistedEditKey('page', 'home', undefined, '_root')
+    const about = persistedEditKey('page', 'about', undefined, '_root')
+    expect(home).not.toBe(about)
+  })
+
+  it('keys for different locales of the same page do NOT collide', () => {
+    const en = persistedEditKey('page', 'home', undefined, '_root')
+    const fr = persistedEditKey('page', 'home', 'fr', '_root')
+    expect(en).not.toBe(fr)
+  })
+})
+
+describe('persistedEditKeyForSelection', () => {
+  it('returns null for fragmentLink (nothing to persist)', () => {
+    const sel: EditorSelection = { kind: 'fragmentLink', treePath: '@header', fragmentName: 'header' }
+    expect(persistedEditKeyForSelection(sel, 'page', 'home', undefined)).toBeNull()
+  })
+
+  it('returns null when kind is missing (no selection yet)', () => {
+    const sel: EditorSelection = { kind: 'root' }
+    expect(persistedEditKeyForSelection(sel, null, null, undefined)).toBeNull()
+  })
+
+  it('builds _root key for root selection', () => {
+    const sel: EditorSelection = { kind: 'root' }
+    expect(persistedEditKeyForSelection(sel, 'page', 'home', undefined)).toBe('page:home::_root')
+  })
+
+  it('builds component-path key for component selection', () => {
+    const sel: EditorSelection = { kind: 'component', path: 'hero', template: 'hero' }
+    expect(persistedEditKeyForSelection(sel, 'page', 'home', 'fr')).toBe('page:home:fr:hero')
+  })
+
+  it('builds fragment _root key for fragmentEdit selection', () => {
+    const sel: EditorSelection = { kind: 'fragmentEdit', fragmentName: 'header' }
+    // fragmentEdit always builds a fragment key regardless of the
+    // surrounding selection (the host page).
+    expect(persistedEditKeyForSelection(sel, 'page', 'home', undefined)).toBe('fragment:header::_root')
+  })
+})
+
+describe('usePersistedEditsStore', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('starts empty', () => {
+    const store = usePersistedEditsStore()
+    expect(store.count).toBe(0)
+    expect(store.hasAny).toBe(false)
+    expect(store.get('any-key')).toBeNull()
+  })
+
+  it('set / get round-trips a value', () => {
+    const store = usePersistedEditsStore()
+    store.set('page:home::_root', { title: 'Mine' })
+    const entry = store.get('page:home::_root')
+    expect(entry).not.toBeNull()
+    expect(entry!.editedContent).toEqual({ title: 'Mine' })
+    expect(entry!.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('set overwrites an existing entry', () => {
+    const store = usePersistedEditsStore()
+    store.set('page:home::_root', { title: 'A' })
+    store.set('page:home::_root', { title: 'B' })
+    expect(store.count).toBe(1)
+    expect(store.get('page:home::_root')!.editedContent).toEqual({ title: 'B' })
+  })
+
+  it('clear removes one entry without touching siblings', () => {
+    const store = usePersistedEditsStore()
+    store.set('page:home::_root', { title: 'Home' })
+    store.set('page:about::_root', { title: 'About' })
+    store.clear('page:home::_root')
+    expect(store.has('page:home::_root')).toBe(false)
+    expect(store.get('page:about::_root')!.editedContent).toEqual({ title: 'About' })
+  })
+
+  it('clearAll empties the store', () => {
+    const store = usePersistedEditsStore()
+    store.set('a', { x: 1 })
+    store.set('b', { y: 2 })
+    store.clearAll()
+    expect(store.count).toBe(0)
+  })
+
+  it('_hydrateAll replaces the entire entries map', () => {
+    const store = usePersistedEditsStore()
+    store.set('stale', { foo: 'old' })
+    store._hydrateAll([
+      [
+        'page:home::_root',
+        { key: 'page:home::_root', editedContent: { title: 'New' }, updatedAt: '2026-05-06T22:00:00Z' },
+      ],
+    ])
+    expect(store.has('stale')).toBe(false)
+    expect(store.get('page:home::_root')!.editedContent).toEqual({ title: 'New' })
+  })
+})

--- a/apps/admin/tests/persistedEditsIntegration.test.ts
+++ b/apps/admin/tests/persistedEditsIntegration.test.ts
@@ -1,0 +1,242 @@
+/**
+ * End-to-end integration tests for Cut 8b — verifies the navigate
+ * flow consults `usePersistedEditsStore` when the in-memory stash
+ * misses, rebuilds the target via buildTarget, and overlays the
+ * persisted dirty content via `ec.open(target, dirtyContent)`.
+ *
+ * Production paths exercised:
+ *   - markDirty() mirrors to persisted store
+ *   - stashCurrent() mirrors stash entries to persisted store
+ *   - navigate() falls through to persisted store on stash miss
+ *   - save() clears persisted entries on success
+ *   - discard() / revertStashed() clean up persisted entries
+ *
+ * Selection state pre-seeded; api stubs return synthetic schemas
+ * so buildTarget runs without a live server.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { api } from '../src/client/api/client.js'
+import { useEditorActions } from '../src/client/composables/useEditorActions.js'
+import { useEditorContentStore } from '../src/client/stores/editorContent.js'
+import { useEditorStashStore } from '../src/client/stores/editorStash.js'
+import { useSelectionStore } from '../src/client/stores/selection.js'
+import { persistedEditKey, usePersistedEditsStore } from '../src/client/stores/persistedEdits.js'
+
+afterEach(() => vi.restoreAllMocks())
+
+beforeEach(() => setActivePinia(createPinia()))
+
+function seedRootSelection(name = 'home') {
+  const sel = useSelectionStore()
+  sel.$patch({
+    selection: {
+      type: 'page',
+      name,
+      detail: {
+        name,
+        route: name === 'home' ? '/' : `/${name}`,
+        template: 'page-default',
+        content: {},
+        components: [],
+        dir: `pages/${name}`,
+      },
+    },
+  })
+}
+
+function stubSchemaFetch() {
+  vi.spyOn(api, 'getTemplateSchema').mockResolvedValue({
+    properties: { title: { type: 'string' } },
+  })
+}
+
+describe('Cut 8b — markDirty mirrors to persistedEdits', () => {
+  it('persists current dirty content under the (kind, name, locale, path) key', async () => {
+    stubSchemaFetch()
+    seedRootSelection('home')
+    const actions = useEditorActions()
+    await actions.openPageRoot()
+
+    actions.markDirty({ title: 'Live edit' })
+
+    const persistedKey = persistedEditKey('page', 'home', undefined, '_root')
+    const entry = usePersistedEditsStore().get(persistedKey)
+    expect(entry).not.toBeNull()
+    expect(entry!.editedContent).toEqual({ title: 'Live edit' })
+  })
+
+  it('uses cross-page-correct keys (does NOT collide between pages)', async () => {
+    stubSchemaFetch()
+
+    // Edit home/_root
+    seedRootSelection('home')
+    let actions = useEditorActions()
+    await actions.openPageRoot()
+    actions.markDirty({ title: 'Home edit' })
+
+    // Edit about/_root via a fresh selection
+    setActivePinia(createPinia())
+    stubSchemaFetch()
+    seedRootSelection('about')
+    actions = useEditorActions()
+    await actions.openPageRoot()
+    actions.markDirty({ title: 'About edit' })
+
+    // Both keys exist independently in the (about) store
+    const aboutStore = usePersistedEditsStore()
+    expect(aboutStore.get(persistedEditKey('page', 'about', undefined, '_root'))!.editedContent).toEqual({
+      title: 'About edit',
+    })
+    // home key is from the previous Pinia (different keyspace);
+    // verify the about key is the only one in this store.
+    expect(aboutStore.count).toBe(1)
+  })
+})
+
+describe('Cut 8b — stashCurrent mirrors stash entries', () => {
+  it('persists a stash entry to the cross-page store', async () => {
+    stubSchemaFetch()
+    seedRootSelection('home')
+    const actions = useEditorActions()
+
+    // Open _root, dirty it, then navigate to a different selection
+    // (here: a synthetic component selection on the same page).
+    // stashCurrent fires on the next navigate() and mirrors the
+    // dirty edit into both stash AND persistedEdits.
+    await actions.openPageRoot()
+    const ec = useEditorContentStore()
+    actions.markDirty({ title: 'Stashing this' })
+    expect(ec.dirty).toBe(true)
+
+    // Trigger stashCurrent via a fresh navigate (stash happens
+    // before the navigation's own buildTarget). Use an
+    // intentionally-failing navigate so we don't need a real
+    // component schema.
+    await actions.navigate({ kind: 'fragmentLink', treePath: '@nope', fragmentName: 'nope' }).catch(() => {})
+
+    const persistedKey = persistedEditKey('page', 'home', undefined, '_root')
+    const entry = usePersistedEditsStore().get(persistedKey)
+    expect(entry).not.toBeNull()
+    expect(entry!.editedContent).toEqual({ title: 'Stashing this' })
+  })
+})
+
+describe('Cut 8b — navigate restores persisted dirty content', () => {
+  it('opens the target with persisted content when stash misses', async () => {
+    stubSchemaFetch()
+    seedRootSelection('home')
+
+    // Pre-populate the persisted store as if a previous tab session
+    // had stashed dirty content; simulates what hydration produces.
+    const persistedStore = usePersistedEditsStore()
+    const key = persistedEditKey('page', 'home', undefined, '_root')
+    persistedStore.set(key, { title: 'Survived reload' })
+
+    const actions = useEditorActions()
+    await actions.openPageRoot()
+
+    // Editor opens with the persisted content overlaid onto the
+    // freshly-built target.
+    const ec = useEditorContentStore()
+    expect(ec.content).toEqual({ title: 'Survived reload' })
+    // dirty=true because content !== savedJson
+    expect(ec.dirty).toBe(true)
+
+    // The persisted entry is consumed (promoted to live edit).
+    // Verify it's been cleared from the store. Note that markDirty
+    // mirrors back into the store on the next ec.markDirty call,
+    // not on the open() — open() doesn't fire markDirty.
+    expect(persistedStore.has(key)).toBe(false)
+  })
+
+  it('does NOT overlay persisted content from a different page', async () => {
+    stubSchemaFetch()
+    // Persisted entry for /about — but we're navigating to /home.
+    const persistedStore = usePersistedEditsStore()
+    persistedStore.set(persistedEditKey('page', 'about', undefined, '_root'), { title: 'About edit' })
+
+    seedRootSelection('home')
+    const actions = useEditorActions()
+    await actions.openPageRoot()
+
+    // Editor opens with the home target's clean content, NOT the
+    // about persisted content.
+    const ec = useEditorContentStore()
+    expect(ec.content).toEqual({})
+    expect(ec.dirty).toBe(false)
+
+    // about's persisted entry untouched.
+    expect(persistedStore.has(persistedEditKey('page', 'about', undefined, '_root'))).toBe(true)
+  })
+})
+
+describe('Cut 8b — save success clears persisted entries', () => {
+  it('clears the current edit and stashed-key entries on successful save', async () => {
+    stubSchemaFetch()
+    vi.spyOn(api, 'updatePage').mockResolvedValue({ ok: true, etag: 'fresh' })
+    seedRootSelection('home')
+
+    const actions = useEditorActions()
+    await actions.openPageRoot()
+    actions.markDirty({ title: 'Save me' })
+
+    const persistedStore = usePersistedEditsStore()
+    const key = persistedEditKey('page', 'home', undefined, '_root')
+    expect(persistedStore.has(key)).toBe(true)
+
+    await actions.save()
+
+    // Persisted entry cleared after successful save — the content
+    // is now on the server; re-applying after reload would resurrect
+    // the dirty state.
+    expect(persistedStore.has(key)).toBe(false)
+  })
+})
+
+describe('Cut 8b — discard / revertStashed clean up persisted entries', () => {
+  it('discard() clears the persisted entry for the current edit', async () => {
+    stubSchemaFetch()
+    seedRootSelection('home')
+    const actions = useEditorActions()
+    await actions.openPageRoot()
+    actions.markDirty({ title: 'Going to discard' })
+
+    const persistedStore = usePersistedEditsStore()
+    const key = persistedEditKey('page', 'home', undefined, '_root')
+    expect(persistedStore.has(key)).toBe(true)
+
+    actions.discard()
+
+    expect(persistedStore.has(key)).toBe(false)
+  })
+
+  it('revertStashed() clears the persisted entry for the reverted stash key', async () => {
+    stubSchemaFetch()
+    seedRootSelection('home')
+    const actions = useEditorActions()
+
+    // Pre-populate stash + persisted with a synthetic component
+    // path (the contract is path-based; the in-memory stash itself
+    // doesn't enforce that the path is currently selectable).
+    const stash = useEditorStashStore()
+    stash.stash(
+      'hero',
+      {
+        template: 'hero',
+        path: 'hero',
+        content: { title: 'Stashed' },
+        schema: {},
+        save: async () => {},
+      },
+      { title: 'Stashed' },
+    )
+    const persistedStore = usePersistedEditsStore()
+    const key = persistedEditKey('page', 'home', undefined, 'hero')
+    persistedStore.set(key, { title: 'Stashed' })
+
+    actions.revertStashed('hero')
+
+    expect(persistedStore.has(key)).toBe(false)
+  })
+})

--- a/apps/admin/tests/persistedEditsPersistence.test.ts
+++ b/apps/admin/tests/persistedEditsPersistence.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for the Cut 8b persistence coordinator
+ * (`attachPersistedEditsPersistence`).
+ *
+ * Mirrors the shape of pendingEditsPersistence.test.ts (Cut 8a)
+ * since the patterns are deliberately parallel:
+ *
+ *   - On attach: hydrates the store from any previously-persisted
+ *     snapshot
+ *   - On mutation: debounce-writes a fresh snapshot
+ *   - On empty: invalidates the cache key
+ *   - Defensive against malformed entries
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import type { AdminCache, CacheStats, InvalidationEvent } from 'gazetta'
+import {
+  attachPersistedEditsPersistence,
+  type PendingEditsPersistenceHandle,
+} from '../src/client/stores/_pendingEditsPersistence.js'
+import { type PersistedEdit, usePersistedEditsStore } from '../src/client/stores/persistedEdits.js'
+
+interface PersistedEditsSnapshot {
+  version: 1
+  entries: Array<[string, PersistedEdit]>
+}
+
+function fakeAdminCache(): AdminCache & { _store: Map<string, unknown> } {
+  const store = new Map<string, unknown>()
+  return {
+    _store: store,
+    async get<T>(key: string): Promise<T | null> {
+      const v = store.get(key)
+      return v === undefined ? null : (v as T)
+    },
+    async set<T>(key: string, value: T): Promise<void> {
+      store.set(key, value)
+    },
+    async invalidate(key: string): Promise<void> {
+      store.delete(key)
+    },
+    async invalidatePrefix(prefix: string): Promise<number> {
+      let cleared = 0
+      for (const key of store.keys()) {
+        if (key.startsWith(prefix)) {
+          store.delete(key)
+          cleared += 1
+        }
+      }
+      return cleared
+    },
+    subscribe(_handler: (event: InvalidationEvent) => void): () => void {
+      return () => {}
+    },
+    async stats(): Promise<CacheStats> {
+      return { hits: 0, misses: 0, size: store.size, evictions: 0 }
+    },
+  }
+}
+
+async function settle(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+describe('attachPersistedEditsPersistence', () => {
+  let handle: PendingEditsPersistenceHandle | null = null
+
+  beforeEach(() => setActivePinia(createPinia()))
+
+  afterEach(() => {
+    handle?.dispose()
+    handle = null
+  })
+
+  it('hydrates the store from a previously-persisted snapshot', async () => {
+    const cache = fakeAdminCache()
+    const persisted: PersistedEditsSnapshot = {
+      version: 1,
+      entries: [
+        [
+          'page:home::_root',
+          { key: 'page:home::_root', editedContent: { title: 'Mine' }, updatedAt: '2026-05-06T22:00:00Z' },
+        ],
+        [
+          'page:about::hero',
+          { key: 'page:about::hero', editedContent: { headline: 'Hi' }, updatedAt: '2026-05-06T22:01:00Z' },
+        ],
+      ],
+    }
+    cache._store.set('pending-edits:dirty', persisted)
+
+    handle = attachPersistedEditsPersistence(cache, { debounceMs: 0 })
+    await handle.hydrated
+
+    const store = usePersistedEditsStore()
+    expect(store.count).toBe(2)
+    expect(store.get('page:home::_root')!.editedContent).toEqual({ title: 'Mine' })
+    expect(store.get('page:about::hero')!.editedContent).toEqual({ headline: 'Hi' })
+  })
+
+  it('writes a snapshot to the cache after a mutation (debounced)', async () => {
+    const cache = fakeAdminCache()
+    handle = attachPersistedEditsPersistence(cache, { debounceMs: 0 })
+    await handle.hydrated
+
+    const store = usePersistedEditsStore()
+    store.set('page:home::_root', { title: 'Hello' })
+
+    await settle()
+    await settle()
+
+    const persisted = cache._store.get('pending-edits:dirty') as PersistedEditsSnapshot | undefined
+    expect(persisted).toBeDefined()
+    expect(persisted!.version).toBe(1)
+    expect(persisted!.entries).toHaveLength(1)
+    expect(persisted!.entries[0][0]).toBe('page:home::_root')
+    expect(persisted!.entries[0][1].editedContent).toEqual({ title: 'Hello' })
+  })
+
+  it('invalidates the cache key when the store empties out', async () => {
+    const cache = fakeAdminCache()
+    cache._store.set('pending-edits:dirty', {
+      version: 1,
+      entries: [
+        ['page:home::_root', { key: 'page:home::_root', editedContent: { x: 1 }, updatedAt: '2026-05-06T22:00:00Z' }],
+      ],
+    })
+
+    handle = attachPersistedEditsPersistence(cache, { debounceMs: 0 })
+    await handle.hydrated
+    expect(usePersistedEditsStore().count).toBe(1)
+
+    usePersistedEditsStore().clear('page:home::_root')
+    await settle()
+    await settle()
+
+    expect(cache._store.has('pending-edits:dirty')).toBe(false)
+  })
+
+  it('debounces multiple mutations into one write', async () => {
+    const cache = fakeAdminCache()
+    const setSpy = vi.spyOn(cache, 'set')
+    handle = attachPersistedEditsPersistence(cache, { debounceMs: 50 })
+    await handle.hydrated
+    setSpy.mockClear()
+
+    const store = usePersistedEditsStore()
+    store.set('a', { x: 1 })
+    store.set('a', { x: 2 })
+    store.set('a', { x: 3 })
+
+    await settle()
+    expect(setSpy).not.toHaveBeenCalled()
+
+    await new Promise(resolve => setTimeout(resolve, 80))
+    expect(setSpy).toHaveBeenCalledTimes(1)
+    const written = setSpy.mock.calls[0][1] as PersistedEditsSnapshot
+    expect(written.entries[0][1].editedContent).toEqual({ x: 3 })
+  })
+
+  it('hydration on empty cache is a no-op', async () => {
+    const cache = fakeAdminCache()
+    handle = attachPersistedEditsPersistence(cache, { debounceMs: 0 })
+    await handle.hydrated
+    expect(usePersistedEditsStore().count).toBe(0)
+  })
+
+  it('hydration ignores wrong-version snapshots', async () => {
+    const cache = fakeAdminCache()
+    cache._store.set('pending-edits:dirty', {
+      version: 99,
+      entries: [['page:home::_root', { key: 'page:home::_root', editedContent: { x: 1 }, updatedAt: '' }]],
+    })
+
+    handle = attachPersistedEditsPersistence(cache, { debounceMs: 0 })
+    await handle.hydrated
+    expect(usePersistedEditsStore().count).toBe(0)
+  })
+
+  it('hydration skips malformed entries but keeps valid ones', async () => {
+    // Defensive: out-of-band corruption or future schema migration
+    // could write entries we can't parse. One bad row shouldn't kill
+    // restoration of valid rows.
+    const cache = fakeAdminCache()
+    cache._store.set('pending-edits:dirty', {
+      version: 1,
+      entries: [
+        // Bad: editedContent is a string, not an object
+        ['malformed', { key: 'malformed', editedContent: 'not-an-object', updatedAt: '' }],
+        // Good
+        ['page:home::_root', { key: 'page:home::_root', editedContent: { title: 'Mine' }, updatedAt: '' }],
+        // Bad: null entry
+        ['null-entry', null],
+        // Bad: non-string key (TypeScript would catch this; runtime
+        // cache might not)
+      ],
+    })
+
+    handle = attachPersistedEditsPersistence(cache, { debounceMs: 0 })
+    await handle.hydrated
+
+    const store = usePersistedEditsStore()
+    expect(store.has('page:home::_root')).toBe(true)
+    expect(store.has('malformed')).toBe(false)
+    expect(store.has('null-entry')).toBe(false)
+  })
+
+  it('dispose() stops the watcher', async () => {
+    const cache = fakeAdminCache()
+    const setSpy = vi.spyOn(cache, 'set')
+    handle = attachPersistedEditsPersistence(cache, { debounceMs: 0 })
+    await handle.hydrated
+    setSpy.mockClear()
+
+    handle.dispose()
+    handle = null
+
+    usePersistedEditsStore().set('page:home::_root', { title: 'Mine' })
+    await settle()
+    await settle()
+
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/admin/tests/provider-selector.test.ts
+++ b/apps/admin/tests/provider-selector.test.ts
@@ -66,3 +66,129 @@ describe('selectBrowserCacheProvider — IndexedDB unavailable', () => {
     expect(await result.cache.get('probe')).toBe('value')
   })
 })
+
+describe('selectBrowserCacheProvider — IndexedDB defined but transactions throw (Safari Lockdown)', () => {
+  // The design-offline.md "Provider selection logic" specifically
+  // calls out: "Some browsers (notably Safari private mode) report
+  // IndexedDB available but throw on actual use." The probe opens
+  // a real database AND runs a smoke transaction precisely so this
+  // browser shape gets caught and falls back to MemoryCache rather
+  // than being trusted with persistence the browser will actively
+  // sabotage.
+
+  let originalIndexedDB: unknown
+  function stubIndexedDB(impl: Partial<IDBFactory>): void {
+    originalIndexedDB = (globalThis as { indexedDB?: unknown }).indexedDB
+    Object.defineProperty(globalThis, 'indexedDB', {
+      value: impl,
+      configurable: true,
+      writable: true,
+    })
+  }
+
+  afterEach(() => {
+    if (originalIndexedDB === undefined) {
+      // @ts-expect-error: deleting stubbed property
+      delete (globalThis as { indexedDB?: unknown }).indexedDB
+    } else {
+      Object.defineProperty(globalThis, 'indexedDB', {
+        value: originalIndexedDB,
+        configurable: true,
+        writable: true,
+      })
+    }
+  })
+
+  it('falls back to MemoryCache when indexedDB.open() throws synchronously', async () => {
+    stubIndexedDB({
+      open: () => {
+        throw new Error('IDBFactory.open is disabled in this context')
+      },
+    } as Partial<IDBFactory>)
+
+    const { selectBrowserCacheProvider } = await import('../src/client/cache/provider-selector.js')
+    const result = await selectBrowserCacheProvider()
+    expect(result.kind).toBe('memory')
+    expect(result.degraded).toBe(true)
+    expect(result.reason).toBeTruthy()
+    // Fallback cache is fully usable.
+    await result.cache.set('probe', 'value')
+    expect(await result.cache.get('probe')).toBe('value')
+  })
+
+  it('falls back to MemoryCache when indexedDB.open() rejects via onerror', async () => {
+    // Asynchronous failure shape — older Safari + private contexts
+    // accept open() but the request emits onerror. The probe wraps
+    // open() in a Promise; onerror rejects the wrapper.
+    stubIndexedDB({
+      open: () => {
+        const req = {
+          onsuccess: null as null | (() => void),
+          onerror: null as null | (() => void),
+          onupgradeneeded: null as null | (() => void),
+          onblocked: null as null | (() => void),
+          error: new Error('open() forbidden'),
+          result: null as unknown,
+        }
+        // Fire onerror on the next microtask — after the probe
+        // attaches its handler.
+        Promise.resolve().then(() => req.onerror?.())
+        return req as unknown as IDBOpenDBRequest
+      },
+    } as Partial<IDBFactory>)
+
+    const { selectBrowserCacheProvider } = await import('../src/client/cache/provider-selector.js')
+    const result = await selectBrowserCacheProvider()
+    expect(result.kind).toBe('memory')
+    expect(result.degraded).toBe(true)
+    expect(result.reason).toMatch(/forbidden/i)
+  })
+
+  it('falls back to MemoryCache when the smoke transaction throws after open() succeeds', async () => {
+    // The Safari Lockdown / private-browsing case the design-offline.md
+    // probe was specifically built to catch: open() reports success,
+    // but the first transaction throws.
+    stubIndexedDB({
+      open: () => {
+        const fakeDb = {
+          transaction: () => {
+            throw new Error('Transactions disabled in private mode')
+          },
+          close: () => {},
+          createObjectStore: () => ({}),
+        }
+        const req = {
+          onsuccess: null as null | (() => void),
+          onerror: null as null | (() => void),
+          onupgradeneeded: null as null | (() => void),
+          onblocked: null as null | (() => void),
+          error: null,
+          result: fakeDb,
+        }
+        Promise.resolve().then(() => {
+          // upgradeneeded fires first (DB version 1 from nothing); then
+          // success, both before any test-side promise tick completes.
+          req.onupgradeneeded?.()
+          req.onsuccess?.()
+        })
+        return req as unknown as IDBOpenDBRequest
+      },
+      deleteDatabase: () => {
+        const req = {
+          onsuccess: null as null | (() => void),
+          onerror: null as null | (() => void),
+          error: null,
+        }
+        Promise.resolve().then(() => req.onsuccess?.())
+        return req as unknown as IDBOpenDBRequest
+      },
+    } as Partial<IDBFactory>)
+
+    const { selectBrowserCacheProvider } = await import('../src/client/cache/provider-selector.js')
+    const result = await selectBrowserCacheProvider()
+    expect(result.kind).toBe('memory')
+    expect(result.degraded).toBe(true)
+    // Reason carries the throw's message, not the API-undefined fallback.
+    expect(result.reason).toMatch(/transaction|disabled|private/i)
+  })
+})

--- a/apps/admin/tests/provider-selector.test.ts
+++ b/apps/admin/tests/provider-selector.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Verify boot-time provider selection per `design-offline.md`'s
+ * "Provider selection logic" — the selector probes IndexedDB and
+ * falls back to MemoryCache when the probe fails.
+ *
+ * Two scenarios in two `describe` blocks (NOT one) because the
+ * IndexedDB-unavailable case requires `globalThis.indexedDB` to be
+ * undefined BEFORE any module loads. fake-indexeddb's `auto` import
+ * is module-scoped — once loaded, even deleting the global doesn't
+ * fully unwind the polyfill's plumbing across imports. Splitting the
+ * scenarios into separate top-level describes lets vitest's module
+ * graph stay clean within each file region.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+describe('selectBrowserCacheProvider — IndexedDB available', () => {
+  beforeEach(async () => {
+    // Polyfill loads once per worker; idempotent on subsequent imports.
+    await import('fake-indexeddb/auto')
+  })
+
+  it('returns the IndexedDB provider with degraded=false', async () => {
+    const { selectBrowserCacheProvider } = await import('../src/client/cache/provider-selector.js')
+    const result = await selectBrowserCacheProvider()
+    expect(result.kind).toBe('indexed-db')
+    expect(result.degraded).toBe(false)
+    expect(result.reason).toBeUndefined()
+    // The cache is usable end-to-end — round-trip a value to prove
+    // we got a wired provider, not a stub.
+    await result.cache.set('probe', { hello: 'world' })
+    expect(await result.cache.get('probe')).toEqual({ hello: 'world' })
+  })
+})
+
+describe('selectBrowserCacheProvider — IndexedDB unavailable', () => {
+  let originalIndexedDB: unknown
+
+  beforeEach(() => {
+    // Stash whatever's there (jsdom + earlier polyfills) and remove
+    // it so the probe's `typeof indexedDB === 'undefined'` short-circuit
+    // fires — exactly the path Safari Lockdown / very-old browsers take.
+    originalIndexedDB = (globalThis as { indexedDB?: unknown }).indexedDB
+    // @ts-expect-error — intentionally clearing the global for the probe
+    delete (globalThis as { indexedDB?: unknown }).indexedDB
+  })
+
+  afterEach(() => {
+    if (originalIndexedDB !== undefined) {
+      ;(globalThis as { indexedDB?: unknown }).indexedDB = originalIndexedDB
+    }
+  })
+
+  it('falls back to MemoryCache with degraded=true and a reason', async () => {
+    // Import inside the test so the probe sees the cleared global.
+    // Vitest module cache is per-file — we share it across both
+    // describes, so the dynamic import returns the same selector
+    // function in both. The probe runs every call.
+    const { selectBrowserCacheProvider } = await import('../src/client/cache/provider-selector.js')
+    const result = await selectBrowserCacheProvider()
+    expect(result.kind).toBe('memory')
+    expect(result.degraded).toBe(true)
+    expect(result.reason).toBeTruthy()
+    expect(result.reason).toMatch(/IndexedDB/i)
+    // The fallback cache works for the in-tab session.
+    await result.cache.set('probe', 'value')
+    expect(await result.cache.get('probe')).toBe('value')
+  })
+})

--- a/apps/admin/tests/queries-client.test.ts
+++ b/apps/admin/tests/queries-client.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Integration test mirroring `main.ts`'s VueQueryPlugin install
+ * flow: build a `QueryClient` + persister, get the `clientPersister`
+ * callback, invoke it, and verify the documented `[unsubscribe,
+ * restored]` tuple shape.
+ *
+ * The plugin contract requires the callback to return that tuple so
+ * Vue Query can await `restored` before mounting the app and
+ * dispose via `unsubscribe()` on teardown. Drift in either direction
+ * would silently break offline rehydration.
+ */
+import { describe, expect, it } from 'vitest'
+import { QueryClient } from '@tanstack/vue-query'
+import type { AdminCache, CacheStats, InvalidationEvent } from 'gazetta'
+import { createAdminQueryClient, createGazettaClientPersister } from '../src/client/queries/client.js'
+import { createGazettaPersister } from '../src/client/queries/persister.js'
+
+function fakeAdminCache(): AdminCache {
+  const store = new Map<string, unknown>()
+  return {
+    async get<T>(key: string): Promise<T | null> {
+      const v = store.get(key)
+      return v === undefined ? null : (v as T)
+    },
+    async set<T>(key: string, value: T): Promise<void> {
+      store.set(key, value)
+    },
+    async invalidate(key: string): Promise<void> {
+      store.delete(key)
+    },
+    async invalidatePrefix(prefix: string): Promise<number> {
+      let cleared = 0
+      for (const key of store.keys()) {
+        if (key.startsWith(prefix)) {
+          store.delete(key)
+          cleared += 1
+        }
+      }
+      return cleared
+    },
+    subscribe(_handler: (event: InvalidationEvent) => void): () => void {
+      return () => {}
+    },
+    async stats(): Promise<CacheStats> {
+      return { hits: 0, misses: 0, size: store.size, evictions: 0 }
+    },
+  }
+}
+
+describe('createAdminQueryClient + clientPersister wiring', () => {
+  it('produces a QueryClient with offline-friendly gcTime defaults', () => {
+    const client = createAdminQueryClient()
+    const queryDefaults = client.getDefaultOptions().queries
+    const mutationDefaults = client.getDefaultOptions().mutations
+    // 24h. Verifies the offline default and pins it in case a future
+    // refactor accidentally resets to Vue Query's 5-minute default.
+    expect(queryDefaults?.gcTime).toBe(24 * 60 * 60 * 1000)
+    expect(mutationDefaults?.gcTime).toBe(24 * 60 * 60 * 1000)
+  })
+
+  it('clientPersister returns the [unsubscribe, restored] tuple Vue Query expects', async () => {
+    const cache = fakeAdminCache()
+    const persister = createGazettaPersister(cache, { throttleTime: 0 })
+    const clientPersister = createGazettaClientPersister(persister)
+    const client = createAdminQueryClient()
+
+    const result = clientPersister(client)
+    expect(Array.isArray(result)).toBe(true)
+    expect(result).toHaveLength(2)
+    const [unsubscribe, restored] = result
+    expect(typeof unsubscribe).toBe('function')
+    expect(restored).toBeInstanceOf(Promise)
+    await restored
+    unsubscribe()
+  })
+
+  it('restoring a fresh client picks up data from a previously persisted session', async () => {
+    const cache = fakeAdminCache()
+    const persister = createGazettaPersister(cache, { throttleTime: 0 })
+    const clientPersister = createGazettaClientPersister(persister)
+
+    // First "session": populate + persist.
+    const session1 = createAdminQueryClient()
+    const [unsubscribe1, restored1] = clientPersister(session1)
+    await restored1
+    session1.setQueryData(['pages'], [{ name: 'home' }])
+    // Persistence happens via cache subscriber; throttleTime 0 in
+    // this test means it fires immediately on the next microtask.
+    await new Promise(resolve => setTimeout(resolve, 10))
+    unsubscribe1()
+
+    // Second "session": empty client, restore from cache.
+    const session2 = createAdminQueryClient()
+    expect(session2.getQueryData(['pages'])).toBeUndefined()
+    const [unsubscribe2, restored2] = clientPersister(session2)
+    await restored2
+    expect(session2.getQueryData(['pages'])).toEqual([{ name: 'home' }])
+    unsubscribe2()
+  })
+
+  it('buster mismatch on restore discards persisted data', async () => {
+    const cache = fakeAdminCache()
+    const persister = createGazettaPersister(cache, { throttleTime: 0 })
+
+    // Save under buster=v1.
+    const v1Persister = createGazettaClientPersister(persister, 'v1')
+    const session1 = createAdminQueryClient()
+    const [unsub1, restored1] = v1Persister(session1)
+    await restored1
+    session1.setQueryData(['pages'], [{ name: 'home' }])
+    await new Promise(resolve => setTimeout(resolve, 10))
+    unsub1()
+
+    // Restore under buster=v2 — should NOT see the v1 data.
+    const v2Persister = createGazettaClientPersister(persister, 'v2')
+    const session2 = createAdminQueryClient()
+    const [unsub2, restored2] = v2Persister(session2)
+    await restored2
+    expect(session2.getQueryData(['pages'])).toBeUndefined()
+    unsub2()
+  })
+})

--- a/apps/admin/tests/queries-persister.test.ts
+++ b/apps/admin/tests/queries-persister.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Round-trip a `PersistedClient` through the Gazetta persister to
+ * pin two contracts:
+ *
+ *   1. The adapter chain (persister → AsyncStorage → AdminCache)
+ *      preserves the dehydrated query state byte-for-byte through
+ *      a save+restore cycle.
+ *
+ *   2. The `buster` parameter discards the persisted client when it
+ *      changes — the cache-reset hook for Gazetta major-version
+ *      upgrades.
+ *
+ * Uses a fake `AdminCache` for the same reasons as the storage-
+ * adapter test (provider-agnostic; no IndexedDB needed).
+ */
+import { describe, expect, it } from 'vitest'
+import { QueryClient } from '@tanstack/vue-query'
+import {
+  type PersistedClient,
+  persistQueryClientRestore,
+  persistQueryClientSave,
+} from '@tanstack/query-persist-client-core'
+import type { AdminCache, CacheStats, InvalidationEvent } from 'gazetta'
+import { createGazettaPersister } from '../src/client/queries/persister.js'
+
+function fakeAdminCache(): AdminCache {
+  const store = new Map<string, unknown>()
+  return {
+    async get<T>(key: string): Promise<T | null> {
+      const v = store.get(key)
+      return v === undefined ? null : (v as T)
+    },
+    async set<T>(key: string, value: T): Promise<void> {
+      store.set(key, value)
+    },
+    async invalidate(key: string): Promise<void> {
+      store.delete(key)
+    },
+    async invalidatePrefix(prefix: string): Promise<number> {
+      let cleared = 0
+      for (const key of store.keys()) {
+        if (key.startsWith(prefix)) {
+          store.delete(key)
+          cleared += 1
+        }
+      }
+      return cleared
+    },
+    subscribe(_handler: (event: InvalidationEvent) => void): () => void {
+      return () => {}
+    },
+    async stats(): Promise<CacheStats> {
+      return { hits: 0, misses: 0, size: store.size, evictions: 0 }
+    },
+  }
+}
+
+describe('createGazettaPersister', () => {
+  it('round-trips a populated QueryClient through save → restore', async () => {
+    const cache = fakeAdminCache()
+    const persister = createGazettaPersister(cache, { throttleTime: 0 })
+
+    // Save phase: build a client, populate it, persist.
+    const saving = new QueryClient()
+    saving.setQueryData(['pages'], [{ name: 'home', route: '/' }])
+    saving.setQueryData(['fragments'], [{ name: 'header' }])
+    await persistQueryClientSave({ queryClient: saving, persister })
+
+    // Restore phase: fresh client (empty), hydrate from persisted.
+    const restoring = new QueryClient()
+    expect(restoring.getQueryData(['pages'])).toBeUndefined()
+    await persistQueryClientRestore({ queryClient: restoring, persister })
+    expect(restoring.getQueryData(['pages'])).toEqual([{ name: 'home', route: '/' }])
+    expect(restoring.getQueryData(['fragments'])).toEqual([{ name: 'header' }])
+  })
+
+  it('returns null restore on empty cache (no persisted client)', async () => {
+    const cache = fakeAdminCache()
+    const persister = createGazettaPersister(cache, { throttleTime: 0 })
+    const persisted = await persister.restoreClient()
+    expect(persisted).toBeUndefined()
+  })
+
+  it('discards persisted client when buster changes', async () => {
+    const cache = fakeAdminCache()
+    // Save with buster=v1.
+    const persisterV1 = createGazettaPersister(cache, { throttleTime: 0 })
+    const saving = new QueryClient()
+    saving.setQueryData(['pages'], [{ name: 'home' }])
+    await persistQueryClientSave({ queryClient: saving, persister: persisterV1, buster: 'v1' })
+
+    // Restore with buster=v2 — different buster, persistQueryClientRestore
+    // should evict and not hydrate.
+    const persisterV2 = createGazettaPersister(cache, { throttleTime: 0 })
+    const restoring = new QueryClient()
+    await persistQueryClientRestore({
+      queryClient: restoring,
+      persister: persisterV2,
+      buster: 'v2',
+    })
+    expect(restoring.getQueryData(['pages'])).toBeUndefined()
+  })
+
+  it('uses a stable default key (one persisted client per origin)', async () => {
+    // Two persister instances against the same cache share the same
+    // storage key — both see each other's writes. Pins the
+    // single-Site-per-process invariant from the design doc.
+    const cache = fakeAdminCache()
+    const persister1 = createGazettaPersister(cache, { throttleTime: 0 })
+    const persister2 = createGazettaPersister(cache, { throttleTime: 0 })
+
+    const persisted: PersistedClient = {
+      buster: '',
+      timestamp: Date.now(),
+      clientState: { mutations: [], queries: [] },
+    }
+    await persister1.persistClient(persisted)
+    const restored = await persister2.restoreClient()
+    expect(restored?.timestamp).toBe(persisted.timestamp)
+  })
+})

--- a/apps/admin/tests/queries-storage-adapter.test.ts
+++ b/apps/admin/tests/queries-storage-adapter.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Verify the `cacheAsyncStorage` adapter conforms to TanStack's
+ * `AsyncStorage<string>` interface and forwards correctly to the
+ * underlying `AdminCache`.
+ *
+ * Uses an in-memory fake `AdminCache` rather than `IndexedDBCache`
+ * — the adapter is provider-agnostic, so a fake exercises the
+ * interface without dragging in `fake-indexeddb`. Cuts 3-4 already
+ * cover the IndexedDB and broadcast paths separately.
+ */
+import { describe, expect, it } from 'vitest'
+import type { AdminCache, CacheStats, InvalidationEvent } from 'gazetta'
+import { cacheAsyncStorage } from '../src/client/queries/storage-adapter.js'
+
+function fakeAdminCache(): AdminCache & { _store: Map<string, unknown> } {
+  const store = new Map<string, unknown>()
+  return {
+    _store: store,
+    async get<T>(key: string): Promise<T | null> {
+      const v = store.get(key)
+      return v === undefined ? null : (v as T)
+    },
+    async set<T>(key: string, value: T): Promise<void> {
+      store.set(key, value)
+    },
+    async invalidate(key: string): Promise<void> {
+      store.delete(key)
+    },
+    async invalidatePrefix(prefix: string): Promise<number> {
+      let cleared = 0
+      for (const key of store.keys()) {
+        if (key.startsWith(prefix)) {
+          store.delete(key)
+          cleared += 1
+        }
+      }
+      return cleared
+    },
+    subscribe(_handler: (event: InvalidationEvent) => void): () => void {
+      return () => {}
+    },
+    async stats(): Promise<CacheStats> {
+      return { hits: 0, misses: 0, size: store.size, evictions: 0 }
+    },
+  }
+}
+
+describe('cacheAsyncStorage adapter', () => {
+  it('round-trips a string through getItem / setItem', async () => {
+    const cache = fakeAdminCache()
+    const storage = cacheAsyncStorage(cache)
+    await storage.setItem('persisted', '{"foo":"bar"}')
+    expect(await storage.getItem('persisted')).toBe('{"foo":"bar"}')
+  })
+
+  it('returns null on miss', async () => {
+    const cache = fakeAdminCache()
+    const storage = cacheAsyncStorage(cache)
+    expect(await storage.getItem('absent')).toBeNull()
+  })
+
+  it('removeItem clears the entry', async () => {
+    const cache = fakeAdminCache()
+    const storage = cacheAsyncStorage(cache)
+    await storage.setItem('k', 'v')
+    await storage.removeItem('k')
+    expect(await storage.getItem('k')).toBeNull()
+  })
+
+  it('forwards keys verbatim — no extra prefix', async () => {
+    // The persister applies its own `tanstack-query-` prefix; the
+    // adapter must NOT add another prefix on top, or
+    // prefix-invalidation in the underlying AdminCache would have to
+    // know about the double layer.
+    const cache = fakeAdminCache()
+    const storage = cacheAsyncStorage(cache)
+    await storage.setItem('exact-key', 'value')
+    expect(cache._store.has('exact-key')).toBe(true)
+  })
+})

--- a/apps/admin/tests/saveConflictIntegration.test.ts
+++ b/apps/admin/tests/saveConflictIntegration.test.ts
@@ -1,0 +1,226 @@
+/**
+ * End-to-end integration test for Cut 9b: when the save flow's API
+ * call throws StaleSaveError (server returned 409 STALE), the
+ * editor:
+ *
+ *   - pushes the conflict into useSaveConflictsStore (keyed by
+ *     manifest path)
+ *   - updates useEditorEtagsStore with the server's currentEtag so
+ *     the next save chains correctly
+ *   - rethrows the error so the editor save flow surfaces failure
+ *     to its caller
+ *
+ * We mock `api.updatePage` / `api.updateFragment` directly so this
+ * test runs without a real server; the unit chain we care about
+ * is `updateManifest` → store updates, which is exercised through
+ * a save closure built by `useEditorActions` (the production seam).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { StaleSaveError, api } from '../src/client/api/client.js'
+import { useEditorActions } from '../src/client/composables/useEditorActions.js'
+import { useEditorContentStore } from '../src/client/stores/editorContent.js'
+import { useSelectionStore } from '../src/client/stores/selection.js'
+import { useEditorEtagsStore, manifestPath } from '../src/client/stores/editorEtags.js'
+import { useSaveConflictsStore } from '../src/client/stores/saveConflicts.js'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('save conflict integration (Cut 9b)', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('on 409 STALE: pushes to conflict store + updates etag store', async () => {
+    // Pre-populate the etag store with a stale value the save flow
+    // will try to send as If-Match.
+    const etags = useEditorEtagsStore()
+    const path = manifestPath('page', 'home')
+    etags.set(path, 'stale-etag')
+
+    // Stub updatePage to throw the documented 409 STALE shape.
+    const updatePage = vi.spyOn(api, 'updatePage').mockImplementation(async () => {
+      throw new StaleSaveError(
+        { template: 'page-default', content: { title: 'Theirs' }, components: [] },
+        'fresh-etag-x',
+      )
+    })
+
+    // Simulate the editor focus on `pages/home` root.
+    const sel = useSelectionStore()
+    sel.$patch({
+      selection: {
+        type: 'page',
+        name: 'home',
+        detail: {
+          name: 'home',
+          route: '/',
+          template: 'page-default',
+          content: {},
+          components: [],
+          dir: 'pages/home',
+        },
+      },
+    })
+
+    // Build the active target's save closure via useEditorActions →
+    // ec.target.save. The simplest path: open a "_root" save context
+    // by mocking `editorContent.target.save` with the closure shape
+    // that buildSaveFn would produce. To stay in production paths,
+    // we go through useEditorActions.openPageRoot → buildTarget,
+    // but that needs a template-schema fetch. Cheapest: directly
+    // instantiate the save closure path.
+    //
+    // Approach: build a synthetic EditingTarget save closure that
+    // mirrors what buildTarget('root') produces — calls api.updatePage
+    // through the etag-aware helper. We do that by invoking
+    // useEditorActions().openPageRoot()? That requires lots of setup.
+    //
+    // Simpler: directly exercise the closure shape. The integration
+    // we care about is: a save → api.updatePage that throws
+    // StaleSaveError → conflict store populated. Use the editing
+    // store's save indirectly by setting up an EditingTarget whose
+    // save() calls api.updatePage with our If-Match.
+    const ec = useEditorContentStore()
+    const localeOpts = { locale: undefined, ifMatch: etags.get(path) ?? undefined }
+    await ec.open({
+      template: 'page-default',
+      path: '_root',
+      content: {},
+      schema: {},
+      save: async newContent => {
+        try {
+          const result = await api.updatePage('home', { content: newContent }, localeOpts)
+          if (result.etag) etags.set(path, result.etag)
+        } catch (err) {
+          if (err instanceof StaleSaveError) {
+            useSaveConflictsStore().set({
+              itemPath: path,
+              current: err.current,
+              currentEtag: err.currentEtag,
+              pending: { template: 'page-default', content: newContent, components: [] },
+            })
+            etags.set(path, err.currentEtag)
+          }
+          throw err
+        }
+      },
+    })
+
+    // Trigger the save closure; expect it to throw the StaleSaveError.
+    await expect(ec.target!.save({ title: 'Mine' })).rejects.toThrow(StaleSaveError)
+
+    // Confirm the side effects landed.
+    const conflicts = useSaveConflictsStore()
+    expect(conflicts.has(path)).toBe(true)
+    const record = conflicts.get(path)!
+    expect(record.currentEtag).toBe('fresh-etag-x')
+    expect((record.current.content as { title: string }).title).toBe('Theirs')
+    expect((record.pending.content as { title: string }).title).toBe('Mine')
+
+    // Etag store updated to the server's fresh etag — chain projection
+    // works on the next save attempt.
+    expect(etags.get(path)).toBe('fresh-etag-x')
+
+    // updatePage was called with the stale If-Match the author had.
+    expect(updatePage).toHaveBeenCalledTimes(1)
+    expect(updatePage.mock.calls[0][2]).toMatchObject({ ifMatch: 'stale-etag' })
+  })
+
+  it('on success: updates etag store from response.etag for chain projection', async () => {
+    const etags = useEditorEtagsStore()
+    const path = manifestPath('page', 'home')
+    etags.set(path, 'baseline-etag')
+
+    vi.spyOn(api, 'updatePage').mockResolvedValue({ ok: true, etag: 'projected-etag' })
+
+    const ec = useEditorContentStore()
+    await ec.open({
+      template: 'page-default',
+      path: '_root',
+      content: {},
+      schema: {},
+      save: async newContent => {
+        const result = await api.updatePage(
+          'home',
+          { content: newContent },
+          {
+            ifMatch: etags.get(path) ?? undefined,
+          },
+        )
+        if (result.etag) etags.set(path, result.etag)
+      },
+    })
+
+    await ec.target!.save({ title: 'New' })
+
+    // Etag store advanced to the server's projected value.
+    expect(etags.get(path)).toBe('projected-etag')
+    // No conflict since save succeeded.
+    expect(useSaveConflictsStore().hasAny).toBe(false)
+  })
+
+  it('via useEditorActions: real save flow sends If-Match + handles 409 STALE', async () => {
+    // Production-path test: build an EditingTarget through the actual
+    // useEditorActions surface and verify the save closure plumbed
+    // by buildTarget invokes the etag-aware helper. Selection store
+    // pre-loaded with a synthetic page detail so buildTarget('root')
+    // can produce a target without a real fetch.
+    const etags = useEditorEtagsStore()
+    const path = manifestPath('page', 'home')
+    etags.set(path, 'baseline-etag')
+
+    // Stub schema fetch (buildTarget calls api.getTemplateSchema).
+    vi.spyOn(api, 'getTemplateSchema').mockResolvedValue({
+      properties: { title: { type: 'string' } },
+    })
+    // Stub updatePage to throw 409 STALE.
+    const updatePage = vi.spyOn(api, 'updatePage').mockImplementation(async () => {
+      throw new StaleSaveError(
+        { template: 'page-default', content: { title: 'Theirs' }, components: [] },
+        'fresh-from-server',
+      )
+    })
+
+    // Selection store needs a `selection` for buildTarget('root') to
+    // resolve.
+    const sel = useSelectionStore()
+    sel.$patch({
+      selection: {
+        type: 'page',
+        name: 'home',
+        detail: {
+          name: 'home',
+          route: '/',
+          template: 'page-default',
+          content: {},
+          components: [],
+          dir: 'pages/home',
+        },
+      },
+    })
+
+    const actions = useEditorActions()
+    await actions.openPageRoot()
+
+    // Now the editor's active target carries a save closure that
+    // routes through updateManifest. Trigger it:
+    const ec = useEditorContentStore()
+    expect(ec.target).not.toBeNull()
+    await expect(ec.target!.save({ title: 'Mine' })).rejects.toThrow(StaleSaveError)
+
+    // The save closure must have sent the stale If-Match.
+    expect(updatePage).toHaveBeenCalled()
+    const callOpts = updatePage.mock.calls[0][2]
+    expect(callOpts).toMatchObject({ ifMatch: 'baseline-etag' })
+
+    // Conflict store populated.
+    const conflicts = useSaveConflictsStore()
+    expect(conflicts.has(path)).toBe(true)
+    const record = conflicts.get(path)!
+    expect(record.currentEtag).toBe('fresh-from-server')
+    expect((record.current.content as { title: string }).title).toBe('Theirs')
+    expect((record.pending.content as { title: string }).title).toBe('Mine')
+
+    // Etag store updated to the fresh server etag for chain projection.
+    expect(etags.get(path)).toBe('fresh-from-server')
+  })
+})

--- a/apps/admin/tests/saveConflicts.test.ts
+++ b/apps/admin/tests/saveConflicts.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Verify the save-conflicts Pinia store contract per
+ * `design-offline.md` Q3.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useSaveConflictsStore } from '../src/client/stores/saveConflicts.js'
+
+describe('useSaveConflictsStore', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('starts empty', () => {
+    const store = useSaveConflictsStore()
+    expect(store.count).toBe(0)
+    expect(store.hasAny).toBe(false)
+  })
+
+  it('set() registers a conflict keyed by itemPath', () => {
+    const store = useSaveConflictsStore()
+    store.set({
+      itemPath: 'pages/home/page.json',
+      current: { template: 'page-default', content: { title: 'Theirs' } },
+      currentEtag: 'fresh',
+      pending: { template: 'page-default', content: { title: 'Mine' } },
+    })
+
+    expect(store.count).toBe(1)
+    expect(store.has('pages/home/page.json')).toBe(true)
+    const record = store.get('pages/home/page.json')
+    expect(record).not.toBeNull()
+    expect(record!.currentEtag).toBe('fresh')
+    expect(record!.surfacedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('set() overwrites an existing conflict on the same path', () => {
+    const store = useSaveConflictsStore()
+    store.set({
+      itemPath: 'pages/home/page.json',
+      current: { template: 't', content: { title: 'A' } },
+      currentEtag: 'old',
+      pending: {},
+    })
+    store.set({
+      itemPath: 'pages/home/page.json',
+      current: { template: 't', content: { title: 'B' } },
+      currentEtag: 'new',
+      pending: {},
+    })
+
+    expect(store.count).toBe(1)
+    expect(store.get('pages/home/page.json')!.currentEtag).toBe('new')
+  })
+
+  it('clear() removes the conflict for one path', () => {
+    const store = useSaveConflictsStore()
+    store.set({
+      itemPath: 'pages/home/page.json',
+      current: {},
+      currentEtag: 'a',
+      pending: {},
+    })
+    store.set({
+      itemPath: 'pages/about/page.json',
+      current: {},
+      currentEtag: 'b',
+      pending: {},
+    })
+    expect(store.count).toBe(2)
+
+    store.clear('pages/home/page.json')
+    expect(store.count).toBe(1)
+    expect(store.has('pages/home/page.json')).toBe(false)
+    expect(store.has('pages/about/page.json')).toBe(true)
+  })
+
+  it('clear() on a non-existent path is a no-op', () => {
+    const store = useSaveConflictsStore()
+    store.clear('nope')
+    expect(store.count).toBe(0)
+  })
+
+  it('clearAll() drops every conflict', () => {
+    const store = useSaveConflictsStore()
+    store.set({ itemPath: 'a', current: {}, currentEtag: 'x', pending: {} })
+    store.set({ itemPath: 'b', current: {}, currentEtag: 'y', pending: {} })
+    expect(store.count).toBe(2)
+
+    store.clearAll()
+    expect(store.count).toBe(0)
+    expect(store.hasAny).toBe(false)
+  })
+
+  it('get() returns null for unknown paths', () => {
+    const store = useSaveConflictsStore()
+    expect(store.get('nope')).toBeNull()
+  })
+
+  it('keys can hold path-style strings (page) and locale variants', () => {
+    // Pin: the key is the manifest path. Locale variants live at
+    // distinct paths (`page.fr.json`) so a French conflict and an
+    // English conflict on the same name coexist as separate entries.
+    const store = useSaveConflictsStore()
+    store.set({ itemPath: 'pages/home/page.json', current: {}, currentEtag: 'en', pending: {} })
+    store.set({ itemPath: 'pages/home/page.fr.json', current: {}, currentEtag: 'fr', pending: {} })
+
+    expect(store.count).toBe(2)
+    expect(store.get('pages/home/page.json')!.currentEtag).toBe('en')
+    expect(store.get('pages/home/page.fr.json')!.currentEtag).toBe('fr')
+  })
+})

--- a/apps/admin/tests/storageQuota.test.ts
+++ b/apps/admin/tests/storageQuota.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the storage-quota composable + banner per
+ * `design-offline.md` Q4 "Storage approaching limit."
+ *
+ * Composable tests use `pollIntervalMs: 0` to disable the timer
+ * and drive transitions via `sample()` directly. Banner tests
+ * use `mount` with a mock estimate.
+ */
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PrimeVue from 'primevue/config'
+import { useStorageQuota } from '../src/client/composables/useStorageQuota.js'
+import StorageQuotaBanner from '../src/client/components/StorageQuotaBanner.vue'
+
+describe('useStorageQuota', () => {
+  function makeEstimate(usage: number, quota: number) {
+    return async () => ({ usage, quota })
+  }
+
+  it('starts with usageRatio=null + showWarning=false', () => {
+    const q = useStorageQuota({ pollIntervalMs: 0, estimateFn: makeEstimate(0, 0) })
+    expect(q.usageRatio.value).toBeNull()
+    expect(q.showWarning.value).toBe(false)
+    q.stop()
+  })
+
+  it('reports usage ratio after sampling', async () => {
+    const q = useStorageQuota({ pollIntervalMs: 0, estimateFn: makeEstimate(40, 100) })
+    await q.sample()
+    expect(q.usageRatio.value).toBe(0.4)
+    expect(q.showWarning.value).toBe(false)
+    q.stop()
+  })
+
+  it('does NOT warn below 80% threshold', async () => {
+    const q = useStorageQuota({ pollIntervalMs: 0, estimateFn: makeEstimate(79, 100) })
+    await q.sample()
+    expect(q.showWarning.value).toBe(false)
+    q.stop()
+  })
+
+  it('warns at or above 80% threshold', async () => {
+    const q = useStorageQuota({ pollIntervalMs: 0, estimateFn: makeEstimate(85, 100) })
+    await q.sample()
+    expect(q.usageRatio.value).toBe(0.85)
+    expect(q.showWarning.value).toBe(true)
+    q.stop()
+  })
+
+  it('dismiss() stops the warning at the current ratio', async () => {
+    const q = useStorageQuota({ pollIntervalMs: 0, estimateFn: makeEstimate(85, 100) })
+    await q.sample()
+    expect(q.showWarning.value).toBe(true)
+    q.dismiss()
+    expect(q.showWarning.value).toBe(false)
+    q.stop()
+  })
+
+  it('re-fires the warning when usage climbs back through the dismissal threshold', async () => {
+    let usage = 85
+    const q = useStorageQuota({ pollIntervalMs: 0, estimateFn: async () => ({ usage, quota: 100 }) })
+    await q.sample()
+    q.dismiss()
+    expect(q.showWarning.value).toBe(false)
+
+    // Usage drops below threshold — dismissal clears.
+    usage = 70
+    await q.sample()
+    expect(q.showWarning.value).toBe(false)
+
+    // Usage climbs strictly above the dismissal point (0.85) — warning reappears.
+    usage = 90
+    await q.sample()
+    expect(q.showWarning.value).toBe(true)
+    q.stop()
+  })
+
+  it('stays suppressed when usage stays at the dismissal threshold after sampling drift', async () => {
+    let usage = 85
+    const q = useStorageQuota({ pollIntervalMs: 0, estimateFn: async () => ({ usage, quota: 100 }) })
+    await q.sample()
+    q.dismiss()
+    expect(q.showWarning.value).toBe(false)
+
+    // Same usage on the next poll — banner stays dismissed.
+    await q.sample()
+    expect(q.showWarning.value).toBe(false)
+    q.stop()
+  })
+
+  it('handles missing usage / quota fields by reporting null ratio', async () => {
+    const q = useStorageQuota({ pollIntervalMs: 0, estimateFn: async () => ({}) })
+    await q.sample()
+    expect(q.usageRatio.value).toBeNull()
+    expect(q.showWarning.value).toBe(false)
+    q.stop()
+  })
+
+  it('handles estimate rejection gracefully (no crash, no warning)', async () => {
+    const q = useStorageQuota({
+      pollIntervalMs: 0,
+      estimateFn: async () => {
+        throw new Error('navigator.storage.estimate rejected')
+      },
+    })
+    await q.sample()
+    expect(q.usageRatio.value).toBeNull()
+    expect(q.showWarning.value).toBe(false)
+    q.stop()
+  })
+
+  it('quota=0 reports null (avoids divide-by-zero)', async () => {
+    const q = useStorageQuota({ pollIntervalMs: 0, estimateFn: makeEstimate(50, 0) })
+    await q.sample()
+    expect(q.usageRatio.value).toBeNull()
+    q.stop()
+  })
+})
+
+describe('StorageQuotaBanner', () => {
+  it('renders nothing when storage usage is below threshold', async () => {
+    const wrapper = mount(StorageQuotaBanner, {
+      global: {
+        plugins: [PrimeVue],
+      },
+    })
+    // No estimate has been sampled yet → showWarning = false.
+    expect(wrapper.find('[data-testid="storage-quota-banner"]').exists()).toBe(false)
+  })
+
+  it('renders banner with plain-language copy + dismiss button', () => {
+    // Mount the banner; the composable inside polls at default
+    // interval. We can't easily inject an estimate fn through the
+    // component (that'd require a prop). Instead, smoke-test the
+    // render by triggering the composable's reactivity directly
+    // via a separate mount with stubbed reactive showWarning.
+    //
+    // Simpler approach: assert plain-language copy is present in
+    // the SFC source. The composable contract is already tested
+    // above; the banner just renders the visible state.
+    const wrapper = mount(StorageQuotaBanner, {
+      global: { plugins: [PrimeVue] },
+    })
+    // Banner only renders when showWarning is true; we verify the
+    // copy exists in the template by checking the SFC's HTML
+    // structure rather than mounting with a forced state.
+    const html = wrapper.html()
+    // The template is conditionally rendered, so when the warning
+    // is off, only the comment placeholder is rendered. This is
+    // the correct shape — the banner is hidden by default.
+    expect(html).not.toContain('quota')
+    expect(html).not.toContain('exceeded')
+  })
+})

--- a/apps/admin/tests/storageQuota.test.ts
+++ b/apps/admin/tests/storageQuota.test.ts
@@ -6,7 +6,7 @@
  * and drive transitions via `sample()` directly. Banner tests
  * use `mount` with a mock estimate.
  */
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { mount } from '@vue/test-utils'
 import PrimeVue from 'primevue/config'
 import { useStorageQuota } from '../src/client/composables/useStorageQuota.js'
@@ -118,37 +118,95 @@ describe('useStorageQuota', () => {
 })
 
 describe('StorageQuotaBanner', () => {
-  it('renders nothing when storage usage is below threshold', async () => {
-    const wrapper = mount(StorageQuotaBanner, {
-      global: {
-        plugins: [PrimeVue],
-      },
+  /**
+   * The banner consumes `useStorageQuota()` internally — that
+   * composable reads `navigator.storage.estimate()`. We stub the
+   * navigator method globally for these tests so the banner sees a
+   * real ratio without polling against a real browser API.
+   *
+   * jsdom doesn't ship `navigator.storage`, so the stub also
+   * defines the shape if missing.
+   */
+  type StorageEstimateImpl = () => Promise<{ usage?: number; quota?: number }>
+  let originalStorage: typeof navigator.storage | undefined
+  function stubStorageEstimate(impl: StorageEstimateImpl): void {
+    originalStorage = (navigator as { storage?: typeof navigator.storage }).storage
+    Object.defineProperty(navigator, 'storage', {
+      value: { estimate: impl },
+      configurable: true,
     })
-    // No estimate has been sampled yet → showWarning = false.
-    expect(wrapper.find('[data-testid="storage-quota-banner"]').exists()).toBe(false)
-  })
+  }
+  function restoreStorageEstimate(): void {
+    if (originalStorage === undefined) {
+      // @ts-expect-error: deleting a stubbed property on navigator
+      delete (navigator as { storage?: typeof navigator.storage }).storage
+    } else {
+      Object.defineProperty(navigator, 'storage', {
+        value: originalStorage,
+        configurable: true,
+      })
+    }
+  }
 
-  it('renders banner with plain-language copy + dismiss button', () => {
-    // Mount the banner; the composable inside polls at default
-    // interval. We can't easily inject an estimate fn through the
-    // component (that'd require a prop). Instead, smoke-test the
-    // render by triggering the composable's reactivity directly
-    // via a separate mount with stubbed reactive showWarning.
-    //
-    // Simpler approach: assert plain-language copy is present in
-    // the SFC source. The composable contract is already tested
-    // above; the banner just renders the visible state.
+  afterEach(() => restoreStorageEstimate())
+
+  async function settle(): Promise<void> {
+    // Component's onMounted calls `sample()` which awaits
+    // navigator.storage.estimate(). Two ticks for safety: one for
+    // the awaited estimate, one for Vue's reactivity flush.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+
+  it('renders nothing when storage usage is below threshold', async () => {
+    stubStorageEstimate(async () => ({ usage: 40, quota: 100 }))
     const wrapper = mount(StorageQuotaBanner, {
       global: { plugins: [PrimeVue] },
     })
-    // Banner only renders when showWarning is true; we verify the
-    // copy exists in the template by checking the SFC's HTML
-    // structure rather than mounting with a forced state.
-    const html = wrapper.html()
-    // The template is conditionally rendered, so when the warning
-    // is off, only the comment placeholder is rendered. This is
-    // the correct shape — the banner is hidden by default.
-    expect(html).not.toContain('quota')
-    expect(html).not.toContain('exceeded')
+    await settle()
+    expect(wrapper.find('[data-testid="storage-quota-banner"]').exists()).toBe(false)
+  })
+
+  it('renders banner with plain-language copy when usage exceeds 80%', async () => {
+    stubStorageEstimate(async () => ({ usage: 85, quota: 100 }))
+    const wrapper = mount(StorageQuotaBanner, {
+      global: { plugins: [PrimeVue] },
+    })
+    await settle()
+
+    const banner = wrapper.find('[data-testid="storage-quota-banner"]')
+    expect(banner.exists()).toBe(true)
+    // Plain-language copy lock: "almost full" is the user-facing
+    // phrasing per design-offline.md Q4.
+    expect(banner.text()).toContain('almost full')
+    // No jargon.
+    const text = banner.text().toLowerCase()
+    expect(text).not.toContain('quota')
+    expect(text).not.toContain('exceeded')
+    expect(text).not.toContain('80')
+  })
+
+  it('exposes a dismiss button when banner is shown', async () => {
+    stubStorageEstimate(async () => ({ usage: 90, quota: 100 }))
+    const wrapper = mount(StorageQuotaBanner, {
+      global: { plugins: [PrimeVue] },
+    })
+    await settle()
+
+    expect(wrapper.find('[data-testid="storage-quota-banner-dismiss"]').exists()).toBe(true)
+  })
+
+  it('clicking the dismiss button hides the banner', async () => {
+    stubStorageEstimate(async () => ({ usage: 90, quota: 100 }))
+    const wrapper = mount(StorageQuotaBanner, {
+      global: { plugins: [PrimeVue] },
+    })
+    await settle()
+    expect(wrapper.find('[data-testid="storage-quota-banner"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="storage-quota-banner-dismiss"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="storage-quota-banner"]').exists()).toBe(false)
   })
 })

--- a/apps/admin/tests/sw-build.test.ts
+++ b/apps/admin/tests/sw-build.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Build-smoke test for the Cut 11 service worker.
+ *
+ * Runtime SW behavior (precache hit on offline cold load,
+ * skipWaiting on update) is e2e territory — needs a real browser
+ * with network throttling. THIS test validates the build wiring:
+ *
+ *   - `vite build` produces dist/sw.js
+ *   - sw.js contains a non-empty precache manifest with the app
+ *     shell entries (index.html, vendor chunks, CSS)
+ *   - sw.js wires the SKIP_WAITING listener so the update toast
+ *     can activate the new SW
+ *   - sw.js calls clientsClaim() so the new SW takes over open tabs
+ *   - sw.js calls cleanupOutdatedCaches() so prior versions don't
+ *     leak storage
+ *
+ * The build runs in `beforeAll` once for the whole file. Output is
+ * read directly from `dist/`. We don't tear down dist/ — concurrent
+ * test files don't interfere with these assertions.
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+const adminRoot = resolve(import.meta.dirname, '..')
+const swPath = resolve(adminRoot, 'dist/sw.js')
+
+describe('service worker build', () => {
+  let sw: string
+
+  beforeAll(() => {
+    // Skip if dist/sw.js was already built (CI may pre-build).
+    // Otherwise run vite build to produce it.
+    if (!existsSync(swPath)) {
+      execSync('npx vite build', { cwd: adminRoot, stdio: 'pipe' })
+    }
+    sw = readFileSync(swPath, 'utf-8')
+  }, 120_000) // build can take 30-60s on cold cache
+
+  it('produces dist/sw.js', () => {
+    expect(existsSync(swPath)).toBe(true)
+    expect(sw.length).toBeGreaterThan(1000)
+  })
+
+  it('precaches the app shell (index.html + vendor chunks + CSS)', () => {
+    // The precache manifest is bundled inline as an array of
+    // `{ revision, url }` entries. Smoke-check that the shell files
+    // are listed.
+    expect(sw).toMatch(/index\.html/)
+    expect(sw).toMatch(/vendor-vue/)
+    expect(sw).toMatch(/vendor-primevue/)
+    expect(sw).toMatch(/\.css/)
+  })
+
+  it('wires SKIP_WAITING handler for the update toast handshake', () => {
+    expect(sw).toContain('SKIP_WAITING')
+    expect(sw).toContain('skipWaiting')
+  })
+
+  it('calls clientsClaim so the new SW controls open tabs', () => {
+    // workbox-core's clientsClaim minifies but the activate-and-claim
+    // signature stays recognizable.
+    expect(sw).toContain('clients.claim')
+  })
+
+  it('calls cleanupOutdatedCaches to drop prior-version storage', () => {
+    // workbox-precaching's cleanupOutdatedCaches generates a cache-
+    // keys-walk; the `-precache-` suffix is the stable marker.
+    expect(sw).toContain('-precache-')
+  })
+})

--- a/apps/admin/tests/useConflictDiscard.test.ts
+++ b/apps/admin/tests/useConflictDiscard.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for `useConflictDiscard` — the orchestrator the editor's
+ * ConflictBanner calls when the author clicks "Discard my changes."
+ *
+ * Three side effects must fire in order per `design-offline.md` Q3:
+ *
+ *   1. `conflicts.clear(itemPath)` — banner closes
+ *   2. `editing.discard()` — editor reverts to saved baseline
+ *   3. `selection.reload()` — fresh manifest + etag from server
+ *
+ * Production path: ConflictBanner emits `@discard` → EditorPanel
+ * calls `conflictDiscard.run(activeManifestPath)`. Tests construct
+ * a fresh Pinia + spy on the three side effects.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useConflictDiscard } from '../src/client/composables/useConflictDiscard.js'
+import { useSaveConflictsStore } from '../src/client/stores/saveConflicts.js'
+
+beforeEach(() => setActivePinia(createPinia()))
+
+describe('useConflictDiscard', () => {
+  it('clears the conflict for the given itemPath', async () => {
+    const conflicts = useSaveConflictsStore()
+    conflicts.set({
+      itemPath: 'pages/home/page.json',
+      current: { template: 'page-default' },
+      currentEtag: 'fresh',
+      pending: { template: 'page-default' },
+    })
+    expect(conflicts.has('pages/home/page.json')).toBe(true)
+
+    const discard = useConflictDiscard()
+    await discard.run('pages/home/page.json')
+
+    expect(conflicts.has('pages/home/page.json')).toBe(false)
+  })
+
+  it('does not clear conflicts on OTHER paths', async () => {
+    const conflicts = useSaveConflictsStore()
+    conflicts.set({
+      itemPath: 'pages/home/page.json',
+      current: {},
+      currentEtag: 'a',
+      pending: {},
+    })
+    conflicts.set({
+      itemPath: 'pages/about/page.json',
+      current: {},
+      currentEtag: 'b',
+      pending: {},
+    })
+
+    const discard = useConflictDiscard()
+    await discard.run('pages/home/page.json')
+
+    expect(conflicts.has('pages/home/page.json')).toBe(false)
+    expect(conflicts.has('pages/about/page.json')).toBe(true)
+  })
+
+  it('drops local pending edits via editing.discard', async () => {
+    // Mount the orchestrator. We stub the editing + selection
+    // methods that get called so we can assert ordering without
+    // standing up the full editor stack.
+    const { useEditingStore } = await import('../src/client/stores/editing.js')
+    const { useSelectionStore } = await import('../src/client/stores/selection.js')
+
+    const editing = useEditingStore()
+    const selection = useSelectionStore()
+
+    const discardSpy = vi.spyOn(editing, 'discard').mockImplementation(() => {})
+    const reloadSpy = vi.spyOn(selection, 'reload').mockResolvedValue()
+
+    const discard = useConflictDiscard()
+    await discard.run('pages/home/page.json')
+
+    expect(discardSpy).toHaveBeenCalledOnce()
+    expect(reloadSpy).toHaveBeenCalledOnce()
+  })
+
+  it('orders side effects: clear → discard → reload', async () => {
+    const { useEditingStore } = await import('../src/client/stores/editing.js')
+    const { useSelectionStore } = await import('../src/client/stores/selection.js')
+
+    const conflicts = useSaveConflictsStore()
+    conflicts.set({
+      itemPath: 'pages/home/page.json',
+      current: {},
+      currentEtag: 'fresh',
+      pending: {},
+    })
+
+    const editing = useEditingStore()
+    const selection = useSelectionStore()
+
+    const order: string[] = []
+    const clearSpy = vi.spyOn(conflicts, 'clear').mockImplementation(() => {
+      order.push('clear')
+    })
+    vi.spyOn(editing, 'discard').mockImplementation(() => {
+      order.push('discard')
+    })
+    vi.spyOn(selection, 'reload').mockImplementation(async () => {
+      order.push('reload')
+    })
+
+    const discard = useConflictDiscard()
+    await discard.run('pages/home/page.json')
+
+    expect(order).toEqual(['clear', 'discard', 'reload'])
+    expect(clearSpy).toHaveBeenCalledWith('pages/home/page.json')
+  })
+
+  it('awaits selection.reload before resolving', async () => {
+    // The reload is async — fetches the manifest + etag from the
+    // server. The composable must await it so callers know "all
+    // side effects are done" when the promise resolves.
+    const { useSelectionStore } = await import('../src/client/stores/selection.js')
+    const selection = useSelectionStore()
+
+    let reloadResolved = false
+    vi.spyOn(selection, 'reload').mockImplementation(async () => {
+      // Simulate server round-trip latency.
+      await new Promise(resolve => setTimeout(resolve, 10))
+      reloadResolved = true
+    })
+
+    const discard = useConflictDiscard()
+    await discard.run('pages/home/page.json')
+
+    // After awaiting run(), reload MUST have completed.
+    expect(reloadResolved).toBe(true)
+  })
+
+  it('idempotent on a path with no active conflict', async () => {
+    // Author clicks Discard, then clicks again rapidly (or two
+    // banners somehow racing) — the second call should not throw
+    // even though there's no conflict to clear. The other side
+    // effects (discard + reload) are also safe to repeat.
+    const { useEditingStore } = await import('../src/client/stores/editing.js')
+    const { useSelectionStore } = await import('../src/client/stores/selection.js')
+
+    const editing = useEditingStore()
+    const selection = useSelectionStore()
+    vi.spyOn(editing, 'discard').mockImplementation(() => {})
+    vi.spyOn(selection, 'reload').mockResolvedValue()
+
+    const discard = useConflictDiscard()
+    // No conflict in the store — clear() is a no-op.
+    await expect(discard.run('pages/home/page.json')).resolves.toBeUndefined()
+  })
+
+  it('propagates selection.reload failures', async () => {
+    // If the reload fails (network error, server 500), the discard
+    // flow must surface it so the caller can show an error toast.
+    // Conflict + editing.discard already fired — that's expected:
+    // the author chose to discard, we did so, only the reload
+    // failed; the editor will retry on the next navigation.
+    const { useEditingStore } = await import('../src/client/stores/editing.js')
+    const { useSelectionStore } = await import('../src/client/stores/selection.js')
+
+    const conflicts = useSaveConflictsStore()
+    conflicts.set({
+      itemPath: 'pages/home/page.json',
+      current: {},
+      currentEtag: 'fresh',
+      pending: {},
+    })
+
+    const editing = useEditingStore()
+    const selection = useSelectionStore()
+    vi.spyOn(editing, 'discard').mockImplementation(() => {})
+    vi.spyOn(selection, 'reload').mockRejectedValue(new Error('reload failed'))
+
+    const discard = useConflictDiscard()
+    await expect(discard.run('pages/home/page.json')).rejects.toThrow('reload failed')
+
+    // Conflict was cleared BEFORE the reload threw — banner closes
+    // even on partial-failure.
+    expect(conflicts.has('pages/home/page.json')).toBe(false)
+  })
+})

--- a/apps/admin/tests/useServiceWorkerUpdate.test.ts
+++ b/apps/admin/tests/useServiceWorkerUpdate.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the Cut 11 service-worker update composable.
+ *
+ * The composable wraps `useRegisterSW` from vite-plugin-pwa's
+ * virtual module. We mock the virtual module so the test runs
+ * without an actual SW registration; then verify:
+ *
+ *   - On boot: useRegisterSW is called with onRegisteredSW that
+ *     wires the periodic update check
+ *   - When `needRefresh` flips to true → toast fires with
+ *     "Refresh" action
+ *   - Clicking the action invokes updateServiceWorker (sends
+ *     SKIP_WAITING + reloads)
+ *   - When `needRefresh` is false (initial state) → no toast
+ *
+ * Module-level vi.mock — the virtual module is replaced before
+ * any imports resolve.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref, type Ref } from 'vue'
+import { setActivePinia, createPinia } from 'pinia'
+
+// Hoisted stubs — available to vi.mock factory before
+// useServiceWorkerUpdate.ts imports the virtual module.
+const mocks = vi.hoisted(() => {
+  const needRefresh: Ref<boolean> = { value: false } as unknown as Ref<boolean>
+  const updateServiceWorker = vi.fn(async () => {})
+  return {
+    needRefresh,
+    updateServiceWorker,
+    capturedOptions: {
+      value: null as unknown as {
+        onRegisteredSW?: (url: string, registration?: ServiceWorkerRegistration) => void
+      } | null,
+    },
+  }
+})
+
+vi.mock('virtual:pwa-register/vue', () => ({
+  useRegisterSW: vi.fn(opts => {
+    mocks.capturedOptions.value = opts ?? null
+    return {
+      needRefresh: mocks.needRefresh,
+      offlineReady: { value: false },
+      updateServiceWorker: mocks.updateServiceWorker,
+    }
+  }),
+}))
+
+// Import AFTER vi.mock so the mocked virtual module is resolved.
+import { useServiceWorkerUpdate } from '../src/client/composables/useServiceWorkerUpdate.js'
+import { useToastStore } from '../src/client/stores/toast.js'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  // Reset the reactive ref + spies between tests. The needRefresh
+  // ref is shared across the test file (it's hoisted); resetting
+  // its value avoids cross-test bleed.
+  mocks.needRefresh.value = false
+  mocks.updateServiceWorker.mockClear()
+  mocks.capturedOptions.value = null
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('useServiceWorkerUpdate', () => {
+  it('does NOT show a toast on initial registration (needRefresh starts false)', () => {
+    // Use a real reactive ref so Vue's watch picks up changes later.
+    mocks.needRefresh = ref(false) as unknown as typeof mocks.needRefresh
+
+    useServiceWorkerUpdate()
+    const toast = useToastStore()
+    // No toast yet — the registered SW hasn't detected an update.
+    expect(toast.current).toBeNull()
+  })
+
+  it('passes onRegisteredSW so vite-plugin-pwa can wire periodic update checks', () => {
+    mocks.needRefresh = ref(false) as unknown as typeof mocks.needRefresh
+    useServiceWorkerUpdate()
+
+    const opts = mocks.capturedOptions.value
+    expect(opts).not.toBeNull()
+    expect(typeof opts!.onRegisteredSW).toBe('function')
+  })
+
+  it('schedules a periodic update.update() when onRegisteredSW receives a registration', () => {
+    mocks.needRefresh = ref(false) as unknown as typeof mocks.needRefresh
+    useServiceWorkerUpdate()
+
+    const updateSpy = vi.fn().mockResolvedValue(undefined)
+    const fakeRegistration = { update: updateSpy } as unknown as ServiceWorkerRegistration
+
+    // Use fake timers to verify the interval schedule without
+    // sleeping for an hour.
+    vi.useFakeTimers()
+    mocks.capturedOptions.value!.onRegisteredSW!('http://x/sw.js', fakeRegistration)
+
+    // No call on registration; the interval fires later.
+    expect(updateSpy).not.toHaveBeenCalled()
+
+    // Advance past the 1-hour periodic check.
+    vi.advanceTimersByTime(60 * 60 * 1000)
+    expect(updateSpy).toHaveBeenCalledTimes(1)
+
+    // Advance another hour — fires again.
+    vi.advanceTimersByTime(60 * 60 * 1000)
+    expect(updateSpy).toHaveBeenCalledTimes(2)
+
+    vi.useRealTimers()
+  })
+
+  it('does NOT schedule an interval when onRegisteredSW is called with undefined registration', () => {
+    mocks.needRefresh = ref(false) as unknown as typeof mocks.needRefresh
+    useServiceWorkerUpdate()
+
+    vi.useFakeTimers()
+    // Some plugin paths invoke onRegisteredSW with no registration
+    // (registration failure, browser blocks SW, etc.). The
+    // composable must not schedule an interval against undefined.
+    mocks.capturedOptions.value!.onRegisteredSW!('http://x/sw.js', undefined)
+    vi.advanceTimersByTime(60 * 60 * 1000)
+    // No timer scheduled → no errors. Sanity check: advanceTimersByTime
+    // doesn't throw, no spy to assert against here. The lack of
+    // crash IS the assertion.
+    vi.useRealTimers()
+  })
+
+  it('shows a "new version available" toast when needRefresh flips to true', async () => {
+    // Real reactive ref so Vue's watch fires on .value change.
+    mocks.needRefresh = ref(false) as unknown as typeof mocks.needRefresh
+
+    useServiceWorkerUpdate()
+    const toast = useToastStore()
+    expect(toast.current).toBeNull()
+
+    // Trigger the new-version detection.
+    mocks.needRefresh.value = true
+    // watch() fires on the next microtask tick.
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(toast.current).not.toBeNull()
+    expect(toast.current!.message).toContain('new version')
+    expect(toast.current!.type).toBe('info')
+    expect(toast.current!.action).toBeDefined()
+    expect(toast.current!.action!.label).toBe('Refresh')
+  })
+
+  it('toast action calls updateServiceWorker(true) on click', async () => {
+    mocks.needRefresh = ref(false) as unknown as typeof mocks.needRefresh
+
+    useServiceWorkerUpdate()
+    mocks.needRefresh.value = true
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const toast = useToastStore()
+    expect(toast.current?.action).toBeDefined()
+
+    // Trigger the action — should send SKIP_WAITING + reload via
+    // the mocked updateServiceWorker.
+    await toast.runAction()
+    expect(mocks.updateServiceWorker).toHaveBeenCalledOnce()
+    expect(mocks.updateServiceWorker).toHaveBeenCalledWith(true)
+  })
+
+  it('does NOT re-fire toast when needRefresh stays true across reactive ticks', async () => {
+    mocks.needRefresh = ref(false) as unknown as typeof mocks.needRefresh
+
+    useServiceWorkerUpdate()
+    const toast = useToastStore()
+    const showSpy = vi.spyOn(toast, 'show')
+
+    mocks.needRefresh.value = true
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(showSpy).toHaveBeenCalledTimes(1)
+
+    // Keep needRefresh true — Vue's watch only fires on value
+    // CHANGE. Setting the same value shouldn't re-fire.
+    mocks.needRefresh.value = true
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(showSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits a sticky toast (duration: 0) so author can finish editing before refreshing', async () => {
+    mocks.needRefresh = ref(false) as unknown as typeof mocks.needRefresh
+
+    useServiceWorkerUpdate()
+    const toast = useToastStore()
+    const showSpy = vi.spyOn(toast, 'show')
+
+    mocks.needRefresh.value = true
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(showSpy).toHaveBeenCalledOnce()
+    const opts = showSpy.mock.calls[0][1]
+    // duration: 0 = no auto-dismiss; toast hangs until user clicks
+    // Refresh or another toast replaces it.
+    expect(opts?.duration).toBe(0)
+  })
+})

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,8 +1,63 @@
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import { VitePWA } from 'vite-plugin-pwa'
+
+// Anchor PWA plugin's `srcDir` to this config file's location, not
+// the runner's cwd. The gazetta package's `build:admin` script runs
+// vite from `packages/gazetta` with this config file as
+// `-c ../../apps/admin/vite.config.ts`; without an absolute path,
+// `srcDir: 'src/client'` resolves to packages/gazetta/src/client
+// and the SW source isn't found.
+//
+// We anchor ONLY the PWA srcDir, not Vite's `root` — overriding root
+// would also redirect `--outDir admin-dist` (relative to root) to
+// `apps/admin/admin-dist/` instead of the packaged location
+// `packages/gazetta/admin-dist/`.
+const configDir = dirname(fileURLToPath(import.meta.url))
+const swSrcDir = resolve(configDir, 'src/client')
 
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [
+    vue(),
+    // Service worker for app-shell precache per design-offline.md Cut 11.
+    // Scoped to "open admin offline → blank screen" — without the SW, a
+    // cold load offline can't fetch /admin/index.html. With the SW, the
+    // precached shell loads, the L6 IndexedDB cache hydrates state, and
+    // the app renders. The IDB cache (Cuts 2-4) handles data; this SW
+    // handles the app bundle.
+    //
+    // injectManifest strategy because v2 background sync (deferred) wants
+    // a custom SW source to drop into. generateSW would work for v1
+    // alone but would require a strategy migration when v2 lands;
+    // shipping injectManifest now means v2 adds handlers without
+    // touching the build wiring.
+    VitePWA({
+      strategies: 'injectManifest',
+      srcDir: swSrcDir,
+      filename: 'sw.ts',
+      // No PWA install prompt in v1 — `registerType: 'prompt'` ships the
+      // update-available toast (per design-offline.md "update detection
+      // UX"), but skips the install prompt + manifest.webmanifest.
+      registerType: 'prompt',
+      injectRegister: false, // we register manually from main.ts via virtual:pwa-register/vue
+      // Manifest stays minimal — we're not a PWA (yet); just precaching
+      // for offline reload reliability. The web manifest landing page
+      // and install prompt flow is a v2 feature.
+      manifest: false,
+      injectManifest: {
+        // Bumped from default 2 MB so the admin bundle (PrimeVue + rjsf
+        // + Tiptap clocks in around ~3 MB minified) precaches without
+        // warnings. Each chunk ships independently; this is the per-file
+        // cap, not total.
+        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
+      },
+      // Don't enable in dev — Vite HMR + SW caching fight each other.
+      // SW only runs in production builds.
+      devOptions: { enabled: false },
+    }),
+  ],
   root: '.',
   build: {
     rolldownOptions: {

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -1,8 +1,21 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
   plugins: [vue()],
+  resolve: {
+    alias: {
+      // `virtual:pwa-register/vue` is created at build time by
+      // vite-plugin-pwa; vitest's dev resolver doesn't see it.
+      // Alias to a stub so modules importing the virtual specifier
+      // load cleanly during tests. Tests that drive the update
+      // flow override via `vi.mock('virtual:pwa-register/vue')`.
+      'virtual:pwa-register/vue': fileURLToPath(
+        new URL('./tests/_setup/virtual-pwa-register-stub.ts', import.meta.url),
+      ),
+    },
+  },
   test: {
     environment: 'jsdom',
     setupFiles: ['./tests/_setup/suppress-webstorage-warning.ts'],

--- a/docs/offline.md
+++ b/docs/offline.md
@@ -1,0 +1,301 @@
+# Offline mode
+
+How Gazetta admin handles transient connectivity loss — what authors see,
+what changes for operators, and what's intentionally not in v1.
+
+For the design model + architectural locks, see
+[`.claude/rules/design-offline.md`](../.claude/rules/design-offline.md).
+
+## What it is
+
+The admin keeps working when the network goes away. Pages already loaded
+stay viewable, edits in progress aren't lost, and saves either land
+silently when connection comes back or surface as something the author
+can act on. The browser fetches the SPA bundle once and serves it from
+disk on subsequent visits, including cold loads while offline.
+
+This is offline-AWARE, not offline-FIRST. Authors don't choose to "go
+offline"; offline is what happens to them. There's no toggle.
+
+## What changes for authors
+
+### Connection state
+
+A thin strip appears at the top of the admin when the connection isn't
+healthy:
+
+| State | What you see | What it means |
+|---|---|---|
+| Online | Nothing | Saves go through normally. The absence is the state. |
+| Connection unstable | Subtle "Connection unstable" with spinner | Recent request failed; admin is probing the server. Editing keeps working. |
+| Offline | Persistent "Offline" banner with "Send now" button | Server unreachable. Saves go to the local store and replay later. |
+| Reconnecting | Subtle "Reconnecting" indicator | Server just answered; admin is catching up. Brief — usually a flash. |
+
+When connection returns after offline, a transient toast says "Connection
+back" so you know without checking the banner.
+
+### Save behavior
+
+Click Save the same way regardless of connection state. The button label
+doesn't change between online and offline — your mental model is
+"I clicked Save; it says saved."
+
+What happens underneath:
+
+| Situation | Outcome |
+|---|---|
+| Online; save succeeds | Standard. Editor goes clean. |
+| Online; save fails partway (server crashed mid-response) | Admin checks what landed; either silently confirms success or surfaces an error. No silent loss. |
+| Offline; save attempted | Saved locally. Will send when connection comes back. |
+| Save attempted while someone else just saved the same item | "Was edited by someone else" banner with "Show what changed" + "Discard my changes" |
+
+### "Was edited by someone else"
+
+If the server's version of a page or fragment changed between when you
+loaded it and when you tried to save (typical scenario: a colleague
+edited the same item from another browser, or the file was edited
+out-of-band by `git pull` or a text editor), you get a banner instead
+of a silent overwrite.
+
+Two actions:
+
+- **Show what changed** — opens a field-by-field diff. "Title: 'Mine'
+  vs 'Theirs.'" Object/array fields show "(changes inside)" without
+  diving deep — at-a-glance information so you can decide.
+- **Discard my changes** — drops your local edits and reloads the
+  server's current version.
+
+There's deliberately no "Save anyway / Overwrite" button. If you want
+your changes on top of theirs, view the diff, manually port the edits
+you care about onto the new version, and save fresh. Keeps the team
+from accidentally clobbering each other's work.
+
+### Pending edits across tabs and reload
+
+Component reorders / adds / removes (the structural lane) survive
+browser reload. If you reorder components on `/home`, then close the
+tab and reopen it, the reordered tree is still there waiting for save.
+
+Field-level edits (title text, content blocks) currently don't
+persist across reload — they're held in browser memory until you save
+or navigate. Persisting field edits across reload is in the roadmap.
+
+### "Send now"
+
+When you're offline and the admin says it's offline, but you know the
+network is actually back (you just reconnected to Wi-Fi, or the VPN
+came up), click "Send now" on the offline banner. The admin probes
+immediately rather than waiting for the next scheduled check.
+
+This is purely a hint to the admin's heartbeat scheduler — it doesn't
+override anything. If the network really is down, the probe just
+fails again and the banner stays.
+
+### Storage warning
+
+If your browser's local storage approaches its cap (around 80%), a
+subtle banner appears: "Storage almost full — please connect to send
+your saved items." Dismissing the banner suppresses it at that level;
+it reappears only if usage climbs strictly above the dismissal point.
+
+This is rare in practice. The admin's persistent storage is small
+(query results + structural pending edits); the warning fires when
+the whole-origin storage budget is being consumed by something else
+(other apps on the same domain, browser caches accumulating).
+
+## What v1 does NOT do
+
+Setting expectations honestly. These items are deliberately not in v1
+and have specific triggers to revisit.
+
+### No replay while the tab is closed
+
+If you save offline, close the tab, then reconnect: the save sends on
+your **next admin open**, not in the background. The browser would
+need a service worker with [Background Sync](https://developer.mozilla.org/en-US/docs/Web/API/Background_Synchronization_API)
+to do this — possible technically, but adds machinery for marginal
+value (authors reopen the admin to check status anyway).
+
+### No live multi-author concurrent editing
+
+Two authors editing the same page simultaneously can both type freely;
+the second one to save sees the "Was edited by someone else" banner.
+There's no live cursor / presence indicator showing "Bob is also
+editing this." That kind of real-time collaboration requires a
+persistent connection layer (WebSocket / SSE-with-back-channel) and
+conflict-free data structures (OT or CRDT) — its own design space,
+not in this v1 scope.
+
+### Not installable as a PWA
+
+The admin runs in a regular tab. There's no install prompt, no
+home-screen icon, no standalone window mode. The service worker is
+scoped to caching the SPA bundle for offline-reload reliability,
+not full PWA installation.
+
+### No push notifications
+
+If a colleague edits content while you're not looking at the admin,
+you find out the next time you open the affected page (via the
+"Was edited by someone else" banner). No browser notification
+("Bob saved /home").
+
+## Operator concerns
+
+### Browser support
+
+Hard requirements for the offline experience to work at all:
+
+| Browser | IndexedDB | BroadcastChannel | Service Worker | Status |
+|---|---|---|---|---|
+| Chrome 80+ | ✓ | ✓ | ✓ | Fully supported |
+| Edge (Chromium) 80+ | ✓ | ✓ | ✓ | Fully supported |
+| Firefox 78+ | ✓ | ✓ | ✓ | Fully supported |
+| Safari 15.4+ | ✓ | ✓ | ✓ | Fully supported |
+| Safari < 15.4 | partial | partial | ✓ | Degrades gracefully |
+| Private / incognito modes | usually disabled | varies | varies | Falls back to in-memory |
+
+When IndexedDB is unavailable, the admin warns once via console and
+falls back to in-memory storage — works for the tab session, lost on
+reload. Authors using private browsing should expect the warning.
+
+### HTTPS requirement
+
+Service workers require HTTPS in production. Localhost development
+works on HTTP. This was already a Gazetta requirement for auth
+cookies — no new constraint introduced by offline mode.
+
+If you're serving the admin behind a reverse proxy, terminate TLS at
+the proxy (Caddy, nginx, Cloudflare) and pass through. The admin's
+service worker registers at `/admin/sw.js` and scopes to `/admin/`.
+
+### What needs to be deployed
+
+Nothing extra. Offline mode is built into the admin SPA; the service
+worker ships in the same `dist/` bundle as `index.html` and the JS/CSS
+chunks. Standard `gazetta serve` or any static host serving the
+admin works.
+
+If you're behind a CDN, make sure `sw.js` isn't aggressively cached
+by an intermediary — when a new admin version ships, the SW file at
+`/admin/sw.js` needs to update so users get the toast. A short
+`Cache-Control` (e.g., `no-cache`, `max-age=0`) on `sw.js`
+specifically is the right move; the chunks it precaches have
+content-hashed filenames and can be cached forever.
+
+### Configuration
+
+The defaults are correct. There are no required knobs. If you need to
+opt out (corporate environments that block service workers, sandboxed
+deployments), the admin still works — connection-state and save-conflict
+detection don't depend on the SW; only the cold-load-while-offline
+path does.
+
+### Update flow
+
+When you publish a new version of Gazetta and authors load the admin:
+
+1. The browser fetches `/admin/sw.js`. If the content changed (it does
+   on every release), the SW enters the "waiting" state.
+2. Within an hour (or on next page reload), the admin detects the
+   waiting SW and shows a toast: "A new version is available — Refresh."
+3. The author clicks "Refresh." The SW activates and the page reloads
+   with the new bundle.
+
+Users running with one tab open all day get the toast; users who close
+and reopen pick up the new version on the next load. No silent
+upgrades — if an author is mid-edit, they see the toast but aren't
+forced to refresh until they choose.
+
+### Verifying it works
+
+Quick check after deploying a new version:
+
+```
+1. Open the admin in a normal tab → admin loads.
+2. DevTools → Application → Service Workers → confirm /admin/sw.js
+   is registered + active.
+3. DevTools → Application → Storage → confirm IndexedDB has a
+   `gazetta-cache` database.
+4. DevTools → Network → throttle to "Offline."
+5. Reload the page.
+6. Admin should still load (from SW cache) with the "Offline" banner
+   at the top.
+7. Throttle back to "Online."
+8. Banner replaces with brief "Connection back" toast; admin
+   reconnects.
+```
+
+If step 5 shows "site can't be reached" rather than the admin loading
+offline, the service worker isn't registered correctly. Check that
+`/admin/sw.js` is reachable directly (HTTP 200, `Content-Type:
+application/javascript`).
+
+### Multi-instance deployments
+
+If you run the admin behind a load balancer with multiple instances:
+
+- Each browser tab talks to one instance at a time. Offline state and
+  save conflicts are detected per-tab; nothing flows across instances
+  in the offline path.
+- IndexedDB storage is per-browser-origin, not per-instance — same
+  storage regardless of which instance the tab last hit.
+- Service worker registration is per-origin; load-balanced instances
+  serving the same `/admin/sw.js` content (which they should, if they
+  shipped the same admin build) is the standard pattern.
+
+### Troubleshooting
+
+**"Was edited by someone else" appears unexpectedly.**
+
+Either someone really did edit the page (check the audit log when
+audit ships in a future release), or the file was changed on disk
+out-of-band — `git pull`, manual `sed`, an editor watching the
+filesystem, etc. The admin compares the manifest's content hash
+between your read and your write; any change between those two
+moments triggers the conflict.
+
+**Banner says "Offline" but I can browse other sites.**
+
+The admin probes `GET /api/health`. If that endpoint is reachable
+but returning errors (5xx), the admin treats it as offline — the
+server is up but unhealthy. Check the admin process logs for the
+underlying cause.
+
+**Service worker doesn't update.**
+
+Force a refresh in DevTools → Application → Service Workers →
+"Update on reload" + click "Update." If the new SW still isn't
+served, the `/admin/sw.js` URL is being cached by an intermediary
+(CDN, proxy). Add a short `Cache-Control` to the SW URL specifically.
+
+**IndexedDB warning in console.**
+
+Most likely the user is in private browsing. Admin still works,
+just without persistence — refresh loses tab-session state.
+Document this for users who need to know; nothing to fix on the
+operator side.
+
+## Roadmap
+
+What's deferred in v1 with documented triggers to revisit:
+
+- **Persisted field edits across reload** — title / content text in
+  the editor doesn't survive browser close yet. Lands when the
+  closure-rebuild flow for the editor's save state ships.
+- **Replay while tab closed (Background Sync)** — see "What v1 does
+  NOT do" above.
+- **Live multi-author concurrent editing** — Tier 3 strategic bet;
+  needs OT/CRDT design.
+- **Audit integration** — replayed save events should mark
+  `metadata.replayed: true` with the original-attempt timestamp.
+  Lands when the audit-log foundation ships.
+
+## Reference
+
+- Design doc: [`.claude/rules/design-offline.md`](../.claude/rules/design-offline.md)
+- Cache layer (read-side, server): [`docs/cache.md`](cache.md) — the L4
+  cache the offline L6 cache mirrors
+- Save concurrency (the etag mechanism): admin API documents the
+  `If-Match` header contract; refer to the design doc for the
+  client-side chain projection model

--- a/docs/offline.md
+++ b/docs/offline.md
@@ -72,13 +72,23 @@ from accidentally clobbering each other's work.
 
 ### Pending edits across tabs and reload
 
-Component reorders / adds / removes (the structural lane) survive
-browser reload. If you reorder components on `/home`, then close the
-tab and reopen it, the reordered tree is still there waiting for save.
+Two kinds of edits both survive reload:
 
-Field-level edits (title text, content blocks) currently don't
-persist across reload — they're held in browser memory until you save
-or navigate. Persisting field edits across reload is in the roadmap.
+- **Structural** — component reorders / adds / removes. Reorder
+  components on `/home`, close the tab, reopen — tree comes back
+  the way you left it.
+- **Field-level** — title text, content blocks, anything you type
+  into the editor form. Edit a heading on `/home`, close the tab,
+  reopen `/home` — the heading you typed is back, dirty, waiting
+  to save.
+
+Both work across multiple pages. If you have unsaved edits on
+`/home/_root` AND on `/about/_root`, both come back when you
+navigate to those pages after reload. The saved baseline is
+fetched fresh from the server; your dirty edits overlay on top.
+
+Save clears the dirty state for the saved item; navigating to a
+different page doesn't lose the others.
 
 ### "Send now"
 
@@ -280,9 +290,6 @@ operator side.
 
 What's deferred in v1 with documented triggers to revisit:
 
-- **Persisted field edits across reload** — title / content text in
-  the editor doesn't survive browser close yet. Lands when the
-  closure-rebuild flow for the editor's save state ships.
 - **Replay while tab closed (Background Sync)** — see "What v1 does
   NOT do" above.
 - **Live multi-author concurrent editing** — Tier 3 strategic bet;

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,12 @@
       "dependencies": {
         "@hono/node-server": "^2.0.1",
         "@primeuix/themes": "^2.0.3",
+        "@tanstack/query-async-storage-persister": "^5.100.9",
+        "@tanstack/vue-query": "^5.100.9",
         "@vueuse/core": "^14.3.0",
         "gazetta": "*",
         "hono": "^4.12.16",
+        "idb": "^8.0.3",
         "morphdom": "^2.7.8",
         "pinia": "^3.0.0",
         "primeicons": "^7.0.0",
@@ -52,6 +55,7 @@
         "tsx": "^4.21.0",
         "typescript": "^6.0.3",
         "vite": "^8.0.10",
+        "vite-plugin-pwa": "^1.3.0",
         "vitest": "^4.1.5"
       }
     },
@@ -66,6 +70,63 @@
       "peerDependencies": {
         "hono": "^4"
       }
+    },
+    "apps/admin/node_modules/@tanstack/vue-query": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-query/-/vue-query-5.100.9.tgz",
+      "integrity": "sha512-wGiv/AirRuITlTDl87zdBRaZIZTejMItUswKgMzzcX/1gfn95iKw2EaCuz7qlX9ceB0DwBj9FqaroLnDoJCecg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "^8.19.4",
+        "@tanstack/query-core": "5.100.9",
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.1.2",
+        "vue": "^2.6.0 || ^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "apps/admin/node_modules/@tanstack/vue-query/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "apps/admin/node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "examples/starter": {
       "name": "@gazetta/starter",
@@ -98,6 +159,23 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@apideck/better-ajv-errors": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.7.tgz",
+      "integrity": "sha512-TajUJwGWbDwkCx/CZi7tRE8PVB7simCvKJfHUsSdvps+aTM/PDPP4gkLmKnc+x3CE//y9i/nj74GqdL/hwk7Iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonpointer": "^5.0.1",
+        "leven": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "ajv": ">=8"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1331,9 +1409,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1480,6 +1558,51 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@babel/helper-create-regexp-features-plugin": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
+      "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "regexpu-core": "^6.3.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+      "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "debug": "^4.4.3",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.22.11"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
@@ -1559,6 +1682,24 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-remap-async-to-generator": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
+      "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-wrap-function": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
@@ -1619,6 +1760,21 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-wrap-function": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
+      "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helpers": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
@@ -1648,6 +1804,107 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.28.5.tgz",
+      "integrity": "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
+      "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
+      "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.3.tgz",
+      "integrity": "sha512-SRS46DFR4HqzUzCVgi90/xMoL+zeBDBvWdKYXSEzh79kXswNFEglUpMKxR04//dPqwYXWUBJ3mpUd933ru9Kmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
+      "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-transform-optional-chaining": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
+      "integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/plugin-proposal-decorators": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.0.tgz",
@@ -1666,10 +1923,55 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-decorators": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.28.6.tgz",
       "integrity": "sha512-71EYI0ONURHJBL4rSFXnITXqXrrY8q4P0q006DPfN+Rk+ASM+++IBXem/ruokgBZR8YNEWZ8R6B+rCb8VcUTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-assertions": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
+      "integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1714,6 +2016,179 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-arrow-functions": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
+      "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-generator-functions": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
+      "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-remap-async-to-generator": "^7.27.1",
+        "@babel/traverse": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
+      "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-remap-async-to-generator": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
+      "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoping": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
+      "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-properties": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
+      "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-static-block": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
+      "integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-classes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
+      "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-computed-properties": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
+      "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/template": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-destructuring": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
@@ -1723,6 +2198,72 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
         "@babel/traverse": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dotall-regex": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
+      "integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-keys": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
+      "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
+      "integrity": "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-dynamic-import": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
+      "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1748,6 +2289,154 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
+      "integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-export-namespace-from": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
+      "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-for-of": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
+      "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-function-name": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
+      "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-json-strings": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
+      "integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
+      "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-logical-assignment-operators": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
+      "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-member-expression-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
+      "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-amd": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
+      "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
@@ -1757,6 +2446,374 @@
       "dependencies": {
         "@babel/helper-module-transforms": "^7.28.6",
         "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-systemjs": {
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-umd": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
+      "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
+      "integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-new-target": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
+      "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
+      "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-numeric-separator": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
+      "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-rest-spread": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
+      "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-object-super": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
+      "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-catch-binding": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
+      "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
+      "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-parameters": {
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+      "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-methods": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
+      "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-property-in-object": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
+      "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-property-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
+      "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regenerator": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
+      "integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-regexp-modifiers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
+      "integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-reserved-words": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
+      "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-shorthand-properties": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
+      "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-spread": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
+      "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-sticky-regex": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
+      "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typeof-symbol": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
+      "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1783,6 +2840,184 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-escapes": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
+      "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-property-regex": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
+      "integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-regex": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
+      "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-unicode-sets-regex": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
+      "integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/preset-env": {
+      "version": "7.29.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.5.tgz",
+      "integrity": "sha512-/69t2aEzGKHD76DyLbHysF/QH2LJOB8iFnYO37unDTKBTubzcMRv0f3H5EiN1Q6ajOd/eB7dAInF0qdFVS06kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.3",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+        "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.3",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
+        "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+        "@babel/plugin-syntax-import-assertions": "^7.28.6",
+        "@babel/plugin-syntax-import-attributes": "^7.28.6",
+        "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+        "@babel/plugin-transform-arrow-functions": "^7.27.1",
+        "@babel/plugin-transform-async-generator-functions": "^7.29.0",
+        "@babel/plugin-transform-async-to-generator": "^7.28.6",
+        "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
+        "@babel/plugin-transform-block-scoping": "^7.28.6",
+        "@babel/plugin-transform-class-properties": "^7.28.6",
+        "@babel/plugin-transform-class-static-block": "^7.28.6",
+        "@babel/plugin-transform-classes": "^7.28.6",
+        "@babel/plugin-transform-computed-properties": "^7.28.6",
+        "@babel/plugin-transform-destructuring": "^7.28.5",
+        "@babel/plugin-transform-dotall-regex": "^7.28.6",
+        "@babel/plugin-transform-duplicate-keys": "^7.27.1",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.0",
+        "@babel/plugin-transform-dynamic-import": "^7.27.1",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
+        "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
+        "@babel/plugin-transform-export-namespace-from": "^7.27.1",
+        "@babel/plugin-transform-for-of": "^7.27.1",
+        "@babel/plugin-transform-function-name": "^7.27.1",
+        "@babel/plugin-transform-json-strings": "^7.28.6",
+        "@babel/plugin-transform-literals": "^7.27.1",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
+        "@babel/plugin-transform-member-expression-literals": "^7.27.1",
+        "@babel/plugin-transform-modules-amd": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.28.6",
+        "@babel/plugin-transform-modules-systemjs": "^7.29.4",
+        "@babel/plugin-transform-modules-umd": "^7.27.1",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
+        "@babel/plugin-transform-new-target": "^7.27.1",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
+        "@babel/plugin-transform-numeric-separator": "^7.28.6",
+        "@babel/plugin-transform-object-rest-spread": "^7.28.6",
+        "@babel/plugin-transform-object-super": "^7.27.1",
+        "@babel/plugin-transform-optional-catch-binding": "^7.28.6",
+        "@babel/plugin-transform-optional-chaining": "^7.28.6",
+        "@babel/plugin-transform-parameters": "^7.27.7",
+        "@babel/plugin-transform-private-methods": "^7.28.6",
+        "@babel/plugin-transform-private-property-in-object": "^7.28.6",
+        "@babel/plugin-transform-property-literals": "^7.27.1",
+        "@babel/plugin-transform-regenerator": "^7.29.0",
+        "@babel/plugin-transform-regexp-modifiers": "^7.28.6",
+        "@babel/plugin-transform-reserved-words": "^7.27.1",
+        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
+        "@babel/plugin-transform-spread": "^7.28.6",
+        "@babel/plugin-transform-sticky-regex": "^7.27.1",
+        "@babel/plugin-transform-template-literals": "^7.27.1",
+        "@babel/plugin-transform-typeof-symbol": "^7.27.1",
+        "@babel/plugin-transform-unicode-escapes": "^7.27.1",
+        "@babel/plugin-transform-unicode-property-regex": "^7.28.6",
+        "@babel/plugin-transform-unicode-regex": "^7.27.1",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
+        "@babel/preset-modules": "0.1.6-no-external-plugins",
+        "babel-plugin-polyfill-corejs2": "^0.4.15",
+        "babel-plugin-polyfill-corejs3": "^0.14.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.6",
+        "core-js-compat": "^3.48.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/preset-modules": {
+      "version": "0.1.6-no-external-plugins",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+      "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/@babel/preset-typescript": {
@@ -3794,6 +5029,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -4487,6 +5733,483 @@
       "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-babel": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.1.0.tgz",
+      "integrity": "sha512-dFZNuFD2YRcoomP4oYf+DvQNSUA9ih+A3vUqopQx5EdtPGo3WBnQcI/S8pwpz91UsGfL0HsMSOlaMld8HrbubA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.18.6",
+        "@rollup/pluginutils": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@types/babel__core": "^7.1.9",
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/babel__core": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+      "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "serialize-javascript": "^7.0.3",
+        "smob": "^1.0.0",
+        "terser": "^5.17.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -5568,6 +7291,59 @@
         "vitest": ">=2.0.0"
       }
     },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.19.4.tgz",
+      "integrity": "sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==",
+      "license": "MIT",
+      "dependencies": {
+        "remove-accents": "0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-async-storage-persister": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-async-storage-persister/-/query-async-storage-persister-5.100.9.tgz",
+      "integrity": "sha512-KTWqpXIAwuR1bSIxfOnoRr7hOMxfrtLk9kxSuDfOu4sSBEFqHp9+aDp8Ig6YdHxCclNI86SizPnmKmSqNxcJxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.9",
+        "@tanstack/query-persist-client-core": "5.100.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
+      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-persist-client-core": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-5.100.9.tgz",
+      "integrity": "sha512-sCPZZp3D9sOeqcA4SDxjUIm4wVq8PwHebH4ouFZetwjT4xvGjT/cLBQ4Sst+BFcFuk745pCPkf3T4MFliLHECQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tiptap/core": {
       "version": "3.22.5",
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.5.tgz",
@@ -6036,6 +7812,22 @@
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "license": "MIT"
     },
+    "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
+      "version": "3.0.0-pre1",
+      "resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
+      "integrity": "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ejs": "^3.1.10",
+        "json5": "^2.2.3",
+        "magic-string": "^0.30.21",
+        "string.prototype.matchall": "^4.0.12"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -6149,6 +7941,13 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/set-cookie-parser": {
       "version": "2.4.10",
       "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
@@ -6207,8 +8006,8 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -6694,6 +8493,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6796,6 +8596,45 @@
         "node": ">= 14"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -6855,12 +8694,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/async-lock": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
       "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/axe-core": {
       "version": "4.11.4",
@@ -6885,6 +8760,58 @@
         "react-native-b4a": {
           "optional": true
         }
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+      "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
+        "semver": "^6.3.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+      "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
+        "core-js-compat": "^3.48.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+      "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.8"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -7216,6 +9143,13 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/buildcheck": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
@@ -7243,6 +9177,25 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -7442,6 +9395,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/compress-commons": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
@@ -7538,6 +9501,20 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/core-js-compat": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -7618,6 +9595,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/css-box-model": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
@@ -7659,6 +9646,60 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -7681,6 +9722,52 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -7903,6 +9990,22 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.339",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
@@ -7948,6 +10051,75 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -7983,6 +10155,40 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/esbuild": {
@@ -8051,6 +10257,29 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eta": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-4.6.0.tgz",
+      "integrity": "sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/bgub/eta?sponsor=1"
       }
     },
     "node_modules/etag": {
@@ -8289,6 +10518,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -8418,6 +10654,29 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
+    "node_modules/filelist": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -8437,6 +10696,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/foreground-child": {
@@ -8494,6 +10769,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -8517,9 +10808,50 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gazetta": {
       "resolved": "packages/gazetta",
       "link": true
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -8564,6 +10896,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/get-port": {
       "version": "7.2.0",
@@ -8619,6 +10958,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-tsconfig": {
@@ -8691,6 +11048,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -8720,6 +11094,48 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -8732,10 +11148,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8903,6 +11335,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -8936,6 +11374,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
@@ -8954,6 +11407,157 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -8964,12 +11568,92 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-node-process": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
       "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
@@ -8996,6 +11680,64 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -9009,6 +11751,57 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -9020,6 +11813,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-what": {
@@ -9074,6 +11913,24 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jiti": {
@@ -9282,6 +12139,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsonpointer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
@@ -9335,6 +12205,16 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lightningcss": {
@@ -9640,10 +12520,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.groupby": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
       "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true,
       "license": "MIT"
     },
@@ -10289,6 +13183,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -10372,6 +13297,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -10449,6 +13392,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "2.0.2",
@@ -10580,6 +13530,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.13",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
@@ -10616,6 +13576,19 @@
       "license": "MIT",
       "peerDependencies": {
         "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
+      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pretty-ms": {
@@ -11124,6 +14097,49 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/regenerate-unicode-properties": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
+      "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
@@ -11148,6 +14164,71 @@
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexpu-core": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
+      "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.2.2",
+        "regjsgen": "^0.8.0",
+        "regjsparser": "^0.13.0",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/regjsparser": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jsesc": "~3.1.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -11165,6 +14246,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -11241,6 +14344,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/rope-sequence": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
@@ -11273,6 +14422,33 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-array-concat/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -11293,6 +14469,48 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -11362,6 +14580,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/serialize-javascript": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/serve-static": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
@@ -11387,6 +14615,55 @@
       "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -11570,6 +14847,16 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/smob": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.1.tgz",
+      "integrity": "sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -11584,6 +14871,27 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -11678,6 +14986,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
@@ -11764,6 +15086,93 @@
         "node": ">=8"
       }
     },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -11776,6 +15185,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/strip-ansi": {
@@ -11803,6 +15227,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/strip-final-newline": {
@@ -11857,6 +15291,19 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/symbol-tree": {
@@ -11915,6 +15362,74 @@
       "dependencies": {
         "streamx": "^2.12.5"
       }
+    },
+    "node_modules/temp-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tempy": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.6.0.tgz",
+      "integrity": "sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "temp-dir": "^2.0.0",
+        "type-fest": "^0.16.0",
+        "unique-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/type-fest": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
+      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/testcontainers": {
       "version": "11.14.0",
@@ -12193,6 +15708,84 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typed-inject": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-5.0.0.tgz",
@@ -12253,6 +15846,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/underscore": {
       "version": "1.13.8",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
@@ -12276,6 +15888,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+      "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-value-ecmascript": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
+      "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-property-aliases-ecmascript": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
+      "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -12287,6 +15943,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/unist-util-is": {
@@ -12357,6 +16026,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -12404,6 +16083,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
+    "node_modules/upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -12579,6 +16269,37 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-pwa": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-1.3.0.tgz",
+      "integrity": "sha512-c5kMgN+ITrOtHXp8PAtk2uOIEea6XjP/unCGxOWWBzQ6qa65qj/awHg0wf+QF9E/2u9vh86LqxPwzEPNbM2r5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.6",
+        "pretty-bytes": "^6.1.1",
+        "tinyglobby": "^0.2.10",
+        "workbox-build": "^7.4.1",
+        "workbox-window": "^7.4.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vite-pwa/assets-generator": "^1.0.0",
+        "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "workbox-build": "^7.4.1",
+        "workbox-window": "^7.4.1"
+      },
+      "peerDependenciesMeta": {
+        "@vite-pwa/assets-generator": {
           "optional": true
         }
       }
@@ -12874,6 +16595,102 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -12896,6 +16713,373 @@
       "resolved": "https://registry.npmjs.org/win-guid/-/win-guid-0.2.1.tgz",
       "integrity": "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==",
       "license": "MIT"
+    },
+    "node_modules/workbox-background-sync": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.1.tgz",
+      "integrity": "sha512-HhT7KE8tOWDm02wRNshXUnUPofMlhenF2DBdUnDPOubhizzPeItkYTmAB6td1Z2cjYPa98vzEiPLEuzn5hN66g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "idb": "^7.0.1",
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-background-sync/node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/workbox-broadcast-update": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.4.1.tgz",
+      "integrity": "sha512-uAlgslKLvbQY+suirIdnBCSYrcgBhjp81Nj4l1lj/Jmj0MJO2CJERnCJjT0GFVwmReV0N+zs78K6gqd5gr9/+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-build": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.4.1.tgz",
+      "integrity": "sha512-SDhxIvEAde9Gy/5w4Yo1Jh/M49Z0qE3q0oteyE8zGq0DScxFqVBcCtIXFuLtmtxRQZCMbf0prco4VyEu3KBQuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apideck/better-ajv-errors": "^0.3.1",
+        "@babel/core": "^7.24.4",
+        "@babel/preset-env": "^7.11.0",
+        "@babel/runtime": "^7.11.2",
+        "@rollup/plugin-babel": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "@rollup/plugin-replace": "^6.0.3",
+        "@rollup/plugin-terser": "^1.0.0",
+        "@trickfilm400/rollup-plugin-off-main-thread": "^3.0.0-pre1",
+        "ajv": "^8.6.0",
+        "common-tags": "^1.8.0",
+        "eta": "^4.5.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "fs-extra": "^9.0.1",
+        "glob": "^11.0.1",
+        "pretty-bytes": "^5.3.0",
+        "rollup": "^4.53.3",
+        "source-map": "^0.8.0-beta.0",
+        "stringify-object": "^3.3.0",
+        "strip-comments": "^2.0.1",
+        "tempy": "^0.6.0",
+        "upath": "^1.2.0",
+        "workbox-background-sync": "7.4.1",
+        "workbox-broadcast-update": "7.4.1",
+        "workbox-cacheable-response": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-expiration": "7.4.1",
+        "workbox-google-analytics": "7.4.1",
+        "workbox-navigation-preload": "7.4.1",
+        "workbox-precaching": "7.4.1",
+        "workbox-range-requests": "7.4.1",
+        "workbox-recipes": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1",
+        "workbox-streams": "7.4.1",
+        "workbox-sw": "7.4.1",
+        "workbox-window": "7.4.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/workbox-build/node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/workbox-build/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/workbox-build/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/workbox-build/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/workbox-build/node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/workbox-build/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/workbox-build/node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/workbox-build/node_modules/source-map": {
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "deprecated": "The work that was done in this beta branch won't be included in future versions",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/workbox-build/node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/workbox-build/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/workbox-build/node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/workbox-cacheable-response": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.4.1.tgz",
+      "integrity": "sha512-8xaFoJdDc2OjrlbbL3gEeBO1WKcMwRqwLRupgqahYXu75yXajPLuwrbXMrIGZuWYXrQwk0xDjOxZ/ujCy/oJYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-core": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.1.tgz",
+      "integrity": "sha512-DT+vu46eh/2vRsSHTY4Xmc32Z1rr9PRlQUXr1Dx30ZuXRWwOsvZgGgcwxcasubQLQmbTNYZjv44LkBAQ4tT5tQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/workbox-expiration": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.4.1.tgz",
+      "integrity": "sha512-lRKUF7b+OGbeXkQk1s6MHXOa3d7Xxf7Of31W6c6hCfipfIyrtdWZ89stq21AHZMaoG7VNFoHply4Ox+rU31TWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "idb": "^7.0.1",
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-expiration/node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/workbox-google-analytics": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.4.1.tgz",
+      "integrity": "sha512-Mks1JwLEt++ZAkF6sS1OpSh9RtAMIsiDgRpK+codiHGIPXeaUOgi4cPc3GFadUl8V5QPeypEk8Oxgl3HlwVzHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-background-sync": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
+      }
+    },
+    "node_modules/workbox-navigation-preload": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.4.1.tgz",
+      "integrity": "sha512-C4KVsjPcYKJOhr631AxR9XoG2rLF3QiTk5aMv36MXOjtWvm8axwNFAtKUPGsWUwLXXAMgYM1En7fsvndaXeXRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-precaching": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.4.1.tgz",
+      "integrity": "sha512-cdr/9qByww7yzEp7zg/qI4ukUrrNjQLgN+ONQRpjy/VqGQXwkgHwr00KksGJK8v0VifwDXBb8a4cWNZH71jn3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
+      }
+    },
+    "node_modules/workbox-range-requests": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.4.1.tgz",
+      "integrity": "sha512-7i2oxAUE82gHdAJBCAQ04JzNOdRPqzuOzGfoUyJpFSmeqBNYGPrAH8GPoPjUQTfp+NycwrD2H68VtuF8qxv0vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-recipes": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.4.1.tgz",
+      "integrity": "sha512-gnbVfmV4/TtmQaM4x9AtuXhcdstJsep3XMVeztOrQVPT+R6+6DeBjGTCQ7fFCXm+4GEHUA5VEBTyi5+4gWGeog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-cacheable-response": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-expiration": "7.4.1",
+        "workbox-precaching": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
+      }
+    },
+    "node_modules/workbox-routing": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.4.1.tgz",
+      "integrity": "sha512-yubJGErZOusuidAenaL5ypfhQOa7urxP/f8E0ws7FPb4039RiWXUWBAyUkmUoOL/BcQGen3h0J8872d51IYxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-strategies": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.4.1.tgz",
+      "integrity": "sha512-GZxpaw9NbmOelj7667uZ2kpk5BFpOGbO4X0qjwh5ls8XQ8C+Lha5LQchTiUzsTFSS+NlUpftYAyOVXvQUrcqOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/workbox-streams": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.4.1.tgz",
+      "integrity": "sha512-HWWtraKUbJknd9kgqGcpQ3G114HOPYvqs8HaJMDs2ebLNAimDkVDaWfAXE6Ybl+m8U6KsCE6pWyLYuigWmnAXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1"
+      }
+    },
+    "node_modules/workbox-sw": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.4.1.tgz",
+      "integrity": "sha512-fez5f2DUlDJWTFYkCWQpY10N8gtztd849NswCbVFk0QlcSM4HT5A8x4g4ii650yem4I8tHY0R7JZahwp3ltIPw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/workbox-window": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.1.tgz",
+      "integrity": "sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2",
+        "workbox-core": "7.4.1"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@types/node": "^25.6.0",
         "@vitejs/plugin-vue": "^6.0.6",
         "@vue/test-utils": "^2.4.10",
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^29.0.2",
         "testcontainers": "^11.13.0",
         "tsx": "^4.21.0",
@@ -10472,6 +10473,16 @@
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "license": "MIT"
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fast-check": {
       "version": "4.7.0",

--- a/packages/gazetta/package.json
+++ b/packages/gazetta/package.json
@@ -34,6 +34,10 @@
       "types": "./dist/format.d.ts",
       "import": "./dist/format.js"
     },
+    "./save-etag": {
+      "types": "./dist/save-etag.d.ts",
+      "import": "./dist/save-etag.js"
+    },
     "./editor": {
       "types": "./dist/editor/mount.d.ts",
       "import": "./dist/editor/mount.js"

--- a/packages/gazetta/src/admin-api/index.ts
+++ b/packages/gazetta/src/admin-api/index.ts
@@ -27,6 +27,7 @@ import { fieldRoutes } from './routes/fields.js'
 import { historyRoutes } from './routes/history.js'
 import { assetRoutes } from './routes/assets.js'
 import { systemRoutes } from './routes/system.js'
+import { healthRoutes } from './routes/health.js'
 import { startCacheStatsLogger } from './cache-stats-logger.js'
 
 export interface AdminAppOptions {
@@ -190,6 +191,7 @@ export function createAdminApp(opts: AdminAppOptions): AdminApp {
   app.route('/', historyRoutes(resolveSource, opts.targets, opts.targetConfigs))
   app.route('/', assetRoutes(resolveSource))
   app.route('/', systemRoutes(resolveSource))
+  app.route('/', healthRoutes())
 
   // Periodic cache stats log — fires every 5 minutes against the
   // bootstrap source's cache. Runs unobtrusively (timer.unref()

--- a/packages/gazetta/src/admin-api/routes/fragments.ts
+++ b/packages/gazetta/src/admin-api/routes/fragments.ts
@@ -10,6 +10,7 @@ import { rebuildFragmentDeps } from '../../fragment-deps.js'
 import { hasBlockingIssues, runSaveDelta } from '../../validation/save-delta.js'
 import type { ValidatorRegistry } from '../../validation/registry.js'
 import type { FragmentManifest } from '../../types.js'
+import { computeSaveEtag } from '../../save-etag.js'
 
 export function fragmentRoutes(resolve: SourceContextResolver, validators: ValidatorRegistry, templatesDir?: string) {
   const app = new Hono()
@@ -101,6 +102,14 @@ export function fragmentRoutes(resolve: SourceContextResolver, validators: Valid
     if (!fragment) return c.json({ error: `Fragment "${name}" not found` }, 404)
 
     const localeEntry = site.fragmentLocales.get(name)
+    // Save-concurrency etag — see save-etag.ts. Same shape as pages
+    // (without metadata + route since fragments don't carry them).
+    const etag = await computeSaveEtag({
+      template: fragment.template,
+      content: fragment.content,
+      components: fragment.components,
+    })
+    c.header('ETag', `"${etag}"`)
     return c.json({
       name,
       template: fragment.template,
@@ -126,6 +135,34 @@ export function fragmentRoutes(resolve: SourceContextResolver, validators: Valid
     if (!defaultFragment) return c.json({ error: `Fragment "${name}" not found` }, 404)
     const localeVariant = locale ? site.fragmentLocales.get(name)?.locales.get(locale) : undefined
     const fragment = localeVariant ?? defaultFragment
+
+    // Save-concurrency check per design-offline.md Q3. Mirrors the
+    // pages PUT handler — see pages.ts for the rationale + 409 STALE
+    // shape.
+    const ifMatchRaw = c.req.header('If-Match')
+    const ifMatch = ifMatchRaw?.replace(/^"(.*)"$/, '$1')
+    if (ifMatch) {
+      const currentEtag = await computeSaveEtag({
+        template: fragment.template,
+        content: fragment.content,
+        components: fragment.components,
+      })
+      if (currentEtag !== ifMatch) {
+        return c.json(
+          {
+            code: 'STALE' as const,
+            current: {
+              template: fragment.template,
+              content: fragment.content,
+              components: fragment.components,
+            },
+            currentEtag,
+          },
+          409,
+          { ETag: `"${currentEtag}"` },
+        )
+      }
+    }
 
     const body = await c.req.json()
     const manifest = {
@@ -174,7 +211,9 @@ export function fragmentRoutes(resolve: SourceContextResolver, validators: Valid
       rebuildFragmentDeps(source.contentRoot, item, fragment, manifest),
     ])
     await Promise.all([source.cache.invalidatePrefix('fragments:'), source.cache.invalidatePrefix('pages:')])
-    return c.json({ ok: true })
+    const newEtag = await computeSaveEtag(manifest)
+    c.header('ETag', `"${newEtag}"`)
+    return c.json({ ok: true, etag: newEtag })
   })
 
   app.delete('/api/fragments/:name', async c => {

--- a/packages/gazetta/src/admin-api/routes/health.ts
+++ b/packages/gazetta/src/admin-api/routes/health.ts
@@ -1,0 +1,73 @@
+/**
+ * `GET /api/health` — heartbeat for offline-mode connection
+ * detection per `design-offline.md` Q2 ("hybrid `navigator.onLine` +
+ * heartbeat"). Browser-side connection-state store calls this every
+ * 5s when `navigator.onLine` is false OR a recent request failed,
+ * backing off to 30s after repeated failures, returning to silent
+ * once a heartbeat succeeds.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns "is the admin process reachable?". Cache
+ *     stats live next door in `system.ts`; conflating them would
+ *     couple browser-side connection-detection cadence to per-target
+ *     cache-stats lookups, and would force the heartbeat through any
+ *     future capability gates the system route picks up.
+ *   - DIP: takes no dependencies — the route is genuinely stateless.
+ *     The browser only needs "did the admin process answer at all?".
+ *
+ * # Why public + auth-free
+ *
+ * Per `design-offline.md`: lightweight; no DB query; no auth check.
+ * Two reasons matter:
+ *
+ *   1. The browser must reach this endpoint while offline (where the
+ *      browser THINKS the network is up but auth tokens may have
+ *      expired). Gating on auth means an expired-token user appears
+ *      "offline" even when the server is reachable — wrong UX.
+ *   2. CDNs / edge runtimes can cache this response cheaply for
+ *      `dynamic` targets behind a worker. Auth would defeat that.
+ *
+ * # Cacheable?
+ *
+ * Response includes a `timestamp` so accidentally-cached responses
+ * don't lie about freshness. Operators behind a CDN should set the
+ * cache TTL low (a few seconds at most); browsers don't cache by
+ * default since EventSource / `fetch` cache semantics are GET-only
+ * and the `timestamp` makes byte-identical responses unlikely.
+ *
+ * # Design-locked response shape
+ *
+ *   { ok: true, timestamp: '2026-05-06T15:23:04.567Z' }
+ *
+ * `ok: true` is always returned when the route reaches this handler
+ * — by definition, a process that can serve the route is healthy
+ * enough for the browser's "can I reach the server?" question. Any
+ * deeper liveness check (DB, storage, cache) would be a separate
+ * `/api/system/*` endpoint, NOT this one.
+ */
+import { Hono } from 'hono'
+
+export interface HealthResponse {
+  ok: true
+  /** ISO 8601 timestamp the server generated this response. */
+  timestamp: string
+}
+
+/**
+ * Build the health-check route. Takes no parameters — health is
+ * process-level, not per-source.
+ */
+export function healthRoutes() {
+  const app = new Hono()
+
+  app.get('/api/health', c => {
+    const body: HealthResponse = {
+      ok: true,
+      timestamp: new Date().toISOString(),
+    }
+    return c.json(body)
+  })
+
+  return app
+}

--- a/packages/gazetta/src/admin-api/routes/pages.ts
+++ b/packages/gazetta/src/admin-api/routes/pages.ts
@@ -10,6 +10,7 @@ import { rebuildFragmentDeps } from '../../fragment-deps.js'
 import { hasBlockingIssues, runSaveDelta } from '../../validation/save-delta.js'
 import type { ValidatorRegistry } from '../../validation/registry.js'
 import type { PageManifest } from '../../types.js'
+import { computeSaveEtag } from '../../save-etag.js'
 
 export function pageRoutes(resolve: SourceContextResolver, validators: ValidatorRegistry, templatesDir?: string) {
   const app = new Hono()
@@ -140,6 +141,18 @@ export function pageRoutes(resolve: SourceContextResolver, validators: Validator
     if (!page) return c.json({ error: `Page "${name}" not found` }, 404)
 
     const localeEntry = site.pageLocales.get(name)
+    // Save-concurrency etag — see save-etag.ts. Client uses this in
+    // If-Match on the next PUT to detect mid-edit drift (someone else
+    // saved while the author was editing). Different from the
+    // `.{8hex}.hash` publish-state hash; both run.
+    const etag = await computeSaveEtag({
+      template: page.template,
+      content: page.content,
+      components: page.components,
+      metadata: page.metadata,
+      route: page.route,
+    })
+    c.header('ETag', `"${etag}"`)
     return c.json({
       name,
       route: page.route,
@@ -168,6 +181,41 @@ export function pageRoutes(resolve: SourceContextResolver, validators: Validator
     if (!defaultPage) return c.json({ error: `Page "${name}" not found` }, 404)
     const localeVariant = locale ? site.pageLocales.get(name)?.locales.get(locale) : undefined
     const page = localeVariant ?? defaultPage
+
+    // Save-concurrency check per design-offline.md Q3. If-Match
+    // present → server compares against current on-disk etag; mismatch
+    // returns 409 STALE with current manifest body so the client can
+    // surface a conflict diff. Absent If-Match → no concurrency check
+    // (online clients without offline-awareness keep working — last-
+    // write-wins). Header value is RFC-7232 quoted; normalize.
+    const ifMatchRaw = c.req.header('If-Match')
+    const ifMatch = ifMatchRaw?.replace(/^"(.*)"$/, '$1')
+    if (ifMatch) {
+      const currentEtag = await computeSaveEtag({
+        template: page.template,
+        content: page.content,
+        components: page.components,
+        metadata: page.metadata,
+        route: page.route,
+      })
+      if (currentEtag !== ifMatch) {
+        return c.json(
+          {
+            code: 'STALE' as const,
+            current: {
+              template: page.template,
+              content: page.content,
+              components: page.components,
+              metadata: page.metadata,
+              route: page.route,
+            },
+            currentEtag,
+          },
+          409,
+          { ETag: `"${currentEtag}"` },
+        )
+      }
+    }
 
     const body = await c.req.json()
     const manifest: Record<string, unknown> = {
@@ -231,7 +279,17 @@ export function pageRoutes(resolve: SourceContextResolver, validators: Validator
       rebuildFragmentDeps(source.contentRoot, item, page, manifest),
     ])
     await source.cache.invalidatePrefix('pages:')
-    return c.json({ ok: true })
+    // Echo the new save-etag so the client updates its baseline
+    // without a separate GET. The shape MUST match what the next
+    // GET produces — `route` is derived from the folder, not stored
+    // in the file, but the in-memory entry carries it. Carry it
+    // here so the projection chain works for offline replay
+    // sequences (design-offline.md Q3).
+    const echoShape: Record<string, unknown> = { ...manifest }
+    if (page.route !== undefined) echoShape.route = page.route
+    const newEtag = await computeSaveEtag(echoShape)
+    c.header('ETag', `"${newEtag}"`)
+    return c.json({ ok: true, etag: newEtag })
   })
 
   app.delete('/api/pages/:name{.+}', async c => {

--- a/packages/gazetta/src/admin-api/schemas/site.ts
+++ b/packages/gazetta/src/admin-api/schemas/site.ts
@@ -9,6 +9,8 @@ import { z } from 'zod'
 
 export const LocalesConfigSchema = z.object({
   supported: z.array(z.string()),
+  /** Default locale; falls back to supported[0] when omitted. */
+  default: z.string().optional(),
   fallbacks: z.record(z.string(), z.string()).optional(),
   defaultPrefix: z.boolean().optional(),
   detection: z.boolean().optional(),
@@ -18,7 +20,6 @@ export const SiteManifestSchema = z
   .object({
     name: z.string(),
     version: z.string().optional(),
-    locale: z.string().optional(),
     locales: LocalesConfigSchema.optional(),
     systemPages: z.array(z.string()).optional(),
   })

--- a/packages/gazetta/src/save-etag.ts
+++ b/packages/gazetta/src/save-etag.ts
@@ -1,0 +1,101 @@
+/**
+ * Save-concurrency etag — a content hash used by the save endpoints
+ * to detect stale writes. Different from the publish-state hash in
+ * `hash.ts`:
+ *
+ *   `.{8hex}.hash` (publish-state, MD5)
+ *     - Substitutes template + fragment hashes into the manifest
+ *     - Drives sidecars, compare, cache invalidation
+ *     - Server-only: requires `templateHashes` and `fragmentHashes`
+ *       maps that the client doesn't have
+ *
+ *   save etag (this module, SHA-256, 16 hex)
+ *     - Pure manifest content; no template/fragment substitution
+ *     - Drives `If-Match` save concurrency per `design-offline.md` Q3
+ *     - Computable identically by client + server (same canonicalization,
+ *       same Web Crypto API)
+ *
+ * # Why two etags
+ *
+ * Save concurrency asks: "did THIS page's manifest change between
+ * my read and my write?" A template change doesn't dirty individual
+ * pages from the author's perspective — the author edits page X;
+ * if a colleague separately edits the template, that's a render
+ * concern, not a save-conflict concern. Mixing the two would force
+ * 409 STALE on every author after a template edit, which is wrong UX.
+ *
+ * The `.{8hex}.hash` etag legitimately includes template/fragment
+ * dependencies because IT drives publish + cache invalidation, where
+ * the question IS "did anything in the dep tree change."
+ *
+ * Two etags, two semantics, two consumers. Locked per `design-offline.md`
+ * Cut 9 grilling.
+ *
+ * # Why SHA-256 truncated to 16 hex (not MD5 truncated to 8)
+ *
+ * Save etags collide more often than publish hashes — every save is
+ * a new etag candidate; many saves per page over a long offline
+ * session. A collision = silent stale-write (false negative on
+ * conflict). 8 hex MD5 = 4B keyspace; tens of thousands of saves
+ * across thousands of pages would hit the birthday bound. 16 hex
+ * SHA-256 = 18.4 quintillion keyspace; collisions are not a
+ * realistic concern. Cost: 8 extra characters in the ETag header.
+ *
+ * # Client + server parity contract
+ *
+ * Both call `computeSaveEtag(manifest)` and MUST produce identical
+ * output. Canonicalization rules:
+ *
+ *   1. Pick fields: `template`, `content`, `components`, `metadata`,
+ *      `route`. Other fields ignored (sidecars, derived state, etc.).
+ *   2. JSON.stringify with sorted keys via the existing
+ *      `sortedReplacer` (deep recursive object-key sort).
+ *   3. SHA-256 via `globalThis.crypto.subtle.digest('SHA-256', bytes)`
+ *      (Web Crypto; works in Node 18+ and all browsers).
+ *   4. Take first 8 bytes (16 hex characters).
+ */
+
+/** Manifest fields that participate in the save etag. */
+const SAVE_ETAG_FIELDS = ['template', 'content', 'components', 'metadata', 'route'] as const
+
+/** Canonical JSON via sorted-key recursion. Same shape as the
+ *  publish-hash module's sortedReplacer; duplicated here so this
+ *  module is self-contained (see SRP note in the file header). */
+function sortedReplacer(_key: string, value: unknown): unknown {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const out: Record<string, unknown> = {}
+    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+      out[k] = (value as Record<string, unknown>)[k]
+    }
+    return out
+  }
+  return value
+}
+
+/**
+ * Compute the save etag for a page or fragment manifest. Returns 16
+ * lowercase hex characters (first 8 bytes of SHA-256).
+ *
+ * Both client and server call this with the same manifest object;
+ * both produce the same etag. Used for `ETag` response header on
+ * GET and `If-Match` request header on PUT.
+ *
+ * Async because Web Crypto's `digest` is async. Callers in hot paths
+ * (save handlers, contract tests) await once per save.
+ */
+export async function computeSaveEtag(manifest: Record<string, unknown>): Promise<string> {
+  const picked: Record<string, unknown> = {}
+  for (const field of SAVE_ETAG_FIELDS) {
+    if (field in manifest) picked[field] = manifest[field]
+  }
+  const json = JSON.stringify(picked, sortedReplacer)
+  const bytes = new TextEncoder().encode(json)
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes)
+  // First 8 bytes = 16 hex characters.
+  const view = new Uint8Array(digest, 0, 8)
+  let out = ''
+  for (let i = 0; i < view.length; i++) {
+    out += view[i].toString(16).padStart(2, '0')
+  }
+  return out
+}

--- a/packages/gazetta/tests/admin-api.test.ts
+++ b/packages/gazetta/tests/admin-api.test.ts
@@ -548,6 +548,157 @@ describe('PUT /api/pages/:name', () => {
   })
 })
 
+describe('save-etag concurrency (design-offline.md Q3)', () => {
+  afterAll(async () => {
+    await rm(resolve(localTargetDir, 'pages/etag-test'), { recursive: true, force: true })
+    await rm(resolve(localTargetDir, 'fragments/etag-test'), { recursive: true, force: true })
+  })
+
+  function unquote(etag: string | null): string | null {
+    return etag?.replace(/^"(.*)"$/, '$1') ?? null
+  }
+
+  it('GET /api/pages/:name returns ETag header (16 hex, RFC-7232 quoted)', async () => {
+    const res = await app.request('/api/pages/home')
+    expect(res.status).toBe(200)
+    const etag = res.headers.get('ETag')
+    expect(etag).not.toBeNull()
+    expect(etag).toMatch(/^"[0-9a-f]{16}"$/)
+  })
+
+  it('GET /api/fragments/:name returns ETag header', async () => {
+    const res = await app.request('/api/fragments/header')
+    expect(res.status).toBe(200)
+    const etag = res.headers.get('ETag')
+    expect(etag).toMatch(/^"[0-9a-f]{16}"$/)
+  })
+
+  it('PUT without If-Match succeeds (last-write-wins for non-offline-aware clients)', async () => {
+    await app.request('/api/pages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'etag-test', template: 'page-default' }),
+    })
+    const res = await app.request('/api/pages/etag-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: { title: 'No If-Match' } }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: boolean; etag?: string }
+    expect(body.ok).toBe(true)
+    // Successful save echoes the new etag for client baseline update.
+    expect(body.etag).toMatch(/^[0-9a-f]{16}$/)
+    expect(res.headers.get('ETag')).toBe(`"${body.etag}"`)
+  })
+
+  it('PUT with matching If-Match succeeds', async () => {
+    // Read current etag.
+    const readRes = await app.request('/api/pages/etag-test')
+    const currentEtag = unquote(readRes.headers.get('ETag'))!
+    expect(currentEtag).toMatch(/^[0-9a-f]{16}$/)
+
+    const res = await app.request('/api/pages/etag-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'If-Match': `"${currentEtag}"` },
+      body: JSON.stringify({ content: { title: 'Matching If-Match' } }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: boolean; etag: string }
+    // New etag MUST differ from the pre-save etag (content changed).
+    expect(body.etag).not.toBe(currentEtag)
+  })
+
+  it('PUT with stale If-Match returns 409 STALE with current manifest', async () => {
+    // Read once to capture an etag, save twice via the no-If-Match
+    // path so the etag goes stale.
+    const readRes = await app.request('/api/pages/etag-test')
+    const staleEtag = unquote(readRes.headers.get('ETag'))!
+
+    // Drift the server state — simulates "another author saved while
+    // I was offline."
+    await app.request('/api/pages/etag-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: { title: 'Drift' } }),
+    })
+
+    // Now try to save with the stale etag.
+    const res = await app.request('/api/pages/etag-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'If-Match': `"${staleEtag}"` },
+      body: JSON.stringify({ content: { title: 'My Edit' } }),
+    })
+    expect(res.status).toBe(409)
+    const body = (await res.json()) as {
+      code: string
+      current: { content: { title: string } }
+      currentEtag: string
+    }
+    expect(body.code).toBe('STALE')
+    // Current manifest body so the client can show the conflict diff.
+    expect(body.current.content.title).toBe('Drift')
+    expect(body.currentEtag).toMatch(/^[0-9a-f]{16}$/)
+    expect(body.currentEtag).not.toBe(staleEtag)
+    expect(res.headers.get('ETag')).toBe(`"${body.currentEtag}"`)
+  })
+
+  it('chained saves with projected etags work (offline replay sequence)', async () => {
+    // Simulates the chained-projection pattern from design-offline.md
+    // Q3: A1 saves with If-Match=baseline; A2 saves with If-Match=
+    // projected-from-A1's-result. Both succeed end-to-end.
+    const readRes = await app.request('/api/pages/etag-test')
+    const baselineEtag = unquote(readRes.headers.get('ETag'))!
+
+    // A1
+    const a1 = await app.request('/api/pages/etag-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'If-Match': `"${baselineEtag}"` },
+      body: JSON.stringify({ content: { title: 'A1' } }),
+    })
+    expect(a1.status).toBe(200)
+    const a1Body = (await a1.json()) as { etag: string }
+
+    // A2 chains via A1's projected etag.
+    const a2 = await app.request('/api/pages/etag-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'If-Match': `"${a1Body.etag}"` },
+      body: JSON.stringify({ content: { title: 'A2' } }),
+    })
+    expect(a2.status).toBe(200)
+  })
+
+  it('fragments PUT honors If-Match (same shape as pages)', async () => {
+    await app.request('/api/fragments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'etag-test', template: 'header-layout' }),
+    })
+    const readRes = await app.request('/api/fragments/etag-test')
+    const currentEtag = unquote(readRes.headers.get('ETag'))!
+    expect(currentEtag).toMatch(/^[0-9a-f]{16}$/)
+
+    // Stale If-Match → 409 STALE.
+    const stale = await app.request('/api/fragments/etag-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'If-Match': '"0000000000000000"' },
+      body: JSON.stringify({ content: { title: 'Stale' } }),
+    })
+    expect(stale.status).toBe(409)
+    const staleBody = (await stale.json()) as { code: string; current: unknown }
+    expect(staleBody.code).toBe('STALE')
+    expect(staleBody.current).toBeDefined()
+
+    // Matching If-Match → success.
+    const ok = await app.request('/api/fragments/etag-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'If-Match': `"${currentEtag}"` },
+      body: JSON.stringify({ content: { title: 'Fresh' } }),
+    })
+    expect(ok.status).toBe(200)
+  })
+})
+
 describe('PUT /api/pages/:name (metadata round-trip)', () => {
   afterAll(async () => {
     await rm(resolve(localTargetDir, 'pages/meta-test'), { recursive: true, force: true })

--- a/packages/gazetta/tests/admin-api.test.ts
+++ b/packages/gazetta/tests/admin-api.test.ts
@@ -68,6 +68,30 @@ describe('GET /api/site', () => {
   })
 })
 
+describe('GET /api/health', () => {
+  it('returns ok + ISO timestamp without auth', async () => {
+    const { status, body } = await get('/api/health')
+    expect(status).toBe(200)
+    expect(body.ok).toBe(true)
+    // ISO 8601 with Z; smoke check that timestamp parses back as the
+    // same instant. Pins the documented response shape from
+    // design-offline.md Q2.
+    expect(typeof body.timestamp).toBe('string')
+    const parsed = new Date(body.timestamp)
+    expect(Number.isFinite(parsed.getTime())).toBe(true)
+  })
+
+  it('produces a fresh timestamp on each call', async () => {
+    // Browser-side connection-detection cadence relies on each call
+    // getting a fresh response so a CDN-cached old response can't
+    // masquerade as a live heartbeat.
+    const a = (await get('/api/health')).body.timestamp as string
+    await new Promise(r => setTimeout(r, 5))
+    const b = (await get('/api/health')).body.timestamp as string
+    expect(b).not.toBe(a)
+  })
+})
+
 describe('GET /api/system/cache/stats', () => {
   it('returns the source cache snapshot', async () => {
     // Hit /api/pages first so the cache has something to report —

--- a/packages/gazetta/tests/save-etag.test.ts
+++ b/packages/gazetta/tests/save-etag.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Pin the save-concurrency etag contract per `design-offline.md` Q3.
+ *
+ * This module's primary load-bearing property is **client+server
+ * parity** — both sides call computeSaveEtag and MUST produce
+ * identical output. The browser-side test (in apps/admin/tests)
+ * imports the same function via 'gazetta/save-etag' and runs the
+ * same fixtures; if either drifts, both fail.
+ */
+import { describe, it, expect } from 'vitest'
+import { computeSaveEtag } from '../src/save-etag.js'
+
+describe('computeSaveEtag', () => {
+  it('produces a 16-char lowercase hex string', async () => {
+    const etag = await computeSaveEtag({ template: 'hero', content: { title: 'Hi' } })
+    expect(etag).toMatch(/^[0-9a-f]{16}$/)
+  })
+
+  it('is deterministic — same input → same etag', async () => {
+    const a = await computeSaveEtag({ template: 'hero', content: { title: 'Hi' } })
+    const b = await computeSaveEtag({ template: 'hero', content: { title: 'Hi' } })
+    expect(a).toBe(b)
+  })
+
+  it('changes when content changes', async () => {
+    const a = await computeSaveEtag({ template: 'hero', content: { title: 'Hi' } })
+    const b = await computeSaveEtag({ template: 'hero', content: { title: 'Hello' } })
+    expect(a).not.toBe(b)
+  })
+
+  it('changes when template changes', async () => {
+    const a = await computeSaveEtag({ template: 'hero', content: { title: 'Hi' } })
+    const b = await computeSaveEtag({ template: 'banner', content: { title: 'Hi' } })
+    expect(a).not.toBe(b)
+  })
+
+  it('changes when components change', async () => {
+    const a = await computeSaveEtag({ template: 'page', components: ['hero'] })
+    const b = await computeSaveEtag({ template: 'page', components: ['hero', 'footer'] })
+    expect(a).not.toBe(b)
+  })
+
+  it('changes when route changes (page-only field)', async () => {
+    const a = await computeSaveEtag({ template: 'page', route: '/old' })
+    const b = await computeSaveEtag({ template: 'page', route: '/new' })
+    expect(a).not.toBe(b)
+  })
+
+  it('changes when metadata changes (page-only field)', async () => {
+    const a = await computeSaveEtag({ template: 'page', metadata: { title: 'A' } })
+    const b = await computeSaveEtag({ template: 'page', metadata: { title: 'B' } })
+    expect(a).not.toBe(b)
+  })
+
+  it('is invariant to non-save fields (sidecars, derived state)', async () => {
+    // The save etag covers manifest fields the save endpoint writes.
+    // Other fields (sidecars, locales array, dir, etc.) are NOT part
+    // of the save concurrency check — adding/removing them does not
+    // dirty the etag.
+    const a = await computeSaveEtag({ template: 'hero', content: { title: 'Hi' } })
+    const b = await computeSaveEtag({
+      template: 'hero',
+      content: { title: 'Hi' },
+      // None of these fields are part of SAVE_ETAG_FIELDS:
+      dir: '/some/path',
+      locales: ['en', 'fr'],
+      hash: 'abc12345',
+    })
+    expect(a).toBe(b)
+  })
+
+  it('is invariant to JSON key ordering', async () => {
+    // Sorted-key canonicalization — different insertion order of the
+    // same logical content produces the same etag.
+    const a = await computeSaveEtag({
+      template: 'hero',
+      content: { title: 'Hi', subtitle: 'Yo' },
+    })
+    const b = await computeSaveEtag({
+      content: { subtitle: 'Yo', title: 'Hi' },
+      template: 'hero',
+    })
+    expect(a).toBe(b)
+  })
+
+  it('treats absent fields and explicit undefined the same way', async () => {
+    // JSON.stringify drops undefined; an absent field and an explicit
+    // undefined produce identical canonical JSON.
+    const a = await computeSaveEtag({ template: 'hero', content: { title: 'Hi' } })
+    const b = await computeSaveEtag({ template: 'hero', content: { title: 'Hi' }, metadata: undefined })
+    expect(a).toBe(b)
+  })
+
+  it('treats null and absent differently (intentional)', async () => {
+    // JSON.stringify keeps null. Explicit null is a meaningful value
+    // (e.g., "this field is intentionally cleared"); the etag MUST
+    // reflect that distinction.
+    const a = await computeSaveEtag({ template: 'hero', content: null })
+    const b = await computeSaveEtag({ template: 'hero' })
+    expect(a).not.toBe(b)
+  })
+
+  it('handles deeply-nested content', async () => {
+    const etag = await computeSaveEtag({
+      template: 'page',
+      content: {
+        hero: { title: 'A', meta: { tags: ['x', 'y'] } },
+        sections: [{ id: 1, body: { text: 'one' } }],
+      },
+    })
+    expect(etag).toMatch(/^[0-9a-f]{16}$/)
+  })
+})


### PR DESCRIPTION
## Summary

- Admin keeps working when the network goes away — pages already loaded
  stay viewable, edits in progress aren't lost, saves either land silently
  on reconnect or surface as actionable conflicts. Cold-loading the admin
  offline now serves the SPA bundle from a service-worker precache.
- Save concurrency lands as a real contract: server etag → \`If-Match\` →
  \`409 STALE\` with the conflicting current manifest → field-by-field
  diff banner + Discard action (no overwrite button per Krug-aligned UX).
- 15 of 16 cuts shipped (Cut 15 audit integration deferred — waits for
  the audit-log foundation). All design-locked behavior is live.

## Cuts shipped

| # | What |
|---|---|
| 1 | Dependencies (idb, @tanstack/vue-query, query-async-storage-persister, vite-plugin-pwa) |
| 2 | \`IndexedDBCache\` provider — browser-side \`AdminCache\` |
| 3 | Provider selector + browser-native \`MemoryCache\` fallback (Safari Lockdown / private mode) |
| 4 | BroadcastChannel cross-tab invalidation |
| 5 | Vue Query setup + persister bridge → L6 |
| 6 | \`useConnectionState\` Pinia store (5-state model + hybrid heartbeat) |
| 7 | \`GET /api/health\` server endpoint |
| 8a | Persist \`editorStructural\` (pure-data subset) |
| 8b | Persist \`editorStash\` + \`editorContent\` (cross-page key + closure-rebuild via navigate seam) |
| 9 | Save-etag plumbing (server \`ETag\` + \`If-Match\` + 409 STALE; client \`StaleSaveError\` + \`getPageWithEtag\` + \`updatePage(..., ifMatch)\`) |
| 9b | Save-flow integration end-to-end (\`useEditorEtags\` store, \`updateManifest\` helper, \`EditorPanel\` ConflictBanner wiring) |
| 10 | Conflict UX (\`useSaveConflictsStore\` + \`ConflictBanner.vue\` + \`ConflictDiffView.vue\`) |
| 11 | Service worker via \`vite-plugin-pwa\` (injectManifest) — app-shell precache + Refresh-toast update flow |
| 12 | Global offline banner + reconnect toast (Krug-aligned; "Send now" affordance) |
| 13 | Mid-save connection-loss reconcile (TypeError → GET-and-compare → silent success or \`StaleSaveError\`) |
| 14 | Storage quota warning at 80% (per-tab-session dismiss-once) |
| 16 | \`docs/offline.md\` author + operator guide |

**Cut 15 deferred** — Audit integration (\`metadata.replayed: true\`,
\`queuedAt\`, \`replayedAt\`) lands when the audit-log foundation ships;
it's an additive enhancement on top of the working primitives.

## Architecture highlights

- **Two etags coexist by design** — the publish-state \`.{8hex}.hash\`
  includes template + fragment hashes (drives publish/cache invalidation);
  the new save-etag is pure manifest content (browser can't access
  template hashes; mixing would force false 409s after every template
  edit). Different semantics, different consumers.
- **Save-conflict UX deliberately has no "Save anyway / Overwrite"
  button** — authors who genuinely want to overwrite manually port
  their edits onto the new version. Removes a footgun; matches
  Linear / Notion / Figma.
- **Cross-page persistence keys** — the in-memory \`editorStash\` keys
  by \`target.path\` (collides across pages). The cross-reload
  \`usePersistedEditsStore\` uses richer \`(kind, name, locale, path)\`
  tuples so dirty content on \`pages/home/_root\` doesn't overlay on
  \`pages/about/_root\` after a reload.
- **Mid-save handled invisibly** — when a save fails with a network
  error mid-flight, the client doesn't know if the save landed.
  GET-and-compare reconciles: matches → silent success; differs →
  surfaces as a normal stale-save conflict.

## Test coverage

- **730 admin tests** (was 567 before the branch)
- **1554 gazetta core tests** (was 1533)

Audit went through three honest rounds:

1. **Initial coverage** of each cut as it shipped — every public
   primitive, every error path, every store has direct tests.
2. **First gap-fill** — \`useServiceWorkerUpdate\` was untested;
   \`StorageQuotaBanner\` only asserted the empty state; the
   provider-selector missed the Safari Lockdown probe path
   the design specifically calls out.
3. **Second gap-fill** — \`EditorPanel.handleConflictDiscard\`
   orchestration was untested; extracted to \`useConflictDiscard\`
   composable for testability.
4. **Third gap-fill** — browser \`MemoryCache\` had no contract
   coverage (only transitive); eviction-at-cap was untested in
   BOTH providers (cursor walks, byte accounting, evictions
   counter).

What's NOT covered, with documented reasons:
- \`sw.ts\` SW behavior — workbox library code; e2e is the right place
- E2E validation-gate scenarios (3 flows in design-offline.md) —
  tracked at #253

## Test plan

- [ ] CI green on push
- [ ] Manual smoke: \`gazetta dev\`; open admin; edit a page; navigate
      away + back → edit persists. Reload page → edit persists.
- [ ] Manual smoke: open admin in two browser tabs on the same page;
      edit + save in tab A; edit in tab B and try to save → "Was
      edited by someone else" banner with diff
- [ ] Manual smoke: DevTools → Application → throttle Offline → reload
      page → SPA loads with "Offline" banner
- [ ] Verify both build paths: \`apps/admin\` local build + gazetta
      package's \`build:admin\` script (output to \`packages/gazetta/admin-dist/\`)

## Reference

- Design: [\`.claude/rules/design-offline.md\`](.claude/rules/design-offline.md)
- Implementation status: [\`.claude/rules/design-offline-implementation.md\`](.claude/rules/design-offline-implementation.md)
- User docs: [\`docs/offline.md\`](docs/offline.md)
- E2E validation-gate follow-up: #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)