### PR TITLE
Component IDs: stable identifiers on InlineComponent entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17315,6 +17315,7 @@
         "jiti": "^2.6.1",
         "marked": "^18.0.3",
         "music-metadata": "^11.12.3",
+        "nanoid": "^3.3.11",
         "openai": "^6.35.0",
         "postcss": "^8.5.13",
         "postcss-prefix-selector": "^2.1.1",

--- a/packages/gazetta/package.json
+++ b/packages/gazetta/package.json
@@ -106,6 +106,7 @@
     "jiti": "^2.6.1",
     "marked": "^18.0.3",
     "music-metadata": "^11.12.3",
+    "nanoid": "^3.3.11",
     "openai": "^6.35.0",
     "postcss": "^8.5.13",
     "postcss-prefix-selector": "^2.1.1",

--- a/packages/gazetta/src/admin-api/routes/fragments.ts
+++ b/packages/gazetta/src/admin-api/routes/fragments.ts
@@ -11,6 +11,7 @@ import { hasBlockingIssues, runSaveDelta } from '../../validation/save-delta.js'
 import type { ValidatorRegistry } from '../../validation/registry.js'
 import type { FragmentManifest } from '../../types.js'
 import { computeSaveEtag } from '../../save-etag.js'
+import { ensureComponentIds } from '../../component-ids.js'
 
 export function fragmentRoutes(resolve: SourceContextResolver, validators: ValidatorRegistry, templatesDir?: string) {
   const app = new Hono()
@@ -165,10 +166,14 @@ export function fragmentRoutes(resolve: SourceContextResolver, validators: Valid
     }
 
     const body = await c.req.json()
+    // Auto-generate stable component IDs on every save (per
+    // `design-collaboration.md`'s component-ID anchor primitive).
+    // See pages.ts PUT handler for full rationale; same shape here.
+    const components = ensureComponentIds(body.components ?? fragment.components)
     const manifest = {
       template: body.template ?? fragment.template,
       content: body.content ?? fragment.content,
-      components: body.components ?? fragment.components,
+      components,
     }
 
     const filename = locale ? `fragment.${locale}.json` : 'fragment.json'

--- a/packages/gazetta/src/admin-api/routes/pages.ts
+++ b/packages/gazetta/src/admin-api/routes/pages.ts
@@ -11,6 +11,7 @@ import { hasBlockingIssues, runSaveDelta } from '../../validation/save-delta.js'
 import type { ValidatorRegistry } from '../../validation/registry.js'
 import type { PageManifest } from '../../types.js'
 import { computeSaveEtag } from '../../save-etag.js'
+import { ensureComponentIds } from '../../component-ids.js'
 
 export function pageRoutes(resolve: SourceContextResolver, validators: ValidatorRegistry, templatesDir?: string) {
   const app = new Hono()
@@ -218,10 +219,18 @@ export function pageRoutes(resolve: SourceContextResolver, validators: Validator
     }
 
     const body = await c.req.json()
+    // Auto-generate stable component IDs on every save. Existing IDs
+    // are preserved; ID-less components get NanoIDs. Per
+    // `design-collaboration.md`, IDs are the load-bearing anchor for
+    // inline comments + future per-component overrides. Running this
+    // on every save (not just creation) means existing pages migrate
+    // to having IDs the first time the author saves them — no separate
+    // migration step required.
+    const components = ensureComponentIds(body.components ?? page.components)
     const manifest: Record<string, unknown> = {
       template: body.template ?? page.template,
       content: body.content ?? page.content,
-      components: body.components ?? page.components,
+      components,
     }
     if (body.metadata !== undefined) manifest.metadata = body.metadata
     else if (page.metadata) manifest.metadata = page.metadata

--- a/packages/gazetta/src/component-ids.ts
+++ b/packages/gazetta/src/component-ids.ts
@@ -1,0 +1,99 @@
+/**
+ * Component IDs — stable identifiers for InlineComponent entries
+ * within page and fragment manifests.
+ *
+ * # Why this exists
+ *
+ * Inline anchors (per `design-collaboration.md`) need a stable
+ * reference to a specific component within a page/fragment that
+ * survives reorders, edits, and template switches. The component's
+ * `name` field is author-meaningful and not unique site-wide; the
+ * tree path is unstable across reorders. A dedicated `id` field is
+ * the load-bearing primitive for:
+ *
+ *   - Inline comments anchored to a component
+ *   - Per-field overlays in i18n (when #192 lands; per-component
+ *     overrides need a stable component reference)
+ *   - Future use cases that need "this exact component, not a
+ *     name-collision-prone or order-dependent reference"
+ *
+ * # When IDs are assigned
+ *
+ * On save: every InlineComponent without an `id` gets one. Existing
+ * IDs are preserved across saves. Fragment-reference strings
+ * (`"@header"`) don't get IDs — they reference a separate manifest
+ * with its own components.
+ *
+ * # Why NanoID over UUID
+ *
+ * NanoID is 21 chars vs UUID's 36; both have collision-resistance
+ * well past the operating envelope (5000 pages × 50 components =
+ * 250K IDs; NanoID's 21-char alphabet of 64 symbols gives ~10^36
+ * keyspace — birthday-bound nowhere near our scale). Component IDs
+ * appear in audit metadata, comment payloads, and (future) persisted
+ * edits — shorter is friendlier to humans skimming logs.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns ID generation + recursive injection
+ *     into a manifest's components tree. Doesn't read or write
+ *     storage; pure transformations.
+ *   - DIP: the ID generator is injectable so tests can pass a
+ *     deterministic stub. Production uses NanoID.
+ */
+import { nanoid } from 'nanoid'
+import type { ComponentEntry, InlineComponent } from './types.js'
+
+/**
+ * The shape NanoID produces with the default 21-char length. Exposed
+ * as a string type alias so call sites read cleanly without coupling
+ * to the underlying generator's specifics.
+ */
+export type ComponentId = string
+
+/**
+ * Generator function — `() => ComponentId`. Default implementation
+ * is `nanoid()`; tests inject deterministic counters.
+ */
+export type ComponentIdGenerator = () => ComponentId
+
+/** Default generator — 21-char NanoID. */
+export const defaultComponentIdGenerator: ComponentIdGenerator = () => nanoid()
+
+/**
+ * Walk a `components` array and inject IDs on any InlineComponent
+ * that lacks one. Existing IDs are preserved; fragment-reference
+ * strings pass through unchanged.
+ *
+ * Returns a new array (functional, never mutates input). Components
+ * with nested `components` recurse; the same generator instance is
+ * threaded so deterministic stubs in tests produce predictable trees.
+ */
+export function ensureComponentIds(
+  components: readonly ComponentEntry[] | undefined,
+  generate: ComponentIdGenerator = defaultComponentIdGenerator,
+): ComponentEntry[] {
+  if (!components) return []
+  return components.map(entry => ensureEntry(entry, generate))
+}
+
+function ensureEntry(entry: ComponentEntry, generate: ComponentIdGenerator): ComponentEntry {
+  // Fragment refs pass through — they point at a separate manifest
+  // whose components carry their own IDs.
+  if (typeof entry === 'string') return entry
+  return ensureInline(entry, generate)
+}
+
+function ensureInline(component: InlineComponent, generate: ComponentIdGenerator): InlineComponent {
+  const nextChildren = component.components ? component.components.map(c => ensureEntry(c, generate)) : undefined
+  const id = component.id ?? generate()
+  // Only build a new object when something would actually change —
+  // either a missing id, or recursion changed a nested entry. Keeps
+  // identity-equality stable for callers that compare by reference.
+  const idChanged = component.id === undefined
+  const childrenChanged = nextChildren !== component.components
+  if (!idChanged && !childrenChanged) return component
+  const next: InlineComponent = { ...component, id }
+  if (nextChildren !== undefined) next.components = nextChildren
+  return next
+}

--- a/packages/gazetta/src/manifest.ts
+++ b/packages/gazetta/src/manifest.ts
@@ -21,12 +21,17 @@ function parseComponents(raw: unknown): ComponentEntry[] | undefined {
     if (typeof entry === 'string') return entry
     if (typeof entry === 'object' && entry !== null && typeof entry.template === 'string') {
       const comp = entry as Record<string, unknown>
-      return {
+      const parsed: import('./types.js').InlineComponent = {
         name: comp.name as string,
         template: comp.template as string,
         content: comp.content as Record<string, unknown> | undefined,
         components: parseComponents(comp.components),
       }
+      // Preserve component IDs (per design-collaboration.md Cut 1).
+      // IDs are written by the save handlers and must round-trip
+      // through read so inline anchors stay valid.
+      if (typeof comp.id === 'string') parsed.id = comp.id
+      return parsed
     }
     return entry as string
   })

--- a/packages/gazetta/src/types.ts
+++ b/packages/gazetta/src/types.ts
@@ -69,6 +69,17 @@ export interface TemplateModule {
 
 /** Inline component — nested within a page or fragment manifest */
 export interface InlineComponent {
+  /**
+   * Stable identifier for this component within its containing
+   * manifest. Auto-generated on save when absent (per
+   * `component-ids.ts`); preserved across reorders, edits, and
+   * template switches. Used as the anchor for inline comments
+   * (per `design-collaboration.md`) and per-component overrides
+   * (future, per i18n #192). Fragment-reference strings (e.g.
+   * `"@header"`) don't carry IDs — they point at a separate
+   * manifest whose components have their own IDs.
+   */
+  id?: string
   name: string
   template: string
   content?: Record<string, unknown>

--- a/packages/gazetta/tests/admin-api.test.ts
+++ b/packages/gazetta/tests/admin-api.test.ts
@@ -546,6 +546,104 @@ describe('PUT /api/pages/:name', () => {
     expect(body.issues.some(i => i.validator === 'referenced-fragment-exists')).toBe(true)
     await rm(resolve(localTargetDir, 'pages/val-frag-test'), { recursive: true, force: true })
   })
+
+  // Component IDs (per design-collaboration.md Cut 1) — saves auto-
+  // generate stable IDs on InlineComponent entries lacking one;
+  // existing IDs are preserved across reorders.
+  // Templates must be real for the save-delta validator to pass —
+  // these tests use templates that exist in examples/starter/templates/
+  // (banner, counter, features-grid).
+  it('auto-generates IDs on ID-less InlineComponents', async () => {
+    await app.request('/api/pages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'cid-test', template: 'page-default' }),
+    })
+    const putRes = await app.request('/api/pages/cid-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        components: [
+          { name: 'a', template: 'banner', content: { heading: 'Hi', text: '', buttonText: '', buttonUrl: '' } },
+          { name: 'b', template: 'counter' },
+        ],
+      }),
+    })
+    expect(putRes.status).toBe(200)
+    const { body } = await get('/api/pages/cid-test')
+    expect(body.components).toHaveLength(2)
+    expect(body.components[0].id).toBeDefined()
+    expect(body.components[1].id).toBeDefined()
+    expect(body.components[0].id).not.toBe(body.components[1].id)
+    await rm(resolve(localTargetDir, 'pages/cid-test'), { recursive: true, force: true })
+  })
+
+  it('preserves existing IDs across saves (the load-bearing reorder invariant)', async () => {
+    await app.request('/api/pages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'cid-reorder', template: 'page-default' }),
+    })
+    // First save adds IDs
+    const first = await app.request('/api/pages/cid-reorder', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        components: [
+          { name: 'a', template: 'banner', content: { heading: 'A', text: '', buttonText: '', buttonUrl: '' } },
+          { name: 'b', template: 'counter' },
+        ],
+      }),
+    })
+    expect(first.status).toBe(200)
+    const firstBody = (await get('/api/pages/cid-reorder')).body
+    const aId = firstBody.components[0].id
+    const bId = firstBody.components[1].id
+    // Author reorders and re-saves with the existing IDs intact —
+    // simulating the admin's component-tree reorder flow.
+    const second = await app.request('/api/pages/cid-reorder', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        components: [
+          { id: bId, name: 'b', template: 'counter' },
+          {
+            id: aId,
+            name: 'a',
+            template: 'banner',
+            content: { heading: 'A', text: '', buttonText: '', buttonUrl: '' },
+          },
+        ],
+      }),
+    })
+    expect(second.status).toBe(200)
+    const after = (await get('/api/pages/cid-reorder')).body
+    expect(after.components[0].id).toBe(bId)
+    expect(after.components[1].id).toBe(aId)
+    await rm(resolve(localTargetDir, 'pages/cid-reorder'), { recursive: true, force: true })
+  })
+
+  it('does not assign IDs to fragment-reference strings', async () => {
+    await app.request('/api/pages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'cid-frags', template: 'page-default' }),
+    })
+    const res = await app.request('/api/pages/cid-frags', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        components: ['@header', { name: 'body', template: 'counter' }, '@footer'],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const { body } = await get('/api/pages/cid-frags')
+    expect(body.components[0]).toBe('@header')
+    expect(body.components[2]).toBe('@footer')
+    expect(typeof body.components[1]).toBe('object')
+    expect(body.components[1].id).toBeDefined()
+    await rm(resolve(localTargetDir, 'pages/cid-frags'), { recursive: true, force: true })
+  })
 })
 
 describe('save-etag concurrency (design-offline.md Q3)', () => {
@@ -856,6 +954,37 @@ describe('POST /api/fragments (create)', () => {
       body: JSON.stringify({ name: 'x' }),
     })
     expect(res.status).toBe(400)
+  })
+})
+
+describe('PUT /api/fragments/:name component IDs', () => {
+  // Component IDs apply uniformly to pages and fragments. The pages
+  // suite covers full reorder semantics; here we just verify the
+  // save handler wires the generator on this route too.
+  afterAll(async () => {
+    await rm(resolve(localTargetDir, 'fragments/cid-frag-test'), { recursive: true, force: true })
+  })
+
+  it('auto-generates IDs on InlineComponents within fragments', async () => {
+    await app.request('/api/fragments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'cid-frag-test', template: 'footer-layout' }),
+    })
+    const res = await app.request('/api/fragments/cid-frag-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        components: [
+          { name: 'a', template: 'counter' },
+          { id: 'preserved', name: 'b', template: 'counter' },
+        ],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const { body } = await get('/api/fragments/cid-frag-test')
+    expect(body.components[0].id).toBeDefined()
+    expect(body.components[1].id).toBe('preserved')
   })
 })
 

