### PR TITLE
Phase 0: write 5 missing implementation docs

### DIFF
--- a/.claude/rules/design-i18n-implementation.md
+++ b/.claude/rules/design-i18n-implementation.md
@@ -1,0 +1,150 @@
+---
+paths:
+  - "packages/gazetta/src/cli/translate.ts"
+  - "packages/gazetta/src/cli/validate.ts"
+  - "apps/admin/src/client/components/EditorPanel.vue"
+  - "apps/admin/src/client/composables/useEditorActions.ts"
+---
+
+# i18n / Locale — Implementation
+
+Companion to [design-i18n.md](design-i18n.md). Tracks the remaining implementation work; the bulk of the design has shipped.
+
+See [design-i18n.md](design-i18n.md) for the design itself.
+
+## Status
+
+13 of 15 implementation steps have shipped (whole-file locale variants, file-suffix model, fallback chain, hreflang, sitemap, admin locale picker, CLI translate, language detection). Two steps remain. Per-field translation (#192) is the next major chunk and gets its own implementation pass — the design/implementation split for this doc happens when #192 lands.
+
+## Cut sequence
+
+**Status legend**: ✓ shipped · ◐ in progress · ☐ pending
+
+The cuts are small and independent — they don't compose into a single branch. Each ships standalone where the design pass anticipated.
+
+| # | Cut | Status | Risk | Validates |
+|---|---|---|---|---|
+| 1 | Admin "Translate to..." action — design-i18n step 12 | ☐ | Low | Author UX |
+| 2 | `gazetta validate` locale-file checks — design-i18n step 15 | ☐ | Low | Validation surface |
+| 3 | Per-field translation (#192) — major: design pass + implementation cuts | ☐ | High | Per-field overlay model |
+
+## Per-cut scope
+
+### Cut 1: Admin "Translate to..." action (step 12)
+
+**What ships:** an admin UI affordance that creates a new locale variant of the current page or fragment, pre-filled from the default locale's content. Author opens a page, clicks "Translate to French," and lands in `page.fr.json` with the default locale's content as a starting point.
+
+**Files added/modified:**
+- `apps/admin/src/client/components/EditorPanel.vue` — "Translate to..." button in the locale picker / metadata area; opens a small dialog listing supported locales not yet present for this manifest
+- `apps/admin/src/client/composables/useEditorActions.ts` — new `translateTo(targetLocale: string)` function: POST to a new admin-API route that creates the locale variant
+- `packages/gazetta/src/admin-api/routes/pages.ts` + `fragments.ts` — `POST /api/pages/:name/translate` body `{ to: string }`. Server reads the default-locale manifest, writes a new `{name}.{locale}.json` with the same content; rejects 409 if the variant already exists; rejects 400 if `to` not in `locales.supported`
+
+**Why "pre-fill from default" not "create empty":** zero-friction. Author sees the structure they're starting from and edits in place; an empty form forces them to mentally rebuild the page from scratch. CLI `gazetta translate` already does this; admin UI mirrors that behavior.
+
+**Tests:**
+- `admin-api.test.ts` — POST translate creates the locale file with default's content; second POST returns 409
+- Unsupported `to` returns 400
+- Vue component test: button hidden when all locales already exist; click opens dialog; selection navigates to new editor
+
+**Trigger to ship:** alongside the editor papercut cluster (Tier 1) when author UX work picks up; or as its own commit when authors ask.
+
+**Risk:** low. The server-side write is well-understood; the UI adds a button next to the existing locale picker.
+
+**SOLID:** SRP — `translateTo` is its own composable function; doesn't mix with general save/navigate. ISP — the new route is its own admin-API endpoint with a small Zod schema, not a flag on an existing route.
+
+### Cut 2: `gazetta validate` locale-file checks (step 15)
+
+**What ships:** validation of locale-variant manifests at the CLI level. Catches structural breaks specific to multi-locale sites: orphaned variants (e.g., `page.fr.json` exists but `page.json` doesn't), invalid locale codes, locale files referencing fragments that don't have matching locale variants.
+
+**Files added/modified:**
+- `packages/gazetta/src/validation/validators/orphaned-locale-file.ts` (NEW) — already listed in `design-validation.md` as a background-only validator; ship its CLI integration here
+- `packages/gazetta/src/validation/validators/locale-code-valid.ts` (NEW) — validates each variant's locale code is in `locales.supported`; rejects malformed locale codes
+- `packages/gazetta/src/cli/validate.ts` — wire the two new validators into the CLI run
+- `gazetta validate --include-locale` flag (or always-on; locked at implementation time) to enable the locale-specific checks
+
+**Tests:**
+- `tests/validation-locale.test.ts` — orphan variant detected; invalid locale code reported with the file path; valid locale variant passes
+- CLI integration: exits 1 on orphan variant; exits 0 with the flag off
+
+**Trigger to ship:** with validation Cut 5 (CLI rewrite per `design-validation-implementation.md`). The CLI rewrite already has this in its scope.
+
+**Risk:** low. Pure-function validators; no UI; no migration.
+
+**SOLID:** OCP — new validators slot into the existing registry without touching infrastructure.
+
+### Cut 3: Per-field translation (#192)
+
+**What ships:** layered per-field translation overlay on top of the existing whole-file model. Per `design-i18n.md` "Per-field overlay model": each manifest can carry per-locale per-field overrides instead of (or in addition to) a full locale-variant file. Useful for "translate just the title and description" without copying the full structure.
+
+**This cut is a design-and-implement at-once.** The design space is open in `design-i18n.md` — the locked invariant says "Per-field overlay model (asset-side, future for pages/fragments)" — pages/fragments need a design pass for the overlay shape (where do overrides live? merged at read time? per-locale arrays in the manifest? sidecar files? merged before validation or after?).
+
+**Implementation phases** (sequenced after the design pass):
+
+1. **Design grilling** (1 week): merged at read or write? per-locale arrays in manifest, or sidecar `page.fr.overlay.json`? schema validation: full manifest after merge, or per-overlay? component-level overrides (per `design-collaboration.md` Component IDs)?
+2. **Schema + types** (~3 days): manifest shape supports overlay; loader merges per-locale overrides; renderer sees the merged manifest
+3. **Admin UI** (~5 days): per-field "translate this field" affordance; per-field locale picker
+4. **Migration** (~2 days): existing whole-file variants continue to work; operators opt into per-field per file (`page.fr.json` becomes `page.json` + `page.fr.overlay.json` if they choose)
+5. **Validation** (~2 days): locale-aware altRequired and quality validators understand merged manifests
+6. **Docs** (~2 days): operator + template-author guide
+
+**Total estimate:** ~3 weeks including the design grilling. Sized after the design pass.
+
+**Trigger to ship:** Tier 2 / Phase 2 work per ROADMAP. Concrete demand pushes priority.
+
+**Risk:** high. The design pass is open; wrong shape forces a future migration. Component IDs (Phase 1 foundation) is a likely prerequisite for component-level overrides.
+
+**Why this cut is a placeholder:** the meaningful work is the design pass that locks the overlay shape. Once locked, the implementation cuts get their own per-cut breakdown and SOLID checks. Capturing #192 here as "the next big chunk for i18n" rather than punting it.
+
+## Validation gate (definition of done)
+
+Cuts 1 and 2 are independent; each has its own done definition.
+
+**Cut 1 done:**
+- [ ] "Translate to..." button visible when locales are unfilled
+- [ ] POST creates the locale variant; 409 on existing; 400 on unsupported locale
+- [ ] After click, author lands in the new editor with default's content
+
+**Cut 2 done:**
+- [ ] `gazetta validate` reports orphan variants with the file path
+- [ ] `gazetta validate` reports invalid locale codes
+- [ ] CLI Cut 5 (validation rewrite) integrates these checks
+
+**Cut 3 done:**
+- [ ] Design pass landed in `design-i18n.md` (or a successor doc)
+- [ ] Implementation cuts split out and shipped
+- [ ] Backwards-compatible with existing whole-file variants
+- [ ] Author can mix whole-file + per-field per page
+
+## Deferred items
+
+| Item | Trigger to revisit |
+|---|---|
+| Locale-aware comments per `design-collaboration.md` future | Concrete demand |
+| Per-locale CDN cache invalidation | Multi-region operator demand |
+| Auto-translate on save (vs manual `gazetta translate`) | Operator asks; depends on AI translation cut shipping |
+| RTL-specific admin chrome (beyond document `dir`) | Arabic / Hebrew operators report friction |
+| Pluralization conventions | Concrete content authoring demand (current model: each form is its own field) |
+
+## Open implementation questions
+
+1. **"Translate to..." dialog default behavior.** Should it pre-fill from default locale, or from a chosen source locale? Recommend default-locale (matches CLI). Locked at cut 1.
+2. **Per-field overlay shape (cut 3).** The big question. Options listed in cut 3 above; needs a grilling pass.
+3. **Invalid locale code in URL.** What does `?locale=invalid` do today? Per the codebase: falls back to default. Document the behavior in `docs/i18n.md` and add a test.
+
+## Estimates
+
+Wall-clock for solo dev:
+
+| Cut | Estimate |
+|---|---|
+| 1 (Admin "Translate to...") | 1.5 days |
+| 2 (CLI validate locale checks) | 1 day (lands with validation Cut 5) |
+| 3 (Per-field translation #192) | ~3 weeks (design + impl) |
+
+**Cuts 1+2 total: ~2.5 days.** Cut 3 sized after its design pass.
+
+## SOLID checks per cut
+
+- **Cut 1**: SRP — `translateTo` composable owns "create locale variant from default"; route handler owns server-side write. DIP — UI consumes the route via the existing api client; doesn't reach into the server.
+- **Cut 2**: OCP — validators slot into the existing `Validator` registry without changing infrastructure.
+- **Cut 3**: deferred — SOLID review at design-pass time.

--- a/.claude/rules/design-rendering-implementation.md
+++ b/.claude/rules/design-rendering-implementation.md
@@ -1,0 +1,355 @@
+---
+paths:
+  - "packages/gazetta/src/renderer.ts"
+  - "packages/gazetta/src/types.ts"
+  - "packages/gazetta/src/workers/**"
+  - "packages/gazetta/src/runtime/**"
+  - "packages/gazetta/src/admin-api/routes/preview.ts"
+  - "packages/gazetta/src/cli/serve.ts"
+---
+
+# Rendering — Implementation
+
+Companion to [design-rendering.md](design-rendering.md). Cut sequence with risk ordering.
+
+See [design-rendering.md](design-rendering.md) for the design itself.
+
+## Status
+
+Today's codebase ships only the `static` and `esi` target types (the `esi` target type uses string-cat composition via Hono on workers; `static` ships pre-assembled HTML). The locked v1 design adds:
+
+1. The `dynamic` target type (origin Node/Bun process; per-request template execution)
+2. Fragment-level `rendering: 'static' | 'dynamic' | 'island'` declaration
+3. Programmatic `pages.where(...).list()` listings API for templates
+4. Three route modes (static, static-with-params, dynamic)
+5. `RenderContext` per-request object for dynamic fragments
+6. Per-fragment `timeout` + `onFailure` modes
+
+Several open threads are flagged in `design-rendering.md`'s "More grilling needed" — those need a follow-up grilling pass. The cuts below proceed with the locked invariants and call out the provisional ones.
+
+## Cut sequence
+
+**Status legend**: ✓ shipped · ◐ in progress · ☐ pending
+
+Branch: `rendering-v1` off `main`. **No backwards compatibility** — `esi` target stays the current default and works unchanged; `static` and `dynamic` are net-new (static was previously documented but unwired in some paths).
+
+Sequenced server-first (contracts + listings + route discovery), then worker / origin runtime, then UX surfaces (admin preview, sitemap). Risk-ordered: low-risk type/schema changes first; high-risk worker/origin protocol last.
+
+| # | Cut | Status | Risk | Validates |
+|---|---|---|---|---|
+| 1 | `TargetConfig.type` enum + Zod schema; current `esi` config remains as the default; `static` and `dynamic` opt-in | ☐ | Low | Type contract |
+| 2 | `RenderContext` shape locked + plumbed into renderer | ☐ | Medium | Per-request state |
+| 3 | `pages.where(...).list()` + `fragments.where(...).list()` — programmatic listings API at publish time (helpers param) | ☐ | High | New template surface |
+| 4 | Listings caching via `AdminCache` + invalidation on save | ☐ | Medium | Cache contract on listings |
+| 5 | Fragment-level `rendering` declaration + validator coherence check (template signature ↔ manifest field) | ☐ | Medium | Fragment-rendering-type contract |
+| 6 | `routes.json` route manifest + 3 route modes (static / static-with-params / dynamic) + conflict detection | ☐ | High | Route discovery |
+| 7 | Per-fragment `timeout` + `onFailure` (`empty` / `placeholder` / `fail-page`) + audit integration | ☐ | Medium | Failure modes |
+| 8 | `dynamic` target origin runtime: template execution per request, `RenderContext` populated, response shape | ☐ | High | The new target type |
+| 9 | Worker → origin protocol for dynamic fragments (HTTP-based; per-fragment fetch with `RenderContext` payload) | ☐ | High | Cross-process boundary |
+| 10 | Worker cache rule: content-addressed responses only; dynamic responses pass through with origin's `Cache-Control` | ☐ | Medium | Cache correctness |
+| 11 | Admin preview supports dynamic targets (calls origin in-process during dev) | ☐ | Medium | Preview parity |
+| 12 | Sitemap + hreflang for dynamic routes (route enumeration from `routes.json`) | ☐ | Low | SEO surface |
+| 13 | Per-platform deployment matrix verified: Cloudflare + Fly.io split; Node/Bun single-process | ☐ | Medium | End-to-end validation |
+| 14 | Docs (`docs/rendering.md` operator + template-author guide) + ROADMAP + CLAUDE.md | ☐ | Low | User-facing |
+
+Provisional locks flagged in design-rendering.md's "More grilling needed" need resolution before cut 5 (fragment-rendering-type), cut 6 (route discovery), and cut 9 (worker→origin protocol). Each is a small follow-up grilling pass; documented per cut below.
+
+## Per-cut scope
+
+### Cut 1: Target type enum
+
+**Files modified:**
+- `packages/gazetta/src/config/schemas.ts` — `targetSchema.type` is now a closed enum: `z.enum(['static', 'esi', 'dynamic']).default('esi')` (esi stays the default for backwards compat at the schema level)
+- `packages/gazetta/src/types.ts` — `TargetConfig.type: 'static' | 'esi' | 'dynamic'`
+- `packages/gazetta/src/site-loader.ts` — pass through; Zod handles default
+
+**Tests:**
+- Default: target without `type` resolves to `esi`
+- `'static'` resolves directly; `'dynamic'` resolves directly
+- Unknown type rejected with helpful error
+
+**Risk:** low. The field is additive; existing configs default to `esi`.
+
+**SOLID:** ISP — `type` is a single field, not a capability interface. Each target type's behavior lives in its own runtime module.
+
+### Cut 2: `RenderContext` plumbed
+
+**Provisional lock to resolve before this cut**: design-rendering.md item #5 ("`RenderContext` shape lock"). Recommended fields: `{ params, query, headers, cookies, principal, locale, theme, target, requestId, now }`. A 1-day grilling pass to confirm field set + types.
+
+**Files modified:**
+- `packages/gazetta/src/types.ts` — `RenderContext` interface with the locked fields
+- `packages/gazetta/src/renderer.ts` — accept optional `ctx: RenderContext`; pass to dynamic fragment templates as `params.ctx`; static + island templates don't receive `ctx`
+- Static + island template signature: existing `(params: { content, children?, locale, theme })` — unchanged
+- Dynamic fragment template signature: `(params: { content, children?, ctx })` — `locale` and `theme` accessible via `ctx.locale` / `ctx.theme`
+
+**Tests:**
+- Static template invoked without `ctx` → `params.ctx === undefined`
+- Dynamic fragment template invoked with full `RenderContext` populated
+- Property test: `RenderContext` shape immutable (frozen)
+
+**Risk:** medium. Wrong shape forces template-author migration. Property tests guard the contract.
+
+### Cut 3: Programmatic listings API
+
+**Files added:**
+- `packages/gazetta/src/runtime/page-query.ts` — `PageQuery` builder + filter/sort/limit/offset/list semantics
+- `packages/gazetta/src/runtime/fragment-query.ts` — same shape for fragments
+- `packages/gazetta/src/runtime/helpers.ts` — `createHelpers(site, locale, theme)` returns `{ pages: PageQuery, fragments: FragmentQuery }`
+
+**Files modified:**
+- `packages/gazetta/src/renderer.ts` — pass `helpers` to static + island templates; `ctx.pages` and `ctx.fragments` for dynamic templates
+- Template signatures: `helpers` field present at publish time; `ctx` field for dynamic templates exposes the same query objects
+
+**Locked composition rules** (per design):
+- Locale: automatic filter by active locale; opt out via `where({ locale: 'all' })`
+- Theme: automatic filter by active theme; opt out via `where({ theme: 'all' })`
+- RBAC: at request time, automatic filter by `ctx.principal`'s read capabilities; at publish time, no filter (no principal)
+- No free-text search — equality + sort only
+
+**Tests:**
+- Filter by `template`, `tag`, manifest field path → returns matching subset
+- Sort + limit + offset (offset-based pagination per design pass)
+- Locale filter active by default; opt-out works
+- RBAC filter at request time excludes pages the principal can't read (verified via test principal lacking read access)
+- Property test: query is deterministic (same inputs → same output)
+
+**Risk:** high. New template surface; bugs here cause silent data leaks (e.g., RBAC filter not applied; cross-locale results showing up).
+
+**SOLID:** SRP — `PageQuery` owns building the query; the filter implementation is a separate function. DIP — templates depend on the `PageQuery` interface, not on the filesystem walker.
+
+### Cut 4: Listings cache
+
+**Files modified:**
+- `packages/gazetta/src/runtime/page-query.ts` — `list()` checks `AdminCache` first; on miss, computes + sets
+- Save handlers (`pages.ts`, `fragments.ts`) — invalidate `pages-query:` and `fragments-query:` prefixes
+
+**Cache key shape** per `design-cache.md` Q1: `pages-query:{filter-hash}:locale:{l}:theme:{t}:limit:{N}:offset:{M}`. Filter hash is sha256 of canonical-JSON-serialized filter object.
+
+**Tests:**
+- Same query twice → second call cache hit
+- Save → next query is fresh
+- Cross-locale queries don't share cache entries
+
+**Risk:** medium. Wrong cache key = stale listings; tests guard via integration round-trip (save → query → assert fresh).
+
+### Cut 5: Fragment `rendering` declaration
+
+**Provisional lock to resolve before this cut**: design-rendering.md item #2 (explicit `rendering` field vs. inferred from template signature). Recommend explicit field; validator coherence check catches mismatch.
+
+**Files modified:**
+- `packages/gazetta/src/types.ts` — `FragmentManifest.rendering?: 'static' | 'dynamic' | 'island'` (default `'static'`)
+- `packages/gazetta/src/validation/validators/fragment-rendering-coherent.ts` (NEW) — validator: template's TS signature (presence/absence of `ctx` parameter) matches manifest's `rendering`
+- `packages/gazetta/src/renderer.ts` — branch on `fragment.rendering` to pick render-time + invocation shape
+
+**Tests:**
+- Default: fragment without `rendering` field treated as `'static'`
+- `'dynamic'` fragment: template invoked at request time with `ctx`; not at publish time
+- `'island'` fragment: template SSR'd at publish time; hydration script injected
+- Coherence validator: signature mismatch reported with file path
+
+**Risk:** medium. Wrong rendering branch = wrong invocation shape; templates fail at runtime. Coherence validator catches it at validation time.
+
+### Cut 6: Route discovery
+
+**Provisional lock to resolve before this cut**: design-rendering.md item #1 (dynamic routes vs. dynamic fragments). Locked: orthogonal axes; routes determine URL → page resolution; rendering determines per-fragment invocation timing.
+
+**Files modified:**
+- `packages/gazetta/src/types.ts` — `PageManifest.params?: { source: 'list' | 'query', values?: string[], query?: PageFilter }` and `PageManifest.dynamic?: boolean`
+- `packages/gazetta/src/runtime/route-discovery.ts` (NEW) — discovers all routes at publish time; expands static-with-params; emits `routes.json` to target storage
+- `packages/gazetta/src/runtime/route-conflicts.ts` (NEW) — detects two pages claiming same route, slug overlap, dynamic shadowing static (warn)
+- `packages/gazetta/src/publish.ts` (or `publish-rendered.ts`) — call route discovery; bake `routes.json` into target
+
+**Tests:**
+- Static route → 1 entry in routes.json
+- Static-with-params (list) with N values → N entries (one per value)
+- Static-with-params (query) at publish time runs the query; entries match
+- Dynamic route on `static` target → publish error
+- Dynamic route on `esi` target → publish error
+- Dynamic route on `dynamic` target → entry with `dynamic: true`
+- Route conflict: two static routes same path → publish error
+- Route shadow: dynamic shadows static → warning
+
+**Risk:** high. Route discovery is the URL → page resolution contract. Wrong shape = 404s on routes that should resolve, or wrong page rendered.
+
+### Cut 7: Per-fragment timeout + onFailure
+
+**Files modified:**
+- `packages/gazetta/src/types.ts` — `FragmentManifest.timeout?: number`, `onFailure?: 'empty' | 'placeholder' | 'fail-page'`, `fallbackHtml?: string`
+- `packages/gazetta/src/runtime/fragment-failure.ts` (NEW) — handles each failure mode
+- `packages/gazetta/src/audit/types.ts` — extend `action` enum with `'fragment-failed'` and `outcome` enum (per design-rendering.md "Audit integration")
+- `packages/gazetta/src/admin-api/routes/audit.ts` (when audit ships) — surface fragment-failure events
+
+**Tests:**
+- Origin times out → `empty` mode emits HTML comment marker; page renders without the fragment
+- `placeholder` mode renders `fallbackHtml`
+- `fail-page` mode → 504 Gateway Timeout
+- 5xx origin error → 502 Bad Gateway with `fail-page`
+- Audit event fired with action+outcome
+
+**Risk:** medium. The `fail-page` path is the operator-visible failure surface; wrong status code or missing audit = compliance gap.
+
+### Cut 8: Dynamic origin runtime
+
+**Files added:**
+- `packages/gazetta/src/runtime/origin.ts` — origin Node/Bun handler; per-request template execution; `RenderContext` populated; response shape includes content-hash for worker caching of static parts (origin doesn't cache its own per-request output)
+- `packages/gazetta/src/cli/origin.ts` (NEW) — `gazetta origin` CLI command (or extend `gazetta serve` to dual-role for single-process deployments)
+
+**Tests:**
+- Origin handler invoked with `RenderContext` → template returns `{ html, css, js, head }`
+- Origin returns 200 with rendered output; per-request `Cache-Control: no-store` (origin doesn't cache; worker handles it)
+- Multiple concurrent requests with different `RenderContext` produce isolated outputs
+
+**Risk:** high. New runtime; new failure modes; new deployment topology. Heavy on tests + integration testing against real Cloudflare Workers + Fly.io.
+
+**SOLID:** SRP — origin handler does one thing (execute template per request). DIP — origin depends on `StorageProvider` interface for content reads; doesn't reach into specific providers.
+
+### Cut 9: Worker → origin protocol
+
+**Provisional lock to resolve before this cut**: design-rendering.md item #4 (page composition with mixed-rendering fragments) and "Provisional — dynamic side needs more grilling" in Q5. ~2-day grilling pass to lock:
+- HTTP-based per-fragment fetch shape (worker calls origin once per dynamic fragment? batched? per-page?)
+- Cache key for dynamic responses with route params
+- Hot-reload of routes (does worker pick up new dynamic routes at next request, or require redeploy?)
+
+**Files added:**
+- `packages/gazetta/src/workers/origin-client.ts` — worker-side HTTP client to origin; encodes `RenderContext` in request body
+- `packages/gazetta/src/runtime/origin-server.ts` — origin-side request handler; decodes `RenderContext`; invokes template
+
+**Files modified:**
+- `packages/gazetta/src/workers/cloudflare.ts` (or composition logic) — branch on fragment.rendering; static fragments fetched from cache; dynamic fragments fetched from origin via origin-client
+- Page composition assembly: string-concat with placeholder filling per design-rendering.md "Page composition model with mixed-rendering fragments"
+
+**Tests:**
+- Worker fetches static fragments from cache + dynamic from origin → composed page
+- Origin failure → fragment-level fallback (Cut 7) applies
+- Mixed page (static + dynamic + island) renders coherently
+
+**Risk:** high. Cross-process protocol; bugs in encoding/decoding `RenderContext` cause silent data leaks or wrong rendering.
+
+### Cut 10: Worker cache rule
+
+**Files modified:**
+- `packages/gazetta/src/workers/cache.ts` (or wherever worker cache logic lives) — only cache content-addressed responses (immutable hash-in-path URLs); dynamic origin responses pass through with origin's `Cache-Control` headers
+
+**Tests:**
+- Static fragment cached; same URL second request → cache hit
+- Dynamic fragment NOT cached by worker; second request → fresh origin call (or origin-honored cache)
+- Origin sets `Cache-Control: max-age=60` → worker honors via standard HTTP caching
+
+**Risk:** medium. Wrong cache rule = stale dynamic responses or miss-rate spikes on static fragments.
+
+### Cut 11: Admin preview for dynamic targets
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/preview.ts` — when previewing a page on a `dynamic` target, run the origin handler in-process (dev mode); pass admin-provided `RenderContext` (preview's `?preview=draft` etc.)
+- `apps/admin/src/client/components/PreviewPanel.vue` — pass dynamic-target context (params, query) via URL; preview iframe URL builds the right shape
+
+**Tests:**
+- Preview a page with dynamic fragment → origin invoked in-process → composed HTML returned
+- Preview with route params (`/blog/:slug`) → admin lets author specify slug; origin receives `ctx.params.slug`
+
+**Risk:** medium. Preview parity is critical for author trust ("WYSIWYG"); divergence between preview and published causes regression-hunting friction.
+
+### Cut 12: Sitemap + hreflang for dynamic routes
+
+**Files modified:**
+- `packages/gazetta/src/sitemap.ts` — include dynamic-route pages enumerated from `routes.json`
+- Hreflang for dynamic routes: cross-domain targets via sitemap (per design-i18n.md), HTML head injection for subpath targets
+
+**Tests:**
+- Sitemap includes static + static-with-params + dynamic routes
+- Hreflang correctness across all three modes
+
+**Risk:** low. Sitemap is well-understood; cut adds one more enumeration source.
+
+### Cut 13: Per-platform deployment validation
+
+**What ships:** integration tests (or smoke tests in CI) that validate end-to-end dynamic-target deployment on a real platform.
+
+**Files added:**
+- `tests/e2e/rendering-dynamic-cloudflare.spec.ts` (skipped in CI by default; runs on `RENDERING_E2E=cloudflare` env) — deploys a fixture site to Cloudflare Workers + Fly.io origin, asserts page composition works
+- `tests/e2e/rendering-dynamic-single-process.spec.ts` — `gazetta serve` dual-role; same fixture; smaller test envelope (runs in CI by default)
+
+**Tests:**
+- Single-process: dynamic fragment renders fresh content per request
+- Split-deployment: worker calls origin; origin returns rendered fragment; page composes
+
+**Risk:** medium. End-to-end validates the integrated system; bugs at any earlier cut surface here.
+
+### Cut 14: Docs
+
+**Files added/modified:**
+- `docs/rendering.md` (NEW) — operator guide: target type choice; deployment topology; per-fragment timeout/failure; programmatic listings example
+- `docs/cloudflare.md` — extend with per-target-type sections per design's "Operator documentation responsibility"
+- `docs/self-hosted.md` — same for `gazetta serve` dual-role
+- `examples/starter` — add a dynamic fragment example (e.g., a "live trending" widget)
+- `ROADMAP.md` — mark Tier 3 implementation complete
+- `CLAUDE.md` — link `docs/rendering.md`
+
+## Validation gate (definition of done)
+
+- [ ] All 14 cuts merged
+- [ ] Provisional locks resolved before cuts 5, 6, 9 ship
+- [ ] Static target works on Cloudflare Pages (no-Worker) + GitHub Pages
+- [ ] ESI target works on Cloudflare Workers + `gazetta serve`
+- [ ] Dynamic target works split (Cloudflare Workers + Fly.io origin) + single-process (`gazetta serve`)
+- [ ] Listings (`pages.where(...).list()`) work at publish time + request time
+- [ ] Route conflict detection blocks invalid configurations at publish
+- [ ] Per-fragment failure modes work end-to-end with audit integration
+- [ ] Admin preview matches published rendering for all three target types
+
+## Deferred items
+
+| Item | Trigger to revisit |
+|---|---|
+| WinterTC edge as origin (`runtime: 'edge'`) | WASM-compiled templates OR framework support catches up |
+| Cursor pagination for listings | Offset-based pagination becomes the bottleneck at scale |
+| Plugin-registered routes (e.g., search plugin adds `/api/search`) | Concrete plugin demand; covered by `design-plugins.md` future |
+| Per-component cache hints (component-level cache headers) | Operator demand for finer cache tuning |
+| Validator coherence for cache-coherent dynamic outputs | Cache-correctness validators when validation Cut 3 ships |
+| Worker hot-reload of new dynamic routes | Operator demand; today: redeploy required |
+| Free-text search via listings | Out of scope per `docs/non-goals.md` (delegated to Algolia/Meilisearch) |
+| Render-time queries with side effects (writes from templates) | Strategic non-fit (templates are pure functions per `operations.md`) |
+
+## Open implementation questions
+
+1. **`RenderContext` field shape** — provisional. Recommended `{ params, query, headers, cookies, principal, locale, theme, target, requestId, now }`. Lock via 1-day grilling pass before cut 2.
+2. **Fragment `rendering` field: explicit vs. inferred** — recommend explicit + validator. Confirm before cut 5.
+3. **Worker → origin protocol shape** — HTTP-based per-fragment fetch is the recommendation. Final shape locked before cut 9 (~2 days grilling).
+4. **Cache key for dynamic responses with route params** — origin sets `Cache-Control` headers; worker honors. Final shape locked before cut 10.
+5. **`gazetta serve` dual-role vs. separate `gazetta origin`** — recommend dual-role (matches single-process self-hosted operator UX). Lock at cut 8.
+
+## Estimates
+
+Wall-clock for solo dev. Provisional locks take ~3 days total (cuts 2, 5, 6, 9 each gated on small grilling passes).
+
+| Cut | Estimate |
+|---|---|
+| 1 (Target type enum) | 0.5 day |
+| 2 (RenderContext) | 1 day + grilling |
+| 3 (Listings API) | 3 days |
+| 4 (Listings cache) | 1 day |
+| 5 (Fragment rendering field) | 1.5 days + grilling |
+| 6 (Route discovery) | 3 days + grilling |
+| 7 (Timeout + onFailure) | 1.5 days |
+| 8 (Dynamic origin runtime) | 4 days |
+| 9 (Worker → origin protocol) | 4 days + grilling |
+| 10 (Worker cache rule) | 1 day |
+| 11 (Admin preview) | 2 days |
+| 12 (Sitemap + hreflang) | 1 day |
+| 13 (Per-platform validation) | 3 days |
+| 14 (Docs) | 2 days |
+
+**Total: ~28 days + ~3 days grilling.** Budget ~6-8 weeks with iteration on cuts 8-13 (the new runtime + cross-process protocol + integration testing).
+
+## SOLID checks per cut
+
+- **Cut 1**: ISP — `type` enum is a single field; behavior in dedicated runtime modules (`runtime/static.ts`, `runtime/esi.ts`, `runtime/dynamic.ts`).
+- **Cut 2**: ISP — `RenderContext` shape is locked; immutable; doesn't grow per consumer needs without a design-pass amendment.
+- **Cut 3**: SRP — `PageQuery` builder is one concern; filter implementation is a peer module. DIP — templates depend on the `PageQuery` interface; storage walker is the implementation.
+- **Cut 4**: DIP — listings depend on `AdminCache` interface; multi-instance providers slot in without consumer changes.
+- **Cut 5**: OCP — adding a new rendering type (e.g., a future 'partial-hydration' mode) extends the enum and adds a runtime module; existing modes unchanged.
+- **Cut 6**: SRP — route discovery, route-conflict detection, routes.json emission are three concerns in three files.
+- **Cut 7**: SRP — fragment-failure handling is its own module; doesn't bleed into rendering or worker logic.
+- **Cut 8**: SRP — origin handler is one concern; one entry point per request.
+- **Cut 9**: SRP — worker-side origin client and origin-side request handler are two distinct concerns; encoding/decoding is a shared utility.
+- **Cut 10**: ISP — worker cache rule is a pure function over response headers + URL; doesn't grow knowledge of fragment internals.

--- a/.claude/rules/design-review-workflow-implementation.md
+++ b/.claude/rules/design-review-workflow-implementation.md
@@ -1,0 +1,362 @@
+---
+paths:
+  - "packages/gazetta/src/review/**"
+  - "packages/gazetta/src/admin-api/routes/review.ts"
+  - "packages/gazetta/src/admin-api/routes/pages.ts"
+  - "packages/gazetta/src/admin-api/routes/fragments.ts"
+  - "packages/gazetta/src/admin-api/routes/publish.ts"
+  - "apps/admin/src/client/components/ReviewBanner.vue"
+  - "apps/admin/src/client/stores/review.ts"
+---
+
+# Review Workflow — Implementation
+
+Companion to [design-review-workflow.md](design-review-workflow.md). Cut sequence with risk ordering.
+
+See [design-review-workflow.md](design-review-workflow.md) for the design itself.
+
+## Status
+
+The design pass is complete. Implementation depends on three Phase 1 foundations:
+
+1. **AuthIdentity layer** (per `design-auth-rbac-implementation.md`) — `Principal` extraction; capability checks
+2. **Audit primitive** (per `design-audit-implementation.md`) — `recordEvent()` for review transitions
+3. **Hooks lifecycle** (per `design-hooks-implementation.md`) — review-state-transition hooks reserve their phases
+
+This implementation pass runs in Phase 2 of ROADMAP per the dependency chain. The cuts below assume those foundations have shipped.
+
+## Cut sequence
+
+**Status legend**: ✓ shipped · ◐ in progress · ☐ pending
+
+Branch: `review-workflow-v1` off `main`. **No backwards compatibility** — existing sites without `reviewWorkflow` config continue to work unchanged (the dimension is opt-in per the locked invariant).
+
+Sequenced data-shape-first (state machine + storage + capabilities), then admin-API contracts, then UX surfaces. Per-target publish approval lands as a separate cluster after content-review is end-to-end.
+
+| # | Cut | Status | Risk | Validates |
+|---|---|---|---|---|
+| 1 | `reviewWorkflow` config schema (Zod) on target + site config; archetype A-E examples | ☐ | Low | Config contract |
+| 2 | Capability vocabulary additions (`review:submit`, `review:approve`, `publish:request`, `publish:approve`) wired into RBAC | ☐ | Low | Capability layer |
+| 3 | Per-edge sidecar storage shape: `.gazetta/review/{kind}/{name}/state.json` + per-approver sidecars | ☐ | Medium | Storage primitive |
+| 4 | Review state machine: `draft → pending-review → approved` with explicit-action invariant | ☐ | High | The core engine |
+| 5 | Save handler integration: `pending-review` rejects edits with 409; `invalidateOnSave` policies | ☐ | Medium | Edit-during-pending lock |
+| 6 | Audit event integration: 4 content-review action types + outcomes | ☐ | Low | Audit contract |
+| 7 | Admin API routes: `POST /api/review/{kind}/{name}/submit\|approve\|reject\|withdraw` | ☐ | Medium | Server contract |
+| 8 | Admin UX: ReviewBanner.vue + ReviewActions.vue + state badges in site tree | ☐ | High | The visible surface |
+| 9 | Publish-approval state machine + per-target opt-in (`requiresPublishApproval`) | ☐ | High | Per-target gate |
+| 10 | Per-target publish approval admin API + UX (publish dialog gates on approval) | ☐ | High | Per-target visible surface |
+| 11 | Combined "Submit & approve" + "Publish-request & approve" buttons | ☐ | Low | Self-approval UX |
+| 12 | Constructive errors (`409 NO_APPROVER_AVAILABLE`, 403 with suggested action, config validation at boot) | ☐ | Low | Operator UX |
+| 13 | Pending review queue at scale (admin UX surface for reviewers — list of pending submissions) | ☐ | Medium | Reviewer workflow |
+| 14 | Hook integration (10 review-lifecycle hook phases per `design-hooks.md`) | ☐ | Medium | Plugin extension surface |
+| 15 | Docs (`docs/review-workflow.md` operator guide with 5 archetype recipes) + ROADMAP + CLAUDE.md | ☐ | Low | User-facing |
+
+## Per-cut scope
+
+### Cut 1: Config schema
+
+**Files modified:**
+- `packages/gazetta/src/config/schemas.ts` — add `reviewWorkflowSchema`:
+  ```ts
+  z.object({
+    enabled: z.boolean().default(false),
+    requiredApprovers: z.number().int().positive().default(1),
+    allowSelfApproval: z.boolean().default(true),
+    invalidateOnSave: z.enum(['content-diff', 'always']).default('content-diff'),
+  })
+  ```
+- `targetSchema` extends with `reviewWorkflow?: ReviewWorkflowConfig` and `requiresPublishApproval?: boolean`, `requiredPublishApprovers?: number`
+- `siteSchema` extends with site-level `reviewWorkflow?` (target inherits from site if not set)
+- `packages/gazetta/src/types.ts` — `ReviewWorkflowConfig` interface; `TargetConfig` extensions
+
+**Tests:**
+- Schema accepts archetype A-E configurations from the design doc
+- Invalid combinations rejected: `requiredApprovers: 0`, `invalidateOnSave: 'unknown'`, `enabled: true` without `requiredApprovers`
+- Site → target inheritance: target without `reviewWorkflow` inherits from site
+
+**Risk:** low. Pure schema work; no runtime behavior yet.
+
+### Cut 2: Capability vocabulary
+
+**Files modified:**
+- Auth-rbac capability registry — add four new reserved capabilities under `review:` and `publish:` prefixes
+- Default role definitions — `editor` gets `review:submit`; `reviewer` gets `review:approve`; `publisher` gets `publish:request` + `publish:approve`
+- `packages/gazetta/src/auth/capabilities.ts` (or wherever the registry lives) — add to `KNOWN_CAPABILITIES`
+
+**Tests:**
+- Default roles have expected capabilities
+- Unknown capability `review:foo` rejected at config load
+- Capability check `principal.has('review:submit')` works against role mappings
+
+**Risk:** low. Purely additive to the RBAC vocabulary; doesn't change existing checks.
+
+### Cut 3: Per-edge sidecar storage
+
+**Files added:**
+- `packages/gazetta/src/review/sidecars.ts` — read/write helpers for `.gazetta/review/{kind}/{name}/state.json` + `approvers/{actor-id}` zero-byte sidecars
+- Per-edge granularity matches the existing `dep-sidecars.ts` pattern (asset-refs, fragment-deps); reuse the abstraction where possible
+
+**Files modified:**
+- `packages/gazetta/src/types.ts` — `ReviewState = 'draft' | 'pending-review' | 'approved'` + `ReviewSidecar` interface (state, timestamps, requiredApprovers snapshot, comments per approver)
+
+**Tests:**
+- Write state, read it back; idempotent
+- Per-approver sidecar — write `approvers/alice`, `approvers/bob` independently → no race
+- Multi-instance correctness: two instances writing to different `approvers/` paths don't conflict (verified via two-process test)
+
+**Risk:** medium. Sidecar pattern is well-understood; per-edge granularity is the locked invariant. Tests guard the multi-instance path.
+
+### Cut 4: State machine
+
+**Files added:**
+- `packages/gazetta/src/review/state-machine.ts` — `transition(currentState, action, principal, config) → newState | error`
+- Transition rules (per design):
+  - `draft → pending-review`: `submit` action; principal needs `review:submit`
+  - `pending-review → approved`: `approve` action; per-approver sidecar; once N approvers reach `requiredApprovers`, state flips
+  - `pending-review → draft`: `reject` (with mandatory comment) OR `withdraw` (submitter's own action)
+  - `approved → pending-review`: re-submit after `invalidateOnSave` triggered
+  - `approved → draft`: only when content invalidates AND `invalidateOnSave: 'always'`
+
+**Tests:**
+- Each transition with valid principal succeeds
+- Invalid transition rejected (e.g., `approved → pending-review` directly without an invalidating save)
+- `requiredApprovers: 2`: first approve doesn't flip state; second approve flips
+- `allowSelfApproval: false`: submitter trying to approve their own → 403
+- `invalidateOnSave` policies tested with real content-diff cases
+
+**Risk:** high. Wrong transition = state corruption (approved content slips through review; or pending content can't be approved). Heavy on property tests + concrete scenario tests.
+
+**SOLID:** SRP — `transition` is a pure function over state; doesn't read sidecars or write audit (callers do that). FSM logic separated from I/O.
+
+### Cut 5: Save handler integration
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/pages.ts` (PUT handler) — when current state is `pending-review`, return `409 EDIT_LOCKED`; suggest "Withdraw submission to edit"
+- Save success path — if `invalidateOnSave` policy triggers, transition state via state-machine
+- `fragments.ts` — same shape
+
+**Tests:**
+- Save during `pending-review` → 409 with helpful message
+- Save during `approved` with `invalidateOnSave: 'content-diff'` and changed content → state goes to `draft`
+- Save during `approved` with `invalidateOnSave: 'always'` and any save → `draft`
+- Save with no review-workflow enabled → unchanged behavior
+
+**Risk:** medium. Wrong gating = either author locked out unexpectedly (UX bug) or pending-review edits silently apply (correctness bug).
+
+### Cut 6: Audit integration
+
+**Files modified:**
+- `packages/gazetta/src/audit/types.ts` — extend `action` enum with the 4 content-review actions per design
+- Review state-machine call sites — emit audit events on every transition
+
+**Tests:**
+- Submit emits `review-submit` event
+- Approve emits `review-approve` event with optional comment
+- Reject emits `review-reject` event with mandatory comment
+- Failed transition (forbidden) → `outcome: 'forbidden'` audit
+- Audit query for `actor: alice, action: review-*` returns alice's review activity
+
+**Risk:** low. Audit shape is locked; this cut wires the call sites.
+
+### Cut 7: Admin API routes
+
+**Files added:**
+- `packages/gazetta/src/admin-api/routes/review.ts`:
+  - `POST /api/review/:kind/:name/submit` (body: optional comment)
+  - `POST /api/review/:kind/:name/approve` (body: optional comment)
+  - `POST /api/review/:kind/:name/reject` (body: required comment)
+  - `POST /api/review/:kind/:name/withdraw`
+  - `GET /api/review/:kind/:name` — current state + per-approver list + history
+- `packages/gazetta/src/admin-api/schemas/review.ts` — Zod schemas (per MCP discipline)
+
+**Tests:**
+- Each endpoint round-trips: submit → approve → state changes
+- Capability gates (403 without `review:submit` etc.)
+- Validation errors: reject without comment → 400; submit on already-pending → 409
+
+**Risk:** medium. Wire contract is the load-bearing seam for UX cuts.
+
+### Cut 8: Admin UX — review surfaces
+
+**Files added:**
+- `apps/admin/src/client/components/ReviewBanner.vue` — top of editor; shows current state + actions per principal's capabilities
+- `apps/admin/src/client/components/ReviewActions.vue` — buttons (Submit, Approve, Reject, Withdraw) gated on capability
+- `apps/admin/src/client/stores/review.ts` — Pinia store for review state per item; subscribes to SSE for state-change events
+- Site tree state badges (per `design-scale.md`'s per-item indicator pattern) — small dot + tooltip per state
+
+**Tests:**
+- Banner renders correct state per item
+- Actions hidden when capability missing
+- Reject opens comment dialog; empty comment blocks submit
+- State changes via API → SSE → UI updates without reload
+
+**Risk:** high. Visible UX; wrong gating breaks workflow trust. Vue Test Utils + Playwright e2e against archetype B + D fixture sites.
+
+**SOLID:** SRP — `ReviewBanner.vue` renders state; `ReviewActions.vue` owns button gating; the store owns transitions. Composition over inheritance.
+
+### Cut 9: Publish-approval state machine
+
+**Files added:**
+- `packages/gazetta/src/review/publish-state-machine.ts` — `publish-pending → publish-approved → published` with same explicit-action invariant
+- Per-target publish-request sidecars under `{target-root}/.gazetta/publish-requests/{kind}/{name}/{request-id}.json`
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/publish.ts` — when target has `requiresPublishApproval: true`, publish action creates a request instead of executing; once approved, the request executes
+
+**Tests:**
+- Target with `requiresPublishApproval: true`: publish creates request, doesn't deploy
+- Approver clicks approve → request executes
+- Reject cancels request
+- Multiple `requiredPublishApprovers` — first approve doesn't deploy; second does
+
+**Risk:** high. Per-target gate is compliance-critical; wrong implementation = unapproved content reaches prod.
+
+### Cut 10: Publish-approval admin UX
+
+**Files modified:**
+- `apps/admin/src/client/components/PublishPanel.vue` — when target requires approval:
+  - Publish button text becomes "Request publish"
+  - Existing requests visible in the panel; approver sees Approve/Reject
+  - Status indicators per request (pending / approved / executed)
+
+**Tests:**
+- Publish button text changes per target config
+- Approver sees pending requests; non-approver doesn't
+- Approve flow executes the publish
+
+**Risk:** high. Visible UX; mistakes here = compliance gap or UX confusion.
+
+### Cut 11: Combined-action buttons
+
+**Files modified:**
+- `apps/admin/src/client/components/ReviewActions.vue` — when actor has both `review:submit` AND `review:approve`, AND `allowSelfApproval: true`, AND `requiredApprovers: 1` → show "Submit & approve" button (single click → both events)
+- Same for "Publish-request & approve" in `PublishPanel.vue`
+
+**Tests:**
+- Combined button visible only when all four conditions met
+- Click emits both audit events with same timestamp + actor
+- `allowSelfApproval: false` → only "Submit" visible (approve happens later by another actor)
+
+**Risk:** low. UX optimization; falls back to two-click flow when conditions not met.
+
+### Cut 12: Constructive errors
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/review.ts` — return `409 NO_APPROVER_AVAILABLE` when submit happens but no role-mapped actor has `review:approve` (deadlock prevention)
+- `packages/gazetta/src/config/validate.ts` (or boot path) — at boot, validate that review-workflow-enabled targets have at least one role with `review:approve` (or `publish:approve` for publish-approval targets); warn or error per severity
+- 403 error responses include suggested action: "Your role 'editor' doesn't have review:approve. Ask an admin to upgrade your role or contact a reviewer."
+
+**Tests:**
+- Submit on a config with no approver-capable roles → 409 with deadlock-prevention message
+- Boot config validation fires on misconfiguration
+- 403 messages helpful (smoke test on the wording)
+
+**Risk:** low. UX polish; tests guard the wording stays helpful.
+
+### Cut 13: Pending review queue
+
+**Files added:**
+- `apps/admin/src/client/components/PendingReviewQueue.vue` — list view; filter by kind/age; reviewer's "what's waiting for me" surface
+- New admin API: `GET /api/review/pending` — paginated list of items in `pending-review` state visible to the principal
+
+**Tests:**
+- Reviewer with `review:approve` sees the queue
+- Non-reviewer doesn't see the page (403)
+- Pagination works at the operating envelope (e.g., 100 items)
+
+**Risk:** medium. New surface; pagination must hold per `design-scale.md`.
+
+### Cut 14: Hook integration
+
+Per `design-hooks-implementation.md` Phase 4 (when hooks foundation ships): wire 10 review-lifecycle hook phases:
+
+- `beforeReviewSubmit`, `afterReviewSubmit`
+- `beforeReviewApprove`, `afterReviewApprove`
+- `beforeReviewReject`, `afterReviewReject`
+- `beforeReviewWithdraw`, `afterReviewWithdraw`
+- `beforePublishApprove`, `afterPublishApprove`
+
+`before*` hooks can fail-cancel; `after*` hooks parallel + fail-open.
+
+**Tests:**
+- Hook fires on transition with correct payload
+- `before*` returning failure cancels transition + records audit `outcome: 'hook-cancelled'`
+- `after*` failure logged but doesn't undo transition
+
+**Risk:** medium. Hook contract is locked in `design-hooks.md`; bugs in payload shape = plugin authors break.
+
+### Cut 15: Docs
+
+**Files added/modified:**
+- `docs/review-workflow.md` (NEW) — operator guide with 5 archetype recipes (A solo through E compliance); copy-paste config snippets
+- `examples/starter` — add a commented-out `reviewWorkflow` block in `site.config.ts`
+- `ROADMAP.md` — mark Phase 2 review workflow shipped
+- `CLAUDE.md` — link `docs/review-workflow.md`
+
+## Validation gate (definition of done)
+
+- [ ] All 15 cuts merged
+- [ ] Manual test against each of 5 archetypes (A-E): config + role mapping + flow
+- [ ] Compliance archetype E: `requiredApprovers: 2` enforced; self-approval blocked; `invalidateOnSave: 'always'` re-triggers review
+- [ ] Per-target publish approval gates production deployment
+- [ ] Audit log captures every transition with actor + outcome
+- [ ] Hook integration: plugin can `beforeReviewApprove` to add custom validation
+- [ ] Pending queue at envelope (100+ pending items)
+- [ ] Constructive errors: deadlock prevention + helpful 403 messages
+
+## Deferred items
+
+| Item | Trigger to revisit |
+|---|---|
+| Asset and asset-metadata review | v2 — current scope is pages + fragments only |
+| Site config + template review | v2 — same scope reasoning |
+| Per-target capability scoping (`review:approve@{target}`) | Multi-stage release archetype demand |
+| Per-dimension capability scoping (`review:approve@{template}`, `@{locale}`) | Editorial archetype F + translation archetype G demand |
+| "Approve with caveats" (collaboration concern) | `design-collaboration.md`'s scope |
+| Approval expiry (auto-revert after time) | Compliance demand |
+| Multi-stage workflows (draft → editorial → legal → approved) | Concrete archetype demand |
+| Bulk operations on pending queue (approve N items at once) | Reviewer asks; v2 ergonomic |
+| Email/Slack notifications on transitions | NotificationProvider plugins (per `design-collaboration.md`) |
+
+## Open implementation questions
+
+1. **State-machine atomicity.** Per-approver sidecar write + state-write is two operations. Per design's "concurrent approval race tolerance": writes are idempotent; last-write-wins on `state: approved`. Verify in cut 4 with concurrent test.
+2. **`invalidateOnSave: 'content-diff'` hash basis.** Use the existing `.{8hex}.hash` sidecar (publish-state hash) or a save-time content hash (per `design-offline.md` Cut 9's save-etag)? Recommend save-etag because it's content-only (no template/fragment hash). Lock at cut 5.
+3. **Self-approval edge case.** When `allowSelfApproval: false` AND submitter is the only role-mapped approver: deadlock. Cut 12's `409 NO_APPROVER_AVAILABLE` covers this; verify the error fires at submit time, not approve time (UX: don't let them submit then fail mid-flow).
+4. **Pending queue visibility filter.** Reviewer sees items they can approve. RBAC filter at query time, not client-side, to avoid leaking pending items the reviewer doesn't have capability for. Lock at cut 13.
+
+## Estimates
+
+Wall-clock for solo dev. Assumes Phase 1 foundations (auth-rbac, audit, hooks) have shipped.
+
+| Cut | Estimate |
+|---|---|
+| 1 (Config schema) | 0.5 day |
+| 2 (Capability vocabulary) | 0.5 day |
+| 3 (Sidecar storage) | 1 day |
+| 4 (State machine) | 2 days |
+| 5 (Save handler integration) | 1.5 days |
+| 6 (Audit integration) | 0.5 day |
+| 7 (Admin API routes) | 1.5 days |
+| 8 (Admin UX) | 3 days |
+| 9 (Publish-approval state machine) | 2 days |
+| 10 (Publish-approval UX) | 2 days |
+| 11 (Combined-action buttons) | 0.5 day |
+| 12 (Constructive errors) | 1 day |
+| 13 (Pending queue) | 1.5 days |
+| 14 (Hook integration) | 1 day |
+| 15 (Docs) | 1.5 days |
+
+**Total: ~20 days.** Budget ~4-5 weeks with iteration on cuts 8 and 10 (the visible UX surfaces) where Vue + RBAC composition tends to absorb time.
+
+## SOLID checks per cut
+
+- **Cut 1**: ISP — config has narrow per-target shape; no god object. SRP — schema validation in one place.
+- **Cut 2**: SRP — capability registry adds 4 entries; doesn't change existing checks.
+- **Cut 3**: SRP — sidecar I/O in one module; reuses existing per-edge pattern.
+- **Cut 4**: SRP — pure FSM function over state; I/O is the caller's concern. DIP — caller depends on `transition` interface, not implementation.
+- **Cut 5**: SRP — save handlers don't own review semantics; delegate to state machine. ISP — `invalidateOnSave` is a config field, not a separate interface every save consumer must understand.
+- **Cut 7**: SRP — each route handler owns one transition.
+- **Cut 8**: SRP per component (banner / actions / store). Composition — `ReviewActions` consumed by `ReviewBanner`, not inheritance.
+- **Cut 9**: SRP — publish-state-machine peers content-state-machine; same shape, different domain.
+- **Cut 14**: OCP — hook phases are additions to the existing hook lifecycle; review code calls `runHookPhase('beforeReviewSubmit', ctx)` without knowing what plugins are wired in.

--- a/.claude/rules/design-scale-implementation.md
+++ b/.claude/rules/design-scale-implementation.md
@@ -1,0 +1,300 @@
+---
+paths:
+  - "apps/admin/src/client/components/SiteTree.vue"
+  - "apps/admin/src/client/components/ComponentTree.vue"
+  - "apps/admin/src/client/components/AssetLibrary.vue"
+  - "packages/gazetta/src/admin-api/routes/pages.ts"
+  - "packages/gazetta/src/admin-api/routes/fragments.ts"
+  - "packages/gazetta/src/admin-api/routes/assets.ts"
+  - "packages/gazetta/src/storage/**"
+---
+
+# Scale — Implementation
+
+Companion to [design-scale.md](design-scale.md). Cut sequence with risk ordering.
+
+See [design-scale.md](design-scale.md) for the design itself.
+
+## Cut sequence
+
+**Status legend**: ✓ shipped · ◐ in progress · ☐ pending
+
+Branch: `scale-v1` off `main`. **No backwards compatibility** — replaces flat-list endpoints + tree rendering in-place.
+
+The cuts are sequenced server-first (endpoints + cache integration) then client (tree, asset library) so the wire contract is set before the UI consumes it. Benchmark scaffolding lands first so each subsequent cut has a regression gate.
+
+| # | Cut | Status | Risk | Validates |
+|---|---|---|---|---|
+| 1 | Synthetic 5K-page fixture + benchmark suite + perf-regression CI | ☐ | Low | Measurement floor; everything below gates against this |
+| 2 | `StorageProvider.recommendedConcurrency` + `mapLimit` integration | ☐ | Low | Provider-aware concurrency primitive |
+| 3 | `GET /api/pages` prefix-shard contract (no params → top-level + prefix counts; `?prefix=` → page summaries) | ☐ | Medium | Wire contract for prefix-sharded reads |
+| 4 | `GET /api/pages/search?q=` server-side search endpoint | ☐ | Medium | Cross-prefix lookups |
+| 5 | `AdminCache` integration on `/api/pages` summary + search + paired save invalidation | ☐ | Medium | Cache contract on real consumer at scale |
+| 6 | Eager warm at boot (top-level + prefix list) | ☐ | Low | First-request latency on cloud sources |
+| 7 | Same prefix-shard + search + cache pattern for `/api/fragments` | ☐ | Low | Mirrors Cut 3-5 at smaller scale |
+| 8 | `GET /api/assets` cursor-based pagination + filter endpoints | ☐ | Medium | Asset library wire contract |
+| 9 | `SiteTree.vue` hierarchical-on-route + always-on search + `@tanstack/vue-virtual` at ~100-row threshold | ☐ | High | The visible UX |
+| 10 | `ComponentTree.vue` per-build fragment-resolution cache + virtualization + depth/200-component banners | ☐ | Medium | Component tree at envelope |
+| 11 | `AssetLibrary.vue` virtualized grid + lazy thumbnails + cursor pagination | ☐ | Medium | Library at 20K assets |
+| 12 | Compare/Publish dialog summary view above 200-changed-items threshold | ☐ | Low | Compare/publish at fan-out scale |
+| 13 | Docs (`docs/scale.md` operator + envelope reference) + ROADMAP + CLAUDE.md update | ☐ | Low | User-facing |
+
+## Per-cut scope
+
+### Cut 1: Synthetic fixture + benchmark suite + CI gate
+
+**Files added/modified:**
+- `packages/gazetta/tests/_helpers/synthetic-site.ts` — extend existing helper to emit 5000-page realistic-shape fixture; deterministic seed
+- `packages/gazetta/tests/perf-pages.bench.ts` — `/api/pages` cold/warm; `?prefix=`; `/search` (the latter two skipped until cuts 3-4 ship)
+- `packages/gazetta/tests/perf-assets.bench.ts` — `/api/assets` paginated
+- `packages/gazetta/tests/perf-validation.bench.ts` — save-delta validation; background scan boot
+- `scripts/profile-site.sh` — manual operator profile runner
+- `.github/workflows/perf.yml` — nightly perf gate; fail on >10% regression OR p99 above SLA
+
+**Tests:** synthetic site generates deterministically (same seed → same shape); benchmark suite produces p50/p95/p99 metrics; CI workflow lint passes.
+
+**Why first:** every subsequent cut needs a regression gate. The fixture also lets us verify the design pass's locked SLA targets (5K pages: cold ~150ms, warm ~10ms) hold today, before any of the new strategies ship.
+
+**Risk:** low. The synthetic helper exists; this cut extends it. No production code touched.
+
+### Cut 2: Provider-aware concurrency
+
+**Files modified:**
+- `packages/gazetta/src/types.ts` — add `StorageProvider.recommendedConcurrency: number` (numeric, not method — providers know their bound at construction)
+- `packages/gazetta/src/providers/filesystem.ts` — `recommendedConcurrency: 20` (matches existing `DEFAULT_CONCURRENCY`)
+- `packages/gazetta/src/providers/r2.ts` — `recommendedConcurrency: 100`
+- `packages/gazetta/src/providers/s3.ts` — `recommendedConcurrency: 100`
+- `packages/gazetta/src/providers/azure-blob.ts` — `recommendedConcurrency: 100`
+- `packages/gazetta/src/concurrency.ts` — `mapLimit(items, fn, limit)` already exists; expose `mapLimitForProvider(items, fn, provider)` that reads `recommendedConcurrency`
+
+**Tests:** each provider declares the expected concurrency; `mapLimitForProvider` respects it; no regression in existing concurrency-using callers.
+
+**SOLID:** SRP — the provider knows its own bound; consumers don't hardcode per-provider numbers. ISP — `recommendedConcurrency` is a single field, not a capability interface.
+
+**Risk:** low. The new field is additive; existing callers still use `mapLimit(items, fn, DEFAULT_CONCURRENCY)` until cut 3 migrates them.
+
+### Cut 3: `/api/pages` prefix-shard contract
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/pages.ts` — restructure `GET /api/pages`:
+  - No params → `{ topLevel: PageSummary[], prefixes: { prefix: string, count: number }[] }`
+  - `?prefix=blog/` → `{ pages: PageSummary[] }`
+- `packages/gazetta/src/admin-api/schemas/pages.ts` — add `PrefixedPagesResponse`, `PrefixListItem` schemas
+- `apps/admin/src/client/api/client.ts` — `getPages()` returns the new shape; add `getPagesByPrefix(prefix)`
+
+**Tests:**
+- `admin-api.test.ts` — top-level shape + prefix shape + empty-prefix edge case + non-existent prefix → 404
+- Bench: `?prefix=` against 5K-page fixture stays under SLA
+
+**Why now:** the wire contract is the load-bearing seam. Once shipped, the tree (Cut 9) and any other consumer can rely on it. Splitting tree before contract would force tree to consume the legacy flat list and then re-migrate.
+
+**Risk:** medium. Existing callers expect the flat-list shape; this cut is the cutover. No backwards-compat means every consumer migrates in this cut.
+
+### Cut 4: Search endpoint
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/pages.ts` — `GET /api/pages/search?q=foo` returns flat `PageSummary[]` matching name/route/title metadata
+- Schema for the response
+- Client API method `searchPages(q)`
+
+**Tests:** substring case-insensitive on each field; whitespace trimming; empty `q` → 400; bench at 5K pages stays under SLA.
+
+**Risk:** medium. Walking 5K pages on every keystroke needs careful instrumentation (debounced client-side; provider-aware concurrency on server).
+
+### Cut 5: `AdminCache` integration + save invalidation (paired)
+
+**Per the lesson in `design-cache-implementation.md` Cut 5/6 reshuffle**: cache reads + save-side invalidation must ship in the same cut. Splitting them ships a stale-data regression.
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/pages.ts`:
+  - `GET /api/pages` (both shapes): `source.cache.get('pages:summary:...')` first; on miss, compute + set
+  - Same for `/api/pages/search` results — cache key includes the query string
+  - `POST/PUT/DELETE` save handlers: `source.cache.invalidatePrefix('pages:')` before returning
+- Cache key conventions per `design-cache.md` Q1: `pages:top-level`, `pages:prefix:{prefix}`, `pages:search:{q}`, all under per-site auto-prefix
+
+**Tests:**
+- `admin-api.test.ts` — POST→GET round-trip serves fresh data (validates invalidation works end-to-end)
+- Bench: warm read of `/api/pages` is microsecond-scale (cache hit)
+
+**Why paired:** read-only caching without invalidation = stale list after a save. The lesson is documented; we don't repeat it.
+
+**Risk:** medium. Wrong invalidation prefix = silent staleness for hours. The integration tests catch round-trip failures.
+
+### Cut 6: Eager warm at boot
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/index.ts` (or boot path) — after server constructs, kick off `Promise.all([getPages(), getFragments()])` to populate the cache; non-blocking (boot proceeds; warm completes async)
+- Logged via `module: 'admin-api.warm'` per `design-logging.md` conventions
+
+**Tests:** boot completes without warming first; warm completes in expected time on filesystem (verified via bench).
+
+**Risk:** low. Failure in warm = first request takes the cold path (existing behavior). Fail-open.
+
+### Cut 7: `/api/fragments` mirror
+
+Same pattern as cuts 3+4+5 applied to fragments. Smaller scale (envelope: 500 fragments) but the wire contract should match for consumer predictability.
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/fragments.ts` — prefix-shard + search + cache integration
+- Schema additions
+- Client API methods
+
+**Tests:** parity with `/api/pages` test suite.
+
+**Risk:** low. Direct port of cuts 3-5.
+
+### Cut 8: `/api/assets` pagination + filters
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/assets.ts`:
+  - `GET /api/assets?cursor=&limit=` — cursor-based pagination (default 100/page)
+  - `GET /api/assets/search?q=&kind=&tag=` — filter combinations
+- Schema for paginated response (`{ items: AssetSummary[], nextCursor: string | null }`)
+- Cache integration like cuts 5+7
+
+**Cursor encoding:** opaque base64 of `{ lastName, sortKey }` — stable, doesn't depend on shared state. Multi-instance correct.
+
+**Tests:**
+- Pagination: walk through 20K asset fixture; `nextCursor` stable across calls
+- Filter: kind=image; tag=hero; combined; empty match → empty array (not 404)
+- Bench: page 1 + page 200 latencies under SLA
+
+**Risk:** medium. Cursor encoding bugs = duplicate or missing pages on iteration. Property-based test for stability across reorderings.
+
+### Cut 9: SiteTree.vue — hierarchy + search + virtualization
+
+**Files modified:**
+- `apps/admin/src/client/components/SiteTree.vue` — full restructure:
+  - Hierarchical render driven by route paths (`/blog/*` → `blog/` synthetic group)
+  - Always-on search box at the top; case-insensitive; default client-side filter
+  - At >1000 pages: switch to server-side via `searchPages()` (Cut 4)
+  - `@tanstack/vue-virtual` v3 for branches with >100 visible rows
+  - URL hash for selection memory (existing pattern; preserve)
+- `apps/admin/src/client/composables/useSiteTreeData.ts` (NEW) — encapsulates the tree-data fetching: `getPages()` for top-level + prefixes; lazy `getPagesByPrefix(prefix)` on expand
+
+**Dynamic-route pages** (`blog/[slug]`) render as a single node with instance-count badge; expand reveals matched instances (driven by routes that match the dynamic pattern).
+
+**Tests:**
+- Vue Test Utils suite: small site renders flat; 1000+ page mock site renders hierarchy; search filters; virtualization activates above threshold; URL hash sync
+- E2E: smoke test against the synthetic 5K fixture for tree open + search + select
+
+**Why high risk:** the visible UX. Wrong hierarchy = author can't find pages. Wrong virtualization = scroll feels broken. Search misbehavior = author thinks pages are missing. Heavy on testing.
+
+**SOLID:** SRP — `useSiteTreeData` owns fetching; component owns rendering. Composition not inheritance — virtualization is a wrapper, not a base class.
+
+### Cut 10: ComponentTree.vue scale
+
+**Files modified:**
+- `apps/admin/src/client/components/ComponentTree.vue`:
+  - Per-build fragment-resolution cache (Map scoped to one `watch` callback)
+  - Virtualization at >100 rows (same library + threshold)
+  - Depth-warning badge on nodes whose ancestry exceeds 5 fragment levels
+  - 200-component banner above the tree when total component count >200
+
+**Multi-instance constraint enforced**: cache lifetime is one watch callback. Test that ensures cross-build state doesn't leak.
+
+**Tests:**
+- Per-build cache collapses N fetches to N-unique
+- Cache cleared between builds (state from build 1 doesn't leak to build 2)
+- Depth warning fires at 6+ levels; doesn't fire at 5
+- 200-component banner visible at 201, hidden at 200
+
+**Risk:** medium. Cache scope bug = either no perf benefit (re-fetches) or staleness (cross-build leak).
+
+### Cut 11: AssetLibrary.vue scale
+
+**Files modified:**
+- `apps/admin/src/client/components/AssetLibrary.vue`:
+  - Cursor pagination consuming Cut 8's endpoint
+  - Virtualized grid (`@tanstack/vue-virtual`)
+  - `loading="lazy"` on `<img>` thumbnails (existing primitive; verify it's set)
+  - Filter UI consumes `?kind=&tag=`
+
+**Tests:**
+- Bench: scroll-through-all latency under SLA at 20K assets
+- E2E: filter narrows results; pagination loads more on scroll
+
+**Risk:** medium. Grid virtualization with images is trickier than text rows (image height varies before load → layout shift). Use fixed-aspect thumbnail boxes.
+
+### Cut 12: Compare/Publish dialogs
+
+**Files modified:**
+- `apps/admin/src/client/components/PublishPanel.vue` (or wherever compare results render):
+  - <200 changed items → existing flat list
+  - ≥200 → summary view: `{ added: N, removed: M, modified: K }` with per-group expand-to-detail
+- Multi-target picker: virtualize when target count > 100 (rare in practice)
+
+**Tests:**
+- Compare with 50 changed items → flat list (visual sanity)
+- Compare with 500 changed items → summary view with correct counts
+- Expand "modified" group → renders the 200+ items
+
+**Risk:** low. Existing dialogs work; this cut adds a threshold-driven branch.
+
+### Cut 13: Docs
+
+**Files added/modified:**
+- `docs/scale.md` (NEW) — operator guide; envelope table; tuning tips (concurrency, cache provider choice); regression-detection workflow
+- `ROADMAP.md` — mark scale design pass status as Tier 3 implementation
+- `CLAUDE.md` — link `docs/scale.md` from the public docs section
+
+## Validation gate (definition of done)
+
+- [ ] All 13 cuts merged
+- [ ] Bench suite green at 5000 pages: cold p99 ≤ 150ms warm; ≤ 10ms warm
+- [ ] Bench suite green at 20000 assets: paginated p99 ≤ 200ms cold
+- [ ] Tree, asset library, compare/publish all functional at synthetic envelope
+- [ ] Nightly perf-regression CI gate active
+- [ ] No multi-instance regression: per-build caches stay per-build; tested via two-instance harness
+
+## Deferred items
+
+| Item | Trigger to revisit |
+|---|---|
+| Per-edge sidecar page index (`.gazetta/page-index/{prefix}/{name}`) | Sites cross 10K pages and filesystem-walk latency crosses SLA |
+| Faceted browse navigation (alternative to tree) | After `design-rendering.md`'s render-time queries / filtered listings ship |
+| Two-pane navigator (favorites / recents) | Operators report finding-the-same-pages-repeatedly pain |
+| Enterprise-tier envelope (50K+ pages / 200K+ assets) | Concrete operator demand at the boundary |
+| Per-locale search index | If locale-specific search quality issues surface |
+| `posix_fadvise` / mmap StorageProvider extension | Micro-opt not justified at envelope |
+| Deliberate OS-cache eviction control | Enterprise tier where cache pressure becomes a budget item |
+
+## Open implementation questions
+
+1. **Search debounce window.** Client-side filter for <1000 pages should be ~150ms debounce; server-side search should be ~300ms (extra round-trip budget). Confirm thresholds during cut 9 against real fixture.
+2. **Virtualization library final pick.** `@tanstack/vue-virtual` v3 is the recommendation; verify Vue 3.5 compat + bundle size at cut 9 implementation time.
+3. **Cursor encoding format.** Base64-encoded JSON `{ lastName, sortKey }` is the proposed shape. Property-based test ensures stability across iteration; final encoding format locked at cut 8.
+4. **Search index freshness on cloud sources.** Filesystem-backed sites: search walks fresh on every call (fast). Cloud-backed sites: search walks once warm-cached, invalidated on save. Document the trade-off in `docs/scale.md`.
+
+## Estimates
+
+Wall-clock for solo dev with normal CI iteration:
+
+| Cut | Estimate |
+|---|---|
+| 1 (Bench scaffolding + CI) | 1.5 days |
+| 2 (Provider concurrency) | 0.5 day |
+| 3 (`/api/pages` prefix shard) | 1.5 days |
+| 4 (`/api/pages/search`) | 1 day |
+| 5 (Cache + invalidation paired) | 1.5 days |
+| 6 (Boot warm) | 0.5 day |
+| 7 (`/api/fragments` mirror) | 1 day |
+| 8 (`/api/assets` pagination) | 1.5 days |
+| 9 (SiteTree.vue) | 3 days |
+| 10 (ComponentTree.vue) | 1.5 days |
+| 11 (AssetLibrary.vue) | 2 days |
+| 12 (Compare/publish dialogs) | 1 day |
+| 13 (Docs) | 1 day |
+
+**Total: ~17 days.** Budget ~3-4 weeks with iteration on the visible UX cuts (9, 10, 11) where Vue + virtualization library quirks tend to absorb time.
+
+## SOLID checks per cut
+
+- **Cut 1**: SRP — fixture generator, bench suite, CI workflow are three files with one concern each.
+- **Cut 2**: ISP — `recommendedConcurrency` is a numeric field, not a capability interface every provider must implement methods for.
+- **Cut 3, 7, 8**: SRP per route module; OCP via the schema layer (additions don't change existing fields).
+- **Cut 5**: DIP — admin-api consumes `AdminCache` (interface), not `MemoryCache` directly; multi-instance providers slot in without consumer changes.
+- **Cut 9**: SRP — `useSiteTreeData` composable owns fetching; component owns rendering; virtualization is a wrapper, not inheritance.
+- **Cut 10**: ISP — fragment cache is local to one watch callback; doesn't expose a shared API.
+- **Cut 11**: SRP — pagination logic in a composable peer to `useSiteTreeData`; component renders.
+- **Cut 12**: OCP — threshold-driven branch is additive; existing flat-list path stays.

--- a/.claude/rules/design-themes-implementation.md
+++ b/.claude/rules/design-themes-implementation.md
@@ -1,0 +1,201 @@
+---
+paths:
+  - "packages/gazetta/src/renderer.ts"
+  - "packages/gazetta/src/types.ts"
+  - "packages/gazetta/src/admin-api/routes/preview.ts"
+  - "apps/admin/src/client/stores/theme.ts"
+---
+
+# Themes — Implementation
+
+Companion to [design-themes.md](design-themes.md). Cut sequence with risk ordering.
+
+See [design-themes.md](design-themes.md) for the design itself.
+
+## Status
+
+Asset-side theme variants already shipped per [`design-media-implementation.md`](design-media-implementation.md). Admin theme switcher (UI chrome only) shipped per [`css-theming.md`](css-theming.md). What's missing: page/fragment **render-context** for theme — `params.theme` plumbed through the renderer + a request-time resolution chain on dynamic targets.
+
+This is a small, focused implementation pass. The architectural seams already exist (asset resolver accepts `theme` in its context per `design-media.md`'s "v1 scope of theme" note); the cuts wire them through.
+
+## Cut sequence
+
+**Status legend**: ✓ shipped · ◐ in progress · ☐ pending
+
+Branch: `themes-render-context` off `main`. **No backwards compatibility** — sites without `themes.supported` configured continue to work because `params.theme` defaults to the configured default (or `null` when the dimension is unused).
+
+| # | Cut | Status | Risk | Validates |
+|---|---|---|---|---|
+| 1 | `SiteConfig.themes` schema (Zod): `{ supported: string[], default: string }` + theme-name validator (lowercase ASCII, not BCP-47-locale-shaped) | ☐ | Low | Config contract |
+| 2 | `RenderContext.theme: string \| null` + render-context plumbing through renderer | ☐ | Medium | Render-time parameter shape |
+| 3 | Resolution chain on dynamic + ESI targets (`?theme=` > cookie > `prefers-color-scheme` > `themes.default`) | ☐ | Medium | Request-time resolution |
+| 4 | Asset resolver consumes `RenderContext.theme` (already accepted; wire from real call sites) | ☐ | Low | Theme-variant asset selection on real renders |
+| 5 | Admin preview endpoint forwards admin's active theme via `?theme=` | ☐ | Low | Preview parity with rendered targets |
+| 6 | `AdminCache` keys include theme dimension where output differs per theme | ☐ | Low | Cache correctness |
+| 7 | Static publish picks single-theme-per-target (configurable) — ships single-theme variant; flag-gated future multi-theme publish | ☐ | Medium | Static target shape |
+| 8 | Docs (`docs/themes.md` operator + template-author guide) + example template using `params.theme` | ☐ | Low | User-facing |
+
+## Per-cut scope
+
+### Cut 1: `themes` config schema
+
+**Files modified:**
+- `packages/gazetta/src/config/schemas.ts` — add `themesSchema = z.object({ supported: z.array(z.string()).min(1), default: z.string() })` with refinement: each name lowercase ASCII; not matching BCP-47 locale shape (`isValidLocale(name) === false`); `default` must be in `supported`
+- `packages/gazetta/src/types.ts` — add `SiteManifest.themes?: { supported: string[]; default: string }`
+- `packages/gazetta/src/site-loader.ts` — pass through unchanged (Zod validates at boot)
+
+**Tests:**
+- Theme name `'dark'` valid; `'en'` rejected (BCP-47 collision); `'Dark'` rejected (not lowercase); empty array rejected
+- `default` outside `supported` rejected
+- Sites without `themes` block load normally (manifest's `themes` is undefined)
+
+**SOLID:** SRP — config schema is one concern; the validator is a pure function the runtime can also use to validate operator-supplied theme names from query params.
+
+### Cut 2: `RenderContext.theme` plumbing
+
+**Files modified:**
+- `packages/gazetta/src/types.ts` — `RenderContext` already has `locale`; add `theme: string | null` (null = theme dimension unused on this site)
+- `packages/gazetta/src/renderer.ts` — accept `theme` in render entry points; pass through to template invocations as `params.theme`
+- All template signatures: existing `params: { content, children?, locale }` becomes `params: { content, children?, locale, theme }`
+
+**Tests:**
+- Renderer with `theme: 'dark'` → template's `params.theme === 'dark'`
+- Renderer with `theme: null` → template's `params.theme === null` (sites without theme config)
+- Existing tests pass (theme is additive at signature level)
+
+**Risk:** medium. Template signature changes touch every test fixture template. The `null` default keeps existing tests passing without modification.
+
+### Cut 3: Request-time resolution chain
+
+**Files added:**
+- `packages/gazetta/src/runtime/resolve-theme.ts` — `resolveTheme(req, site): string | null`
+  - If site has no `themes` config → `null`
+  - Else lookup chain: `req.query.theme` (validated against `supported`) > cookie `gazetta_theme` > `prefers-color-scheme` request header > `themes.default`
+  - Invalid query/cookie value → falls through to next in chain (don't reject the request)
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/preview.ts` — call `resolveTheme(c.req, site)` to populate render context
+- Worker runtime (`packages/gazetta/src/workers/cloudflare.ts` etc. when shipped) — same hook
+- `gazetta serve` request handler — same hook
+
+**Tests:**
+- Each chain step in isolation: query > cookie > header > default
+- Invalid query value falls through; doesn't error
+- Site without `themes` returns null regardless of query
+- Property test: chain is deterministic (same inputs → same theme)
+
+**Risk:** medium. The chain order is the design pass's locked decision; deviation = wrong theme rendered. Test each step.
+
+### Cut 4: Asset resolver consumes theme
+
+**Files modified:**
+- `packages/gazetta/src/renderer/resolve-asset.ts` — `AssetResolveContext` already accepts `theme` per `design-media.md`; verify call sites pass it through. Where `RenderContext.theme` is `null`, pass `undefined` to the resolver (asset resolver treats `undefined` as "no theme override").
+
+**Tests:**
+- Asset with `dark` variant + render context theme=`dark` → resolver picks dark bytes
+- Same asset + theme=`null` → resolver picks default bytes
+- Cross-dimension fallback (locale=`fr` + theme=`dark`, only `(fr, light)` exists) → `(fr, light)` per locked locale-priority chain
+
+**Risk:** low. The resolver already supports this; cut just ensures the call sites flow `RenderContext.theme` through.
+
+### Cut 5: Admin preview forwards theme
+
+**Files modified:**
+- `apps/admin/src/client/stores/theme.ts` — already exists; verify it exposes the active theme name
+- `apps/admin/src/client/components/PreviewPanel.vue` — preview iframe URL appends `?theme={active}` from the store
+
+**Tests:**
+- Toggle theme in admin → preview iframe URL changes
+- Preview reload picks up new theme (via existing SSE invalidation)
+
+**Risk:** low. Existing pattern (locale already flows this way).
+
+### Cut 6: Cache key includes theme
+
+**Files modified:**
+- `packages/gazetta/src/admin-api/routes/pages.ts` — page-render cache keys append `:theme:{name}` when site has `themes` config
+- Asset URL cache keys (the resolver's per-invocation Map) — already keyed by `(name, locale)`; extend to `(name, locale, theme)` per `design-media.md`'s locked context shape
+- Render-for-analysis cache (validation Cut 3 when it ships) — key includes theme
+
+**Tests:**
+- `pages:detail:home:en:dark` and `pages:detail:home:en:light` are independent entries
+- Save invalidation via `invalidatePrefix('pages:detail:home:')` clears all theme variants
+
+**Risk:** low. Key conventions are established (`design-cache.md` Q1).
+
+### Cut 7: Static publish single-theme
+
+**Files modified:**
+- `packages/gazetta/src/types.ts` — `TargetConfig.theme?: string` (when target has theme set, publish renders that theme variant; default = `themes.default`)
+- `packages/gazetta/src/publish.ts` (or `publish-rendered.ts`) — when site has `themes` config, render with the target's configured theme; static targets store the rendered HTML at the standard path (no per-theme path multiplication in v1)
+- Operator config: `targets.production-dark: { ..., theme: 'dark' }` opt-in
+
+**Why single-theme per static target:** multi-theme static publish would multiply the target's storage and complicate the cache-purge story. Operators wanting both light + dark static deployments configure two targets. ESI / dynamic targets resolve per request and don't need this.
+
+**Tests:**
+- Target with `theme: 'dark'` publishes dark-rendered HTML
+- Target without `theme` publishes `themes.default`-rendered HTML
+- Site without `themes` config: target's `theme` field rejected at config-load (Zod refinement)
+
+**Risk:** medium. Storage layout doesn't change in v1, but the renderer must use the right theme consistently across pages/fragments/assets in one publish run.
+
+### Cut 8: Docs
+
+**Files added/modified:**
+- `docs/themes.md` (NEW) — operator config, template-author guide (how to use `params.theme`), resolution chain, single-theme-per-static-target trade-off
+- `examples/starter/templates/hero/index.tsx` — example using `params.theme` to pick CSS class
+- `examples/starter/sites/main/site.config.ts` — commented-out `themes: { supported: ['light', 'dark'], default: 'light' }` block
+- `CLAUDE.md` — link `docs/themes.md`
+
+## Validation gate (definition of done)
+
+- [ ] All 8 cuts merged
+- [ ] Manual test: site with `themes: { supported: ['light', 'dark'] }` configured; `?theme=dark` renders dark CSS + dark asset variants
+- [ ] Manual test: cookie persists theme across page loads; `prefers-color-scheme` header respected when no cookie
+- [ ] Validation: theme name colliding with BCP-47 locale rejected at config load
+- [ ] Existing sites (no `themes` config) continue to work; `params.theme === null` in templates
+
+## Deferred items
+
+| Item | Trigger to revisit |
+|---|---|
+| Multi-theme static publish (per-theme path multiplication on static targets) | Operator demand for both light + dark on a single static target |
+| Theme-aware validator (e.g., "missing dark variant" warning) | Validation Cut 3 (render-for-analysis); concrete demand |
+| Theme marketplace / curated registry | Strategic; not in v1 scope |
+| Independent theme versioning | Strategic; not in v1 |
+| Admin chrome theming via Theme entity (vs PrimeVue tokens) | `css-theming.md`'s scope; product matures past prototype |
+| Per-role theme gating | Concrete demand from accessibility-context operators |
+| Custom theme dimensions beyond presentation (audience, campaign, A/B, multi-tenant) | Each gets its own design pass when demand surfaces |
+
+## Open implementation questions
+
+1. **Cookie name + lifetime.** Proposed: `gazetta_theme`, 1-year `Max-Age`, `SameSite=Lax`. Lock at cut 3.
+2. **`prefers-color-scheme` mapping.** Browsers send `prefers-color-scheme: dark` or `light`. If site supports those literal names, map directly. If site supports `'midnight'` instead of `'dark'`, the operator declares mapping in config. Defer the explicit mapping until a real operator config requires it; v1 maps `dark`/`light` literals only.
+3. **Worker-target theme cookie storage.** On Cloudflare Workers, setting cookies requires a response-side `Set-Cookie`. The toggle endpoint that sets the cookie is admin-side; published targets just read what's already set. Confirm at cut 3.
+4. **Theme name reserved words.** Do we forbid `default`? `auto`? `system`? Recommend: forbid `default` and `auto` (collisions with the resolution chain semantics); allow others. Lock at cut 1.
+
+## Estimates
+
+Wall-clock for solo dev:
+
+| Cut | Estimate |
+|---|---|
+| 1 (Config schema) | 0.5 day |
+| 2 (RenderContext.theme) | 1 day |
+| 3 (Resolution chain) | 1 day |
+| 4 (Asset resolver wiring) | 0.5 day |
+| 5 (Preview forwards theme) | 0.5 day |
+| 6 (Cache key) | 0.5 day |
+| 7 (Static publish single-theme) | 1 day |
+| 8 (Docs) | 0.5 day |
+
+**Total: ~5.5 days.** Budget ~1 week with iteration on cut 7's static publish details.
+
+## SOLID checks per cut
+
+- **Cut 1**: SRP — schema validator, name validator, BCP-47-collision check are three distinct concerns; each gets its own pure function.
+- **Cut 2**: ISP — `RenderContext.theme` is a single field, not a capability interface. OCP — adding `theme` doesn't change existing `RenderContext.locale` semantics.
+- **Cut 3**: SRP — `resolveTheme` is one pure function; chain rules captured as data, not branches in callers. DIP — runtime modules depend on `resolveTheme`, not on its internal lookup logic.
+- **Cut 4**: DIP — asset resolver already depends on `theme` abstractly (`AssetResolveContext.theme`); cut just connects real call sites.
+- **Cut 6**: SRP — cache keys are encoded once via key utility; consumers don't construct them ad-hoc.
+- **Cut 7**: OCP — `TargetConfig.theme` is additive; targets without it use `themes.default`. Existing target configs unchanged.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -138,16 +138,16 @@ The 13-dimension foundational design corpus is complete. Implementation is now s
 
 Total horizon: ~7-11 months for Phase 0 + Phase 1 + Phase 2 + Phase 3. Tier 3 strategic bets (concurrent editing, etc.) deferred indefinitely.
 
-### Phase 0 — Implementation planning artifacts (1-2 weeks)
+### Phase 0 — Implementation planning artifacts (1 week)
 
-Write 7 missing `design-{feature}-implementation.md` docs:
-- `design-auth-rbac-implementation.md`
-- `design-audit-implementation.md`
-- `design-hooks-implementation.md`
-- `design-plugins-implementation.md`
-- `design-cache-implementation.md`
-- `design-offline-implementation.md`
-- `design-collaboration-implementation.md`
+Write the remaining `design-{feature}-implementation.md` docs. Already shipped: ai, audit, auth-rbac, cache, collaboration, config, hooks, media, offline, plugins, provider-config, validation.
+
+Still missing (5):
+- `design-scale-implementation.md`
+- `design-themes-implementation.md`
+- `design-i18n-implementation.md`
+- `design-rendering-implementation.md`
+- `design-review-workflow-implementation.md`
 
 Each defines cut sequence, per-cut scope, files added/modified, tests, integration consumer for validation, and SOLID checks. No migration sections needed (no backwards compat).
 


### PR DESCRIPTION
## Summary

- ROADMAP Phase 0 listed 7 missing implementation docs; audit found 5 of those had already shipped. The actually-missing 5 are written here.
- Each doc follows the existing impl-doc shape: status legend, cut sequence table, per-cut scope (files, tests, risk, SOLID), validation gate, deferred items, open questions, estimates, SOLID checks per cut.
- ROADMAP updated to reflect what was actually missing.

## What's added

| Doc | Cuts | Estimate | Notes |
|---|---|---|---|
| design-scale-implementation.md | 13 | ~17 days | Benchmark scaffolding first, then prefix-shard `/api/pages`, search, AdminCache integration, UX at envelope |
| design-themes-implementation.md | 8 | ~5.5 days | Render-context parameter plumbing; resolution chain; single-theme static publish |
| design-i18n-implementation.md | 3 | ~2.5d + #192 | 13 of 15 design steps already shipped; this captures the remaining 2 + a placeholder for per-field translation #192 |
| design-rendering-implementation.md | 14 | ~28 days + grilling | Three target types + listings API + dynamic origin runtime; flags 5 provisional locks needing follow-up grilling |
| design-review-workflow-implementation.md | 15 | ~20 days | Full state machine + storage + capabilities + admin UX + per-target publish approval; depends on Phase 1 foundations (auth-rbac, audit, hooks) |

## Test plan

- [ ] `git diff main` reviewable in one pass
- [ ] Each impl doc cross-references its design doc correctly (relative paths)
- [ ] ROADMAP.md Phase 0 section reads accurately against the file system
- [ ] No formatter changes (verified `npm run format` is clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)