--- a/packages/gazetta/tests/component-ids.test.ts
+++ b/packages/gazetta/tests/component-ids.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for `ensureComponentIds` — the stable-ID injector for
+ * InlineComponent entries within page/fragment manifests. The
+ * collaboration design (`design-collaboration.md`) requires that:
+ *
+ *   - Every InlineComponent has an `id` after save
+ *   - Existing IDs are preserved across saves (component reorders
+ *     and edits don't churn IDs)
+ *   - Fragment-reference strings (`"@header"`) don't carry IDs —
+ *     they point at a separate manifest with its own components
+ *   - Nested components (composite InlineComponent → child
+ *     InlineComponents) recurse correctly
+ */
+import { describe, expect, it } from 'vitest'
+import type { ComponentEntry } from '../src/types.js'
+import { ensureComponentIds } from '../src/component-ids.js'
+
+/** Deterministic counter generator for test predictability. */
+function counterGenerator(prefix = 'id'): () => string {
+  let i = 0
+  return () => `${prefix}-${++i}`
+}
+
+describe('ensureComponentIds', () => {
+  it('returns empty array when components is undefined', () => {
+    expect(ensureComponentIds(undefined)).toEqual([])
+  })
+
+  it('returns empty array when components is empty', () => {
+    expect(ensureComponentIds([])).toEqual([])
+  })
+
+  it('passes fragment-reference strings through unchanged', () => {
+    const components: ComponentEntry[] = ['@header', '@footer']
+    const result = ensureComponentIds(components, counterGenerator())
+    expect(result).toEqual(['@header', '@footer'])
+  })
+
+  it('injects IDs on InlineComponents that lack one', () => {
+    const components: ComponentEntry[] = [
+      { name: 'hero', template: 'hero' },
+      { name: 'features', template: 'feature-grid' },
+    ]
+    const result = ensureComponentIds(components, counterGenerator())
+    expect(result).toEqual([
+      { id: 'id-1', name: 'hero', template: 'hero' },
+      { id: 'id-2', name: 'features', template: 'feature-grid' },
+    ])
+  })
+
+  it('preserves existing IDs across saves', () => {
+    const components: ComponentEntry[] = [
+      { id: 'pre-existing-1', name: 'hero', template: 'hero' },
+      { id: 'pre-existing-2', name: 'features', template: 'feature-grid' },
+    ]
+    const result = ensureComponentIds(components, counterGenerator())
+    expect(result).toEqual(components)
+    // Identity-equality preserved when nothing changes (cheap re-saves).
+    expect(result[0]).toBe(components[0])
+    expect(result[1]).toBe(components[1])
+  })
+
+  it('mixes preserved and injected IDs in one pass', () => {
+    const components: ComponentEntry[] = [
+      { id: 'pre-existing', name: 'hero', template: 'hero' },
+      { name: 'features', template: 'feature-grid' },
+      '@footer',
+    ]
+    const result = ensureComponentIds(components, counterGenerator())
+    expect(result).toEqual([
+      { id: 'pre-existing', name: 'hero', template: 'hero' },
+      { id: 'id-1', name: 'features', template: 'feature-grid' },
+      '@footer',
+    ])
+  })
+
+  it('recurses into nested components', () => {
+    const components: ComponentEntry[] = [
+      {
+        name: 'layout',
+        template: 'two-column',
+        components: [
+          { name: 'left', template: 'card' },
+          { id: 'right-existing', name: 'right', template: 'card' },
+          '@sidebar',
+        ],
+      },
+    ]
+    const result = ensureComponentIds(components, counterGenerator())
+    // The outer component gets an ID; its nested children also get
+    // IDs in deterministic order. The fragment ref stays unchanged.
+    // Outer is processed FIRST in the recursion (depth-first per
+    // ensureInline's recurse-then-id construction), so the outer
+    // component's children consume IDs before the outer itself.
+    expect(result).toHaveLength(1)
+    const outer = result[0] as Extract<ComponentEntry, { name: string }>
+    expect(outer.id).toBeDefined()
+    expect(outer.components).toHaveLength(3)
+    const children = outer.components!
+    expect((children[0] as Extract<ComponentEntry, { name: string }>).id).toBe('id-1')
+    expect((children[1] as Extract<ComponentEntry, { name: string }>).id).toBe('right-existing')
+    expect(children[2]).toBe('@sidebar')
+    // Outer's id is whatever counter value followed the children
+    expect(outer.id).toBe('id-2')
+  })
+
+  it('does not mutate the input array', () => {
+    const components: ComponentEntry[] = [{ name: 'hero', template: 'hero' }]
+    const before = JSON.stringify(components)
+    ensureComponentIds(components, counterGenerator())
+    expect(JSON.stringify(components)).toBe(before)
+  })
+
+  it('uses real NanoID by default (no generator provided)', () => {
+    const components: ComponentEntry[] = [{ name: 'hero', template: 'hero' }]
+    const result = ensureComponentIds(components)
+    const first = result[0] as Extract<ComponentEntry, { name: string }>
+    // Default NanoID is 21 chars, URL-safe. Don't assert exact length
+    // because nanoid is a peer dep; just sanity-check shape.
+    expect(typeof first.id).toBe('string')
+    expect(first.id!.length).toBeGreaterThan(10)
+  })
+
+  it('two consecutive runs without IDs produce different IDs (real NanoID)', () => {
+    // Sanity check that the default generator produces distinct IDs
+    // — if not, we'd have a global-counter bug.
+    const a = ensureComponentIds([{ name: 'x', template: 'x' }])
+    const b = ensureComponentIds([{ name: 'x', template: 'x' }])
+    const aId = (a[0] as Extract<ComponentEntry, { name: string }>).id
+    const bId = (b[0] as Extract<ComponentEntry, { name: string }>).id
+    expect(aId).not.toBe(bId)
+  })
+
+  it('preserves content + template fields when adding ID', () => {
+    const components: ComponentEntry[] = [
+      { name: 'hero', template: 'hero', content: { title: 'Welcome', subtitle: 'Hello' } },
+    ]
+    const result = ensureComponentIds(components, counterGenerator())
+    const out = result[0] as Extract<ComponentEntry, { name: string }>
+    expect(out.id).toBe('id-1')
+    expect(out.name).toBe('hero')
+    expect(out.template).toBe('hero')
+    expect(out.content).toEqual({ title: 'Welcome', subtitle: 'Hello' })
+  })
+
+  it('reorder + re-save preserves IDs (the load-bearing collaboration invariant)', () => {
+    // Simulate the most important real-world case: author reorders
+    // components, then saves. IDs must NOT regenerate, or every
+    // reorder would orphan all inline comments anchored to the
+    // reordered components.
+    const original: ComponentEntry[] = [
+      { id: 'hero-001', name: 'hero', template: 'hero' },
+      { id: 'features-001', name: 'features', template: 'feature-grid' },
+      { id: 'cta-001', name: 'cta', template: 'cta' },
+    ]
+    // Author reorders: features moves to position 0
+    const reordered: ComponentEntry[] = [original[1], original[0], original[2]]
+    const result = ensureComponentIds(reordered, counterGenerator())
+    expect(result.map(c => (c as Extract<ComponentEntry, { name: string }>).id)).toEqual([
+      'features-001',
+      'hero-001',
+      'cta-001',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- First Phase 1 foundation from ROADMAP. `InlineComponent` gains an optional `id` field auto-generated on save (NanoID, 21 chars). Existing IDs preserved across saves.
- Anchor primitive for inline comments (per `design-collaboration.md`) and per-component i18n overlays (#192). The reorder invariant — "saving the same content reordered must NOT regenerate IDs" — is the load-bearing test.
- Closes Cut 1 of `design-collaboration-implementation.md` and the "Component IDs" line in ROADMAP Phase 1.

## What's added

| File | Purpose |
|---|---|
| `packages/gazetta/src/component-ids.ts` | `ensureComponentIds` — recursive ID injector; injectable generator (NanoID prod, deterministic stub in tests) |
| `packages/gazetta/src/types.ts` | `InlineComponent.id?: string` |
| `packages/gazetta/src/manifest.ts` | `parseComponents` preserves the `id` field across read (was stripping unknown fields) |
| `packages/gazetta/src/admin-api/routes/pages.ts` + `fragments.ts` | PUT handlers wire `ensureComponentIds` before validation |
| `packages/gazetta/tests/component-ids.test.ts` | 12 unit tests (empty + fragment refs + ID-less injection + existing preservation + nested recursion + identity-equality + non-mutation + real NanoID + reorder invariant) |
| `packages/gazetta/tests/admin-api.test.ts` | 4 integration tests (pages + fragments save handlers wire ID generation) |

## Migration

Existing pages/fragments without IDs get them on first save — no separate migration step. Fragment-reference strings (`"@header"`) don't carry IDs by design (they point at a separate manifest with its own components).

## Test plan

- [ ] `npm test` runs green (1570 gazetta tests)
- [ ] Save flow: edit a page in admin → manifest gains `id` field on every inline component
- [ ] Reorder test: drag-reorder components in admin → IDs preserved on save
- [ ] Fragment refs unchanged: `"@header"` stays a string

🤖 Generated with [Claude Code](https://claude.com/claude-code)