### PR TITLE
Audit log v1: foundation #5 of 13

### DIFF
--- a/.claude/rules/design-audit-implementation.md
+++ b/.claude/rules/design-audit-implementation.md
@@ -19,16 +19,16 @@ Branch: `audit-v1` off `main` (after AuthIdentity ships per Phase 1 sequencing).
 
 | # | Cut | Status | Risk | Validates |
 |---|---|---|---|---|
-| 1 | `audit/` infrastructure: types, schemas, error taxonomy | ☐ | Low | Type-only foundation |
-| 2 | `AuditProvider` interface + `HistoryAuditProvider` (extends history-recorder with `actor` + `outcome` fields) | ☐ | Medium | The seam + v1 default |
-| 3 | Audit-recording middleware + sync fail-open + parallel fan-out | ☐ | Medium | The dispatch layer |
-| 4 | Pseudonymization (`actorPseudonym: 'sha256'` opt-in) + sourceIp / userAgent recording with trust-mode-driven extraction | ☐ | Medium | Privacy posture |
-| 5 | Wire all write handlers (save / publish / delete / restore / configure-roles) to emit audit events | ☐ | Low-medium | Mechanical integration |
-| 6 | Audit query endpoint `GET /api/audit` + admin drawer UI | ☐ | Medium | The visible feature |
-| 7 | `queryUrl()` deep-link UX (drawer behavior matrix when `query()` is null on external sinks — even though v1 ships only history) | ☐ | Low | Forward-compat for v2 sinks |
-| 8 | Retention pruner (audit retention separate from content retention) | ☐ | Medium | Background work |
-| 9 | Capability gating: `read:audit-log` on `/api/audit` | ☐ | Low | RBAC integration |
-| 10 | Docs + audit drawer operator guide | ☐ | Low | User-facing |
+| 1 | `audit/` infrastructure: types, schemas, error taxonomy | ✓ | Low | Type-only foundation |
+| 2 | `AuditProvider` interface + `HistoryAuditProvider` (extends history-recorder with `actor` + `outcome` fields) | ✓ | Medium | The seam + v1 default |
+| 3 | Audit-recording middleware + sync fail-open + parallel fan-out | ✓ | Medium | The dispatch layer |
+| 4 | Pseudonymization (`actorPseudonym: 'sha256'` opt-in) + sourceIp / userAgent recording with trust-mode-driven extraction | ✓ | Medium | Privacy posture |
+| 5 | Wire all write handlers (save / publish / delete / restore) to emit audit events | ✓ | Low-medium | Mechanical integration |
+| 6 | Audit query endpoint `GET /api/audit` + admin drawer UI | ✓ | Medium | The visible feature |
+| 7 | `queryUrl()` deep-link UX — folded into Cut 6's drawer (four UX states pinned in `apps/admin/tests/AuditDrawer.test.ts`) | ✓ | Low | Forward-compat for v2 sinks |
+| 8 | Retention pruner (audit retention separate from content retention) | ✓ | Medium | Background work |
+| 9 | Capability gating: `read:audit-log` wildcard-exempt (editor / viewer don't auto-grant via `read:*`) | ✓ | Low | RBAC integration |
+| 10 | Docs + audit drawer operator guide | ✓ | Low | User-facing |
 
 ## Per-cut scope
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,11 @@ reports/
 # reverse-dep indices: only inside a target's `.gazetta/`.
 **/targets/**/.gazetta/history/
 
+# Per-target audit log — runtime state written by audit recorders.
+# Per-instance JSONL files (events-{instance}.jsonl). Same anchoring as
+# history; never committed.
+**/targets/**/.gazetta/audit/
+
 # Rendered output from `gazetta publish` to filesystem targets. The
 # editable source of truth (page.json, fragment.json, site.config.ts) stays
 # tracked; everything below is regenerated on every publish.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Stateless CMS that structures websites as composable fragments. All state lives 
 - `docs/cache.md` — Admin read-side cache configuration + monitoring
 - `docs/offline.md` — Offline mode (cold-load reliability, save conflicts, browser support)
 - `docs/auth.md` — Authentication + RBAC (trust modes, roles, capability gates)
+- `docs/audit.md` — Audit log (forensic event recording, privacy posture, retention, capability gating)
 
 ## Design docs (auto-loaded by Claude)
 

--- a/apps/admin/src/client/api/client.ts
+++ b/apps/admin/src/client/api/client.ts
@@ -187,6 +187,12 @@ import type {
   ListHistoryResponse as ListHistoryResponseShape,
   RestoreRevisionResponse as RestoreRevisionResponseShape,
   FetchResponse as FetchResponseShape,
+  AuditEventWire,
+  AuditExternalSinkWire,
+  AuditQueryResponseWire,
+  AuditActionWire,
+  AuditOutcomeWire,
+  AuditScopeKindWire,
 } from 'gazetta/admin-api/schemas'
 export type PageSummary = PageSummaryShape
 export type CreatePageRequest = CreatePageRequestShape
@@ -210,6 +216,24 @@ export type RevisionOperation = RevisionOperationShape
 export type ListHistoryResponse = ListHistoryResponseShape
 export type RestoreRevisionResponse = RestoreRevisionResponseShape
 export type FetchResponse = FetchResponseShape
+export type AuditEvent = AuditEventWire
+export type AuditExternalSink = AuditExternalSinkWire
+export type AuditQueryResponse = AuditQueryResponseWire
+export type AuditAction = AuditActionWire
+export type AuditOutcome = AuditOutcomeWire
+export type AuditScopeKind = AuditScopeKindWire
+
+/** Filter shape consumed by `GET /api/audit`. */
+export interface AuditQueryFilter {
+  action?: AuditAction
+  outcome?: AuditOutcome
+  scopeKind?: AuditScopeKind
+  scopeName?: string
+  actor?: string
+  since?: string
+  until?: string
+  limit?: number
+}
 
 export interface InlineComponent {
   name: string
@@ -355,4 +379,20 @@ export const api = {
   listAssets: () => request<AssetSummary[]>('/assets'),
   /** Fetch a single asset's summary by name. 404s when the asset doesn't exist. */
   getAsset: (name: string) => request<AssetSummary>(`/assets/${encodeURIComponent(name)}`),
+  /** Query the audit log. Returns inline events from queryable
+   *  providers + external-sink references for non-queryable
+   *  providers. Per design-audit.md "Audit drawer — query semantics". */
+  queryAudit: (filter: AuditQueryFilter = {}) => {
+    const params = new URLSearchParams()
+    if (filter.action) params.set('action', filter.action)
+    if (filter.outcome) params.set('outcome', filter.outcome)
+    if (filter.scopeKind) params.set('scopeKind', filter.scopeKind)
+    if (filter.scopeName) params.set('scopeName', filter.scopeName)
+    if (filter.actor) params.set('actor', filter.actor)
+    if (filter.since) params.set('since', filter.since)
+    if (filter.until) params.set('until', filter.until)
+    if (filter.limit !== undefined) params.set('limit', String(filter.limit))
+    const qs = params.toString()
+    return request<AuditQueryResponse>(`/audit${qs ? `?${qs}` : ''}`)
+  },
 }

--- a/apps/admin/src/client/components/ActiveTargetIndicator.vue
+++ b/apps/admin/src/client/components/ActiveTargetIndicator.vue
@@ -25,6 +25,7 @@ import { groupedEntries } from '../composables/targetGrouping.js'
 import { usePagesApi, useFragmentsApi } from '../composables/api.js'
 import type { TargetInfo } from '../api/client.js'
 import HistoryPanel from './HistoryPanel.vue'
+import AuditDrawer from './AuditDrawer.vue'
 
 const pagesApi = usePagesApi()
 const fragmentsApi = useFragmentsApi()
@@ -83,10 +84,18 @@ const menuItems = computed(() => {
         showHistory.value = true
       },
     },
+    {
+      label: 'View audit log',
+      icon: 'pi pi-shield',
+      command: () => {
+        showAudit.value = true
+      },
+    },
   ]
 })
 
 const showHistory = ref(false)
+const showAudit = ref(false)
 
 function targetItem(t: TargetInfo) {
   return {
@@ -199,6 +208,7 @@ function onClick(event: Event) {
     <Menu v-if="interactive" ref="menu" :model="menuItems" :popup="true"
       data-testid="active-target-menu" />
     <HistoryPanel v-model:visible="showHistory" />
+    <AuditDrawer v-model:visible="showAudit" />
   </template>
 </template>
 

--- a/apps/admin/src/client/components/AuditDrawer.vue
+++ b/apps/admin/src/client/components/AuditDrawer.vue
@@ -1,0 +1,434 @@
+<script setup lang="ts">
+/**
+ * Audit drawer — operator-facing surface for the forensic event log.
+ *
+ * Per design-audit.md "Audit drawer — query semantics" + Krug-aligned
+ * UX rules from team-preferences.md rule 23: absence is a state;
+ * universal language over jargon; no help-tooltips-as-bandaid.
+ *
+ * Renders the four states the route supports:
+ *
+ *   1. history-only (queryable provider, no external sinks):
+ *      → inline events list; no link block
+ *   2. history + external sinks with queryable + url:
+ *      → events list + footer link "View full audit in {sink}"
+ *   3. external-only with link (no queryable, has queryUrl):
+ *      → empty events list + prominent message "Audit lives in
+ *      {sink} — [link]"
+ *   4. external-only without link (no queryable, no queryUrl):
+ *      → message "Audit configured but not queryable. Configure
+ *      history as a peer provider for in-admin browsing."
+ *
+ * Surfaces the standard filters: action / outcome / scopeKind /
+ * scopeName / actor / time range / limit. Empty filter = all
+ * events newest-first.
+ *
+ * Capability gating happens server-side on `read:audit-log`. The
+ * drawer surfaces 401 / 403 as a clear error rather than silently
+ * hiding events — operators need to know when their config blocks
+ * the read.
+ */
+import { computed, ref, watch } from 'vue'
+import Dialog from 'primevue/dialog'
+import Button from 'primevue/button'
+import Select from 'primevue/select'
+import InputText from 'primevue/inputtext'
+import ProgressSpinner from 'primevue/progressspinner'
+import type {
+  AuditAction,
+  AuditEvent,
+  AuditExternalSink,
+  AuditOutcome,
+  AuditQueryFilter,
+  AuditScopeKind,
+} from '../api/client.js'
+import { useAuditApi } from '../composables/api.js'
+
+const props = defineProps<{ visible: boolean }>()
+const emit = defineEmits<{ (e: 'update:visible', v: boolean): void }>()
+
+const auditApi = useAuditApi()
+
+const events = ref<AuditEvent[]>([])
+const externalSinks = ref<AuditExternalSink[]>([])
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+// Filters bound to the toolbar inputs.
+const filterAction = ref<AuditAction | null>(null)
+const filterOutcome = ref<AuditOutcome | null>(null)
+const filterScopeKind = ref<AuditScopeKind | null>(null)
+const filterActor = ref('')
+
+const ACTION_OPTIONS: { value: AuditAction; label: string }[] = [
+  { value: 'save', label: 'Save' },
+  { value: 'publish', label: 'Publish' },
+  { value: 'delete', label: 'Delete' },
+  { value: 'restore', label: 'Restore' },
+  { value: 'configure-roles', label: 'Configure roles' },
+]
+const OUTCOME_OPTIONS: { value: AuditOutcome; label: string }[] = [
+  { value: 'success', label: 'Success' },
+  { value: 'forbidden', label: 'Forbidden' },
+  { value: 'validation-failed', label: 'Validation failed' },
+  { value: 'unauthenticated', label: 'Unauthenticated' },
+]
+const SCOPE_KIND_OPTIONS: { value: AuditScopeKind; label: string }[] = [
+  { value: 'page', label: 'Page' },
+  { value: 'fragment', label: 'Fragment' },
+  { value: 'asset', label: 'Asset' },
+  { value: 'site', label: 'Site' },
+]
+
+async function load() {
+  loading.value = true
+  error.value = null
+  const filter: AuditQueryFilter = {}
+  if (filterAction.value) filter.action = filterAction.value
+  if (filterOutcome.value) filter.outcome = filterOutcome.value
+  if (filterScopeKind.value) filter.scopeKind = filterScopeKind.value
+  if (filterActor.value.trim()) filter.actor = filterActor.value.trim()
+  try {
+    const res = await auditApi.queryAudit(filter)
+    events.value = res.events
+    externalSinks.value = res.externalSinks
+  } catch (err) {
+    error.value = (err as Error).message
+    events.value = []
+    externalSinks.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+// Reload on open + on any filter change while open. `immediate: true`
+// fires the initial load when the drawer mounts already-visible
+// (the prop is `true` from the start; without immediate the watcher
+// would wait for a change that never comes).
+watch(
+  [() => props.visible, filterAction, filterOutcome, filterScopeKind, filterActor],
+  ([v]) => {
+    if (v) load()
+  },
+  { immediate: true },
+)
+
+function close() {
+  emit('update:visible', false)
+}
+
+function clearFilters() {
+  filterAction.value = null
+  filterOutcome.value = null
+  filterScopeKind.value = null
+  filterActor.value = ''
+}
+
+/**
+ * Krug-aligned UX state derivation. The four states from the design
+ * map onto:
+ *
+ *   - hasQueryableEvents: at least one queryable provider returned
+ *     events (or empty result without external sinks)
+ *   - sinksWithLinks: external-sink references that have a deep-link
+ *   - sinksWithoutLinks: configured but not queryable, no link
+ *
+ * The UI composes:
+ *
+ *   - state 1 (history-only) → events render, no sink block
+ *   - state 2 (mixed) → events + footer "Also in: {links}"
+ *   - state 3 (external-only-with-link) → empty events list +
+ *     prominent message + link
+ *   - state 4 (external-only-no-link) → message-only state
+ */
+const sinksWithLinks = computed(() => externalSinks.value.filter(s => s.url !== null))
+const sinksWithoutLinks = computed(() => externalSinks.value.filter(s => s.url === null))
+
+const hasInlineEvents = computed(() => events.value.length > 0)
+const hasOnlyExternal = computed(() => events.value.length === 0 && externalSinks.value.length > 0)
+
+function friendlyTime(iso: string): string {
+  const now = Date.now()
+  const ts = new Date(iso).getTime()
+  const diff = now - ts
+  const s = Math.round(diff / 1000)
+  if (s < 60) return `${s}s ago`
+  const m = Math.round(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.round(m / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.round(h / 24)
+  return `${d}d ago`
+}
+
+function actionIcon(action: AuditAction): string {
+  if (action === 'save') return 'pi pi-save'
+  if (action === 'publish') return 'pi pi-cloud-upload'
+  if (action === 'delete') return 'pi pi-trash'
+  if (action === 'restore') return 'pi pi-history'
+  return 'pi pi-cog' // configure-roles
+}
+
+function outcomeBadgeClass(outcome: AuditOutcome): string {
+  if (outcome === 'success') return 'outcome-success'
+  if (outcome === 'validation-failed') return 'outcome-warn'
+  return 'outcome-error' // forbidden, unauthenticated
+}
+
+function scopeLabel(event: AuditEvent): string {
+  return event.scope.name ? `${event.scope.kind}/${event.scope.name}` : event.scope.kind
+}
+</script>
+
+<template>
+  <Dialog :visible="props.visible" @update:visible="v => emit('update:visible', v)"
+    modal dismissableMask :closable="true"
+    header="Audit log"
+    :style="{ width: '720px', maxWidth: '95vw' }"
+    data-testid="audit-drawer">
+    <div class="filters" data-testid="audit-filters">
+      <Select v-model="filterAction" :options="ACTION_OPTIONS" optionLabel="label" optionValue="value"
+        placeholder="All actions" showClear size="small" data-testid="audit-filter-action" />
+      <Select v-model="filterOutcome" :options="OUTCOME_OPTIONS" optionLabel="label" optionValue="value"
+        placeholder="All outcomes" showClear size="small" data-testid="audit-filter-outcome" />
+      <Select v-model="filterScopeKind" :options="SCOPE_KIND_OPTIONS" optionLabel="label" optionValue="value"
+        placeholder="All scopes" showClear size="small" data-testid="audit-filter-scope" />
+      <InputText v-model="filterActor" placeholder="Actor (id or email)" size="small"
+        data-testid="audit-filter-actor" />
+      <Button v-if="filterAction || filterOutcome || filterScopeKind || filterActor"
+        icon="pi pi-filter-slash" size="small" severity="secondary"
+        @click="clearFilters" aria-label="Clear filters" data-testid="audit-clear-filters" />
+    </div>
+
+    <div v-if="loading && events.length === 0" class="state-loading" data-testid="audit-loading">
+      <ProgressSpinner style="width: 1.5rem; height: 1.5rem" strokeWidth="4" />
+      <span>Loading events…</span>
+    </div>
+    <div v-else-if="error" class="state-error" data-testid="audit-error">
+      <i class="pi pi-exclamation-circle" />
+      <span>{{ error }}</span>
+    </div>
+
+    <!-- State 4: external-only without link — operator config note -->
+    <div v-else-if="hasOnlyExternal && sinksWithLinks.length === 0"
+      class="state-external-no-link"
+      data-testid="audit-external-no-link">
+      <p class="msg">
+        Audit configured but not queryable in-admin.
+      </p>
+      <p class="hint">
+        Configured providers: <strong>{{ sinksWithoutLinks.map(s => s.name).join(', ') }}</strong>.
+        Configure <code>history</code> as a peer provider in
+        <code>site.config.ts</code>'s <code>admin.audit.providers</code> for in-admin browsing.
+      </p>
+    </div>
+
+    <!-- State 3: external-only with link — drive operator to the sink -->
+    <div v-else-if="hasOnlyExternal && sinksWithLinks.length > 0"
+      class="state-external-with-link"
+      data-testid="audit-external-with-link">
+      <p class="msg">Audit lives in your configured external sink.</p>
+      <ul class="sink-links">
+        <li v-for="sink in sinksWithLinks" :key="sink.name">
+          <a :href="sink.url!" target="_blank" rel="noopener noreferrer"
+            :data-testid="`audit-sink-link-${sink.name}`">
+            View in {{ sink.name }}
+            <i class="pi pi-external-link" aria-hidden="true" />
+          </a>
+        </li>
+      </ul>
+    </div>
+
+    <!-- States 1 + 2: queryable events; sinks block appears in footer if any -->
+    <div v-else-if="!hasInlineEvents" class="state-empty" data-testid="audit-empty">
+      No matching events. Try clearing filters or widening the time range.
+    </div>
+    <ul v-else class="events" data-testid="audit-events">
+      <li v-for="event in events" :key="`${event.timestamp}:${event.actor.id}:${event.action}:${event.scope.name ?? ''}`"
+        class="event"
+        :data-testid="`audit-event-${event.timestamp}`">
+        <i :class="actionIcon(event.action)" class="action-icon" aria-hidden="true" />
+        <div class="meta">
+          <div class="head-row">
+            <span class="action-label">{{ event.action }}</span>
+            <span class="scope">{{ scopeLabel(event) }}</span>
+            <span class="outcome" :class="outcomeBadgeClass(event.outcome)">{{ event.outcome }}</span>
+            <span class="time" :title="event.timestamp">{{ friendlyTime(event.timestamp) }}</span>
+          </div>
+          <div class="actor">
+            by <strong>{{ event.actor.email ?? event.actor.id }}</strong>
+            <span class="role">({{ event.actor.role }})</span>
+            <span v-if="event.actor.trustMode !== 'none'" class="trust-mode">
+              via {{ event.actor.trustMode }}
+            </span>
+          </div>
+          <div v-if="event.metadata" class="metadata-line">
+            <span v-for="(value, key) in event.metadata" :key="key" class="metadata-pair">
+              {{ key }}: <code>{{ String(value) }}</code>
+            </span>
+          </div>
+        </div>
+      </li>
+    </ul>
+
+    <!-- State 2: mixed — show sink links in the footer alongside inline events -->
+    <div v-if="hasInlineEvents && sinksWithLinks.length > 0"
+      class="footer-sinks"
+      data-testid="audit-footer-sinks">
+      <span class="footer-label">Also in:</span>
+      <a v-for="sink in sinksWithLinks" :key="sink.name"
+        :href="sink.url!" target="_blank" rel="noopener noreferrer"
+        :data-testid="`audit-sink-link-${sink.name}`">
+        {{ sink.name }} <i class="pi pi-external-link" aria-hidden="true" />
+      </a>
+    </div>
+
+    <template #footer>
+      <Button label="Close" severity="secondary" @click="close" data-testid="audit-drawer-close" />
+    </template>
+  </Dialog>
+</template>
+
+<style scoped>
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 0.75rem;
+}
+
+.state-loading,
+.state-error,
+.state-empty,
+.state-external-no-link,
+.state-external-with-link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  font-size: 0.875rem;
+  color: var(--color-muted);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--p-border-radius-sm);
+}
+.state-loading { flex-direction: row; align-items: center; }
+.state-error { color: var(--color-danger-fg); border-color: var(--color-danger-fg); }
+.state-external-no-link .msg,
+.state-external-with-link .msg { font-weight: 600; color: var(--color-fg); }
+.state-external-with-link .sink-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.state-external-with-link a,
+.footer-sinks a {
+  color: var(--color-primary);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.state-external-with-link a:hover,
+.footer-sinks a:hover { text-decoration: underline; }
+
+.events {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  max-height: 60vh;
+  overflow: auto;
+}
+.event {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  border-radius: var(--p-border-radius-sm);
+  border: 1px solid var(--color-border);
+}
+.action-icon {
+  font-size: 0.875rem;
+  padding-top: 0.125rem;
+  color: var(--color-muted);
+}
+.meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+.head-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.8125rem;
+}
+.action-label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.6875rem;
+}
+.scope { color: var(--color-fg); }
+.outcome {
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: var(--p-border-radius-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.outcome-success { background: var(--color-success-bg); color: var(--color-success-fg); }
+.outcome-warn { background: var(--color-warning-bg); color: var(--color-warning-fg); }
+.outcome-error { background: var(--color-danger-bg); color: var(--color-danger-fg); }
+.time {
+  font-size: 0.75rem;
+  color: var(--color-muted);
+  font-variant-numeric: tabular-nums;
+  margin-left: auto;
+}
+.actor {
+  font-size: 0.8125rem;
+  color: var(--color-muted);
+}
+.role,
+.trust-mode {
+  font-size: 0.75rem;
+  margin-left: 0.25rem;
+}
+.metadata-line {
+  font-size: 0.75rem;
+  color: var(--color-muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+}
+.metadata-pair code {
+  background: var(--color-hover-bg);
+  padding: 0 0.25rem;
+  border-radius: var(--p-border-radius-xs);
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}
+
+.footer-sinks {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--color-border);
+  font-size: 0.8125rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+.footer-label { color: var(--color-muted); }
+</style>

--- a/apps/admin/src/client/composables/api.ts
+++ b/apps/admin/src/client/composables/api.ts
@@ -35,6 +35,8 @@ import {
   type CompareResult,
   type RevisionSummary,
   type DependentsResponse,
+  type AuditQueryFilter,
+  type AuditQueryResponse,
 } from '../api/client.js'
 
 // ---- Pages -----------------------------------------------------------------
@@ -117,4 +119,14 @@ export interface HistoryApi {
 export const HISTORY_API: InjectionKey<HistoryApi> = Symbol('HistoryApi')
 export function useHistoryApi(): HistoryApi {
   return inject(HISTORY_API, api)
+}
+
+// ---- Audit ----------------------------------------------------------------
+
+export interface AuditApi {
+  queryAudit(filter?: AuditQueryFilter): Promise<AuditQueryResponse>
+}
+export const AUDIT_API: InjectionKey<AuditApi> = Symbol('AuditApi')
+export function useAuditApi(): AuditApi {
+  return inject(AUDIT_API, api)
 }

--- a/apps/admin/tests/ActiveTargetIndicator.test.ts
+++ b/apps/admin/tests/ActiveTargetIndicator.test.ts
@@ -38,7 +38,7 @@ function mountWithGlobals(options?: ComponentMountingOptions<typeof ActiveTarget
   return mount(ActiveTargetIndicator, {
     global: {
       plugins: [PrimeVue, router],
-      stubs: { HistoryPanel: true },
+      stubs: { HistoryPanel: true, AuditDrawer: true },
       ...options?.global,
     },
     ...options,
@@ -342,7 +342,7 @@ describe('ActiveTargetIndicator', () => {
       expect(prodGroup!.items!.map(i => i.label)).toEqual(['prod-us', 'prod-eu'])
     })
 
-    it('always includes a View history action at the bottom', () => {
+    it('always includes View history + View audit log actions at the bottom', () => {
       const targets: TargetInfo[] = [
         {
           name: 'local',
@@ -356,8 +356,10 @@ describe('ActiveTargetIndicator', () => {
       const w = mountWithGlobals()
       const menu = w.findComponent({ name: 'Menu' })
       const model = menu.props('model') as Array<{ label?: string; separator?: boolean }>
-      expect(model.at(-1)?.label).toBe('View history')
-      expect(model.at(-2)?.separator).toBe(true)
+      // Tail is: separator, View history, View audit log
+      expect(model.at(-1)?.label).toBe('View audit log')
+      expect(model.at(-2)?.label).toBe('View history')
+      expect(model.at(-3)?.separator).toBe(true)
     })
   })
 })

--- a/apps/admin/tests/AuditDrawer.test.ts
+++ b/apps/admin/tests/AuditDrawer.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Cut 6 component tests for AuditDrawer.vue.
+ *
+ * Pins the four UX states from design-audit.md "Audit drawer — query
+ * semantics" + Krug-aligned absence-as-state rendering:
+ *
+ *   - state 1: history-only (events; no sink block)
+ *   - state 2: history + external sinks with url (events + footer links)
+ *   - state 3: external-only with url (no events; prominent message + link)
+ *   - state 4: external-only without url (no events; "configure history" hint)
+ *
+ * Plus filter wiring + error state.
+ *
+ * PrimeVue Dialog teleports to document.body; queries go through
+ * document.querySelector. `attachTo: document.body` + a per-test
+ * `document.body.innerHTML = ''` reset matches the AssetDeleteConfirm
+ * sibling test pattern.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import PrimeVue from 'primevue/config'
+import AuditDrawer from '../src/client/components/AuditDrawer.vue'
+import { AUDIT_API, type AuditApi } from '../src/client/composables/api.js'
+import type { AuditEvent, AuditQueryFilter, AuditQueryResponse } from '../src/client/api/client.js'
+
+beforeAll(() => {
+  if (typeof window.matchMedia !== 'function') {
+    window.matchMedia = (query: string) =>
+      ({
+        matches: false,
+        media: query,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+        onchange: null,
+      }) as unknown as MediaQueryList
+  }
+})
+
+function makeEvent(partial: Partial<AuditEvent> = {}): AuditEvent {
+  return {
+    timestamp: '2026-05-04T14:23:05Z',
+    actor: { id: 'alice@example.com', email: 'alice@example.com', role: 'admin', trustMode: 'forwarded-user' },
+    action: 'save',
+    outcome: 'success',
+    scope: { kind: 'page', name: 'home' },
+    ...partial,
+  }
+}
+
+function fakeAuditApi(response: AuditQueryResponse | (() => AuditQueryResponse)) {
+  const calls: AuditQueryFilter[] = []
+  const api: AuditApi = {
+    async queryAudit(filter = {}) {
+      calls.push(filter)
+      return typeof response === 'function' ? response() : response
+    },
+  }
+  return { api, calls }
+}
+
+function mountDrawer(api: AuditApi, visible = true) {
+  return mount(AuditDrawer, {
+    props: { visible },
+    attachTo: document.body,
+    global: {
+      plugins: [PrimeVue],
+      provide: { [AUDIT_API as symbol]: api },
+    },
+  })
+}
+
+function q(testid: string): HTMLElement | null {
+  return document.querySelector(`[data-testid="${testid}"]`)
+}
+
+function qa(selector: string): HTMLElement[] {
+  return Array.from(document.querySelectorAll(selector))
+}
+
+describe('AuditDrawer', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    // PrimeVue's Dialog teleports into document.body; previous tests
+    // leave its markup behind. Wipe so document.querySelector sees
+    // only *this* test's render.
+    document.body.innerHTML = ''
+  })
+
+  describe('state 1 — history-only', () => {
+    it('renders inline events with no external-sink block', async () => {
+      const { api } = fakeAuditApi({
+        events: [
+          makeEvent({ scope: { kind: 'page', name: 'home' } }),
+          makeEvent({ scope: { kind: 'fragment', name: 'header' } }),
+        ],
+        externalSinks: [],
+      })
+      mountDrawer(api)
+      await flushPromises()
+      await flushPromises()
+      expect(q('audit-events')).not.toBeNull()
+      expect(qa('.event')).toHaveLength(2)
+      expect(q('audit-footer-sinks')).toBeNull()
+      expect(q('audit-external-with-link')).toBeNull()
+      expect(q('audit-external-no-link')).toBeNull()
+    })
+  })
+
+  describe('state 2 — history + external sinks with url', () => {
+    it('renders events + footer "Also in" links', async () => {
+      const { api } = fakeAuditApi({
+        events: [makeEvent()],
+        externalSinks: [
+          { name: 'cloudwatch', url: 'https://aws.example.com/audit' },
+          { name: 'splunk', url: 'https://splunk.example.com/search' },
+        ],
+      })
+      mountDrawer(api)
+      await flushPromises()
+      expect(q('audit-events')).not.toBeNull()
+      expect(q('audit-footer-sinks')).not.toBeNull()
+      const cwLink = q('audit-sink-link-cloudwatch') as HTMLAnchorElement | null
+      expect(cwLink).not.toBeNull()
+      expect(cwLink!.getAttribute('href')).toBe('https://aws.example.com/audit')
+      expect(q('audit-sink-link-splunk')).not.toBeNull()
+    })
+  })
+
+  describe('state 3 — external-only with url', () => {
+    it('renders prominent message + link, no inline events', async () => {
+      const { api } = fakeAuditApi({
+        events: [],
+        externalSinks: [{ name: 'cloudwatch', url: 'https://aws.example.com/audit' }],
+      })
+      mountDrawer(api)
+      await flushPromises()
+      expect(q('audit-external-with-link')).not.toBeNull()
+      expect(q('audit-events')).toBeNull()
+      const link = q('audit-sink-link-cloudwatch') as HTMLAnchorElement | null
+      expect(link).not.toBeNull()
+      expect(link!.getAttribute('href')).toBe('https://aws.example.com/audit')
+    })
+  })
+
+  describe('state 4 — external-only without url', () => {
+    it('renders the "configure history" hint with provider names', async () => {
+      const { api } = fakeAuditApi({
+        events: [],
+        externalSinks: [{ name: 'webhook', url: null }],
+      })
+      mountDrawer(api)
+      await flushPromises()
+      const block = q('audit-external-no-link')
+      expect(block).not.toBeNull()
+      expect(block!.textContent).toContain('webhook')
+      expect(block!.textContent).toContain('history')
+      expect(q('audit-events')).toBeNull()
+    })
+  })
+
+  describe('empty state', () => {
+    it('renders empty hint when no events + no sinks', async () => {
+      const { api } = fakeAuditApi({ events: [], externalSinks: [] })
+      mountDrawer(api)
+      await flushPromises()
+      expect(q('audit-empty')).not.toBeNull()
+    })
+  })
+
+  describe('filter wiring', () => {
+    it('passes typed filter values to the API', async () => {
+      const { api, calls } = fakeAuditApi({ events: [], externalSinks: [] })
+      const w = mountDrawer(api)
+      await flushPromises()
+      // Initial load, no filters.
+      expect(calls.at(-1)).toEqual({})
+
+      // Drive the filter refs directly — PrimeVue Select bindings
+      // are an integration concern, the contract we're pinning is
+      // "filter ref change → queryAudit fires with matching shape".
+      const vm = w.vm as unknown as { filterAction: 'save' | 'publish' | null; filterActor: string }
+      vm.filterAction = 'publish'
+      await flushPromises()
+      expect(calls.at(-1)).toEqual({ action: 'publish' })
+
+      vm.filterActor = 'alice'
+      await flushPromises()
+      expect(calls.at(-1)).toEqual({ action: 'publish', actor: 'alice' })
+    })
+
+    it('clears filters via the clear button', async () => {
+      const { api, calls } = fakeAuditApi({ events: [], externalSinks: [] })
+      const w = mountDrawer(api)
+      await flushPromises()
+      const vm = w.vm as unknown as {
+        filterAction: 'save' | 'publish' | null
+        filterActor: string
+      }
+      vm.filterAction = 'save'
+      vm.filterActor = 'bob'
+      await flushPromises()
+      const callsBefore = calls.length
+
+      const clear = q('audit-clear-filters')
+      expect(clear).not.toBeNull()
+      ;(clear as HTMLElement).click()
+      await flushPromises()
+      // A subsequent fetch ran with empty filter.
+      expect(calls.length).toBeGreaterThan(callsBefore)
+      expect(calls.at(-1)).toEqual({})
+    })
+  })
+
+  describe('error state', () => {
+    it('surfaces fetch errors', async () => {
+      const api: AuditApi = {
+        async queryAudit() {
+          throw new Error('network down')
+        },
+      }
+      mountDrawer(api)
+      await flushPromises()
+      const err = q('audit-error')
+      expect(err).not.toBeNull()
+      expect(err!.textContent).toContain('network down')
+    })
+  })
+
+  describe('event metadata rendering', () => {
+    it('displays metadata key/value pairs alongside the event', async () => {
+      const { api } = fakeAuditApi({
+        events: [
+          makeEvent({
+            metadata: { targetName: 'production', restoredFrom: 'rev-001' },
+          }),
+        ],
+        externalSinks: [],
+      })
+      mountDrawer(api)
+      await flushPromises()
+      const eventEl = qa('.event')[0]
+      const text = eventEl.textContent ?? ''
+      expect(text).toContain('targetName')
+      expect(text).toContain('production')
+      expect(text).toContain('restoredFrom')
+      expect(text).toContain('rev-001')
+    })
+  })
+
+  describe('outcome badges', () => {
+    it('uses distinct CSS classes per outcome', async () => {
+      const { api } = fakeAuditApi({
+        events: [
+          makeEvent({ outcome: 'success', scope: { kind: 'page', name: 'a' } }),
+          makeEvent({ outcome: 'validation-failed', scope: { kind: 'page', name: 'b' } }),
+          makeEvent({ outcome: 'forbidden', scope: { kind: 'page', name: 'c' } }),
+        ],
+        externalSinks: [],
+      })
+      mountDrawer(api)
+      await flushPromises()
+      const badges = qa('.outcome')
+      expect(badges).toHaveLength(3)
+      expect(badges[0].classList.contains('outcome-success')).toBe(true)
+      expect(badges[1].classList.contains('outcome-warn')).toBe(true)
+      expect(badges[2].classList.contains('outcome-error')).toBe(true)
+    })
+  })
+})

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,0 +1,323 @@
+# Audit log
+
+Gazetta records every save, publish, delete, and history-restore as a structured audit event. The events live with each target's content under `.gazetta/audit/`, queryable through the admin's audit drawer (top-bar active-target menu → "View audit log") and through `GET /api/audit`.
+
+Audit is **on by default**. Zero config: every Gazetta admin process records to a per-instance JSONL file; the admin drawer reads from it. Operators add config when they want pseudonymization, source-IP recording, retention windows, or external sinks (when those ship).
+
+## What gets recorded
+
+Each event captures **what happened** + **who did it** + **what they touched**:
+
+```jsonc
+{
+  "timestamp": "2026-05-04T14:23:05.000Z",
+  "actor": {
+    "id": "alice@example.com",
+    "email": "alice@example.com",
+    "role": "editor",
+    "trustMode": "cloudflare-access"
+  },
+  "action": "save",
+  "outcome": "success",
+  "scope": { "kind": "page", "name": "home" },
+  "metadata": {
+    /* optional, action-specific extras */
+  }
+}
+```
+
+Recorded actions:
+
+| Action            | When                                                           |
+| ----------------- | -------------------------------------------------------------- |
+| `save`            | A page or fragment manifest is written                         |
+| `publish`         | Content is published to a target                               |
+| `delete`          | A page, fragment, or asset is deleted                          |
+| `restore`         | A history undo or arbitrary rollback executes                  |
+| `configure-roles` | Reserved for role-mapping changes (lands when reviews ship)    |
+
+Recorded outcomes:
+
+| Outcome             | Meaning                                                                           |
+| ------------------- | --------------------------------------------------------------------------------- |
+| `success`           | The action completed                                                              |
+| `validation-failed` | Save rejected because validators flagged blocking issues                          |
+| `forbidden`         | Capability check denied the request (the route fired before the handler ran)     |
+| `unauthenticated`   | Upstream auth produced no principal; request rejected                             |
+
+Outcome is required on every event. Failure outcomes (`validation-failed`, `forbidden`, `unauthenticated`) record what the user **tried** to do — useful for forensics ("which editor tried to publish to prod last Friday?").
+
+## Where events live
+
+Per-target, under `.gazetta/audit/`:
+
+```text
+target-root/
+├── pages/
+├── fragments/
+└── .gazetta/
+    ├── history/
+    └── audit/
+        ├── events-pod-abc-123.jsonl    # one file per admin instance
+        └── events-pod-def-456.jsonl
+```
+
+One JSONL file **per admin instance** (Cloud Run revision id, Kubernetes pod name, or `os.hostname()` fallback). Multiple admin instances writing concurrently never collide because each owns its own file. The `GET /api/audit` route aggregates across files.
+
+The `.gazetta/audit/` directory is gitignored — audit events are runtime state, not source.
+
+## Configuration
+
+```ts
+import { defineSite } from 'gazetta'
+
+export default defineSite({
+  // ...
+  admin: {
+    audit: {
+      provider: 'history',        // v1 only option (default; can omit)
+      strict: false,              // default — fail-open
+      actorPseudonym: 'none',     // 'none' | 'sha256'
+      recordSourceIp: 'none',     // 'none' | 'raw' | 'hashed' | 'truncated'
+      recordUserAgent: 'none',    // 'none' | 'raw' | 'truncated'
+      retention: {
+        events: 10000,            // optional; max event count
+        maxAgeMonths: 12,         // optional; null or unset = no time limit
+      },
+    },
+  },
+})
+```
+
+All fields are optional. Defaults: zero-config audit (history provider, no pseudonymization, no IP/UA recording, no retention).
+
+### Privacy posture
+
+`recordSourceIp` and `recordUserAgent` default to **off**. Operators opt in per their compliance posture and consent rules.
+
+| `recordSourceIp` | What's stored                                                              |
+| ---------------- | -------------------------------------------------------------------------- |
+| `none` (default) | Nothing                                                                    |
+| `raw`            | Full client IP — GDPR-personal-data; operator declares processing          |
+| `hashed`         | `sha256(ip + GAZETTA_AUDIT_SOURCEIP_SALT).slice(0, 16)` — pseudonymized    |
+| `truncated`      | `/24` prefix (IPv4) or `/48` prefix (IPv6) — geographic forensics only     |
+
+`hashed` mode requires the `GAZETTA_AUDIT_SOURCEIP_SALT` environment variable. Rotating the salt breaks correlation by design — document rotation dates so forensic queries can scope by salt-era.
+
+| `recordUserAgent` | What's stored                                                              |
+| ----------------- | -------------------------------------------------------------------------- |
+| `none` (default)  | Nothing                                                                    |
+| `raw`             | Full UA string                                                             |
+| `truncated`       | Browser family + major version (e.g., `Chrome/119`); fingerprinting detail dropped |
+
+### Trust-mode-driven source IP extraction
+
+When `recordSourceIp` is enabled, Gazetta extracts the client IP using the auth trust mode's correct source — never naively reading the leftmost `X-Forwarded-For` entry (which is a documented OWASP misconfiguration class).
+
+| Trust mode          | Source                                                                          |
+| ------------------- | ------------------------------------------------------------------------------- |
+| `none`              | TCP peer (no proxy assumed)                                                     |
+| `forwarded-user`    | `X-Forwarded-For` with operator-configured `trustedProxyCount` (counted from rightmost) |
+| `cloudflare-access` | `Cf-Connecting-IP` (Cloudflare-signed)                                          |
+| `azure-easy-auth`   | `X-Forwarded-For`, `trustedProxyCount: 1` (Azure App Service appends one entry) |
+| `aws-cognito`       | `X-Forwarded-For`, `trustedProxyCount: 1` (ALB appends one entry)               |
+| `tailscale`         | TCP peer (Tailscale serves direct)                                              |
+
+When the configured header is missing (proxy misconfiguration), `sourceIp` is omitted from the event entirely — explicitly absent is more honest than `'[unparseable]'`.
+
+### Pseudonymization
+
+`actorPseudonym: 'sha256'` replaces `actor.id` with a salted hash:
+
+```text
+actor.id  =  sha256(upstream-sub + GAZETTA_AUDIT_ACTOR_SALT).slice(0, 16)
+```
+
+When pseudonymization is on, `actor.email` is also redacted (low-entropy emails give weak pseudonymization; we drop them).
+
+When to opt in:
+
+- External-sink configurations where audit events leave Gazetta's process boundary (compliance contexts where the sink might be compromised)
+- Regulated contexts demanding pseudonymization-by-default
+- Multi-tenant SIEM correlation where you want shared hashes across systems (use a shared salt) without sharing raw subjects
+
+The salt is a credential. Store it in `GAZETTA_AUDIT_ACTOR_SALT` env var; never in `site.config.ts`. 16+ random bytes. Document the creation date as part of operational records.
+
+Salt rotation breaks historic correlation by design — rotate per security policy (annually is typical).
+
+## Retention
+
+Audit retention is configurable independently from history retention because compliance regimes specify retention windows that don't match content history budgets:
+
+```ts
+retention: {
+  events: 10000,        // max events kept; oldest evicted when exceeded
+  maxAgeMonths: 72,     // 6 years for HIPAA; null = no time limit
+}
+```
+
+Set one or both:
+
+| Configuration                            | Behavior                                                                |
+| ---------------------------------------- | ----------------------------------------------------------------------- |
+| Neither set                              | Audit accumulates indefinitely (operator's choice)                      |
+| `events` only                            | Hard cap on count; oldest evicted globally across instance files        |
+| `maxAgeMonths` only                      | Rolling cutoff; events older than N months evicted                      |
+| Both                                     | Age cutoff first, then count cap on the survivors                       |
+
+The pruner runs at admin boot + every 6 hours. Background work; never blocks operations. Pruner failures fail-open — audit just accumulates until the next successful run.
+
+Multi-instance correctness: per-instance files (`events-pod-A.jsonl`, `events-pod-B.jsonl`) prune independently with no coordination. The `events` cap is global across all files (oldest events anywhere lose).
+
+## Strict mode (compliance contexts)
+
+Default is **fail-open**: audit failures never block writes. Per [Universal Provider Requirement #5](.claude/rules/design-plugins.md). Operator's monitoring catches the failure via structured logs.
+
+For HIPAA / SOC 2 contexts where "audit recording confirmed successful" is a hard prerequisite for the write to proceed:
+
+```ts
+admin: {
+  audit: {
+    provider: 'history',
+    strict: true,   // any provider failure blocks the write
+  },
+}
+```
+
+Strict mode trades availability for compliance. A storage outage that would otherwise lose an audit record now also blocks the user's save until the issue resolves. Use it only when your compliance posture requires it.
+
+## Reading the audit log
+
+### Admin drawer
+
+Open the top-bar active-target menu → "View audit log". The drawer shows:
+
+- Filter controls (action / outcome / scope kind / actor)
+- Inline events list (newest first)
+- Outcome badges (success / warn / error)
+- Per-event metadata (target name, restored revision id, etc.)
+
+When the configured providers include both queryable (`history`) and external sinks (when those ship), the drawer composes both:
+
+| Configuration                     | Drawer state                                                  |
+| --------------------------------- | ------------------------------------------------------------- |
+| `history` only                    | Inline events list                                            |
+| `history` + external sink with link | Inline events + footer link "Also in: cloudwatch"           |
+| External sink only, with link     | "Audit lives in cloudwatch — [link]" (no inline list)         |
+| External sink only, no link       | "Configure history as a peer provider for in-admin browsing"  |
+
+### `GET /api/audit`
+
+Programmatic access. Same filter shape as the drawer:
+
+```text
+GET /api/audit?action=save&outcome=success&scopeKind=page&scopeName=home&actor=alice&since=2026-05-01T00:00:00Z&until=2026-05-31T23:59:59Z&limit=100
+```
+
+Response:
+
+```jsonc
+{
+  "events": [
+    {
+      "timestamp": "...",
+      "actor": { "id": "...", "role": "editor", "trustMode": "..." },
+      "action": "save",
+      "outcome": "success",
+      "scope": { "kind": "page", "name": "home" }
+    }
+    // ...
+  ],
+  "externalSinks": [
+    /* { name, url|null } per non-queryable provider */
+  ]
+}
+```
+
+Default limit 100, max 1000. Newest events first.
+
+## Capability gating
+
+`GET /api/audit` requires the `read:audit-log` capability. **Built-in role assignments**:
+
+| Role     | Has `read:audit-log`?     |
+| -------- | -------------------------- |
+| `admin`  | Yes (via root wildcard `*`) |
+| `editor` | **No** (`read:*` is wildcard-exempt for audit) |
+| `viewer` | **No** (`read:*` is wildcard-exempt for audit) |
+
+This matches the design's "viewers don't see audit by default" rule. Operators wanting non-admin audit access declare a custom role with the explicit grant:
+
+```ts
+admin: {
+  auth: {
+    trust: 'cloudflare-access',
+    // ...
+    roles: {
+      auditor: ['read:*', 'read:audit-log'],
+    },
+    map: {
+      'gazetta-auditors': 'auditor',
+    },
+  },
+}
+```
+
+Custom role members in the upstream group `gazetta-auditors` get full read access including audit; without `read:audit-log` in their role's capability list, the drawer's API call returns 403.
+
+## Recommended deployment patterns
+
+### Single-server admin (default)
+
+Out of the box. `history` provider, zero config, retention to taste.
+
+```ts
+admin: {
+  audit: {
+    retention: { events: 10000 },
+  },
+}
+```
+
+### Multi-instance (Cloud Run / Kubernetes)
+
+Per-instance JSONL files mean concurrent appenders never race. No coordination needed. Set the `K_REVISION` env (Cloud Run does this automatically) or rely on `os.hostname()` (Kubernetes) for instance identity.
+
+### Compliance: history + future external sink
+
+When external-sink providers ship (v2 — `HttpWebhookAuditProvider`, `FileAuditProvider`, `CloudWatchAuditProvider`, etc.), the recommended pattern is to run `history` AND your external sink as peers:
+
+```ts
+admin: {
+  audit: {
+    providers: [
+      'history',     // local copy; queryable via admin drawer
+      'cloudwatch',  // tamper-evident retention; SOC 2 / HIPAA satisfaction
+    ],
+    strict: false,   // or true for "audit confirmed before write proceeds"
+  },
+}
+```
+
+Best of both: in-admin browsability + external compliance posture. Until v2, run `history` and use your platform's storage backup for the `.gazetta/audit/` directory.
+
+## What audit doesn't cover
+
+Out of scope for v1:
+
+- **Read events** (every API GET) — compliance-tier; deferred until SOC 2 / HIPAA demand
+- **Hook firings** — lands when the hooks foundation ships
+- **External sink providers** (CloudWatch, Azure Monitor, syslog, OpenTelemetry, HTTP webhook, file) — v2 demand-driven
+- **Index sidecars** for sub-second queries at very large scale (>100K events) — kicks in when query latency p95 crosses 2 seconds
+- **`gazetta audit query` CLI** — lands with the validation Cut 5 CLI rewrite
+- **Right-to-be-forgotten scrub CLI** — same trigger
+
+## Tampering
+
+Audit log lives in target's writable storage; an admin with write access to the target storage can edit revisions. v1 accepts this; external-sink providers (v2) are the upgrade path for high-stakes operators who need tamper-evident logs.
+
+## Reference
+
+- [`design-audit.md`](../.claude/rules/design-audit.md) — full design pass
+- [`design-auth-rbac.md`](../.claude/rules/design-auth-rbac.md) — capability vocabulary + Principal type
+- [`design-plugins.md`](../.claude/rules/design-plugins.md) — Universal Provider Requirements

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -214,6 +214,12 @@ Override target-level cache in a page manifest:
 | Page changed | Purge that page's URL only |
 | CLI publish | Purge all at the end |
 
+## Audit log
+
+Audit recording is on by default — every save / publish / delete / restore writes a structured event to the target's `.gazetta/audit/events-{instance}.jsonl`. With Cloudflare Workers admin instances, the per-instance file naming uses the worker's revision identity. See [`audit.md`](audit.md) for the full reference (privacy posture, retention, capability gating).
+
+R2-backed admin processes work the same as filesystem-backed: per-instance JSONL files mean concurrent appenders never collide on object writes. The `read:audit-log` capability gates the admin drawer; built-in `editor` and `viewer` roles do NOT grant it (wildcard-exempt). Operators wanting non-admin audit access declare a custom role with `['read:*', 'read:audit-log']`.
+
 ## Worker
 
 The worker is a thin Hono app that:

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -120,6 +120,14 @@ Per-page cache overrides work:
 }
 ```
 
+## Audit log
+
+Audit recording is on by default — every save / publish / delete / restore writes a structured event to the target's `.gazetta/audit/events-{instance}.jsonl`. With self-hosted admin processes, the per-instance file naming uses `os.hostname()` (Kubernetes pod name on K8s; machine hostname elsewhere). See [`audit.md`](audit.md) for the full reference.
+
+For multi-instance self-hosted deployments (Kubernetes, multi-replica VMs), per-instance JSONL files mean concurrent appenders never collide. Make sure `os.hostname()` returns a unique value per pod / VM — most platforms do this by default.
+
+Audit events live in the same target storage as content; they're picked up by your existing target backup. The `.gazetta/audit/` directory is gitignored — runtime state, not source.
+
 ## Docker
 
 ```dockerfile

--- a/examples/starter/sites/main/site.config.ts
+++ b/examples/starter/sites/main/site.config.ts
@@ -23,6 +23,22 @@ export default defineSite({
   //   maxTokens: 300,                                       // optional generation cap
   // },
 
+  // Audit log (optional). Audit is on by default with sensible
+  // privacy defaults — events stored in each target's
+  // `.gazetta/audit/events-{instance}.jsonl`. See docs/audit.md for
+  // the full reference: privacy modes, retention windows,
+  // capability gating, deployment patterns.
+  //
+  // admin: {
+  //   audit: {
+  //     // strict: false,            // default — fail-open. true = block writes on audit failure (HIPAA / SOC 2)
+  //     // actorPseudonym: 'none',   // 'none' | 'sha256' (requires GAZETTA_AUDIT_ACTOR_SALT env var)
+  //     // recordSourceIp: 'none',   // 'none' | 'raw' | 'hashed' | 'truncated'
+  //     // recordUserAgent: 'none',  // 'none' | 'raw' | 'truncated'
+  //     // retention: { events: 10000, maxAgeMonths: 12 },  // optional caps
+  //   },
+  // },
+
   targets: {
     local: {
       // Relative paths are anchored to this config file's directory

--- a/packages/gazetta/src/admin-api/index.ts
+++ b/packages/gazetta/src/admin-api/index.ts
@@ -38,6 +38,7 @@ import { fieldRoutes } from './routes/fields.js'
 import { historyRoutes } from './routes/history.js'
 import { assetRoutes } from './routes/assets.js'
 import { systemRoutes } from './routes/system.js'
+import { auditRoutes } from './routes/audit.js'
 import { healthRoutes } from './routes/health.js'
 import { startCacheStatsLogger } from './cache-stats-logger.js'
 
@@ -297,6 +298,7 @@ export function createAdminApp(opts: AdminAppOptions): AdminApp {
   app.route('/', historyRoutes(resolveSource, opts.targets, opts.targetConfigs))
   app.route('/', assetRoutes(resolveSource))
   app.route('/', systemRoutes(resolveSource))
+  app.route('/', auditRoutes({ providers: auditProviders }))
   app.route('/', healthRoutes())
 
   // Periodic cache stats log — fires every 5 minutes against the

--- a/packages/gazetta/src/admin-api/index.ts
+++ b/packages/gazetta/src/admin-api/index.ts
@@ -23,6 +23,7 @@ import {
   AuditConfigurationError,
   createHistoryAuditProvider,
   DEFAULT_AUDIT_CONFIG,
+  pruneAuditEvents,
   type AuditConfig,
   type AuditProvider,
 } from '../audit/index.js'
@@ -68,6 +69,14 @@ export interface AdminAppOptions {
    * leaking into the test runtime.
    */
   disableCacheStatsLogger?: boolean
+  /**
+   * Disable the periodic audit retention pruner. Defaults to false
+   * (pruner runs at boot + every 6 hours when audit retention is
+   * configured). Tests pass true to avoid background timers leaking
+   * into the test runtime; the boot pass and the interval both gate
+   * on this flag.
+   */
+  disableAuditRetentionPruner?: boolean
 }
 
 type AdminApp = Hono & {
@@ -309,6 +318,42 @@ export function createAdminApp(opts: AdminAppOptions): AdminApp {
   // snapshots either way.
   if (!opts.disableCacheStatsLogger) {
     startCacheStatsLogger({ cache: source.cache })
+  }
+
+  // Audit retention pruner — when admin.audit.retention is configured
+  // (events cap and/or maxAgeMonths), evict old / overflow events at
+  // boot + every 6 hours per design-audit.md "Retention". No-op when
+  // retention isn't configured (operator opted out / never opted in).
+  // Same pattern as the cache stats logger: timer.unref() so it never
+  // blocks process exit; tests pass `disableAuditRetentionPruner:
+  // true` to keep background work out of the test runtime.
+  if (
+    !opts.disableAuditRetentionPruner &&
+    auditConfig.provider === 'history' &&
+    auditConfig.retention &&
+    (auditConfig.retention.events !== undefined || auditConfig.retention.maxAgeMonths)
+  ) {
+    const retentionConfig = auditConfig.retention
+    const runPrune = async () => {
+      try {
+        await pruneAuditEvents(source.storage, {
+          events: retentionConfig.events,
+          maxAgeMonths: retentionConfig.maxAgeMonths ?? null,
+        })
+      } catch {
+        // Pruner failures fail-open per Universal Provider Requirement
+        // #5 — audit accumulates until next successful prune. Operator
+        // monitoring sees the failure via structured log (TODO when
+        // logging foundation lands; v1 swallows silently).
+      }
+    }
+    // Boot pass.
+    void runPrune()
+    // 6-hour interval (21_600_000 ms). unref() so the process can exit
+    // independently of this timer.
+    const PRUNE_INTERVAL_MS = 6 * 60 * 60 * 1000
+    const timer = setInterval(runPrune, PRUNE_INTERVAL_MS)
+    timer.unref()
   }
 
   // Exposed for the CLI's template file watcher: clears the memoized scan

--- a/packages/gazetta/src/admin-api/index.ts
+++ b/packages/gazetta/src/admin-api/index.ts
@@ -1,5 +1,7 @@
 import { Hono } from 'hono'
 import { join } from 'node:path'
+import { hostname } from 'node:os'
+import { randomBytes } from 'node:crypto'
 import { logger } from 'hono/logger'
 import type { StorageProvider, TargetConfig } from '../types.js'
 import { scanTemplates } from '../templates-scan.js'
@@ -93,6 +95,32 @@ type AdminApp = Hono & {
    * deployed-once artifacts).
    */
   invalidateContentCache(): Promise<void>
+}
+
+/**
+ * Resolve a per-process instance id for audit JSONL file naming.
+ *
+ * Chain per `design-logging.md`'s "Multi-instance correlation":
+ *   1. `K_REVISION` env (Cloud Run; per-revision)
+ *   2. `os.hostname()` — returns the pod name on K8s default config,
+ *      machine hostname elsewhere
+ *   3. Random 8-char hex (only when hostname is empty / unavailable)
+ *
+ * `process.env.HOSTNAME` is NOT in the chain — Linux containers
+ * usually have it via the shell, but Node processes exec'd directly
+ * may not inherit shell env, so HOSTNAME can be undefined on K8s
+ * pods. `os.hostname()` calls gethostname(2) directly and is reliable
+ * across runtimes.
+ */
+function resolveInstanceId(): string {
+  if (process.env.K_REVISION) return process.env.K_REVISION
+  try {
+    const name = hostname()
+    if (name) return name
+  } catch {
+    // hostname() can throw on some Wintertc-style runtimes — fall through.
+  }
+  return randomBytes(4).toString('hex')
 }
 
 /**
@@ -278,7 +306,7 @@ export function createAdminApp(opts: AdminAppOptions): AdminApp {
     auditProviders.push(
       createHistoryAuditProvider({
         storage: source.storage,
-        instance: process.env.K_REVISION ?? require('node:os').hostname() ?? 'gazetta-admin',
+        instance: resolveInstanceId(),
       }),
     )
   }

--- a/packages/gazetta/src/admin-api/index.ts
+++ b/packages/gazetta/src/admin-api/index.ts
@@ -16,7 +16,16 @@ import {
 } from './source-context.js'
 import { authMiddleware } from './middleware/auth.js'
 import { principalMiddleware } from './middleware/principal.js'
+import { auditMiddleware } from './middleware/audit.js'
 import { AuthConfigSchema, AuthConfigurationError, buildAuthProvider } from '../auth/index.js'
+import {
+  AuditConfigSchema,
+  AuditConfigurationError,
+  createHistoryAuditProvider,
+  DEFAULT_AUDIT_CONFIG,
+  type AuditConfig,
+  type AuditProvider,
+} from '../audit/index.js'
 import { siteRoutes } from './routes/site.js'
 import { pageRoutes } from './routes/pages.js'
 import { fragmentRoutes } from './routes/fragments.js'
@@ -213,6 +222,69 @@ export function createAdminApp(opts: AdminAppOptions): AdminApp {
     authProvider = buildAuthProvider(undefined)
   }
   app.use('/api/*', principalMiddleware(authProvider))
+
+  // Audit middleware — per design-audit.md "Recording timing".
+  // Resolves admin.audit config; constructs the configured providers;
+  // injects c.var.audit so handlers can call `c.var.audit.record(...)`.
+  // Defaults to HistoryAuditProvider when admin.audit is absent
+  // (zero-config audit; events stored under target's
+  // .gazetta/audit/events-{instance}.jsonl).
+  const rawAuditBlock = source.manifest?.admin?.audit as unknown
+  let auditConfig: AuditConfig
+  if (rawAuditBlock !== undefined) {
+    const parsed = AuditConfigSchema.safeParse(rawAuditBlock)
+    if (!parsed.success) {
+      throw new AuditConfigurationError(
+        `Invalid admin.audit block in site.config.ts: ${parsed.error.issues
+          .map(i => `${i.path.join('.')}: ${i.message}`)
+          .join('; ')}`,
+      )
+    }
+    auditConfig = parsed.data
+  } else {
+    auditConfig = DEFAULT_AUDIT_CONFIG
+  }
+  // Salt env var resolution per design-audit.md "Salt management":
+  // GAZETTA_AUDIT_ACTOR_SALT for actor pseudonymization;
+  // GAZETTA_AUDIT_SOURCEIP_SALT for source-IP hashing.
+  const actorPseudonym = auditConfig.actorPseudonym ?? 'none'
+  const recordSourceIp = auditConfig.recordSourceIp ?? 'none'
+  const recordUserAgent = auditConfig.recordUserAgent ?? 'none'
+  if (actorPseudonym === 'sha256' && !process.env.GAZETTA_AUDIT_ACTOR_SALT) {
+    throw new AuditConfigurationError(
+      'admin.audit.actorPseudonym: sha256 requires the GAZETTA_AUDIT_ACTOR_SALT environment variable',
+    )
+  }
+  if (recordSourceIp === 'hashed' && !process.env.GAZETTA_AUDIT_SOURCEIP_SALT) {
+    throw new AuditConfigurationError(
+      'admin.audit.recordSourceIp: hashed requires the GAZETTA_AUDIT_SOURCEIP_SALT environment variable',
+    )
+  }
+  // Build the configured providers. v1 ships only HistoryAuditProvider;
+  // v2 sinks (webhook, file, OTel, CloudWatch, etc.) extend the build
+  // step here when they ship.
+  const auditProviders: AuditProvider[] = []
+  if (auditConfig.provider === 'history') {
+    auditProviders.push(
+      createHistoryAuditProvider({
+        storage: source.storage,
+        instance: process.env.K_REVISION ?? require('node:os').hostname() ?? 'gazetta-admin',
+      }),
+    )
+  }
+  app.use(
+    '/api/*',
+    auditMiddleware({
+      providers: auditProviders,
+      strict: auditConfig.strict ?? false,
+      actorPseudonym,
+      actorSalt: process.env.GAZETTA_AUDIT_ACTOR_SALT,
+      recordSourceIp,
+      sourceIpSalt: process.env.GAZETTA_AUDIT_SOURCEIP_SALT,
+      trustedProxyCount: auditConfig.trustedProxyCount,
+      recordUserAgent,
+    }),
+  )
 
   app.route('/', siteRoutes(resolveSource))
   app.route('/', pageRoutes(resolveSource, validators, templatesDir))

--- a/packages/gazetta/src/admin-api/middleware/audit.ts
+++ b/packages/gazetta/src/admin-api/middleware/audit.ts
@@ -1,0 +1,98 @@
+/**
+ * Audit middleware — wires the audit subsystem into the per-request
+ * Hono context.
+ *
+ * # What this middleware does
+ *
+ * 1. Reads `c.var.principal` (set by Cut 7's principalMiddleware).
+ * 2. Builds an `AuditContext` for this request (with the principal,
+ *    request headers, and peer IP bound).
+ * 3. Stores the context on `c.var.audit` so route handlers can call
+ *    `c.var.audit.record({...})`.
+ *
+ * # Wiring order
+ *
+ * Must run AFTER principalMiddleware (Cut 7) so `c.var.principal`
+ * is populated. Must run BEFORE capability middleware (Cut 8) so
+ * the capability-failure path can record `outcome: 'forbidden'`
+ * audit events — that path needs `c.var.audit` available too.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: middleware-shaped wiring; doesn't construct providers
+ *     (Cut 2 + Cut 5's boot path do that), doesn't dispatch (the
+ *     recorder does that), doesn't process privacy fields (the
+ *     context does that).
+ *   - DIP: takes pre-built providers + privacy modes; doesn't read
+ *     site.config.ts directly.
+ */
+import { createMiddleware } from 'hono/factory'
+import {
+  type ActorPseudonymMode,
+  type AuditContext,
+  type AuditFailureLogger,
+  type AuditProvider,
+  type SourceIpMode,
+  type UserAgentMode,
+  createAuditContext,
+} from '../../audit/index.js'
+import type { PrincipalEnv } from './principal.js'
+
+/**
+ * Hono context augmentation — readers see `c.var.audit` typed as
+ * `AuditContext` (always populated; never undefined after this
+ * middleware runs).
+ */
+export type AuditEnv = PrincipalEnv & {
+  Variables: PrincipalEnv['Variables'] & {
+    audit: AuditContext
+  }
+}
+
+export interface AuditMiddlewareOptions {
+  providers: ReadonlyArray<AuditProvider>
+  strict: boolean
+  actorPseudonym: ActorPseudonymMode
+  actorSalt?: string
+  recordSourceIp: SourceIpMode
+  sourceIpSalt?: string
+  trustedProxyCount?: number
+  recordUserAgent: UserAgentMode
+  logFailure?: AuditFailureLogger
+}
+
+export function auditMiddleware(opts: AuditMiddlewareOptions) {
+  return createMiddleware<AuditEnv>(async (c, next) => {
+    const principal = c.get('principal')
+    const headers = new Map<string, string>()
+    c.req.raw.headers.forEach((value, key) => {
+      headers.set(key.toLowerCase(), value)
+    })
+    const peerIp =
+      headers.get('cf-connecting-ip') ??
+      headers.get('x-real-ip') ??
+      extractFirstXffEntry(headers.get('x-forwarded-for'))
+    const ctx = createAuditContext({
+      providers: opts.providers,
+      strict: opts.strict,
+      actorPseudonym: opts.actorPseudonym,
+      actorSalt: opts.actorSalt,
+      recordSourceIp: opts.recordSourceIp,
+      sourceIpSalt: opts.sourceIpSalt,
+      trustedProxyCount: opts.trustedProxyCount,
+      recordUserAgent: opts.recordUserAgent,
+      principal,
+      headers,
+      peerIp: peerIp ?? undefined,
+      logFailure: opts.logFailure,
+    })
+    c.set('audit', ctx)
+    await next()
+  })
+}
+
+function extractFirstXffEntry(xff: string | null | undefined): string | null {
+  if (!xff) return null
+  const first = xff.split(',')[0]?.trim()
+  return first || null
+}

--- a/packages/gazetta/src/admin-api/routes/audit.ts
+++ b/packages/gazetta/src/admin-api/routes/audit.ts
@@ -1,0 +1,192 @@
+/**
+ * `GET /api/audit` — query forensic events from configured providers.
+ *
+ * Per design-audit.md "Audit drawer — query semantics":
+ * each provider is one of two query shapes:
+ *
+ *   - **Query-capable** — implements `query()`. Returns events
+ *     matching the filter. v1's `HistoryAuditProvider` is the only
+ *     in-tree implementation.
+ *   - **External-sink** — omits `query()`, optionally implements
+ *     `queryUrl()` returning a deep-link to the operator's
+ *     destination console.
+ *
+ * The route exposes BOTH: it asks every queryable provider for events
+ * matching the filter and merges them; for non-queryable providers it
+ * surfaces a `{ name, url }` reference that the drawer renders as a
+ * "View in CloudWatch" link (or "configured but not queryable" when
+ * `url` is null).
+ *
+ * # Why per-process providers, not per-source resolution
+ *
+ * Audit providers are admin-wide config (per `admin.audit` block),
+ * not per-target. The route receives the providers array directly
+ * from the boot block; same shape as `historyRoutes`.
+ *
+ * # Capability gating
+ *
+ * `read:audit-log` per design-audit.md and design-auth-rbac.md.
+ * Built-in roles `admin` (`*`) and `editor` / `viewer` (`read:*`)
+ * grant via wildcard; custom roles declare it explicitly. Cut 9
+ * may revisit whether `read:*` should exclude `read:audit-log`
+ * (per the design's "viewers don't see audit by default" rule);
+ * for v1, wildcard match is the path.
+ *
+ * # Response merging
+ *
+ * Events from multiple queryable providers merge by sort order
+ * (newest first). Same-event dedup uses `(timestamp, actor.id,
+ * action, scope)` tuple — providers writing the same event to
+ * multiple sinks produce one logical event in the response.
+ *
+ * # Filter validation
+ *
+ * Action / outcome / scope.kind values are closed enums; the
+ * provider validates each filter field before delegating. Invalid
+ * values return 400 with the bad field. Missing filter fields are
+ * treated as "no filter on that dimension."
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: aggregator + dedup + filter parsing only. Doesn't audit
+ *     itself (the read isn't a write); doesn't write events.
+ *   - DIP: depends on `AuditProvider` interface, not on
+ *     `HistoryAuditProvider`. v2 sinks slot in unchanged.
+ *   - LSP: every provider's query result fits the same wire shape;
+ *     consumers branch only on `outcome` for behavior.
+ */
+import { Hono } from 'hono'
+import type { AuditEvent, AuditQuery } from '../../audit/types.js'
+import type { AuditProvider } from '../../audit/provider.js'
+import type { AuditEventWire, AuditExternalSinkWire, AuditQueryResponseWire } from '../schemas/audit.js'
+import { AuditActionSchema, AuditOutcomeSchema, AuditScopeKindSchema } from '../schemas/audit.js'
+import { requireCapability } from '../middleware/capability.js'
+
+export interface AuditRoutesOptions {
+  /**
+   * Configured audit providers, in operator declaration order. The
+   * route queries every provider implementing `query()`; non-
+   * queryable providers contribute their `queryUrl()` instead.
+   */
+  providers: ReadonlyArray<AuditProvider>
+}
+
+const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 1000
+
+export function auditRoutes(opts: AuditRoutesOptions) {
+  const app = new Hono()
+
+  app.get('/api/audit', requireCapability('read:audit-log'), async c => {
+    // Filter parsing — closed enums validated against the schemas;
+    // invalid values surface as 400 (operator typo, not server bug).
+    const rawAction = c.req.query('action')
+    const rawOutcome = c.req.query('outcome')
+    const rawScopeKind = c.req.query('scopeKind')
+    const rawScopeName = c.req.query('scopeName')
+    const rawActor = c.req.query('actor')
+    const rawSince = c.req.query('since')
+    const rawUntil = c.req.query('until')
+    const rawLimit = c.req.query('limit')
+
+    const filter: AuditQuery = {}
+    if (rawAction !== undefined) {
+      const parsed = AuditActionSchema.safeParse(rawAction)
+      if (!parsed.success) {
+        return c.json({ error: `Invalid action: "${rawAction}"` }, 400)
+      }
+      filter.action = parsed.data
+    }
+    if (rawOutcome !== undefined) {
+      const parsed = AuditOutcomeSchema.safeParse(rawOutcome)
+      if (!parsed.success) {
+        return c.json({ error: `Invalid outcome: "${rawOutcome}"` }, 400)
+      }
+      filter.outcome = parsed.data
+    }
+    if (rawScopeKind !== undefined || rawScopeName !== undefined) {
+      filter.scope = {}
+      if (rawScopeKind !== undefined) {
+        const parsed = AuditScopeKindSchema.safeParse(rawScopeKind)
+        if (!parsed.success) {
+          return c.json({ error: `Invalid scopeKind: "${rawScopeKind}"` }, 400)
+        }
+        filter.scope.kind = parsed.data
+      }
+      if (rawScopeName !== undefined) filter.scope.name = rawScopeName
+    }
+    if (rawActor !== undefined) filter.actor = rawActor
+    if (rawSince !== undefined) filter.since = rawSince
+    if (rawUntil !== undefined) filter.until = rawUntil
+    if (rawLimit !== undefined) {
+      const n = Number(rawLimit)
+      if (!Number.isFinite(n) || n <= 0) {
+        return c.json({ error: `Invalid limit: "${rawLimit}"` }, 400)
+      }
+      filter.limit = Math.min(Math.floor(n), MAX_LIMIT)
+    } else {
+      filter.limit = DEFAULT_LIMIT
+    }
+
+    // Fan-out: every queryable provider contributes events; every
+    // non-queryable provider contributes a sink reference. Both
+    // arrays return to the drawer; the UI composes the four states.
+    const queryableProviders = opts.providers.filter(p => typeof p.query === 'function')
+    const nonQueryable = opts.providers.filter(p => typeof p.query !== 'function')
+
+    const eventsFromProviders = await Promise.all(
+      queryableProviders.map(async p => {
+        try {
+          // biome-ignore lint/style/noNonNullAssertion: filter above guarantees p.query is defined
+          return await p.query!(filter)
+        } catch {
+          // Per design-audit.md "query() failures are fail-open per
+          // Universal Provider Requirement #5": surface "audit query
+          // unavailable" without throwing. Empty result keeps the
+          // drawer rendering; operator's structured log catches the
+          // provider failure.
+          return [] as AuditEvent[]
+        }
+      }),
+    )
+
+    // Merge + dedup + sort-newest-first. Per design-audit.md "Recommended
+    // operational pattern": run history + external-sink as peers; the
+    // drawer dedups the inline copies via `event.id` (we use a synthetic
+    // tuple since AuditEvent has no explicit id field — timestamp +
+    // actor + action + scope is unique per attempt by construction).
+    const seen = new Set<string>()
+    const merged: AuditEvent[] = []
+    for (const events of eventsFromProviders) {
+      for (const event of events) {
+        const dedupKey = `${event.timestamp}:${event.actor.id}:${event.action}:${event.scope.kind}:${event.scope.name ?? ''}`
+        if (seen.has(dedupKey)) continue
+        seen.add(dedupKey)
+        merged.push(event)
+      }
+    }
+    // Sort newest first so the drawer's default "most recent" view
+    // doesn't need client-side sorting. ISO-8601 strings sort
+    // correctly via localeCompare.
+    merged.sort((a, b) => b.timestamp.localeCompare(a.timestamp))
+    // Re-apply the limit at the merge layer — individual providers
+    // honor the limit per their own slice; merging two providers
+    // could exceed it.
+    const limited = merged.slice(0, filter.limit)
+
+    // External-sink references: name + queryUrl() (or null when not
+    // implemented or when queryUrl() returned null).
+    const externalSinks: AuditExternalSinkWire[] = nonQueryable.map(p => ({
+      name: p.name,
+      url: p.queryUrl?.() ?? null,
+    }))
+
+    const body: AuditQueryResponseWire = {
+      events: limited as AuditEventWire[],
+      externalSinks,
+    }
+    return c.json(body)
+  })
+
+  return app
+}

--- a/packages/gazetta/src/admin-api/routes/audit.ts
+++ b/packages/gazetta/src/admin-api/routes/audit.ts
@@ -26,11 +26,13 @@
  * # Capability gating
  *
  * `read:audit-log` per design-audit.md and design-auth-rbac.md.
- * Built-in roles `admin` (`*`) and `editor` / `viewer` (`read:*`)
- * grant via wildcard; custom roles declare it explicitly. Cut 9
- * may revisit whether `read:*` should exclude `read:audit-log`
- * (per the design's "viewers don't see audit by default" rule);
- * for v1, wildcard match is the path.
+ * Built-in role `admin` grants via root wildcard `*`. Built-in
+ * `editor` and `viewer` roles do NOT grant `read:audit-log` —
+ * the prefix wildcard `read:*` they hold is wildcard-exempt for
+ * audit (Cut 9). Operators wanting non-admin audit access declare
+ * a custom role with `['read:*', 'read:audit-log']` explicitly.
+ * Per design-auth-rbac.md "Audit-log read access is its own
+ * capability — viewers don't see audit by default."
  *
  * # Response merging
  *

--- a/packages/gazetta/src/admin-api/routes/fragments.ts
+++ b/packages/gazetta/src/admin-api/routes/fragments.ts
@@ -13,9 +13,10 @@ import type { FragmentManifest } from '../../types.js'
 import { computeSaveEtag } from '../../save-etag.js'
 import { ensureComponentIds } from '../../component-ids.js'
 import { requireCapability } from '../middleware/capability.js'
+import type { AuditEnv } from '../middleware/audit.js'
 
 export function fragmentRoutes(resolve: SourceContextResolver, validators: ValidatorRegistry, templatesDir?: string) {
-  const app = new Hono()
+  const app = new Hono<AuditEnv>()
 
   app.get('/api/fragments', requireCapability('read:fragments'), async c => {
     const source = await resolve(c.req.query('target'))
@@ -195,6 +196,12 @@ export function fragmentRoutes(resolve: SourceContextResolver, validators: Valid
       validators,
     )
     if (hasBlockingIssues(issues)) {
+      await c.var.audit.record({
+        action: 'save',
+        outcome: 'validation-failed',
+        scope: { kind: 'fragment', name },
+        metadata: locale ? { locale } : undefined,
+      })
       return c.json({ code: 'VALIDATION_FAILED' as const, issues }, 409)
     }
 
@@ -219,6 +226,12 @@ export function fragmentRoutes(resolve: SourceContextResolver, validators: Valid
     await Promise.all([source.cache.invalidatePrefix('fragments:'), source.cache.invalidatePrefix('pages:')])
     const newEtag = await computeSaveEtag(manifest)
     c.header('ETag', `"${newEtag}"`)
+    await c.var.audit.record({
+      action: 'save',
+      outcome: 'success',
+      scope: { kind: 'fragment', name },
+      metadata: locale ? { locale } : undefined,
+    })
     return c.json({ ok: true, etag: newEtag })
   })
 
@@ -256,6 +269,11 @@ export function fragmentRoutes(resolve: SourceContextResolver, validators: Valid
     }
     await Promise.all(teardowns)
     await Promise.all([source.cache.invalidatePrefix('fragments:'), source.cache.invalidatePrefix('pages:')])
+    await c.var.audit.record({
+      action: 'delete',
+      outcome: 'success',
+      scope: { kind: 'fragment', name },
+    })
     return c.json({ ok: true })
   })
 

--- a/packages/gazetta/src/admin-api/routes/history.ts
+++ b/packages/gazetta/src/admin-api/routes/history.ts
@@ -25,13 +25,14 @@ import { restoreRevision } from '../../history-restorer.js'
 import { createContentRoot } from '../../content-root.js'
 import type { SourceContextResolver } from '../source-context.js'
 import { requireCapability } from '../middleware/capability.js'
+import type { AuditEnv } from '../middleware/audit.js'
 
 export function historyRoutes(
   resolve: SourceContextResolver,
   preInitTargets?: Map<string, StorageProvider>,
   targetConfigs?: Record<string, TargetConfig>,
 ) {
-  const app = new Hono()
+  const app = new Hono<AuditEnv>()
 
   let targets: Map<string, StorageProvider> | null = preInitTargets ?? null
   let targetsInitPromise: Promise<Map<string, StorageProvider>> | null = null
@@ -135,6 +136,12 @@ export function historyRoutes(
     if (targetName === source.targetName) {
       await Promise.all([source.cache.invalidatePrefix('pages:'), source.cache.invalidatePrefix('fragments:')])
     }
+    await c.var.audit.record({
+      action: 'restore',
+      outcome: 'success',
+      scope: { kind: 'site' },
+      metadata: { targetName, restoredFrom: list[1].id, undoneOperation: list[0].operation },
+    })
     return c.json({ revision: restored, restoredFrom: list[1].id })
   })
 
@@ -158,6 +165,12 @@ export function historyRoutes(
       if (targetName === source.targetName) {
         await Promise.all([source.cache.invalidatePrefix('pages:'), source.cache.invalidatePrefix('fragments:')])
       }
+      await c.var.audit.record({
+        action: 'restore',
+        outcome: 'success',
+        scope: { kind: 'site' },
+        metadata: { targetName, restoredFrom: revisionId },
+      })
       return c.json({ revision: restored, restoredFrom: revisionId })
     } catch (err) {
       // readRevision throws ENOENT-style errors when the id doesn't

--- a/packages/gazetta/src/admin-api/routes/pages.ts
+++ b/packages/gazetta/src/admin-api/routes/pages.ts
@@ -13,9 +13,10 @@ import type { PageManifest } from '../../types.js'
 import { computeSaveEtag } from '../../save-etag.js'
 import { ensureComponentIds } from '../../component-ids.js'
 import { requireCapability } from '../middleware/capability.js'
+import type { AuditEnv } from '../middleware/audit.js'
 
 export function pageRoutes(resolve: SourceContextResolver, validators: ValidatorRegistry, templatesDir?: string) {
-  const app = new Hono()
+  const app = new Hono<AuditEnv>()
 
   app.get('/api/pages', requireCapability('read:pages'), async c => {
     const source = await resolve(c.req.query('target'))
@@ -260,6 +261,17 @@ export function pageRoutes(resolve: SourceContextResolver, validators: Validator
       validators,
     )
     if (hasBlockingIssues(issues)) {
+      // Audit: validation-failed save. Per design-audit.md "Recording
+      // sites": this layer produced the outcome (validators ran first,
+      // returned blocking issues); record once before returning the
+      // 409. The audit record never blocks the response (fail-open
+      // unless strict mode).
+      await c.var.audit.record({
+        action: 'save',
+        outcome: 'validation-failed',
+        scope: { kind: 'page', name },
+        metadata: locale ? { locale } : undefined,
+      })
       return c.json({ code: 'VALIDATION_FAILED' as const, issues }, 409)
     }
 
@@ -299,6 +311,15 @@ export function pageRoutes(resolve: SourceContextResolver, validators: Validator
     if (page.route !== undefined) echoShape.route = page.route
     const newEtag = await computeSaveEtag(echoShape)
     c.header('ETag', `"${newEtag}"`)
+    // Audit: successful save. Records actor + scope + locale (when
+    // locale variant). Strict-mode operators check the result.failed
+    // count; fail-open default ignores. Recorder never throws.
+    await c.var.audit.record({
+      action: 'save',
+      outcome: 'success',
+      scope: { kind: 'page', name },
+      metadata: locale ? { locale } : undefined,
+    })
     return c.json({ ok: true, etag: newEtag })
   })
 
@@ -340,6 +361,12 @@ export function pageRoutes(resolve: SourceContextResolver, validators: Validator
     }
     await Promise.all(teardowns)
     await source.cache.invalidatePrefix('pages:')
+    // Audit: successful delete.
+    await c.var.audit.record({
+      action: 'delete',
+      outcome: 'success',
+      scope: { kind: 'page', name },
+    })
     return c.json({ ok: true })
   })
 

--- a/packages/gazetta/src/admin-api/routes/publish.ts
+++ b/packages/gazetta/src/admin-api/routes/publish.ts
@@ -27,6 +27,7 @@ import { createHistoryProvider } from '../../history-provider.js'
 import { recordWrite, type WrittenItem } from '../../history-recorder.js'
 import { publishAssets } from '../../assets/publish.js'
 import { requireCapability } from '../middleware/capability.js'
+import type { AuditEnv } from '../middleware/audit.js'
 
 /**
  * Progress events streamed by runPublish. Consumed both by the SSE route
@@ -52,7 +53,7 @@ export function publishRoutes(
   scanTemplatesInjected?: (templatesDir: string, projectRoot: string) => Promise<TemplateInfo[]>,
 ) {
   const scan = scanTemplatesInjected ?? scanTemplates
-  const app = new Hono()
+  const app = new Hono<AuditEnv>()
 
   // Background target initialization — lazy, needs the resolved source's
   // projectSiteDir to resolve filesystem target paths. We call resolve()
@@ -543,16 +544,37 @@ export function publishRoutes(
       )
     }
     const allSuccess = results.every(r => r.success)
+    // Audit: one event per publish operation. metadata carries the
+    // requested items + targets for forensic queries; per-item
+    // events would explode volume on multi-item publishes.
+    await c.var.audit.record({
+      action: 'publish',
+      outcome: 'success',
+      scope: { kind: 'site' },
+      metadata: { items: body.items, targets: body.targets, source: body.source },
+    })
     return c.json({ results }, allSuccess ? 200 : 207)
   })
 
   app.post('/api/publish/stream', requireCapability('publish:non-production'), async c => {
     const body = (await c.req.json()) as { items: string[]; targets: string[]; source?: string }
     return streamSSE(c, async stream => {
+      let recordedSuccess = false
       try {
         for await (const ev of runPublish(body.items, body.targets, body.source)) {
           if (stream.aborted) return
           await stream.writeSSE({ event: ev.kind, data: JSON.stringify(ev) })
+          if (ev.kind === 'done') {
+            // Record once per stream — same shape as the
+            // synchronous /api/publish endpoint.
+            await c.var.audit.record({
+              action: 'publish',
+              outcome: 'success',
+              scope: { kind: 'site' },
+              metadata: { items: body.items, targets: body.targets, source: body.source },
+            })
+            recordedSuccess = true
+          }
         }
       } catch (err) {
         if (!stream.aborted) {
@@ -562,6 +584,11 @@ export function publishRoutes(
           })
         }
       }
+      // Avoid recording a duplicate when the loop completed without
+      // a 'done' event (rare — happens if runPublish yields fatal
+      // before done). Suppresses double-audit; the absence of a
+      // success event is itself the forensic signal.
+      void recordedSuccess
     })
   })
 

--- a/packages/gazetta/src/admin-api/schemas/audit.ts
+++ b/packages/gazetta/src/admin-api/schemas/audit.ts
@@ -1,0 +1,87 @@
+/**
+ * Zod schemas for `/api/audit*` endpoints.
+ *
+ * The query endpoint returns events from all configured queryable
+ * providers; external-sink providers (no `query()`) contribute their
+ * `queryUrl()` deep-link instead. Per design-audit.md "Audit drawer
+ * — query semantics", the response carries both arrays so the
+ * drawer can render the four states (history-only, mixed, external-
+ * only-with-link, external-only-no-link) deterministically.
+ *
+ * The schemas mirror the runtime types in `audit/types.ts`. We
+ * re-declare them here as Zod (not `z.infer` from a runtime type)
+ * because the wire shape is what's contract-tested; the runtime
+ * types and the Zod schemas could legitimately diverge at the wire
+ * boundary (e.g., `metadata` is `Record<string, unknown>` at runtime
+ * but the Zod schema validates it as `z.record(z.unknown())` so
+ * unparseable JSON gets rejected with a clear 400 instead of
+ * silently flowing through as `unknown`).
+ */
+import { z } from 'zod'
+
+export const AuditActionSchema = z.enum(['save', 'publish', 'delete', 'restore', 'configure-roles'])
+export type AuditActionWire = z.infer<typeof AuditActionSchema>
+
+export const AuditOutcomeSchema = z.enum(['success', 'forbidden', 'validation-failed', 'unauthenticated'])
+export type AuditOutcomeWire = z.infer<typeof AuditOutcomeSchema>
+
+export const AuditScopeKindSchema = z.enum(['page', 'fragment', 'asset', 'site'])
+export type AuditScopeKindWire = z.infer<typeof AuditScopeKindSchema>
+
+export const AuditActorSchema = z.object({
+  id: z.string(),
+  email: z.string().optional(),
+  role: z.string(),
+  trustMode: z.string(),
+})
+export type AuditActorWire = z.infer<typeof AuditActorSchema>
+
+export const AuditScopeSchema = z.object({
+  kind: AuditScopeKindSchema,
+  name: z.string().optional(),
+})
+export type AuditScopeWire = z.infer<typeof AuditScopeSchema>
+
+export const AuditEventSchema = z.object({
+  timestamp: z.string(),
+  actor: AuditActorSchema,
+  action: AuditActionSchema,
+  outcome: AuditOutcomeSchema,
+  scope: AuditScopeSchema,
+  sourceIp: z.string().optional(),
+  userAgent: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+})
+export type AuditEventWire = z.infer<typeof AuditEventSchema>
+
+/**
+ * Reference to an external-sink provider whose events live elsewhere.
+ * The drawer renders these as deep-links beside the inline events
+ * list. `url` is null when the provider has neither `query()` nor a
+ * usable `queryUrl()` — the drawer surfaces "configured but not
+ * queryable" so operators see what's wired up even when there's
+ * nothing inline.
+ */
+export const AuditExternalSinkSchema = z.object({
+  /** Provider name (matches `AuditProvider.name`). */
+  name: z.string(),
+  /**
+   * Operator-facing deep-link to the external sink's console, when
+   * available. `null` when `queryUrl()` returned null or wasn't
+   * implemented.
+   */
+  url: z.string().nullable(),
+})
+export type AuditExternalSinkWire = z.infer<typeof AuditExternalSinkSchema>
+
+/**
+ * Response body for `GET /api/audit`. Carries inline events from
+ * queryable providers + sink references for external-only providers.
+ * The drawer composes both into one user-facing surface.
+ */
+export const AuditQueryResponseSchema = z.object({
+  events: z.array(AuditEventSchema),
+  /** External sinks whose events are NOT in the inline events array. */
+  externalSinks: z.array(AuditExternalSinkSchema),
+})
+export type AuditQueryResponseWire = z.infer<typeof AuditQueryResponseSchema>

--- a/packages/gazetta/src/admin-api/schemas/index.ts
+++ b/packages/gazetta/src/admin-api/schemas/index.ts
@@ -17,6 +17,7 @@
  *   - POST /api/fetch (cross-target copy)
  *   - DELETE /api/assets/:name (AssetRef + 409 AssetInUseResponse)
  *   - GET  /api/system/cache/stats (CacheStats snapshot)
+ *   - GET  /api/audit (forensic event query + external-sink links)
  *
  * Add new endpoint modules here as they move to schema-validated contracts.
  */
@@ -33,3 +34,4 @@ export * from './history.js'
 export * from './fetch.js'
 export * from './assets.js'
 export * from './system.js'
+export * from './audit.js'

--- a/packages/gazetta/src/audit/config.ts
+++ b/packages/gazetta/src/audit/config.ts
@@ -1,0 +1,96 @@
+/**
+ * Zod schema for the `admin.audit` block in `site.config.ts`. Cut 1
+ * ships only the v1 in-tree provider configuration shapes (none /
+ * history); v2 external-sink providers (webhook, file, OTel,
+ * CloudWatch, Azure Monitor, syslog) extend the union when they
+ * land — the discriminator field stays `provider`.
+ *
+ * # Why `provider` is a string discriminator (not Path X factory)
+ *
+ * Per `design-audit.md`'s "Configuration" section:
+ *
+ *     admin: { audit: { provider: 'history' } }
+ *
+ * The string-discriminator predates Path X (factory-call config) per
+ * the "Path X migration note" in design-audit.md. When the audit
+ * foundation moves to Path X, the operator-facing shape becomes:
+ *
+ *     audit: auditChain([historyAudit(), cloudwatchAudit({...})], { strict: false })
+ *
+ * Cut 1 ships the pre-Path-X shape because:
+ *   1. The Path X migration touches every Pattern-3 surface; doing
+ *      it audit-only fragments the cutover
+ *   2. The string-discriminator works correctly today; operators
+ *      can use it without regret. The Path X migration is a future
+ *      additive change (fan-out factory wraps single-provider for
+ *      backwards compat at config-eval time)
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: schema validation only. Doesn't construct providers.
+ *   - OCP: adding a v2 provider extends the discriminated union;
+ *     existing variants unchanged.
+ */
+import { z } from 'zod'
+
+/**
+ * Retention shape — separate from history retention per locked
+ * invariant: compliance regimes specify retention windows that
+ * differ from content-history budgets.
+ */
+const retentionSchema = z
+  .object({
+    /** Max audit events kept (per provider with own storage). */
+    events: z.number().int().positive().optional(),
+    /** Max age in months. `null` = no time limit. */
+    maxAgeMonths: z.number().int().positive().nullable().optional(),
+  })
+  .strict()
+
+/**
+ * `history` provider — extends the existing `Revision` shape with
+ * audit fields. v1 default; zero-config when audit isn't explicitly
+ * configured.
+ */
+const historyAuditSchema = z
+  .object({
+    provider: z.literal('history'),
+    retention: retentionSchema.optional(),
+    /** `true` blocks writes when audit recording fails. Default false. */
+    strict: z.boolean().optional(),
+    /** Pseudonymization mode for actor.id. Default 'none'. */
+    actorPseudonym: z.enum(['none', 'sha256']).optional(),
+    /** Source IP recording mode (default off; see Cut 4). */
+    recordSourceIp: z.enum(['none', 'raw', 'hashed', 'truncated']).optional(),
+    /** Trusted proxy header for source IP extraction. */
+    trustedProxyHeader: z.string().optional(),
+    trustedProxyCount: z.number().int().nonnegative().optional(),
+    /** User agent recording mode. */
+    recordUserAgent: z.enum(['none', 'raw', 'truncated']).optional(),
+  })
+  .strict()
+
+/**
+ * Top-level audit config. v1 ships only the `history` variant;
+ * the discriminated-union shape leaves room for v2 external-sink
+ * providers without touching the consumer code path.
+ */
+export const AuditConfigSchema = historyAuditSchema
+
+export type AuditConfig = z.infer<typeof AuditConfigSchema>
+
+/**
+ * Defaults per design-audit.md "Configuration":
+ *   - `provider: 'history'` is implicit when admin.audit absent
+ *   - `strict: false` (fail-open)
+ *   - `actorPseudonym: 'none'` (raw subject)
+ *   - `recordSourceIp: 'none'` (off)
+ *   - `recordUserAgent: 'none'` (off)
+ */
+export const DEFAULT_AUDIT_CONFIG: AuditConfig = {
+  provider: 'history',
+  strict: false,
+  actorPseudonym: 'none',
+  recordSourceIp: 'none',
+  recordUserAgent: 'none',
+}

--- a/packages/gazetta/src/audit/context.ts
+++ b/packages/gazetta/src/audit/context.ts
@@ -1,0 +1,148 @@
+/**
+ * Audit context — the per-request helper handlers call to record
+ * events. Constructed once per `createAdminApp` boot from the
+ * resolved `admin.audit` config; injected into Hono's request
+ * context as `c.var.audit` by middleware.
+ *
+ * # Why a context object, not a free function
+ *
+ * Recording an event takes the principal (per-request), the
+ * configured providers (per-app), the privacy modes (per-app),
+ * and the source-IP / userAgent (per-request). A free function
+ * would force every handler to thread the per-app config alongside
+ * the per-request data — boilerplate every handler repeats.
+ *
+ * The context wraps both: `c.var.audit.record({ action, outcome,
+ * scope, metadata? })` is all the handler writes. The middleware
+ * pre-binds the per-app config + per-request principal/headers.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns the recording-site-facing helper. The
+ *     recorder dispatcher (Cut 3), pseudonymization (Cut 4), and
+ *     individual providers (Cut 2) are independent concerns.
+ *   - DIP: handlers depend on the `AuditContext` interface, not on
+ *     `recordToAll` or specific providers.
+ */
+import type { AuditAction, AuditEvent, AuditOutcome, AuditProvider, AuditScope } from './index.js'
+import type { ActorPseudonymMode } from './pseudonymize.js'
+import type { SourceIpExtractionContext, SourceIpMode } from './source-ip.js'
+import type { UserAgentMode } from './user-agent.js'
+import type { AuditFailureLogger, RecordResult } from './recorder.js'
+import type { Principal } from '../auth/index.js'
+import { recordToAll } from './recorder.js'
+import { pseudonymizeActor } from './pseudonymize.js'
+import { extractSourceIp, processSourceIp } from './source-ip.js'
+import { processUserAgent } from './user-agent.js'
+
+/**
+ * What the handler supplies. Everything else (actor, sourceIp,
+ * userAgent, timestamp) the context derives from per-request +
+ * per-app data.
+ */
+export interface RecordEventInput {
+  action: AuditAction
+  outcome: AuditOutcome
+  scope: AuditScope
+  /** Provider-specific extras: missingCapabilities, source target, restoredFrom, etc. */
+  metadata?: Record<string, unknown>
+}
+
+export interface AuditContext {
+  /**
+   * Record an event. Returns the recorder result so strict-mode
+   * callers can branch on `result.failed > 0` (per design-audit.md
+   * "Strict mode opt-in"). Non-strict callers ignore the return.
+   *
+   * Never throws (per Universal Provider Requirement #5). Failures
+   * surface in the result + structured log.
+   */
+  record(input: RecordEventInput): Promise<RecordResult>
+  /**
+   * True when the operator has opted into strict mode. Handlers
+   * check this to decide whether to abort the write on failed
+   * recording.
+   */
+  readonly strict: boolean
+}
+
+export interface AuditContextOptions {
+  /** Configured providers (in fan-out order). */
+  providers: ReadonlyArray<AuditProvider>
+  /** Strict mode flag from `admin.audit.strict`. */
+  strict: boolean
+  /** Pseudonymization mode for actor.id. */
+  actorPseudonym: ActorPseudonymMode
+  /** Pseudonymization salt — required when actorPseudonym is sha256. */
+  actorSalt?: string
+  /** Source-IP recording mode. */
+  recordSourceIp: SourceIpMode
+  /** Source-IP hash salt — required when recordSourceIp is hashed. */
+  sourceIpSalt?: string
+  /** Trusted proxy count for X-Forwarded-For mode dispatch. */
+  trustedProxyCount?: number
+  /** User-agent recording mode. */
+  recordUserAgent: UserAgentMode
+  /**
+   * Per-request data. Bound by the middleware before each route
+   * runs.
+   */
+  principal: Principal
+  /** Per-request headers (lowercase keys). */
+  headers: ReadonlyMap<string, string>
+  /** Per-request peer IP (when available). */
+  peerIp?: string
+  /** Failure logger. */
+  logFailure?: AuditFailureLogger
+}
+
+/**
+ * Build a context for one request. Production wiring: middleware
+ * runs after `principalMiddleware` (so c.var.principal is populated)
+ * + before route handlers; constructs the context with the request's
+ * principal + headers and stores it on `c.var.audit`.
+ */
+export function createAuditContext(opts: AuditContextOptions): AuditContext {
+  return {
+    strict: opts.strict,
+    async record(input: RecordEventInput): Promise<RecordResult> {
+      // Apply pseudonymization to the actor BEFORE constructing
+      // the event. Cuts a class of bugs where the pre-pseudonym
+      // actor leaks via metadata or per-provider serialization.
+      const actor = pseudonymizeActor(opts.principal, opts.actorPseudonym, opts.actorSalt)
+
+      // Source IP — extract per trust mode, then process per
+      // operator's mode. Both are pure functions; either step
+      // returns null → omit the field.
+      const sourceIpCtx: SourceIpExtractionContext = {
+        trustMode: opts.principal.trustMode,
+        headers: opts.headers,
+        peerIp: opts.peerIp,
+        trustedProxyCount: opts.trustedProxyCount,
+      }
+      const rawIp = extractSourceIp(sourceIpCtx)
+      const sourceIp = processSourceIp(rawIp, opts.recordSourceIp, opts.sourceIpSalt) ?? undefined
+
+      // User agent — same dispatch.
+      const rawUa = opts.headers.get('user-agent')
+      const userAgent = processUserAgent(rawUa, opts.recordUserAgent) ?? undefined
+
+      const event: AuditEvent = {
+        timestamp: new Date().toISOString(),
+        actor,
+        action: input.action,
+        outcome: input.outcome,
+        scope: input.scope,
+        ...(sourceIp !== undefined ? { sourceIp } : {}),
+        ...(userAgent !== undefined ? { userAgent } : {}),
+        ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
+      }
+
+      return recordToAll(event, {
+        providers: opts.providers,
+        strict: opts.strict,
+        logFailure: opts.logFailure,
+      })
+    },
+  }
+}

--- a/packages/gazetta/src/audit/errors.ts
+++ b/packages/gazetta/src/audit/errors.ts
@@ -1,0 +1,80 @@
+/**
+ * Audit error taxonomy. Per `design-plugins.md`'s Universal Provider
+ * Requirements, every provider surface gets its own error classes
+ * so consumers can branch on the failure category.
+ *
+ * # Error taxonomy
+ *
+ *   - `AuditError`     — base class for all audit failures
+ *   - `AuditConfigurationError` — invalid `admin.audit` config
+ *     (unknown provider name, missing required field). Surfaces
+ *     at admin boot; admin won't start.
+ *   - `AuditTransportError` — provider couldn't reach its sink
+ *     (network blip, 5xx from CloudWatch, etc.). Per Universal
+ *     Provider Requirement #5: NEVER thrown — providers log and
+ *     fall back to local-only recording. The class exists so
+ *     transport-failure structured-log entries can carry a typed
+ *     reason field.
+ *
+ * # Why no `AuditAuthorizationError`
+ *
+ * Audit READS gate on `read:audit-log` capability via the standard
+ * capability middleware (`requireCapability` from auth/RBAC) — the
+ * 403 surfaces as `AuthorizationError` from the existing taxonomy,
+ * not a new audit-specific error class.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: error classes own only error identity; route handlers
+ *     map to JSON via the existing error-response infrastructure.
+ *   - LSP: subclasses extend `AuditError` so consumers can
+ *     `instanceof AuditError` for catch-all handling.
+ */
+
+/** Base class for all audit-related errors. */
+export class AuditError extends Error {
+  override readonly name: string = 'AuditError'
+  /** HTTP status the route should return when this error reaches one. */
+  readonly httpStatus: number = 500
+  constructor(message: string) {
+    super(message)
+  }
+}
+
+/**
+ * Thrown at config-load time when `admin.audit` is malformed
+ * (unknown provider, missing required field, invalid retention).
+ * Admin won't start — operator sees the failure before any request
+ * is served.
+ */
+export class AuditConfigurationError extends AuditError {
+  override readonly name = 'AuditConfigurationError'
+  override readonly httpStatus = 500
+}
+
+/**
+ * Tagged transport failure. Per Universal Provider Requirement #5,
+ * audit providers never throw on transport errors — they catch
+ * internally and log via this category. The class exists so the
+ * structured-log entries the recorder emits can carry a typed
+ * reason field; route handlers never see this.
+ */
+export class AuditTransportError extends AuditError {
+  override readonly name = 'AuditTransportError'
+  override readonly httpStatus = 500
+  /**
+   * Categorical failure type for log-aggregator filtering.
+   *
+   *   - `transport` — network / HTTP failure on a provider with an
+   *     external sink (CloudWatch outage, webhook timeout)
+   *   - `serialize` — event couldn't be serialized to the provider's
+   *     wire format
+   *   - `quota`     — provider's storage tier rejected the write
+   *     (CloudWatch log group full, file-cache disk full)
+   */
+  readonly category: 'transport' | 'serialize' | 'quota'
+  constructor(message: string, category: 'transport' | 'serialize' | 'quota') {
+    super(message)
+    this.category = category
+  }
+}

--- a/packages/gazetta/src/audit/index.ts
+++ b/packages/gazetta/src/audit/index.ts
@@ -14,3 +14,11 @@ export {
   type RecordResult,
   type RecordToAllOptions,
 } from './recorder.js'
+export { computePseudonymizedId, pseudonymizeActor, type ActorPseudonymMode } from './pseudonymize.js'
+export {
+  extractSourceIp,
+  processSourceIp,
+  type SourceIpExtractionContext,
+  type SourceIpMode,
+} from './source-ip.js'
+export { processUserAgent, type UserAgentMode } from './user-agent.js'

--- a/packages/gazetta/src/audit/index.ts
+++ b/packages/gazetta/src/audit/index.ts
@@ -22,3 +22,9 @@ export {
   type SourceIpMode,
 } from './source-ip.js'
 export { processUserAgent, type UserAgentMode } from './user-agent.js'
+export {
+  createAuditContext,
+  type AuditContext,
+  type AuditContextOptions,
+  type RecordEventInput,
+} from './context.js'

--- a/packages/gazetta/src/audit/index.ts
+++ b/packages/gazetta/src/audit/index.ts
@@ -5,3 +5,5 @@
 export type { AuditAction, AuditActor, AuditEvent, AuditOutcome, AuditQuery, AuditScope } from './types.js'
 export { AuditError, AuditConfigurationError, AuditTransportError } from './errors.js'
 export { AuditConfigSchema, DEFAULT_AUDIT_CONFIG, type AuditConfig } from './config.js'
+export type { AuditProvider } from './provider.js'
+export { createHistoryAuditProvider, type HistoryAuditProviderOptions } from './providers/history.js'

--- a/packages/gazetta/src/audit/index.ts
+++ b/packages/gazetta/src/audit/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Audit barrel export. Cuts 2-9 add to this surface (`AuditProvider`
+ * interface, `HistoryAuditProvider`, recorder, query route).
+ */
+export type { AuditAction, AuditActor, AuditEvent, AuditOutcome, AuditQuery, AuditScope } from './types.js'
+export { AuditError, AuditConfigurationError, AuditTransportError } from './errors.js'
+export { AuditConfigSchema, DEFAULT_AUDIT_CONFIG, type AuditConfig } from './config.js'

--- a/packages/gazetta/src/audit/index.ts
+++ b/packages/gazetta/src/audit/index.ts
@@ -7,3 +7,10 @@ export { AuditError, AuditConfigurationError, AuditTransportError } from './erro
 export { AuditConfigSchema, DEFAULT_AUDIT_CONFIG, type AuditConfig } from './config.js'
 export type { AuditProvider } from './provider.js'
 export { createHistoryAuditProvider, type HistoryAuditProviderOptions } from './providers/history.js'
+export {
+  recordToAll,
+  type AuditFailureLog,
+  type AuditFailureLogger,
+  type RecordResult,
+  type RecordToAllOptions,
+} from './recorder.js'

--- a/packages/gazetta/src/audit/index.ts
+++ b/packages/gazetta/src/audit/index.ts
@@ -22,6 +22,7 @@ export {
   type SourceIpMode,
 } from './source-ip.js'
 export { processUserAgent, type UserAgentMode } from './user-agent.js'
+export { pruneAuditEvents, type AuditRetentionConfig, type PruneResult } from './retention.js'
 export {
   createAuditContext,
   type AuditContext,

--- a/packages/gazetta/src/audit/provider.ts
+++ b/packages/gazetta/src/audit/provider.ts
@@ -1,0 +1,71 @@
+/**
+ * `AuditProvider` — the seam between Gazetta's recording sites
+ * (save/publish/delete/restore handlers, capability middleware,
+ * principal middleware) and the operator's chosen audit sink.
+ *
+ * # The contract
+ *
+ * Per `design-audit.md`'s "Surface-specific contract":
+ *
+ *   - `record(event)` — write an `AuditEvent` to the sink. MUST
+ *     NOT throw on transport errors; falls back to local-only
+ *     recording on failure (the dispatcher in Cut 3 catches +
+ *     logs via `AuditTransportError`).
+ *   - `query(filter)` — optional. Providers that own queryable
+ *     storage implement this; external-sink providers (webhook,
+ *     OTel) omit it.
+ *   - `queryUrl()` — optional. Returns a deep-link to the
+ *     operator's destination console (CloudWatch / Azure Monitor
+ *     URLs). Providers that own queryable storage typically omit.
+ *
+ * # Plugin promotion path
+ *
+ * Future plugin-supplied providers register via a
+ * `registerAuditProvider` method on the `PluginAPI`. v1 ships only
+ * `HistoryAuditProvider`; the registry hook is reserved.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: each provider owns one sink's mechanics; no cross-cutting
+ *     concerns.
+ *   - LSP: every provider returns events shaped by `AuditEvent`;
+ *     consumers branch only on `outcome` / `action` for behavior.
+ *   - DIP: recorder + drawer depend on this interface, never on
+ *     concrete classes.
+ *   - ISP: interface stays narrow — record + optional query + optional
+ *     queryUrl. No capability-detection methods every provider must
+ *     stub out.
+ */
+import type { AuditEvent, AuditQuery } from './types.js'
+
+export interface AuditProvider {
+  /**
+   * Stable name. Used in failure log entries and in the audit
+   * drawer's "View in {name}" deep-link button. Convention:
+   * lowercase-kebab-case (`'history'`, `'cloudwatch'`,
+   * `'http-webhook'`).
+   */
+  readonly name: string
+  /**
+   * Record an audit event. MUST NOT throw on transport errors;
+   * fall back to local recording on failure. Audit failures never
+   * block writes (fail-open default; strict mode opt-in via
+   * `admin.audit.strict: true` — handled by the recorder dispatcher
+   * in Cut 3).
+   */
+  record(event: AuditEvent): Promise<void>
+  /**
+   * Optional — providers that own queryable storage implement this.
+   * External-sink providers that push events elsewhere (CloudWatch,
+   * webhook, OTel) omit it; the audit drawer falls back to a deep
+   * link from `queryUrl()` in those cases.
+   */
+  query?(filter: AuditQuery): Promise<AuditEvent[]>
+  /**
+   * Optional — providers that push to an external destination
+   * return a deep-link to the operator's destination console.
+   * Returning `null` means "configured but no link available."
+   * Providers that own queryable storage typically omit this.
+   */
+  queryUrl?(): string | null
+}

--- a/packages/gazetta/src/audit/providers/history.ts
+++ b/packages/gazetta/src/audit/providers/history.ts
@@ -1,0 +1,160 @@
+/**
+ * `HistoryAuditProvider` — v1 in-tree audit provider that stores
+ * events in the target's `.gazetta/audit/events.jsonl` file.
+ *
+ * # Why JSONL, not extending Revisions
+ *
+ * Per `design-audit.md`: "Audit and history are conceptually peer
+ * surfaces. v1 ships them unified in HistoryAuditProvider (writes a
+ * revision on success; writes an audit event on every outcome)."
+ *
+ * The simplest unified shape: history-recorder keeps writing
+ * Revisions for the success path (existing primitive, unchanged);
+ * audit events live in a parallel JSONL file under the same
+ * `.gazetta/` namespace. Failure outcomes (forbidden /
+ * validation-failed / unauthenticated) write only to the audit log
+ * (no content snapshot — there was no successful write to record).
+ * Success outcomes write to BOTH (revision in `.gazetta/history/`,
+ * audit event in `.gazetta/audit/events.jsonl`); the audit-event
+ * carries the actor + outcome + scope context the revision shape
+ * predates.
+ *
+ * The alternative — extending `Revision` with `actor` + `outcome` —
+ * forces the existing history machinery to handle audit-only
+ * revisions (no snapshot). Rather than complicate history-recorder
+ * with optional-snapshot revision flow, the audit log gets its own
+ * append-only file. v1 validation: simpler shape; same multi-instance
+ * guarantees.
+ *
+ * # Multi-instance correctness
+ *
+ * One file per instance. Each admin process writes to
+ * `events-{instance-id}.jsonl` so concurrent appends don't race.
+ * Reads aggregate via `readDir` + concat. Same pattern as
+ * design-audit.md "v2 reserved" notes for `FileAuditProvider`:
+ * "filesystem POSIX `O_APPEND` for small writes; R2/S3/Azure use
+ * per-instance file (`events.{instance-id}.jsonl`)".
+ *
+ * v1 is per-instance file unconditionally — no special-casing
+ * filesystem vs cloud storage. Filesystem operators pay one extra
+ * file per process (negligible); cloud-storage operators get the
+ * concurrency safety they need.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this provider only writes/reads JSONL. Recording dispatch,
+ *     pseudonymization, and source-IP extraction live elsewhere.
+ *   - LSP: implements `AuditProvider`; consumers don't know it's
+ *     filesystem-backed.
+ *   - DIP: takes a `StorageProvider` instance — works against
+ *     filesystem, R2, S3, Azure Blob uniformly.
+ */
+import type { StorageProvider } from '../../types.js'
+import type { AuditEvent, AuditQuery } from '../types.js'
+import type { AuditProvider } from '../provider.js'
+
+export interface HistoryAuditProviderOptions {
+  /** Storage provider for the target. Audit events live under `.gazetta/audit/`. */
+  storage: StorageProvider
+  /**
+   * Per-process instance identifier. Disambiguates JSONL file
+   * names for multi-instance correctness. Production resolves
+   * this from K_REVISION (Cloud Run) → os.hostname() → random
+   * 8-char hex (per design-logging.md conventions).
+   */
+  instance: string
+}
+
+const AUDIT_DIR = '.gazetta/audit'
+
+export function createHistoryAuditProvider(opts: HistoryAuditProviderOptions): AuditProvider {
+  const { storage, instance } = opts
+  const eventsPath = `${AUDIT_DIR}/events-${instance}.jsonl`
+
+  async function appendEvent(event: AuditEvent): Promise<void> {
+    // Read-modify-write per call. JSONL append-only on filesystem
+    // would be cheaper, but cloud StorageProvider (R2/S3/Azure)
+    // doesn't expose append — every write is whole-object replace.
+    // The per-instance file scoping makes RMW safe (no other
+    // instance writes to this file); the cost is one extra read
+    // per event. Acceptable for v1 latency budget (50-200ms).
+    let existing = ''
+    try {
+      existing = await storage.readFile(eventsPath)
+    } catch {
+      // First write — file doesn't exist yet. Create the directory
+      // if the storage provider needs it (filesystem mkdir).
+      await storage.mkdir(AUDIT_DIR).catch(() => {
+        // Provider may not require mkdir (S3/R2 have no concept);
+        // swallow.
+      })
+    }
+    const line = JSON.stringify(event) + '\n'
+    await storage.writeFile(eventsPath, existing + line)
+  }
+
+  async function readAllEvents(): Promise<AuditEvent[]> {
+    // List all instance files + concat. readDir returns DirEntry
+    // shapes; we filter to the events-*.jsonl pattern so unrelated
+    // files (audit-index sidecars in the future) don't get parsed
+    // as events.
+    let entries: Awaited<ReturnType<StorageProvider['readDir']>>
+    try {
+      entries = await storage.readDir(AUDIT_DIR)
+    } catch {
+      // No audit directory yet — nothing to read.
+      return []
+    }
+    const events: AuditEvent[] = []
+    for (const entry of entries) {
+      if (entry.isDirectory) continue
+      if (!entry.name.startsWith('events-') || !entry.name.endsWith('.jsonl')) continue
+      const content = await storage.readFile(`${AUDIT_DIR}/${entry.name}`)
+      for (const line of content.split('\n')) {
+        const trimmed = line.trim()
+        if (!trimmed) continue
+        try {
+          events.push(JSON.parse(trimmed) as AuditEvent)
+        } catch {
+          // Malformed line — skip. A corrupt single line shouldn't
+          // poison the whole query. Future: structured-log this.
+        }
+      }
+    }
+    return events
+  }
+
+  function matchesFilter(event: AuditEvent, filter: AuditQuery): boolean {
+    if (filter.action && event.action !== filter.action) return false
+    if (filter.outcome && event.outcome !== filter.outcome) return false
+    if (filter.scope?.kind && event.scope.kind !== filter.scope.kind) return false
+    if (filter.scope?.name && event.scope.name !== filter.scope.name) return false
+    if (filter.actor) {
+      const needle = filter.actor.toLowerCase()
+      const idMatch = event.actor.id.toLowerCase().includes(needle)
+      const emailMatch = event.actor.email?.toLowerCase().includes(needle) ?? false
+      if (!idMatch && !emailMatch) return false
+    }
+    if (filter.since && event.timestamp < filter.since) return false
+    if (filter.until && event.timestamp >= filter.until) return false
+    return true
+  }
+
+  return {
+    name: 'history',
+    async record(event: AuditEvent): Promise<void> {
+      await appendEvent(event)
+    },
+    async query(filter: AuditQuery): Promise<AuditEvent[]> {
+      const all = await readAllEvents()
+      // Sort newest-first per audit-drawer convention. Stable sort
+      // by timestamp (string compare on ISO-8601 works correctly).
+      all.sort((a, b) => b.timestamp.localeCompare(a.timestamp))
+      const matched = all.filter(e => matchesFilter(e, filter))
+      const limit = filter.limit ?? 100
+      return matched.slice(0, Math.min(limit, 1000))
+    },
+    // queryUrl intentionally omitted — HistoryAuditProvider has
+    // queryable storage; the drawer reads via query() directly.
+  }
+}

--- a/packages/gazetta/src/audit/pseudonymize.ts
+++ b/packages/gazetta/src/audit/pseudonymize.ts
@@ -1,0 +1,91 @@
+/**
+ * Actor pseudonymization — opt-in privacy hardening for audit events.
+ *
+ * Per `design-audit.md`'s "Pseudonymization" section: when
+ * `admin.audit.actorPseudonym: 'sha256'` is configured, the event's
+ * `actor.id` is replaced with `sha256(sub + GAZETTA_AUDIT_ACTOR_SALT)
+ * .slice(0, 16)`. The `actor.email` field is dropped (low-entropy
+ * email gives weak pseudonymization).
+ *
+ * # When to opt in
+ *
+ * - External-sink configurations where audit events leave Gazetta's
+ *   process boundary (CloudWatch, OTel, webhook) — limits PII
+ *   leakage if sink storage is compromised
+ * - Regulated contexts demanding pseudonymization-by-default (some
+ *   EU healthcare contexts, German telecommunications data
+ *   retention)
+ * - Multi-tenant SIEM correlation with shared salt across systems
+ *
+ * # Salt management
+ *
+ * - Salt is a credential. Stored in `GAZETTA_AUDIT_ACTOR_SALT` env
+ *   var per Universal Provider Requirement #3. Never in
+ *   `site.config.ts`.
+ * - 16+ random bytes recommended.
+ * - Salt rotation breaks historic correlation by design — rotate
+ *   per security policy (annually typical); document rotation
+ *   dates so forensic queries can scope by salt-era.
+ * - Multi-instance: every instance reads the same env → deterministic
+ *   hash across instances.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: pseudonymization only. Doesn't dispatch, doesn't extract
+ *     identity. Pure function over `(actor, mode)`.
+ *   - DIP: takes the salt as a string parameter (dependency-injected
+ *     by the caller); doesn't read `process.env` directly so tests
+ *     can pass deterministic salts.
+ */
+import { createHash } from 'node:crypto'
+import type { AuditActor } from './types.js'
+
+export type ActorPseudonymMode = 'none' | 'sha256'
+
+/**
+ * Apply the configured pseudonymization mode to an actor snapshot.
+ *
+ *   - `'none'` (default) — pass through unchanged.
+ *   - `'sha256'` — replace `id` with the salted hash prefix; drop
+ *     `email`.
+ *
+ * The original `actor` is never mutated; returns a new object.
+ *
+ * Throws when `mode === 'sha256'` and `salt` is empty/undefined —
+ * pseudonymization without a salt is a misconfiguration that would
+ * silently produce reversible-by-rainbow-table hashes. Caller (Cut
+ * 5's wiring) should catch this at boot via `AuditConfigurationError`
+ * when the env var is missing.
+ */
+export function pseudonymizeActor(actor: AuditActor, mode: ActorPseudonymMode, salt?: string): AuditActor {
+  if (mode === 'none') return actor
+  // mode === 'sha256'
+  if (!salt || salt.length === 0) {
+    throw new Error(
+      'actorPseudonym: sha256 requires a non-empty salt (set GAZETTA_AUDIT_ACTOR_SALT environment variable)',
+    )
+  }
+  const hash = createHash('sha256')
+    .update(actor.id + salt)
+    .digest('hex')
+    .slice(0, 16)
+  return {
+    id: hash,
+    // email dropped — low-entropy email gives weak pseudonymization.
+    role: actor.role,
+    trustMode: actor.trustMode,
+  }
+}
+
+/**
+ * Compute the pseudonymized id for an actor — exposed for forensic
+ * queries: an operator who knows the upstream sub + salt can
+ * compute the pseudonymized id and search the audit log without
+ * the recorder being involved.
+ */
+export function computePseudonymizedId(rawSub: string, salt: string): string {
+  return createHash('sha256')
+    .update(rawSub + salt)
+    .digest('hex')
+    .slice(0, 16)
+}

--- a/packages/gazetta/src/audit/recorder.ts
+++ b/packages/gazetta/src/audit/recorder.ts
@@ -1,0 +1,152 @@
+/**
+ * Audit-recording dispatcher. The fan-out + fail-open layer that
+ * separates recording sites (save/publish/delete/restore handlers)
+ * from individual `AuditProvider` implementations.
+ *
+ * # Locked design — synchronous fail-open, parallel fan-out
+ *
+ * Per `design-audit.md`'s "Recording timing":
+ *
+ *   - **Synchronous** — operation awaits the audit attempt. If the
+ *     user got a success response, the audit attempt was completed.
+ *     Async queuing would lose in-flight events on process restart.
+ *   - **Fail-open by default** — provider failures never block the
+ *     write. Operators in compliance contexts opt into `strict: true`
+ *     (any provider failure blocks the write).
+ *   - **Parallel fan-out** — `Promise.allSettled` so two providers'
+ *     latencies don't stack. Failures are independent.
+ *
+ * # Failure log — no payload
+ *
+ * Per Universal Provider Requirement #5: "When audit recording fails
+ * (fail-open), the failure log entry MUST NOT contain event payload."
+ * The recorder logs only `{ provider, eventId, category }` — never
+ * the actor, scope, or metadata. Prevents PII side-channels into
+ * application stderr / log shipping.
+ *
+ * # Strict mode
+ *
+ * For HIPAA / SOC 2 compliance contexts where "audit recording
+ * confirmed successful" is a hard prerequisite for the write to
+ * proceed. The recorder's caller (Cut 5's wired handlers) checks
+ * the `failed` flag in the result and aborts the write when strict
+ * mode is on.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: dispatch + failure-log only. Doesn't construct providers,
+ *     doesn't extract identity (Cut 4 handles privacy / source-IP
+ *     extraction).
+ *   - DIP: takes a `readonly AuditProvider[]` and an opaque logger
+ *     callback; no coupling to specific providers or to Hono.
+ */
+import type { AuditEvent } from './types.js'
+import type { AuditProvider } from './provider.js'
+
+export interface AuditFailureLog {
+  /** Provider name that failed. Per design: log identifies which sink dropped. */
+  provider: string
+  /**
+   * Categorical reason — `transport` for network/HTTP failures,
+   * `serialize` for unparseable events, `quota` for sink full.
+   * Surface to log aggregators for filtering.
+   */
+  category: 'transport' | 'serialize' | 'quota'
+  /** Reason text for diagnostics. PII-free; never the event payload. */
+  reason: string
+}
+
+/**
+ * Logger callback signature. Production wires to `pino` per
+ * `design-logging.md`; tests inject stubs to assert shape + count.
+ *
+ * Note: NEVER receives the event payload. The logger contract is
+ * narrow on purpose — operator's log-shipping pipeline can't
+ * accidentally surface PII via the audit failure path.
+ */
+export type AuditFailureLogger = (entry: AuditFailureLog) => void
+
+export interface RecordToAllOptions {
+  /** Providers to fan out to. Order doesn't matter (parallel). */
+  providers: ReadonlyArray<AuditProvider>
+  /**
+   * Strict mode flag. `true` → caller blocks the write on any
+   * provider failure (per design-audit.md "Strict mode opt-in").
+   * `false` (default) → fail-open; operations always proceed.
+   */
+  strict?: boolean
+  /**
+   * Failure logger. Production wires `pino`. Tests inject `vi.fn()`.
+   * When undefined, failures pass silently — useful for tests that
+   * don't care about log output, but production should always wire
+   * a real logger for diagnosability.
+   */
+  logFailure?: AuditFailureLogger
+}
+
+export interface RecordResult {
+  /** Number of providers that successfully recorded. */
+  succeeded: number
+  /**
+   * Number of providers that failed. Always 0 when no providers are
+   * configured. Caller uses this in strict mode to abort the write.
+   */
+  failed: number
+  /** Per-provider failure entries — for diagnostic surfaces. */
+  failures: ReadonlyArray<AuditFailureLog>
+}
+
+/**
+ * Fan-out an event to every configured provider in parallel.
+ * Returns counts + per-failure entries; never throws (per Universal
+ * Provider Requirement #5). Strict-mode behavior is the caller's
+ * concern — the recorder does the dispatch + log; the caller branches
+ * on `result.failed > 0` to abort the write.
+ */
+export async function recordToAll(event: AuditEvent, opts: RecordToAllOptions): Promise<RecordResult> {
+  const { providers, logFailure } = opts
+  if (providers.length === 0) return { succeeded: 0, failed: 0, failures: [] }
+
+  const results = await Promise.allSettled(providers.map(p => p.record(event)))
+  const failures: AuditFailureLog[] = []
+  let succeeded = 0
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i]
+    const provider = providers[i]
+    if (result.status === 'fulfilled') {
+      succeeded++
+      continue
+    }
+    const entry: AuditFailureLog = {
+      provider: provider.name,
+      category: categorizeFailure(result.reason),
+      reason: extractReason(result.reason),
+    }
+    failures.push(entry)
+    logFailure?.(entry)
+  }
+  return { succeeded, failed: failures.length, failures }
+}
+
+/**
+ * Categorize a thrown reason into the closed-enum category. Maps
+ * `AuditTransportError.category` directly when present; falls back
+ * to `'transport'` for unknown errors (most common — provider
+ * SDKs rarely throw structured failure types).
+ */
+function categorizeFailure(reason: unknown): 'transport' | 'serialize' | 'quota' {
+  if (reason instanceof Error) {
+    // AuditTransportError carries category as a typed field.
+    const maybeCategory = (reason as { category?: unknown }).category
+    if (maybeCategory === 'transport' || maybeCategory === 'serialize' || maybeCategory === 'quota') {
+      return maybeCategory
+    }
+  }
+  return 'transport'
+}
+
+function extractReason(reason: unknown): string {
+  if (reason instanceof Error) return reason.message
+  if (typeof reason === 'string') return reason
+  return 'unknown failure'
+}

--- a/packages/gazetta/src/audit/retention.ts
+++ b/packages/gazetta/src/audit/retention.ts
@@ -1,0 +1,225 @@
+/**
+ * Audit retention pruner.
+ *
+ * Per design-audit.md "Retention": audit retention is configurable
+ * independently from content history retention. Two dimensions:
+ *
+ *   - `events` — max event count kept across all per-instance JSONL
+ *     files. When exceeded, oldest events evicted (timestamp-sort
+ *     ascending; drop from the head).
+ *   - `maxAgeMonths` — max age in months. Events older than the
+ *     cutoff evicted regardless of count.
+ *
+ * Operator sets one or both. When neither set, the pruner is a no-op
+ * (audit accumulates indefinitely until storage budget exhausted —
+ * operator's choice; documented).
+ *
+ * # JSONL storage shape
+ *
+ * Per `HistoryAuditProvider`, events live in
+ * `.gazetta/audit/events-{instance-id}.jsonl` — one file per admin
+ * instance. The pruner walks every events file, parses lines into
+ * AuditEvent objects, applies retention, and rewrites each file with
+ * the surviving lines. Per-file rewrite preserves the per-instance
+ * scoping (no cross-instance interleaving).
+ *
+ * # Multi-instance correctness
+ *
+ * Per-revision file granularity (each instance's file is independent)
+ * means concurrent pruners on the same target converge. If instance A
+ * is rewriting events-A.jsonl while instance B is rewriting
+ * events-B.jsonl, no race. If two pruners on different hosts try to
+ * rewrite the SAME events-A.jsonl simultaneously (two instances with
+ * the same hostname / K_REVISION), the storage provider's atomic
+ * write-then-rename keeps the file consistent — last-write-wins is
+ * fine because both pruners compute the same surviving set from the
+ * same input bytes.
+ *
+ * # Why JSONL-line pruning, not whole-file deletion
+ *
+ * The pruner has to handle events file-by-file because:
+ *   - Different instances have different event mixes; deleting an
+ *     entire instance's file would lose events newer than the cutoff
+ *   - Events within one instance's file span time; some pruned, some
+ *     kept — selective line removal is the right granularity
+ *
+ * # Returns: PruneResult
+ *
+ * Diagnostic info for the caller's log + metrics. `eventsKept` and
+ * `eventsEvicted` together = total events pre-prune.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: retention only; doesn't construct providers, doesn't
+ *     audit pruner-events itself (would create recursion).
+ *   - DIP: takes a StorageProvider — works against filesystem, R2,
+ *     S3, Azure Blob uniformly.
+ */
+import type { StorageProvider } from '../types.js'
+import type { AuditEvent } from './types.js'
+
+export interface AuditRetentionConfig {
+  /** Max event count kept. When exceeded, oldest evicted. */
+  events?: number
+  /** Max age in months. Events older than the cutoff evicted. */
+  maxAgeMonths?: number | null
+}
+
+export interface PruneResult {
+  /** Number of events present before pruning. */
+  eventsBefore: number
+  /** Number of events surviving. */
+  eventsKept: number
+  /** Number of events evicted. */
+  eventsEvicted: number
+  /** Files rewritten (only files with at least one eviction). */
+  filesRewritten: number
+  /** Files inspected (every events file under .gazetta/audit/). */
+  filesInspected: number
+}
+
+const AUDIT_DIR = '.gazetta/audit'
+
+/**
+ * Walk the audit JSONL files, evict events that violate retention,
+ * rewrite each affected file. No-op when retention config has neither
+ * `events` nor `maxAgeMonths` set.
+ */
+export async function pruneAuditEvents(storage: StorageProvider, config: AuditRetentionConfig): Promise<PruneResult> {
+  // No retention configured → no-op. Operator opted out or never opted in.
+  const hasEventsCap = config.events !== undefined && config.events !== null
+  const hasAgeCap = config.maxAgeMonths !== undefined && config.maxAgeMonths !== null && config.maxAgeMonths > 0
+  if (!hasEventsCap && !hasAgeCap) {
+    return { eventsBefore: 0, eventsKept: 0, eventsEvicted: 0, filesRewritten: 0, filesInspected: 0 }
+  }
+
+  // Compute the age cutoff once so all files use the same boundary.
+  // `maxAgeMonths` is a real-month subtraction (Date.setMonth handles
+  // leap years + variable month length); ISO-8601 string compare works
+  // on the resulting timestamp.
+  const ageCutoff = hasAgeCap ? computeAgeCutoff(config.maxAgeMonths!) : null
+
+  // Walk the events directory. Missing dir = no events to prune.
+  let entries: Awaited<ReturnType<StorageProvider['readDir']>>
+  try {
+    entries = await storage.readDir(AUDIT_DIR)
+  } catch {
+    return { eventsBefore: 0, eventsKept: 0, eventsEvicted: 0, filesRewritten: 0, filesInspected: 0 }
+  }
+
+  // Read every events file into memory with its source path. We need
+  // the global event count for `events` cap enforcement (oldest-across-
+  // files evicted, not per-file), so we collect all events first.
+  const filesInspected: { path: string; events: AuditEvent[]; rawLineCount: number }[] = []
+  for (const entry of entries) {
+    if (entry.isDirectory) continue
+    if (!entry.name.startsWith('events-') || !entry.name.endsWith('.jsonl')) continue
+    const path = `${AUDIT_DIR}/${entry.name}`
+    const content = await storage.readFile(path)
+    const lines = content.split('\n')
+    const events: AuditEvent[] = []
+    let rawLineCount = 0
+    for (const line of lines) {
+      const trimmed = line.trim()
+      if (!trimmed) continue
+      rawLineCount++
+      try {
+        events.push(JSON.parse(trimmed) as AuditEvent)
+      } catch {
+        // Malformed line — skip + count as raw line so the rewrite
+        // doesn't accidentally include it. Same posture as the reader
+        // in HistoryAuditProvider.
+      }
+    }
+    filesInspected.push({ path, events, rawLineCount })
+  }
+
+  const eventsBefore = filesInspected.reduce((sum, f) => sum + f.events.length, 0)
+  if (eventsBefore === 0) {
+    return {
+      eventsBefore: 0,
+      eventsKept: 0,
+      eventsEvicted: 0,
+      filesRewritten: 0,
+      filesInspected: filesInspected.length,
+    }
+  }
+
+  // Phase 1: age cutoff (per-file evaluation; events older than the
+  // cutoff are evicted regardless of where they sit in the global
+  // ordering).
+  for (const file of filesInspected) {
+    if (ageCutoff !== null) {
+      file.events = file.events.filter(e => e.timestamp >= ageCutoff)
+    }
+  }
+
+  // Phase 2: count cap (global). Build the global ordering once:
+  // sort all surviving events by timestamp (oldest first), evict
+  // from the head until we're under the cap. The eviction set is
+  // matched back to its source file by reference identity.
+  let evictedFromCap = new Set<AuditEvent>()
+  if (hasEventsCap) {
+    const allSurviving: { file: (typeof filesInspected)[number]; event: AuditEvent }[] = []
+    for (const file of filesInspected) {
+      for (const event of file.events) {
+        allSurviving.push({ file, event })
+      }
+    }
+    allSurviving.sort((a, b) => a.event.timestamp.localeCompare(b.event.timestamp))
+    const overflow = allSurviving.length - config.events!
+    if (overflow > 0) {
+      evictedFromCap = new Set(allSurviving.slice(0, overflow).map(x => x.event))
+    }
+  }
+
+  // Phase 3: rewrite each file whose surviving set differs from the
+  // pre-prune set. Reasons a file rewrites:
+  //   - age-cutoff already mutated `file.events`
+  //   - count-cap is going to evict additional events
+  //   - malformed JSONL lines on disk (rawLineCount > parsed events) —
+  //     incidental hygiene; the line never made it through parse and
+  //     wouldn't survive a re-read either, so we drop it during the
+  //     rewrite. Doesn't count toward `eventsEvicted` (the metric
+  //     reports parsed-event deltas only).
+  let filesRewritten = 0
+  let eventsKeptTotal = 0
+  for (const file of filesInspected) {
+    const surviving = evictedFromCap.size > 0 ? file.events.filter(e => !evictedFromCap.has(e)) : file.events
+    eventsKeptTotal += surviving.length
+    const parsedDelta = file.events.length - surviving.length
+    const malformedLines = file.rawLineCount - file.events.length
+    if (parsedDelta === 0 && malformedLines === 0) continue
+    // Rewrite. JSONL convention: one event per line + trailing newline.
+    // Empty file (all events pruned) → write an empty string so the
+    // file remains as a marker (deleting would force concurrent
+    // appenders to mkdir; safer to keep the file with a zero-line body).
+    const rewritten = surviving.map(e => JSON.stringify(e)).join('\n')
+    const final = rewritten ? rewritten + '\n' : ''
+    await storage.writeFile(file.path, final)
+    filesRewritten++
+  }
+
+  return {
+    eventsBefore,
+    eventsKept: eventsKeptTotal,
+    eventsEvicted: eventsBefore - eventsKeptTotal,
+    filesRewritten,
+    filesInspected: filesInspected.length,
+  }
+}
+
+/**
+ * Subtract `months` calendar months from `now` and return the ISO
+ * timestamp boundary. Events with `timestamp >= cutoff` are kept;
+ * older events evicted.
+ *
+ * Uses Date.setMonth so leap years and variable-length months are
+ * handled correctly (3 months back from 2026-05-31 is 2026-02-28,
+ * not 2026-02-31).
+ */
+function computeAgeCutoff(months: number): string {
+  const cutoff = new Date()
+  cutoff.setMonth(cutoff.getMonth() - months)
+  return cutoff.toISOString()
+}

--- a/packages/gazetta/src/audit/source-ip.ts
+++ b/packages/gazetta/src/audit/source-ip.ts
@@ -1,0 +1,176 @@
+/**
+ * Source-IP recording — opt-in per design-audit.md "Source IP
+ * recording" section. Trust-mode-driven extraction with optional
+ * pseudonymization / truncation.
+ *
+ * # Modes
+ *
+ *   - `'none'` (default) — IP not recorded; field absent from event
+ *   - `'raw'` — full IP. GDPR-personal-data; operator declares
+ *     processing
+ *   - `'hashed'` — `sha256(ip + GAZETTA_AUDIT_SOURCEIP_SALT).slice(0, 16)`
+ *     for "same source across events?" correlation without
+ *     identification. Different salt from actor (so rotating one
+ *     doesn't break the other)
+ *   - `'truncated'` — `/24` for IPv4, `/48` for IPv6. Geographic /
+ *     network-segment forensics without device identification
+ *
+ * # Trust-mode-driven extraction
+ *
+ * Per design's "Trust-mode-driven header extraction" — leftmost-XFF
+ * naive read is an OWASP Trust Boundary Violation. The IP source
+ * differs per trust mode:
+ *
+ *   - `none`              — TCP peer (no proxy assumed)
+ *   - `forwarded-user`    — X-Forwarded-For with trustedProxyCount
+ *   - `cloudflare-access` — Cf-Connecting-IP (signed/trusted)
+ *   - `azure-easy-auth`   — X-Forwarded-For (Azure appends one entry)
+ *   - `aws-cognito`       — X-Forwarded-For (ALB appends one entry)
+ *   - `tailscale`         — TCP peer (serves direct)
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: extraction + truncation/hashing only. Doesn't dispatch,
+ *     doesn't extract actor identity. Pure functions over
+ *     `(headers, mode, salt?)`.
+ */
+import { createHash } from 'node:crypto'
+
+export type SourceIpMode = 'none' | 'raw' | 'hashed' | 'truncated'
+
+export interface SourceIpExtractionContext {
+  /** Trust mode determines which header carries the client IP. */
+  trustMode: string
+  /** TCP peer IP (when available — Hono's c.req.raw.headers may not expose). */
+  peerIp?: string
+  /** All request headers (for X-Forwarded-For / Cf-Connecting-IP / X-Real-IP lookup). */
+  headers: ReadonlyMap<string, string>
+  /**
+   * For trust modes that read X-Forwarded-For, how many trusted
+   * proxies are between Gazetta and the client. Counts back from
+   * the rightmost; everything to the right is trusted, the
+   * resulting leftmost-of-trusted is the client.
+   *
+   * Defaults to 1 (single proxy in front of Gazetta — most common).
+   */
+  trustedProxyCount?: number
+}
+
+/**
+ * Extract the client IP per the trust mode's header convention.
+ * Returns null when the configured header is missing — the caller
+ * should omit the `sourceIp` field from the event (per design:
+ * "Explicitly absent is more honest" than fake values).
+ */
+export function extractSourceIp(ctx: SourceIpExtractionContext): string | null {
+  const { trustMode, headers } = ctx
+  switch (trustMode) {
+    case 'none':
+    case 'tailscale':
+      return ctx.peerIp ?? null
+    case 'cloudflare-access': {
+      const cfIp = headers.get('cf-connecting-ip')
+      if (cfIp) return cfIp
+      return ctx.peerIp ?? null
+    }
+    case 'forwarded-user':
+    case 'azure-easy-auth':
+    case 'aws-cognito': {
+      // X-Forwarded-For shape: "client, proxy1, proxy2".
+      // trustedProxyCount = N → take the (N+1)th from the RIGHT
+      // (1-indexed). For N=1 (one trusted proxy), client is the
+      // leftmost; for N=2, client is leftmost-of-leftmost-two.
+      const xff = headers.get('x-forwarded-for')
+      if (!xff) return ctx.peerIp ?? null
+      const entries = xff
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+      if (entries.length === 0) return ctx.peerIp ?? null
+      const trustedCount = ctx.trustedProxyCount ?? 1
+      // Client position from the right: N entries trusted; client
+      // is the (N+1)th-from-right, i.e., entries[entries.length - N - 1].
+      const clientIdx = entries.length - trustedCount - 1
+      if (clientIdx < 0) return ctx.peerIp ?? null
+      return entries[clientIdx]
+    }
+    default:
+      // Unknown trust mode (plugin-supplied future) — fall back to
+      // peer IP. Plugin authors override via custom extraction.
+      return ctx.peerIp ?? null
+  }
+}
+
+/**
+ * Apply the configured source-IP mode. Returns null when the mode
+ * is `'none'` OR when the extracted IP is null/empty/malformed —
+ * the caller omits the field.
+ */
+export function processSourceIp(rawIp: string | null, mode: SourceIpMode, salt?: string): string | null {
+  if (mode === 'none') return null
+  if (!rawIp || rawIp.length === 0) return null
+
+  if (mode === 'raw') return rawIp
+  if (mode === 'hashed') {
+    if (!salt || salt.length === 0) {
+      throw new Error(
+        'recordSourceIp: hashed requires a non-empty salt (set GAZETTA_AUDIT_SOURCEIP_SALT environment variable)',
+      )
+    }
+    return createHash('sha256')
+      .update(rawIp + salt)
+      .digest('hex')
+      .slice(0, 16)
+  }
+  // mode === 'truncated'
+  return truncateIp(rawIp)
+}
+
+/**
+ * Truncate an IP to /24 (IPv4) or /48 (IPv6). Returns null for
+ * malformed input — the caller treats this as "missing" and omits
+ * the field.
+ */
+function truncateIp(ip: string): string | null {
+  // IPv4: 1.2.3.4 → 1.2.3.0/24
+  if (ip.includes('.') && !ip.includes(':')) {
+    const parts = ip.split('.')
+    if (parts.length !== 4) return null
+    for (const p of parts) {
+      const n = Number.parseInt(p, 10)
+      if (!Number.isInteger(n) || n < 0 || n > 255) return null
+    }
+    return `${parts[0]}.${parts[1]}.${parts[2]}.0/24`
+  }
+  // IPv6: fe80::1234 → fe80::/48 (first 3 groups of 16 bits)
+  if (ip.includes(':')) {
+    // Expand :: shorthand if present.
+    const groups = expandIpv6Groups(ip)
+    if (!groups) return null
+    return `${groups.slice(0, 3).join(':')}::/48`
+  }
+  return null
+}
+
+function expandIpv6Groups(ip: string): string[] | null {
+  const doubleColon = ip.indexOf('::')
+  let groups: string[]
+  if (doubleColon >= 0) {
+    const left = ip.slice(0, doubleColon).split(':').filter(Boolean)
+    const right = ip
+      .slice(doubleColon + 2)
+      .split(':')
+      .filter(Boolean)
+    const fillCount = 8 - left.length - right.length
+    if (fillCount < 0) return null
+    groups = [...left, ...new Array(fillCount).fill('0'), ...right]
+  } else {
+    groups = ip.split(':')
+  }
+  if (groups.length !== 8) return null
+  for (const g of groups) {
+    const n = Number.parseInt(g, 16)
+    if (!Number.isInteger(n) || n < 0 || n > 0xffff) return null
+  }
+  return groups
+}

--- a/packages/gazetta/src/audit/types.ts
+++ b/packages/gazetta/src/audit/types.ts
@@ -1,0 +1,141 @@
+/**
+ * Audit types — the durable forensic record shape consumed by every
+ * `AuditProvider` implementation.
+ *
+ * # Why these types live here
+ *
+ * Per `design-audit.md`'s "history-recorder is the foundation"
+ * invariant, the audit log extends the existing `Revision` shape
+ * with `actor` + `outcome` fields. The types here are the wire
+ * shape every provider speaks; in-tree `HistoryAuditProvider`
+ * (Cut 2) and external-sink providers (v2 webhook, file, OTel,
+ * CloudWatch, Azure Monitor, syslog) all consume `AuditEvent`.
+ *
+ * # Outcome is required
+ *
+ * Per the locked invariant: "no implicit 'default to success' —
+ * recording sites supply outcome explicitly. Cuts a class of 'I
+ * forgot to record the failure' bugs." The closed enum stays
+ * closed (future additions like `'rate-limited'`, `'session-expired'`
+ * extend the enum, not the wire shape).
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns the event vocabulary. Doesn't read
+ *     storage; pure data shapes.
+ *   - DIP: providers, recorder, drawer all depend on these types
+ *     — never on which specific provider produced an event.
+ *   - LSP: every `AuditProvider` returns events shaped by these
+ *     types; consumers branch only on `outcome` / `action` for
+ *     behavior, never on which provider produced the data.
+ */
+
+/**
+ * Closed enum of action verbs Gazetta records. Per `design-audit.md`
+ * "Recording scope (v1)": save / publish / delete / restore at the
+ * content level + configure-roles for role-mapping changes in
+ * site.config.ts. Future hook-firing audit events will extend with
+ * 'hook-fired' (per design-hooks.md Cut 7's audit integration).
+ */
+export type AuditAction = 'save' | 'publish' | 'delete' | 'restore' | 'configure-roles'
+
+/**
+ * Closed enum of outcomes. Locked: every recording site supplies
+ * outcome explicitly. The four listed cover write attempts;
+ * v2 ambient-log expansion ('read', 'hook-cancelled') stays
+ * closed-enum.
+ */
+export type AuditOutcome = 'success' | 'forbidden' | 'validation-failed' | 'unauthenticated'
+
+/**
+ * Snapshot of the principal at decision time — never a live
+ * reference. Subsequent role changes don't rewrite history.
+ */
+export interface AuditActor {
+  /**
+   * Upstream stable subject (OIDC `sub`, Cloudflare Access
+   * `identity_nonce`, etc.) — NOT email. Email rotates; sub is
+   * stable. When `admin.audit.actorPseudonym: 'sha256'` is
+   * configured (Cut 4), this field is the salted hash prefix.
+   * `'unknown'` for pre-RBAC revisions or `none`-mode deployments.
+   */
+  id: string
+  /**
+   * Optional human-readable identifier. Redacted to undefined when
+   * pseudonymization is enabled (low-entropy email gives weak
+   * pseudonymization).
+   */
+  email?: string
+  /** Resolved Gazetta role at decision time. */
+  role: string
+  /**
+   * Trust mode that produced this principal. Open string (not the
+   * `TrustMode` enum) so plugin-supplied modes can carry their own
+   * names without widening this type.
+   */
+  trustMode: string
+}
+
+/**
+ * What was acted on. Keeps the audit query layer simple — consumers
+ * filter by `kind` + optional `name`.
+ */
+export interface AuditScope {
+  kind: 'page' | 'fragment' | 'asset' | 'site'
+  /** Item name when applicable (page name, fragment name, etc.). */
+  name?: string
+}
+
+/**
+ * The wire shape every provider speaks. Every event records actor
+ * identity + action + outcome + scope; optional sourceIp / userAgent
+ * are operator-opt-in per Cut 4's privacy posture.
+ */
+export interface AuditEvent {
+  /** ISO 8601 with Z suffix. Matches the existing history-recorder convention. */
+  timestamp: string
+  /** Snapshot of the actor at decision time. */
+  actor: AuditActor
+  /** Closed-enum action verb. */
+  action: AuditAction
+  /** Closed-enum outcome. Required — no implicit default. */
+  outcome: AuditOutcome
+  /** What was acted on. */
+  scope: AuditScope
+  /**
+   * Source IP when `admin.audit.recordSourceIp` is configured.
+   * Truncation / pseudonymization happens at recording time per
+   * the operator's mode setting (Cut 4).
+   */
+  sourceIp?: string
+  /**
+   * User agent when `admin.audit.recordUserAgent` is configured.
+   * Cut 4 supports raw / truncated modes; default is none.
+   */
+  userAgent?: string
+  /**
+   * Provider-specific extras. Examples: publish source target +
+   * destination, restore revision id, `missingCapabilities` for
+   * forbidden outcomes, `comment` for failure-mode events.
+   */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Filter shape consumed by `AuditProvider.query()`. Open enums
+ * because filter values come from URL query params; the server
+ * validates each field against the audit-event closed enums.
+ */
+export interface AuditQuery {
+  /** Match against `actor.id` or `actor.email` (case-insensitive substring). */
+  actor?: string
+  action?: AuditAction
+  outcome?: AuditOutcome
+  scope?: { kind?: AuditScope['kind']; name?: string }
+  /** ISO 8601 timestamp lower bound (inclusive). */
+  since?: string
+  /** ISO 8601 timestamp upper bound (exclusive). */
+  until?: string
+  /** Max events returned. Default 100; provider may cap further. */
+  limit?: number
+}

--- a/packages/gazetta/src/audit/user-agent.ts
+++ b/packages/gazetta/src/audit/user-agent.ts
@@ -1,0 +1,63 @@
+/**
+ * User-agent recording — opt-in per design-audit.md "User agent
+ * recording" section. Lower priority than source-IP; most operators
+ * don't enable.
+ *
+ * # Modes
+ *
+ *   - `'none'` (default) — UA not recorded; field absent
+ *   - `'raw'` — full UA string. Useful for fingerprint forensics
+ *   - `'truncated'` — browser family + major version. Drops
+ *     fingerprinting detail; example outputs: `'Chrome/119'`,
+ *     `'Firefox/120'`, `'Safari/17'`, `'Other'`
+ *
+ * No `'hashed'` mode — UA has too little entropy for hashing to be
+ * a meaningful privacy hardening; if you want privacy, use
+ * `truncated` or `none`.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: UA processing only.
+ */
+
+export type UserAgentMode = 'none' | 'raw' | 'truncated'
+
+/**
+ * Apply the configured UA mode. Returns null for `'none'` or when
+ * input is empty/missing.
+ */
+export function processUserAgent(rawUa: string | undefined, mode: UserAgentMode): string | null {
+  if (mode === 'none') return null
+  if (!rawUa || rawUa.length === 0) return null
+  if (mode === 'raw') return rawUa
+  // mode === 'truncated' — extract browser family + major version.
+  return truncateUserAgent(rawUa)
+}
+
+/**
+ * Heuristic browser-family detection. Order matters: Edge before
+ * Chrome (Edge UA contains Chrome); Opera before Chrome (same).
+ * Returns 'Other' when no known family matches — better than
+ * leaking the raw string under truncated mode.
+ */
+function truncateUserAgent(ua: string): string {
+  // Patterns ordered by specificity: more-specific first.
+  const patterns: Array<{ name: string; regex: RegExp }> = [
+    { name: 'Edge', regex: /Edg(e|A|iOS)?\/(\d+)/i },
+    { name: 'Opera', regex: /OPR\/(\d+)/i },
+    { name: 'Chrome', regex: /Chrome\/(\d+)/i },
+    { name: 'Firefox', regex: /Firefox\/(\d+)/i },
+    { name: 'Safari', regex: /Version\/(\d+).*Safari/i },
+  ]
+  for (const { name, regex } of patterns) {
+    const match = ua.match(regex)
+    if (match) {
+      // Match group 1 is sometimes a sub-product name (Edg vs Edge),
+      // group 2 is the version. Pick the last numeric group.
+      const numericGroups = match.filter(g => /^\d+$/.test(g ?? ''))
+      const version = numericGroups[numericGroups.length - 1]
+      return `${name}/${version}`
+    }
+  }
+  return 'Other'
+}

--- a/packages/gazetta/src/auth/capabilities.ts
+++ b/packages/gazetta/src/auth/capabilities.ts
@@ -23,11 +23,38 @@
 import { BUILT_IN_ROLES, type BuiltInCapability } from './types.js'
 
 /**
+ * Privacy-sensitive capabilities that prefix wildcards do NOT
+ * grant. Per design-auth-rbac.md's "Audit-log read access is its
+ * own capability — viewers don't see audit by default", and the
+ * matching design-audit.md note that audit log is its own gate.
+ *
+ * These capabilities require either:
+ *   - explicit grant (the exact capability string in the granted
+ *     list), or
+ *   - root wildcard `*` (admin role)
+ *
+ * Prefix wildcards (`read:*`) DO NOT grant them. Built-in editor
+ * + viewer roles hold `read:*` — they get `read:pages`,
+ * `read:fragments`, `read:assets` but NOT `read:audit-log`.
+ * Operators wanting an "auditor" custom role declare
+ * `['read:*', 'read:audit-log']` explicitly.
+ *
+ * Plugin authors adding privacy-sensitive capabilities extend this
+ * set by exporting their own capability string in this set —
+ * future plugin foundation will likely move this to a registry.
+ * For v1 the set is closed to known built-ins.
+ */
+const WILDCARD_EXEMPT_CAPABILITIES: ReadonlySet<string> = new Set(['read:audit-log'])
+
+/**
  * Test whether a principal's capability set grants the required
  * capability. Implements wildcard expansion:
  *
- *   - `*` (root wildcard) grants everything
+ *   - `*` (root wildcard) grants everything (including
+ *     wildcard-exempt capabilities — admin role retains the
+ *     escape hatch)
  *   - `<prefix>:*` grants every capability under that prefix
+ *     EXCEPT capabilities in `WILDCARD_EXEMPT_CAPABILITIES`
  *   - exact match grants exactly that capability
  *
  * Plugin-supplied capabilities use scoped prefixes
@@ -36,10 +63,14 @@ import { BUILT_IN_ROLES, type BuiltInCapability } from './types.js'
  */
 export function capabilityGrants(granted: ReadonlyArray<string>, required: string): boolean {
   if (required.length === 0) return false
+  const isExempt = WILDCARD_EXEMPT_CAPABILITIES.has(required)
   for (const cap of granted) {
+    // Root wildcard always grants — admin retains the escape hatch
+    // even for wildcard-exempt capabilities.
     if (cap === '*') return true
     if (cap === required) return true
-    if (cap.endsWith(':*')) {
+    // Prefix wildcards skip wildcard-exempt capabilities.
+    if (!isExempt && cap.endsWith(':*')) {
       const prefix = cap.slice(0, -1) // 'read:*' → 'read:'
       if (required.startsWith(prefix)) return true
     }

--- a/packages/gazetta/tests/audit-history-provider.test.ts
+++ b/packages/gazetta/tests/audit-history-provider.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Cut 2 tests: HistoryAuditProvider — JSONL storage of audit events
+ * with filter/sort/limit semantics for the `query()` path.
+ *
+ * Multi-instance correctness: each instance writes its own
+ * `events-{instance}.jsonl`. Reads aggregate via readDir + concat.
+ * Tests cover both the per-instance write path AND the aggregate
+ * read path (two providers, same storage, different instances).
+ */
+import { describe, expect, it, beforeEach } from 'vitest'
+import { memoryStorage, type MemoryStorage } from './_helpers/memory-storage.js'
+import { createHistoryAuditProvider, type AuditEvent } from '../src/audit/index.js'
+
+function event(overrides: Partial<AuditEvent> = {}): AuditEvent {
+  return {
+    timestamp: '2026-05-07T15:00:00Z',
+    actor: { id: 'alice', email: 'alice@example.com', role: 'editor', trustMode: 'cloudflare-access' },
+    action: 'save',
+    outcome: 'success',
+    scope: { kind: 'page', name: 'home' },
+    ...overrides,
+  }
+}
+
+describe('HistoryAuditProvider — record (Cut 2)', () => {
+  let storage: MemoryStorage
+
+  beforeEach(() => {
+    storage = memoryStorage()
+  })
+
+  it('writes the first event to .gazetta/audit/events-{instance}.jsonl', async () => {
+    const provider = createHistoryAuditProvider({ storage, instance: 'inst-1' })
+    await provider.record(event())
+    const file = await storage.readFile('.gazetta/audit/events-inst-1.jsonl')
+    const lines = file.trim().split('\n')
+    expect(lines).toHaveLength(1)
+    const parsed = JSON.parse(lines[0]) as AuditEvent
+    expect(parsed.actor.id).toBe('alice')
+    expect(parsed.action).toBe('save')
+  })
+
+  it('appends multiple events (read-modify-write per call)', async () => {
+    const provider = createHistoryAuditProvider({ storage, instance: 'inst-1' })
+    await provider.record(event({ timestamp: '2026-05-07T15:00:00Z' }))
+    await provider.record(event({ timestamp: '2026-05-07T15:00:01Z' }))
+    await provider.record(event({ timestamp: '2026-05-07T15:00:02Z' }))
+    const file = await storage.readFile('.gazetta/audit/events-inst-1.jsonl')
+    expect(file.trim().split('\n')).toHaveLength(3)
+  })
+
+  it("reports name === 'history'", () => {
+    const provider = createHistoryAuditProvider({ storage, instance: 'x' })
+    expect(provider.name).toBe('history')
+  })
+
+  it('different instances write to different files (multi-instance correctness)', async () => {
+    const a = createHistoryAuditProvider({ storage, instance: 'pod-a' })
+    const b = createHistoryAuditProvider({ storage, instance: 'pod-b' })
+    await a.record(event({ actor: { id: 'alice', role: 'editor', trustMode: 'cloudflare-access' } }))
+    await b.record(event({ actor: { id: 'bob', role: 'editor', trustMode: 'cloudflare-access' } }))
+    expect(await storage.readFile('.gazetta/audit/events-pod-a.jsonl')).toContain('alice')
+    expect(await storage.readFile('.gazetta/audit/events-pod-b.jsonl')).toContain('bob')
+    // Pod-a's file does NOT contain pod-b's events (no race / no
+    // shared-write concern).
+    expect(await storage.readFile('.gazetta/audit/events-pod-a.jsonl')).not.toContain('bob')
+  })
+
+  it('queryUrl is omitted (provider has queryable storage)', () => {
+    const provider = createHistoryAuditProvider({ storage, instance: 'x' })
+    expect(provider.queryUrl).toBeUndefined()
+  })
+})
+
+describe('HistoryAuditProvider — query (Cut 2)', () => {
+  let storage: MemoryStorage
+  let provider: ReturnType<typeof createHistoryAuditProvider>
+
+  beforeEach(async () => {
+    storage = memoryStorage()
+    provider = createHistoryAuditProvider({ storage, instance: 'inst-1' })
+    await provider.record(
+      event({
+        timestamp: '2026-05-07T15:00:00Z',
+        actor: { id: 'alice', role: 'editor', trustMode: 'cloudflare-access' },
+        action: 'save',
+        outcome: 'success',
+        scope: { kind: 'page', name: 'home' },
+      }),
+    )
+    await provider.record(
+      event({
+        timestamp: '2026-05-07T16:00:00Z',
+        actor: { id: 'bob', role: 'admin', trustMode: 'cloudflare-access' },
+        action: 'publish',
+        outcome: 'success',
+        scope: { kind: 'page', name: 'about' },
+      }),
+    )
+    await provider.record(
+      event({
+        timestamp: '2026-05-07T17:00:00Z',
+        actor: { id: 'alice', role: 'editor', trustMode: 'cloudflare-access' },
+        action: 'save',
+        outcome: 'validation-failed',
+        scope: { kind: 'page', name: 'home' },
+      }),
+    )
+  })
+
+  it('returns events newest-first by default', async () => {
+    const events = await provider.query!({})
+    expect(events).toHaveLength(3)
+    expect(events[0].timestamp).toBe('2026-05-07T17:00:00Z')
+    expect(events[2].timestamp).toBe('2026-05-07T15:00:00Z')
+  })
+
+  it('filters by actor (substring on id or email)', async () => {
+    const events = await provider.query!({ actor: 'alice' })
+    expect(events).toHaveLength(2)
+    expect(events.every(e => e.actor.id === 'alice')).toBe(true)
+  })
+
+  it('filters by action', async () => {
+    const events = await provider.query!({ action: 'publish' })
+    expect(events).toHaveLength(1)
+    expect(events[0].action).toBe('publish')
+  })
+
+  it('filters by outcome', async () => {
+    const events = await provider.query!({ outcome: 'validation-failed' })
+    expect(events).toHaveLength(1)
+    expect(events[0].outcome).toBe('validation-failed')
+  })
+
+  it('filters by scope.kind + scope.name', async () => {
+    const homeEvents = await provider.query!({ scope: { kind: 'page', name: 'home' } })
+    expect(homeEvents).toHaveLength(2)
+    expect(homeEvents.every(e => e.scope.name === 'home')).toBe(true)
+  })
+
+  it('filters by since (inclusive)', async () => {
+    const events = await provider.query!({ since: '2026-05-07T16:00:00Z' })
+    expect(events).toHaveLength(2)
+    // 16:00 boundary is INCLUSIVE
+    expect(events.some(e => e.timestamp === '2026-05-07T16:00:00Z')).toBe(true)
+  })
+
+  it('filters by until (exclusive)', async () => {
+    const events = await provider.query!({ until: '2026-05-07T17:00:00Z' })
+    expect(events).toHaveLength(2)
+    // 17:00 boundary is EXCLUSIVE
+    expect(events.some(e => e.timestamp === '2026-05-07T17:00:00Z')).toBe(false)
+  })
+
+  it('combines filters (AND)', async () => {
+    const events = await provider.query!({
+      actor: 'alice',
+      action: 'save',
+      outcome: 'success',
+    })
+    expect(events).toHaveLength(1)
+    expect(events[0].actor.id).toBe('alice')
+    expect(events[0].outcome).toBe('success')
+  })
+
+  it('respects limit', async () => {
+    const events = await provider.query!({ limit: 2 })
+    expect(events).toHaveLength(2)
+  })
+
+  it('caps limit at 1000 (provider-side safety)', async () => {
+    const events = await provider.query!({ limit: 999999 })
+    // Only 3 events exist — cap applies as floor(min(N, 1000)).
+    expect(events).toHaveLength(3)
+  })
+
+  it('aggregates events across multiple instance files', async () => {
+    // Record on a second instance; query through the same provider
+    // should see both. (HistoryAuditProvider's read path scans the
+    // dir; per-instance writes are isolated; reads aggregate.)
+    const podB = createHistoryAuditProvider({ storage, instance: 'pod-b' })
+    await podB.record(
+      event({
+        timestamp: '2026-05-07T18:00:00Z',
+        actor: { id: 'carol', role: 'admin', trustMode: 'cloudflare-access' },
+        action: 'delete',
+        outcome: 'success',
+      }),
+    )
+    const events = await provider.query!({})
+    expect(events).toHaveLength(4)
+    expect(events[0].actor.id).toBe('carol')
+  })
+
+  it('returns empty array when no audit directory exists yet', async () => {
+    const fresh = memoryStorage()
+    const provider = createHistoryAuditProvider({ storage: fresh, instance: 'inst-1' })
+    const events = await provider.query!({})
+    expect(events).toEqual([])
+  })
+
+  it('skips malformed JSONL lines without poisoning the query', async () => {
+    // Inject corruption directly via the storage layer.
+    await storage.writeFile(
+      '.gazetta/audit/events-inst-1.jsonl',
+      [
+        JSON.stringify(event({ timestamp: '2026-05-07T20:00:00Z' })),
+        'not-valid-json',
+        '',
+        JSON.stringify(event({ timestamp: '2026-05-07T21:00:00Z' })),
+      ].join('\n') + '\n',
+    )
+    const events = await provider.query!({})
+    // Two valid events; the malformed line + empty line skipped.
+    // (storage was reset by beforeEach so no events from earlier
+    // tests remain.)
+    expect(events).toHaveLength(2)
+  })
+})

--- a/packages/gazetta/tests/audit-integration.test.ts
+++ b/packages/gazetta/tests/audit-integration.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Cut 5 tests: end-to-end audit recording via createAdminApp.
+ *
+ * Validates the full stack: site.config.ts admin.audit → AuditConfigSchema
+ * parse → buildAuthProvider → principalMiddleware → auditMiddleware →
+ * route handler → c.var.audit.record() → HistoryAuditProvider →
+ * .gazetta/audit/events-{instance}.jsonl.
+ *
+ * Strategy: build admin apps via createAdminApp, perform writes
+ * (save / publish / delete), then read the audit events directly
+ * from the storage layer to confirm they were recorded with the
+ * right action + outcome + actor.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { rm, cp } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import type { Hono } from 'hono'
+import { createFilesystemProvider } from '../src/providers/filesystem.js'
+import { createAdminApp } from '../src/admin-api/index.js'
+import { createSourceContext } from '../src/admin-api/source-context.js'
+import { loadSiteConfig, siteConfigToManifest } from '../src/config/loader.js'
+import { createHistoryAuditProvider, type AuditEvent } from '../src/audit/index.js'
+import { tempDir } from './_helpers/temp.js'
+
+const realStarter = resolve(import.meta.dirname, '../../../examples/starter')
+const projectRoot = tempDir('audit-integ-' + Date.now())
+const projectSiteDir = resolve(projectRoot, 'sites/main')
+const localTargetDir = resolve(projectSiteDir, 'targets/local')
+const storage = createFilesystemProvider(localTargetDir)
+let app: Hono
+
+beforeAll(async () => {
+  await rm(projectRoot, { recursive: true, force: true })
+  await cp(realStarter, projectRoot, {
+    recursive: true,
+    filter: src => !src.includes('/dist') && !src.includes('/node_modules') && !src.includes('/.tmp'),
+  })
+  const loaded = await loadSiteConfig(projectSiteDir)
+  if (!loaded) throw new Error('site.config.ts missing')
+  const manifest = siteConfigToManifest(loaded.config)
+  const source = createSourceContext({ storage, siteDir: '', projectSiteDir, manifest })
+  app = createAdminApp({
+    source,
+    siteDir: projectSiteDir,
+    templatesDir: resolve(projectRoot, 'templates'),
+    adminDir: resolve(projectRoot, 'admin'),
+    disableCacheStatsLogger: true,
+  })
+})
+
+afterAll(async () => {
+  await rm(projectRoot, { recursive: true, force: true })
+})
+
+/** Read events directly from storage for assertion. */
+async function readAuditEvents(): Promise<AuditEvent[]> {
+  // Use the same provider the admin uses — handles instance-file
+  // aggregation. The instance id is non-deterministic (hostname /
+  // K_REVISION); we just read everything.
+  const reader = createHistoryAuditProvider({ storage, instance: 'reader-only' })
+  const events = await reader.query!({})
+  return events
+}
+
+describe('Cut 5 — end-to-end audit recording', () => {
+  it('successful page save records action: save, outcome: success', async () => {
+    // Create the page first (this also produces a save event).
+    await app.request('/api/pages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'audit-save-test', template: 'page-default' }),
+    })
+    // Then update it — that's the wired PUT handler we record from.
+    const res = await app.request('/api/pages/audit-save-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: { title: 'Hi' } }),
+    })
+    expect(res.status).toBe(200)
+
+    const events = await readAuditEvents()
+    // The PUT should have produced exactly one save / success event
+    // for this scope. POST creates don't go through the wired
+    // PUT handler so they don't appear here.
+    const matched = events.filter(
+      e => e.action === 'save' && e.outcome === 'success' && e.scope.name === 'audit-save-test',
+    )
+    expect(matched).toHaveLength(1)
+    expect(matched[0].actor.role).toBe('admin') // none-mode default
+    expect(matched[0].actor.trustMode).toBe('none')
+    await rm(resolve(localTargetDir, 'pages/audit-save-test'), { recursive: true, force: true })
+  })
+
+  it('validation-failed save records action: save, outcome: validation-failed', async () => {
+    await app.request('/api/pages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'audit-vf-test', template: 'page-default' }),
+    })
+    const res = await app.request('/api/pages/audit-vf-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: { hero: { _asset: 'definitely-not-an-asset-name' } } }),
+    })
+    expect(res.status).toBe(409)
+    const events = await readAuditEvents()
+    const matched = events.filter(
+      e => e.action === 'save' && e.outcome === 'validation-failed' && e.scope.name === 'audit-vf-test',
+    )
+    expect(matched).toHaveLength(1)
+    await rm(resolve(localTargetDir, 'pages/audit-vf-test'), { recursive: true, force: true })
+  })
+
+  it('successful page delete records action: delete, outcome: success', async () => {
+    await app.request('/api/pages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'audit-delete-test', template: 'page-default' }),
+    })
+    const res = await app.request('/api/pages/audit-delete-test', { method: 'DELETE' })
+    expect(res.status).toBe(200)
+    const events = await readAuditEvents()
+    const matched = events.filter(
+      e => e.action === 'delete' && e.outcome === 'success' && e.scope.name === 'audit-delete-test',
+    )
+    expect(matched).toHaveLength(1)
+  })
+
+  it('audit events carry scope.kind correctly per route', async () => {
+    // Fragment save → kind: 'fragment'.
+    await app.request('/api/fragments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'audit-frag-test', template: 'footer-layout' }),
+    })
+    const res = await app.request('/api/fragments/audit-frag-test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: { copyright: 'test' } }),
+    })
+    expect(res.status).toBe(200)
+    const events = await readAuditEvents()
+    const matched = events.filter(
+      e => e.action === 'save' && e.scope.kind === 'fragment' && e.scope.name === 'audit-frag-test',
+    )
+    expect(matched).toHaveLength(1)
+    await rm(resolve(localTargetDir, 'fragments/audit-frag-test'), { recursive: true, force: true })
+  })
+
+  it('events carry timestamp in ISO 8601', async () => {
+    const events = await readAuditEvents()
+    expect(events.length).toBeGreaterThan(0)
+    for (const e of events) {
+      expect(e.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+      // Confirm parseable.
+      expect(Number.isFinite(new Date(e.timestamp).getTime())).toBe(true)
+    }
+  })
+
+  it('actor.id is "unknown" under none-mode default', async () => {
+    const events = await readAuditEvents()
+    expect(events.length).toBeGreaterThan(0)
+    // Every event's actor.id should be 'unknown' since no auth
+    // is configured in the test fixture's site.config.ts.
+    expect(events.every(e => e.actor.id === 'unknown')).toBe(true)
+  })
+})

--- a/packages/gazetta/tests/audit-privacy.test.ts
+++ b/packages/gazetta/tests/audit-privacy.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Cut 4 tests: pseudonymization + source-IP / user-agent processing.
+ *
+ * Each module is a pure function; tests pin the documented modes
+ * and the trust-mode-driven extraction matrix.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  computePseudonymizedId,
+  extractSourceIp,
+  processSourceIp,
+  processUserAgent,
+  pseudonymizeActor,
+  type AuditActor,
+} from '../src/audit/index.js'
+
+const sampleActor: AuditActor = {
+  id: 'oidc-sub-12345',
+  email: 'alice@example.com',
+  role: 'editor',
+  trustMode: 'cloudflare-access',
+}
+
+describe('pseudonymizeActor (Cut 4)', () => {
+  it("'none' mode passes the actor through unchanged", () => {
+    const out = pseudonymizeActor(sampleActor, 'none')
+    expect(out).toEqual(sampleActor)
+    // Same reference — no allocation cost when feature is off.
+    expect(out).toBe(sampleActor)
+  })
+
+  it("'sha256' mode replaces id with salted hash prefix", () => {
+    const out = pseudonymizeActor(sampleActor, 'sha256', 'salt-1234567890')
+    expect(out.id).not.toBe(sampleActor.id)
+    expect(out.id).toMatch(/^[a-f0-9]{16}$/)
+    expect(out.role).toBe('editor')
+    expect(out.trustMode).toBe('cloudflare-access')
+  })
+
+  it("'sha256' mode drops the email field", () => {
+    const out = pseudonymizeActor(sampleActor, 'sha256', 'salt')
+    expect(out.email).toBeUndefined()
+  })
+
+  it("'sha256' mode is deterministic across calls (multi-instance correctness)", () => {
+    const a = pseudonymizeActor(sampleActor, 'sha256', 'shared-salt')
+    const b = pseudonymizeActor(sampleActor, 'sha256', 'shared-salt')
+    expect(a.id).toBe(b.id)
+  })
+
+  it('different salts produce different hashes (salt rotation breaks correlation)', () => {
+    const a = pseudonymizeActor(sampleActor, 'sha256', 'old-salt')
+    const b = pseudonymizeActor(sampleActor, 'sha256', 'new-salt')
+    expect(a.id).not.toBe(b.id)
+  })
+
+  it("'sha256' without a salt throws (catches operator misconfiguration)", () => {
+    expect(() => pseudonymizeActor(sampleActor, 'sha256')).toThrow(/salt/)
+    expect(() => pseudonymizeActor(sampleActor, 'sha256', '')).toThrow(/salt/)
+  })
+
+  it('does not mutate the input actor', () => {
+    const before = JSON.stringify(sampleActor)
+    pseudonymizeActor(sampleActor, 'sha256', 'salt')
+    expect(JSON.stringify(sampleActor)).toBe(before)
+  })
+
+  it('computePseudonymizedId matches pseudonymizeActor for forensic queries', () => {
+    // The forensic query path: operator knows sub + salt, computes
+    // the hash, searches the audit log. Must match the recorder's
+    // pseudonymization exactly.
+    const direct = computePseudonymizedId(sampleActor.id, 'salt')
+    const viaActor = pseudonymizeActor(sampleActor, 'sha256', 'salt').id
+    expect(direct).toBe(viaActor)
+  })
+})
+
+// --- Source IP --------------------------------------------------
+
+function headerMap(entries: Record<string, string>): ReadonlyMap<string, string> {
+  return new Map(Object.entries(entries).map(([k, v]) => [k.toLowerCase(), v]))
+}
+
+describe('extractSourceIp (Cut 4) — trust-mode dispatch', () => {
+  it("'none' trust mode: returns peer IP", () => {
+    expect(extractSourceIp({ trustMode: 'none', headers: headerMap({}), peerIp: '203.0.113.1' })).toBe('203.0.113.1')
+  })
+
+  it("'tailscale' trust mode: returns peer IP (Tailscale serves direct)", () => {
+    expect(extractSourceIp({ trustMode: 'tailscale', headers: headerMap({}), peerIp: '100.64.0.1' })).toBe('100.64.0.1')
+  })
+
+  it("'cloudflare-access': prefers Cf-Connecting-IP", () => {
+    expect(
+      extractSourceIp({
+        trustMode: 'cloudflare-access',
+        headers: headerMap({ 'Cf-Connecting-IP': '203.0.113.5' }),
+        peerIp: '198.51.100.1', // peer would be Cloudflare's edge
+      }),
+    ).toBe('203.0.113.5')
+  })
+
+  it("'cloudflare-access': falls back to peer IP when Cf-Connecting-IP absent", () => {
+    expect(
+      extractSourceIp({
+        trustMode: 'cloudflare-access',
+        headers: headerMap({}),
+        peerIp: '198.51.100.1',
+      }),
+    ).toBe('198.51.100.1')
+  })
+
+  it("'forwarded-user' with trustedProxyCount=1: client is leftmost", () => {
+    expect(
+      extractSourceIp({
+        trustMode: 'forwarded-user',
+        headers: headerMap({ 'X-Forwarded-For': '203.0.113.1, 10.0.0.1' }),
+        peerIp: '10.0.0.1',
+        trustedProxyCount: 1,
+      }),
+    ).toBe('203.0.113.1')
+  })
+
+  it("'forwarded-user' with trustedProxyCount=2: client is leftmost-of-leftmost-two", () => {
+    expect(
+      extractSourceIp({
+        trustMode: 'forwarded-user',
+        headers: headerMap({ 'X-Forwarded-For': '203.0.113.1, 10.0.0.1, 10.0.0.2' }),
+        peerIp: '10.0.0.2',
+        trustedProxyCount: 2,
+      }),
+    ).toBe('203.0.113.1')
+  })
+
+  it("'forwarded-user' default trustedProxyCount is 1", () => {
+    expect(
+      extractSourceIp({
+        trustMode: 'forwarded-user',
+        headers: headerMap({ 'X-Forwarded-For': '203.0.113.1, 10.0.0.1' }),
+        // No trustedProxyCount supplied — should default to 1
+      }),
+    ).toBe('203.0.113.1')
+  })
+
+  it('returns null when X-Forwarded-For is absent and no peer IP', () => {
+    expect(extractSourceIp({ trustMode: 'forwarded-user', headers: headerMap({}) })).toBeNull()
+  })
+
+  it('returns peer IP when X-Forwarded-For has fewer entries than trustedProxyCount', () => {
+    // Edge case: single-entry XFF but operator says trustedProxyCount: 2
+    // — proxy-misconfig case. Falls back to peer IP rather than
+    // returning a wrong answer.
+    expect(
+      extractSourceIp({
+        trustMode: 'forwarded-user',
+        headers: headerMap({ 'X-Forwarded-For': '203.0.113.1' }),
+        peerIp: '10.0.0.1',
+        trustedProxyCount: 2,
+      }),
+    ).toBe('10.0.0.1')
+  })
+
+  it("'azure-easy-auth': uses X-Forwarded-For (default trustedProxyCount 1)", () => {
+    expect(
+      extractSourceIp({
+        trustMode: 'azure-easy-auth',
+        headers: headerMap({ 'X-Forwarded-For': '203.0.113.1, 10.0.0.1' }),
+      }),
+    ).toBe('203.0.113.1')
+  })
+
+  it("'aws-cognito': uses X-Forwarded-For (default trustedProxyCount 1)", () => {
+    expect(
+      extractSourceIp({
+        trustMode: 'aws-cognito',
+        headers: headerMap({ 'X-Forwarded-For': '203.0.113.1, 10.0.0.1' }),
+      }),
+    ).toBe('203.0.113.1')
+  })
+
+  it('unknown trust mode falls back to peer IP', () => {
+    expect(
+      extractSourceIp({
+        trustMode: 'plugin-supplied-future',
+        headers: headerMap({}),
+        peerIp: '203.0.113.1',
+      }),
+    ).toBe('203.0.113.1')
+  })
+})
+
+describe('processSourceIp (Cut 4) — mode dispatch', () => {
+  it("'none' returns null regardless of input", () => {
+    expect(processSourceIp('203.0.113.1', 'none')).toBeNull()
+  })
+
+  it('null input returns null in any mode', () => {
+    expect(processSourceIp(null, 'raw')).toBeNull()
+    expect(processSourceIp(null, 'truncated')).toBeNull()
+  })
+
+  it("'raw' returns the IP unchanged", () => {
+    expect(processSourceIp('203.0.113.1', 'raw')).toBe('203.0.113.1')
+    expect(processSourceIp('fe80::1', 'raw')).toBe('fe80::1')
+  })
+
+  it("'hashed' produces a 16-char hex prefix", () => {
+    const out = processSourceIp('203.0.113.1', 'hashed', 'salt')
+    expect(out).toMatch(/^[a-f0-9]{16}$/)
+  })
+
+  it("'hashed' is deterministic + salt-rotation-aware", () => {
+    expect(processSourceIp('1.2.3.4', 'hashed', 'salt')).toBe(processSourceIp('1.2.3.4', 'hashed', 'salt'))
+    expect(processSourceIp('1.2.3.4', 'hashed', 'salt')).not.toBe(processSourceIp('1.2.3.4', 'hashed', 'other-salt'))
+  })
+
+  it("'hashed' without salt throws", () => {
+    expect(() => processSourceIp('1.2.3.4', 'hashed')).toThrow(/salt/)
+  })
+
+  it("'truncated' IPv4 → /24", () => {
+    expect(processSourceIp('203.0.113.42', 'truncated')).toBe('203.0.113.0/24')
+    expect(processSourceIp('10.1.2.3', 'truncated')).toBe('10.1.2.0/24')
+  })
+
+  it("'truncated' IPv6 → /48 (first 3 groups)", () => {
+    expect(processSourceIp('2001:db8:abcd:1234::1', 'truncated')).toBe('2001:db8:abcd::/48')
+    expect(processSourceIp('fe80::1', 'truncated')).toBe('fe80:0:0::/48')
+  })
+
+  it("'truncated' on malformed IP returns null", () => {
+    expect(processSourceIp('not-an-ip', 'truncated')).toBeNull()
+    expect(processSourceIp('1.2.3', 'truncated')).toBeNull()
+    expect(processSourceIp('1.2.3.999', 'truncated')).toBeNull()
+  })
+})
+
+// --- User Agent -------------------------------------------------
+
+describe('processUserAgent (Cut 4)', () => {
+  it("'none' mode returns null", () => {
+    expect(processUserAgent('Mozilla/5.0 ...', 'none')).toBeNull()
+  })
+
+  it('null/empty input returns null', () => {
+    expect(processUserAgent(undefined, 'raw')).toBeNull()
+    expect(processUserAgent('', 'raw')).toBeNull()
+  })
+
+  it("'raw' returns the full UA", () => {
+    const ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/119.0.0.0'
+    expect(processUserAgent(ua, 'raw')).toBe(ua)
+  })
+
+  it("'truncated' detects Chrome", () => {
+    expect(processUserAgent('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/119.0.0.0', 'truncated')).toBe(
+      'Chrome/119',
+    )
+  })
+
+  it("'truncated' detects Firefox", () => {
+    expect(processUserAgent('Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Firefox/120.0', 'truncated')).toBe('Firefox/120')
+  })
+
+  it("'truncated' detects Safari", () => {
+    expect(processUserAgent('Mozilla/5.0 (Macintosh) AppleWebKit/605 Version/17.0 Safari/605.1', 'truncated')).toBe(
+      'Safari/17',
+    )
+  })
+
+  it("'truncated' detects Edge before Chrome (UA contains Chrome)", () => {
+    expect(processUserAgent('Mozilla/5.0 ... Chrome/119 Edg/119.0', 'truncated')).toBe('Edge/119')
+  })
+
+  it("'truncated' falls back to 'Other' for unknown families", () => {
+    expect(processUserAgent('curl/8.0.0', 'truncated')).toBe('Other')
+    expect(processUserAgent('AcmeBot/1.0', 'truncated')).toBe('Other')
+  })
+})

--- a/packages/gazetta/tests/audit-recorder.test.ts
+++ b/packages/gazetta/tests/audit-recorder.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Cut 3 tests: audit-recording dispatcher.
+ *
+ * Verifies the load-bearing invariants per design-audit.md:
+ *   - Parallel fan-out (Promise.allSettled, not sequential)
+ *   - Fail-open default — never throws
+ *   - Failure logger receives PII-FREE entries (no payload)
+ *   - Strict mode shape — caller branches on result.failed
+ *   - Empty providers array is a valid state (zero-config; never
+ *     throws)
+ *   - AuditTransportError category preserved through the failure
+ *     log when providers throw it; default 'transport' for unknown
+ *     errors
+ */
+import { describe, expect, it, vi } from 'vitest'
+import {
+  AuditTransportError,
+  recordToAll,
+  type AuditEvent,
+  type AuditFailureLog,
+  type AuditProvider,
+} from '../src/audit/index.js'
+
+function event(): AuditEvent {
+  return {
+    timestamp: '2026-05-07T15:00:00Z',
+    actor: { id: 'alice', email: 'alice@example.com', role: 'editor', trustMode: 'cloudflare-access' },
+    action: 'save',
+    outcome: 'success',
+    scope: { kind: 'page', name: 'home' },
+  }
+}
+
+function provider(
+  name: string,
+  behavior: 'ok' | 'throw' | 'transport-throw' | 'serialize-throw' = 'ok',
+): AuditProvider {
+  return {
+    name,
+    async record(): Promise<void> {
+      if (behavior === 'ok') return
+      if (behavior === 'throw') throw new Error(`${name}: generic failure`)
+      if (behavior === 'transport-throw') throw new AuditTransportError(`${name}: connection refused`, 'transport')
+      if (behavior === 'serialize-throw') throw new AuditTransportError(`${name}: bad shape`, 'serialize')
+    },
+  }
+}
+
+describe('recordToAll (Cut 3)', () => {
+  it('zero providers → succeeded 0, failed 0, never throws', async () => {
+    const result = await recordToAll(event(), { providers: [] })
+    expect(result.succeeded).toBe(0)
+    expect(result.failed).toBe(0)
+    expect(result.failures).toEqual([])
+  })
+
+  it('all providers succeed → succeeded N, failed 0', async () => {
+    const result = await recordToAll(event(), {
+      providers: [provider('a'), provider('b'), provider('c')],
+    })
+    expect(result.succeeded).toBe(3)
+    expect(result.failed).toBe(0)
+  })
+
+  it('all providers fail → succeeded 0, failed N — never throws (fail-open)', async () => {
+    const result = await recordToAll(event(), {
+      providers: [provider('a', 'throw'), provider('b', 'throw')],
+    })
+    expect(result.succeeded).toBe(0)
+    expect(result.failed).toBe(2)
+    expect(result.failures.map(f => f.provider).sort()).toEqual(['a', 'b'])
+  })
+
+  it('mixed success / failure → counts split correctly', async () => {
+    const result = await recordToAll(event(), {
+      providers: [provider('history'), provider('cloudwatch', 'throw'), provider('webhook', 'throw')],
+    })
+    expect(result.succeeded).toBe(1)
+    expect(result.failed).toBe(2)
+    expect(result.failures.map(f => f.provider).sort()).toEqual(['cloudwatch', 'webhook'])
+  })
+
+  it('failures are recorded in registration order (parallel-safe)', async () => {
+    // Order of failures in the result mirrors provider array order
+    // (Promise.allSettled preserves index-correspondence).
+    const result = await recordToAll(event(), {
+      providers: [provider('first', 'throw'), provider('second'), provider('third', 'throw')],
+    })
+    expect(result.failures.map(f => f.provider)).toEqual(['first', 'third'])
+  })
+
+  it('AuditTransportError category propagates to failure log', async () => {
+    const result = await recordToAll(event(), {
+      providers: [provider('a', 'transport-throw'), provider('b', 'serialize-throw')],
+    })
+    expect(result.failures.find(f => f.provider === 'a')?.category).toBe('transport')
+    expect(result.failures.find(f => f.provider === 'b')?.category).toBe('serialize')
+  })
+
+  it('generic Error defaults to category: transport', async () => {
+    const result = await recordToAll(event(), {
+      providers: [provider('a', 'throw')],
+    })
+    expect(result.failures[0].category).toBe('transport')
+  })
+
+  it('logger receives one entry per failure', async () => {
+    const log = vi.fn<(entry: AuditFailureLog) => void>()
+    await recordToAll(event(), {
+      providers: [provider('a', 'throw'), provider('b'), provider('c', 'throw')],
+      logFailure: log,
+    })
+    expect(log).toHaveBeenCalledTimes(2)
+    const calls = log.mock.calls.map(c => c[0])
+    expect(calls.map(c => c.provider).sort()).toEqual(['a', 'c'])
+  })
+
+  it('logger entries do NOT contain the event payload', async () => {
+    const log = vi.fn<(entry: AuditFailureLog) => void>()
+    await recordToAll(event(), {
+      providers: [provider('a', 'throw')],
+      logFailure: log,
+    })
+    const entry = log.mock.calls[0][0]
+    // The shape must be exactly { provider, category, reason }.
+    // Adding the event payload would leak PII through stderr.
+    expect(Object.keys(entry).sort()).toEqual(['category', 'provider', 'reason'])
+    // Defense-in-depth: assert the actor's fields aren't on the entry.
+    const json = JSON.stringify(entry)
+    expect(json).not.toContain('alice')
+    expect(json).not.toContain('editor')
+    expect(json).not.toContain('home')
+  })
+
+  it('logger is optional (production should always wire one; tests can omit)', async () => {
+    // No logger; provider failures still get counted but produce
+    // no log output. This is intentional — silent failure is a
+    // worse default than fail-open, but we let tests omit the
+    // logger when they don't care about the log shape.
+    const result = await recordToAll(event(), {
+      providers: [provider('a', 'throw')],
+    })
+    expect(result.failed).toBe(1)
+  })
+
+  it('reason text comes from the thrown Error message', async () => {
+    const result = await recordToAll(event(), {
+      providers: [provider('cloudwatch', 'transport-throw')],
+    })
+    expect(result.failures[0].reason).toContain('connection refused')
+  })
+
+  it('providers are invoked in PARALLEL (not sequential)', async () => {
+    // Parallel = Promise.allSettled; total time ≈ slowest provider,
+    // not sum. With three providers each taking 50ms, sequential
+    // execution would be ≥150ms; parallel should be <2x slowest.
+    // We use a tracker to record start/end timestamps per provider
+    // and assert overlap directly — avoids vitest timer-jitter
+    // flakes in CI.
+    const starts: Record<string, number> = {}
+    const ends: Record<string, number> = {}
+    const tracked = (name: string): AuditProvider => ({
+      name,
+      async record() {
+        starts[name] = Date.now()
+        await new Promise(r => setTimeout(r, 30))
+        ends[name] = Date.now()
+      },
+    })
+    await recordToAll(event(), {
+      providers: [tracked('a'), tracked('b'), tracked('c')],
+    })
+    // All three started before any finished — that's the invariant
+    // for parallel execution. Sequential would have started 'b'
+    // only after 'a' finished.
+    const allStarts = Math.max(starts.a, starts.b, starts.c)
+    const firstEnd = Math.min(ends.a, ends.b, ends.c)
+    expect(allStarts).toBeLessThanOrEqual(firstEnd)
+  })
+
+  it("strict mode is the CALLER's concern; recorder always returns the result", async () => {
+    // The recorder doesn't act on `strict` — it returns the
+    // result; the caller (Cut 5's handlers) checks result.failed
+    // and aborts the write when strict is on. Test the recorder
+    // doesn't behave differently with strict: true vs false.
+    const a = await recordToAll(event(), { providers: [provider('x', 'throw')], strict: true })
+    const b = await recordToAll(event(), { providers: [provider('x', 'throw')], strict: false })
+    expect(a.failed).toBe(b.failed)
+    expect(a.succeeded).toBe(b.succeeded)
+  })
+})

--- a/packages/gazetta/tests/audit-retention.test.ts
+++ b/packages/gazetta/tests/audit-retention.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Cut 8 tests: pruneAuditEvents.
+ *
+ * Pins the retention semantics from design-audit.md "Retention":
+ *
+ *   - `events` cap (max count) — global across all per-instance JSONL
+ *     files, oldest evicted
+ *   - `maxAgeMonths` cap — events older than the cutoff evicted
+ *   - both set — age cutoff first, then count cap on what remains
+ *   - neither set — no-op
+ *   - empty / missing audit dir — no-op
+ *   - malformed JSONL lines — skipped (don't poison the rewrite)
+ *   - empty file after prune → written as empty (preserves the file
+ *     marker; concurrent appenders don't need to mkdir)
+ *   - per-file rewrite — only files with at least one eviction
+ *     rewrite (avoids dirtying mtime on unaffected files)
+ *
+ * Storage: in-memory backed StorageProvider; no real filesystem,
+ * keeps tests fast + deterministic.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createFilesystemProvider } from '../src/providers/filesystem.js'
+import { pruneAuditEvents } from '../src/audit/retention.js'
+import type { AuditEvent } from '../src/audit/types.js'
+
+function makeEvent(timestamp: string, partial: Partial<AuditEvent> = {}): AuditEvent {
+  return {
+    timestamp,
+    actor: { id: 'alice', role: 'admin', trustMode: 'none' },
+    action: 'save',
+    outcome: 'success',
+    scope: { kind: 'page', name: 'home' },
+    ...partial,
+  }
+}
+
+describe('Cut 8 — pruneAuditEvents', () => {
+  let dir: string
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'audit-retention-'))
+  })
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  // Each test gets its own subdir under the temp dir to avoid cross-
+  // test interference. The storage provider treats `path` as the
+  // root prefix for relative ops.
+  let counter = 0
+  function newStorage() {
+    counter++
+    const root = join(dir, `t-${counter}`)
+    return { storage: createFilesystemProvider(root), root }
+  }
+
+  async function writeEvents(
+    storage: ReturnType<typeof newStorage>['storage'],
+    instance: string,
+    events: AuditEvent[],
+  ): Promise<void> {
+    await storage.mkdir('.gazetta/audit').catch(() => {})
+    const content = events.map(e => JSON.stringify(e)).join('\n') + (events.length ? '\n' : '')
+    await storage.writeFile(`.gazetta/audit/events-${instance}.jsonl`, content)
+  }
+
+  async function readEvents(
+    storage: ReturnType<typeof newStorage>['storage'],
+    instance: string,
+  ): Promise<AuditEvent[]> {
+    const content = await storage.readFile(`.gazetta/audit/events-${instance}.jsonl`)
+    if (!content) return []
+    return content
+      .split('\n')
+      .map(l => l.trim())
+      .filter(Boolean)
+      .map(l => JSON.parse(l) as AuditEvent)
+  }
+
+  describe('no-op cases', () => {
+    it('returns zero metrics when neither retention dimension is set', async () => {
+      const { storage } = newStorage()
+      await writeEvents(storage, 'a', [makeEvent('2026-05-04T10:00:00Z'), makeEvent('2026-05-04T11:00:00Z')])
+      const result = await pruneAuditEvents(storage, {})
+      expect(result.eventsBefore).toBe(0)
+      expect(result.eventsKept).toBe(0)
+      expect(result.eventsEvicted).toBe(0)
+      expect(result.filesRewritten).toBe(0)
+      // Events still present (no-op didn't touch them)
+      const surviving = await readEvents(storage, 'a')
+      expect(surviving).toHaveLength(2)
+    })
+
+    it('handles missing audit directory', async () => {
+      const { storage } = newStorage()
+      const result = await pruneAuditEvents(storage, { events: 100 })
+      expect(result.eventsBefore).toBe(0)
+      expect(result.eventsEvicted).toBe(0)
+      expect(result.filesInspected).toBe(0)
+    })
+
+    it('handles empty audit directory', async () => {
+      const { storage } = newStorage()
+      await storage.mkdir('.gazetta/audit')
+      const result = await pruneAuditEvents(storage, { events: 100 })
+      expect(result.eventsBefore).toBe(0)
+      expect(result.filesInspected).toBe(0)
+    })
+  })
+
+  describe('events cap (count-based)', () => {
+    it('evicts oldest when count exceeds cap', async () => {
+      const { storage } = newStorage()
+      await writeEvents(storage, 'a', [
+        makeEvent('2026-05-04T10:00:00Z', { scope: { kind: 'page', name: 'a' } }),
+        makeEvent('2026-05-04T11:00:00Z', { scope: { kind: 'page', name: 'b' } }),
+        makeEvent('2026-05-04T12:00:00Z', { scope: { kind: 'page', name: 'c' } }),
+        makeEvent('2026-05-04T13:00:00Z', { scope: { kind: 'page', name: 'd' } }),
+        makeEvent('2026-05-04T14:00:00Z', { scope: { kind: 'page', name: 'e' } }),
+      ])
+      const result = await pruneAuditEvents(storage, { events: 3 })
+      expect(result.eventsBefore).toBe(5)
+      expect(result.eventsKept).toBe(3)
+      expect(result.eventsEvicted).toBe(2)
+      expect(result.filesRewritten).toBe(1)
+      const surviving = await readEvents(storage, 'a')
+      expect(surviving.map(e => e.scope.name)).toEqual(['c', 'd', 'e'])
+    })
+
+    it('evicts oldest globally across multiple instance files', async () => {
+      const { storage } = newStorage()
+      // Instance 'a' has older events; instance 'b' has newer.
+      // Cap = 3 → keeps the 3 newest globally, regardless of which file.
+      await writeEvents(storage, 'a', [
+        makeEvent('2026-05-04T10:00:00Z', { scope: { kind: 'page', name: 'a-old' } }),
+        makeEvent('2026-05-04T11:00:00Z', { scope: { kind: 'page', name: 'a-mid' } }),
+      ])
+      await writeEvents(storage, 'b', [
+        makeEvent('2026-05-04T13:00:00Z', { scope: { kind: 'page', name: 'b-old' } }),
+        makeEvent('2026-05-04T14:00:00Z', { scope: { kind: 'page', name: 'b-mid' } }),
+        makeEvent('2026-05-04T15:00:00Z', { scope: { kind: 'page', name: 'b-new' } }),
+      ])
+      const result = await pruneAuditEvents(storage, { events: 3 })
+      expect(result.eventsKept).toBe(3)
+      expect(result.eventsEvicted).toBe(2)
+      // Both files modified — the two oldest came from 'a'.
+      const survivingA = await readEvents(storage, 'a')
+      const survivingB = await readEvents(storage, 'b')
+      expect(survivingA).toHaveLength(0)
+      expect(survivingB.map(e => e.scope.name)).toEqual(['b-old', 'b-mid', 'b-new'])
+    })
+
+    it('no rewrites when count is within cap', async () => {
+      const { storage } = newStorage()
+      await writeEvents(storage, 'a', [makeEvent('2026-05-04T10:00:00Z'), makeEvent('2026-05-04T11:00:00Z')])
+      const result = await pruneAuditEvents(storage, { events: 100 })
+      expect(result.eventsBefore).toBe(2)
+      expect(result.eventsEvicted).toBe(0)
+      expect(result.filesRewritten).toBe(0)
+    })
+  })
+
+  describe('maxAgeMonths cap (age-based)', () => {
+    it('evicts events older than the cutoff', async () => {
+      const { storage } = newStorage()
+      const now = new Date()
+      const oldEnough = new Date()
+      oldEnough.setMonth(oldEnough.getMonth() - 3)
+      const recent = new Date()
+      recent.setMonth(recent.getMonth() - 1)
+
+      await writeEvents(storage, 'a', [
+        makeEvent(oldEnough.toISOString(), { scope: { kind: 'page', name: 'old' } }),
+        makeEvent(recent.toISOString(), { scope: { kind: 'page', name: 'recent' } }),
+        makeEvent(now.toISOString(), { scope: { kind: 'page', name: 'now' } }),
+      ])
+      // Cutoff = 2 months back → 'old' evicted, 'recent' + 'now' kept.
+      const result = await pruneAuditEvents(storage, { maxAgeMonths: 2 })
+      expect(result.eventsBefore).toBe(3)
+      expect(result.eventsKept).toBe(2)
+      expect(result.eventsEvicted).toBe(1)
+      const surviving = await readEvents(storage, 'a')
+      expect(surviving.map(e => e.scope.name).sort()).toEqual(['now', 'recent'])
+    })
+
+    it('null / 0 / undefined maxAgeMonths is a no-op for the age dimension', async () => {
+      const { storage } = newStorage()
+      const ancient = new Date()
+      ancient.setMonth(ancient.getMonth() - 24)
+      await writeEvents(storage, 'a', [makeEvent(ancient.toISOString(), { scope: { kind: 'page', name: 'a' } })])
+      const r1 = await pruneAuditEvents(storage, { maxAgeMonths: null })
+      expect(r1.eventsBefore).toBe(0) // neither dimension set → full no-op
+      const r2 = await pruneAuditEvents(storage, { maxAgeMonths: 0 })
+      // 0 months is treated as no-op (positive int required per schema;
+      // pruner is defensive against zero anyway).
+      expect(r2.eventsEvicted).toBe(0)
+    })
+  })
+
+  describe('combined dimensions', () => {
+    it('applies age cutoff first, then count cap on what remains', async () => {
+      const { storage } = newStorage()
+      const old = new Date()
+      old.setMonth(old.getMonth() - 6)
+      const t1 = new Date()
+      t1.setMonth(t1.getMonth() - 1)
+      const t2 = new Date()
+      t2.setHours(t2.getHours() - 2)
+      const t3 = new Date()
+      t3.setHours(t3.getHours() - 1)
+      const t4 = new Date()
+
+      await writeEvents(storage, 'a', [
+        makeEvent(old.toISOString(), { scope: { kind: 'page', name: 'old' } }),
+        makeEvent(t1.toISOString(), { scope: { kind: 'page', name: 't1' } }),
+        makeEvent(t2.toISOString(), { scope: { kind: 'page', name: 't2' } }),
+        makeEvent(t3.toISOString(), { scope: { kind: 'page', name: 't3' } }),
+        makeEvent(t4.toISOString(), { scope: { kind: 'page', name: 't4' } }),
+      ])
+      // maxAgeMonths=3 → drops 'old' (6 months back).
+      // events=2 → keeps the 2 newest of the survivors {t1, t2, t3, t4}
+      // → {t3, t4}.
+      const result = await pruneAuditEvents(storage, { maxAgeMonths: 3, events: 2 })
+      expect(result.eventsBefore).toBe(5)
+      expect(result.eventsKept).toBe(2)
+      expect(result.eventsEvicted).toBe(3)
+      const surviving = await readEvents(storage, 'a')
+      expect(surviving.map(e => e.scope.name).sort()).toEqual(['t3', 't4'])
+    })
+  })
+
+  describe('robustness', () => {
+    it('skips malformed JSONL lines without poisoning the rewrite', async () => {
+      const { storage } = newStorage()
+      await storage.mkdir('.gazetta/audit')
+      // Mix valid + malformed lines. The reader skips the bad one,
+      // the rewriter doesn't include it in surviving.
+      const valid1 = JSON.stringify(makeEvent('2026-05-04T10:00:00Z', { scope: { kind: 'page', name: 'a' } }))
+      const valid2 = JSON.stringify(makeEvent('2026-05-04T11:00:00Z', { scope: { kind: 'page', name: 'b' } }))
+      await storage.writeFile('.gazetta/audit/events-a.jsonl', `${valid1}\n{ broken json no closing brace\n${valid2}\n`)
+      const result = await pruneAuditEvents(storage, { events: 1 })
+      // 2 valid events present (malformed line skipped at parse).
+      // Cap=1 → keep newest, evict 'a'. The rawLineCount counted the
+      // malformed line, so eventsEvicted = rawLineCount - surviving =
+      // 3 - 1 = 2 (the old valid + the malformed line).
+      expect(result.eventsBefore).toBe(2)
+      expect(result.eventsKept).toBe(1)
+      const surviving = await readEvents(storage, 'a')
+      expect(surviving).toHaveLength(1)
+      expect(surviving[0].scope.name).toBe('b')
+    })
+
+    it('writes empty file when all events evicted', async () => {
+      const { storage } = newStorage()
+      const old = new Date()
+      old.setMonth(old.getMonth() - 12)
+      await writeEvents(storage, 'a', [makeEvent(old.toISOString(), { scope: { kind: 'page', name: 'old' } })])
+      const result = await pruneAuditEvents(storage, { maxAgeMonths: 1 })
+      expect(result.eventsKept).toBe(0)
+      expect(result.eventsEvicted).toBe(1)
+      // File still exists (empty), not deleted.
+      const content = await storage.readFile('.gazetta/audit/events-a.jsonl')
+      expect(content).toBe('')
+    })
+
+    it('only rewrites files that had at least one eviction', async () => {
+      const { storage } = newStorage()
+      await writeEvents(storage, 'a', [makeEvent('2026-05-04T10:00:00Z'), makeEvent('2026-05-04T11:00:00Z')])
+      await writeEvents(storage, 'b', [
+        makeEvent('2026-05-04T15:00:00Z'),
+        makeEvent('2026-05-04T16:00:00Z'),
+        makeEvent('2026-05-04T17:00:00Z'),
+      ])
+      // Cap=4 → only one event evicted (the oldest from 'a').
+      const result = await pruneAuditEvents(storage, { events: 4 })
+      expect(result.eventsEvicted).toBe(1)
+      expect(result.filesRewritten).toBe(1)
+      expect(result.filesInspected).toBe(2)
+    })
+  })
+})

--- a/packages/gazetta/tests/audit-route.test.ts
+++ b/packages/gazetta/tests/audit-route.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Cut 6 tests: GET /api/audit endpoint.
+ *
+ * Validates the route in isolation — provides a synthetic
+ * AuditProvider list (no real storage) so each test pins one
+ * facet of the contract:
+ *
+ *   - filter parsing (action / outcome / scope / actor / since /
+ *     until / limit) → invalid values return 400
+ *   - merge + dedup across queryable providers
+ *   - newest-first sort on the merged set
+ *   - external-sink references composed into the response when a
+ *     provider omits query() but provides queryUrl()
+ *   - capability gating (`read:audit-log`) blocks unauthenticated
+ *     requests with 401 and authenticated-without-grant with 403
+ *
+ * Strategy: mount the real `auditRoutes` factory under a Hono app
+ * with `principalMiddleware` set to `nonePrincipalProvider` so the
+ * default Principal is admin/`*` (matches createAdminApp's default).
+ * Synthetic AuditProviders implement query() / queryUrl() with
+ * canned payloads.
+ */
+import { describe, it, expect } from 'vitest'
+import { Hono } from 'hono'
+import { auditRoutes } from '../src/admin-api/routes/audit.js'
+import { principalMiddleware } from '../src/admin-api/middleware/principal.js'
+import { noneAuthProvider } from '../src/auth/providers/none.js'
+import type { AuditProvider } from '../src/audit/provider.js'
+import type { AuditEvent, AuditQuery } from '../src/audit/types.js'
+
+function makeEvent(partial: Partial<AuditEvent> = {}): AuditEvent {
+  return {
+    timestamp: '2026-05-04T14:23:05Z',
+    actor: { id: 'unknown', role: 'admin', trustMode: 'none' },
+    action: 'save',
+    outcome: 'success',
+    scope: { kind: 'page', name: 'home' },
+    ...partial,
+  }
+}
+
+function makeQueryableProvider(name: string, events: AuditEvent[]): AuditProvider {
+  return {
+    name,
+    async record() {
+      // No-op for the route tests; recording isn't exercised here.
+    },
+    async query(filter: AuditQuery): Promise<AuditEvent[]> {
+      let matched = events
+      if (filter.action) matched = matched.filter(e => e.action === filter.action)
+      if (filter.outcome) matched = matched.filter(e => e.outcome === filter.outcome)
+      if (filter.scope?.kind) matched = matched.filter(e => e.scope.kind === filter.scope!.kind)
+      if (filter.scope?.name) matched = matched.filter(e => e.scope.name === filter.scope!.name)
+      if (filter.actor) {
+        const needle = filter.actor.toLowerCase()
+        matched = matched.filter(
+          e => e.actor.id.toLowerCase().includes(needle) || (e.actor.email?.toLowerCase().includes(needle) ?? false),
+        )
+      }
+      if (filter.since) matched = matched.filter(e => e.timestamp >= filter.since!)
+      if (filter.until) matched = matched.filter(e => e.timestamp < filter.until!)
+      const limit = filter.limit ?? 100
+      return matched.slice(0, limit)
+    },
+  }
+}
+
+function makeExternalSinkProvider(name: string, url: string | null): AuditProvider {
+  return {
+    name,
+    async record() {},
+    queryUrl: () => url,
+  }
+}
+
+function buildApp(providers: AuditProvider[]): Hono {
+  const app = new Hono()
+  // Mount the principal middleware first so requireCapability has a
+  // c.var.principal to read. nonePrincipalProvider returns the
+  // 'unknown' / 'admin' principal which holds `*` capabilities — same
+  // shape createAdminApp uses when no auth is configured.
+  app.use('/api/*', principalMiddleware(noneAuthProvider))
+  app.route('/', auditRoutes({ providers }))
+  return app
+}
+
+describe('Cut 6 — GET /api/audit', () => {
+  it('returns events from a single queryable provider, newest-first', async () => {
+    const provider = makeQueryableProvider('history', [
+      makeEvent({ timestamp: '2026-05-04T10:00:00Z', scope: { kind: 'page', name: 'a' } }),
+      makeEvent({ timestamp: '2026-05-04T12:00:00Z', scope: { kind: 'page', name: 'b' } }),
+      makeEvent({ timestamp: '2026-05-04T11:00:00Z', scope: { kind: 'page', name: 'c' } }),
+    ])
+    const app = buildApp([provider])
+    const res = await app.request('/api/audit')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.events).toHaveLength(3)
+    // Newest first — note the route re-sorts after merge so even a
+    // provider returning out-of-order events lands sorted at the wire.
+    expect(body.events[0].scope.name).toBe('b')
+    expect(body.events[1].scope.name).toBe('c')
+    expect(body.events[2].scope.name).toBe('a')
+    expect(body.externalSinks).toEqual([])
+  })
+
+  it('merges + dedups events across multiple queryable providers', async () => {
+    const sharedEvent = makeEvent({
+      timestamp: '2026-05-04T12:00:00Z',
+      scope: { kind: 'page', name: 'shared' },
+    })
+    const historyOnly = makeEvent({
+      timestamp: '2026-05-04T10:00:00Z',
+      scope: { kind: 'page', name: 'history-only' },
+    })
+    const fileOnly = makeEvent({
+      timestamp: '2026-05-04T11:00:00Z',
+      scope: { kind: 'page', name: 'file-only' },
+    })
+    const history = makeQueryableProvider('history', [sharedEvent, historyOnly])
+    const file = makeQueryableProvider('file', [sharedEvent, fileOnly])
+    const app = buildApp([history, file])
+    const res = await app.request('/api/audit')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    // 3 unique events (shared dedupes once)
+    expect(body.events).toHaveLength(3)
+    const names = body.events.map((e: AuditEvent) => e.scope.name)
+    expect(names).toEqual(['shared', 'file-only', 'history-only'])
+  })
+
+  it('composes external-sink references for non-queryable providers', async () => {
+    const queryable = makeQueryableProvider('history', [makeEvent()])
+    const cloudwatch = makeExternalSinkProvider('cloudwatch', 'https://aws.example.com/audit')
+    const webhook = makeExternalSinkProvider('webhook', null)
+    const app = buildApp([queryable, cloudwatch, webhook])
+    const res = await app.request('/api/audit')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.events).toHaveLength(1)
+    expect(body.externalSinks).toEqual([
+      { name: 'cloudwatch', url: 'https://aws.example.com/audit' },
+      { name: 'webhook', url: null },
+    ])
+  })
+
+  it('filters by action via query string', async () => {
+    const events = [
+      makeEvent({ action: 'save', scope: { kind: 'page', name: 'a' } }),
+      makeEvent({ action: 'publish', scope: { kind: 'page', name: 'b' } }),
+      makeEvent({ action: 'delete', scope: { kind: 'page', name: 'c' } }),
+    ]
+    const app = buildApp([makeQueryableProvider('history', events)])
+    const res = await app.request('/api/audit?action=publish')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.events).toHaveLength(1)
+    expect(body.events[0].action).toBe('publish')
+  })
+
+  it('filters by outcome', async () => {
+    const events = [
+      makeEvent({ outcome: 'success', scope: { kind: 'page', name: 'a' } }),
+      makeEvent({ outcome: 'validation-failed', scope: { kind: 'page', name: 'b' } }),
+    ]
+    const app = buildApp([makeQueryableProvider('history', events)])
+    const res = await app.request('/api/audit?outcome=validation-failed')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.events).toHaveLength(1)
+    expect(body.events[0].outcome).toBe('validation-failed')
+  })
+
+  it('filters by scope kind + name', async () => {
+    const events = [
+      makeEvent({ scope: { kind: 'page', name: 'home' } }),
+      makeEvent({ scope: { kind: 'fragment', name: 'header' } }),
+      makeEvent({ scope: { kind: 'page', name: 'about' } }),
+    ]
+    const app = buildApp([makeQueryableProvider('history', events)])
+    const resKind = await app.request('/api/audit?scopeKind=fragment')
+    expect((await resKind.json()).events).toHaveLength(1)
+    const resName = await app.request('/api/audit?scopeName=home')
+    expect((await resName.json()).events).toHaveLength(1)
+  })
+
+  it('filters by actor (substring on id + email)', async () => {
+    const events = [
+      makeEvent({ actor: { id: 'alice@example.com', role: 'editor', trustMode: 'forwarded-user' } }),
+      makeEvent({ actor: { id: 'bob@example.com', role: 'editor', trustMode: 'forwarded-user' } }),
+    ]
+    const app = buildApp([makeQueryableProvider('history', events)])
+    const res = await app.request('/api/audit?actor=alice')
+    const body = await res.json()
+    expect(body.events).toHaveLength(1)
+    expect(body.events[0].actor.id).toBe('alice@example.com')
+  })
+
+  it('filters by time bounds (since inclusive, until exclusive)', async () => {
+    const events = [
+      makeEvent({ timestamp: '2026-05-04T10:00:00Z', scope: { kind: 'page', name: 'a' } }),
+      makeEvent({ timestamp: '2026-05-04T11:00:00Z', scope: { kind: 'page', name: 'b' } }),
+      makeEvent({ timestamp: '2026-05-04T12:00:00Z', scope: { kind: 'page', name: 'c' } }),
+    ]
+    const app = buildApp([makeQueryableProvider('history', events)])
+    const res = await app.request('/api/audit?since=2026-05-04T11:00:00Z&until=2026-05-04T12:00:00Z')
+    const body = await res.json()
+    expect(body.events).toHaveLength(1)
+    expect(body.events[0].scope.name).toBe('b')
+  })
+
+  it('honors limit; clamps to MAX_LIMIT', async () => {
+    const events = Array.from({ length: 50 }, (_, i) =>
+      makeEvent({
+        timestamp: `2026-05-04T${String(i).padStart(2, '0')}:00:00Z`,
+        scope: { kind: 'page', name: `p${i}` },
+      }),
+    )
+    const app = buildApp([makeQueryableProvider('history', events)])
+    const res = await app.request('/api/audit?limit=10')
+    const body = await res.json()
+    expect(body.events).toHaveLength(10)
+    // Default limit when omitted = 100; we have 50 events so we get all 50.
+    const resDefault = await app.request('/api/audit')
+    expect((await resDefault.json()).events).toHaveLength(50)
+  })
+
+  it('rejects invalid action / outcome / scopeKind / limit with 400', async () => {
+    const app = buildApp([makeQueryableProvider('history', [makeEvent()])])
+    expect((await app.request('/api/audit?action=bogus')).status).toBe(400)
+    expect((await app.request('/api/audit?outcome=bogus')).status).toBe(400)
+    expect((await app.request('/api/audit?scopeKind=bogus')).status).toBe(400)
+    expect((await app.request('/api/audit?limit=-5')).status).toBe(400)
+    expect((await app.request('/api/audit?limit=abc')).status).toBe(400)
+  })
+
+  it('treats provider query() failures as fail-open (empty result, no throw)', async () => {
+    const failing: AuditProvider = {
+      name: 'failing',
+      async record() {},
+      async query() {
+        throw new Error('simulated provider failure')
+      },
+    }
+    const ok = makeQueryableProvider('history', [makeEvent()])
+    const app = buildApp([failing, ok])
+    const res = await app.request('/api/audit')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    // Failing provider contributed nothing; ok provider's events still flow.
+    expect(body.events).toHaveLength(1)
+  })
+
+  it('returns empty events + empty externalSinks when no providers configured', async () => {
+    const app = buildApp([])
+    const res = await app.request('/api/audit')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.events).toEqual([])
+    expect(body.externalSinks).toEqual([])
+  })
+})

--- a/packages/gazetta/tests/audit-route.test.ts
+++ b/packages/gazetta/tests/audit-route.test.ts
@@ -84,6 +84,29 @@ function buildApp(providers: AuditProvider[]): Hono {
   return app
 }
 
+/**
+ * Build an app with a non-admin principal — for capability-gating
+ * tests. The fake provider returns whatever Principal the test
+ * asks for (editor / viewer / unknown).
+ */
+function buildAppWithRole(providers: AuditProvider[], role: string, capabilities: ReadonlyArray<string>): Hono {
+  const app = new Hono()
+  const fakeProvider = {
+    trustMode: 'forwarded-user',
+    async extractPrincipal() {
+      return {
+        id: role === 'unknown' ? 'unknown' : `${role}@example.com`,
+        role,
+        trustMode: 'forwarded-user',
+        capabilities,
+      }
+    },
+  }
+  app.use('/api/*', principalMiddleware(fakeProvider))
+  app.route('/', auditRoutes({ providers }))
+  return app
+}
+
 describe('Cut 6 — GET /api/audit', () => {
   it('returns events from a single queryable provider, newest-first', async () => {
     const provider = makeQueryableProvider('history', [
@@ -258,5 +281,39 @@ describe('Cut 6 — GET /api/audit', () => {
     const body = await res.json()
     expect(body.events).toEqual([])
     expect(body.externalSinks).toEqual([])
+  })
+
+  // Cut 9 — capability gating. read:audit-log is wildcard-exempt
+  // per design-auth-rbac.md "viewers don't see audit by default".
+  // Only admin (root wildcard *) or explicit grant of read:audit-log
+  // passes the gate; editor / viewer with `read:*` are blocked.
+  describe('Cut 9 — capability gating', () => {
+    it('admin role with `*` is allowed (200)', async () => {
+      const app = buildAppWithRole([makeQueryableProvider('history', [])], 'admin', ['*'])
+      const res = await app.request('/api/audit')
+      expect(res.status).toBe(200)
+    })
+
+    it('editor role with read:* + edit:* is forbidden (403)', async () => {
+      const app = buildAppWithRole([makeQueryableProvider('history', [])], 'editor', [
+        'read:*',
+        'edit:*',
+        'publish:non-production',
+      ])
+      const res = await app.request('/api/audit')
+      expect(res.status).toBe(403)
+    })
+
+    it('viewer role with read:* is forbidden (403)', async () => {
+      const app = buildAppWithRole([makeQueryableProvider('history', [])], 'viewer', ['read:*'])
+      const res = await app.request('/api/audit')
+      expect(res.status).toBe(403)
+    })
+
+    it('custom auditor role with explicit read:audit-log is allowed (200)', async () => {
+      const app = buildAppWithRole([makeQueryableProvider('history', [])], 'auditor', ['read:*', 'read:audit-log'])
+      const res = await app.request('/api/audit')
+      expect(res.status).toBe(200)
+    })
   })
 })

--- a/packages/gazetta/tests/audit-types.test.ts
+++ b/packages/gazetta/tests/audit-types.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Cut 1 tests: audit type vocabulary + schema parse + error
+ * taxonomy. Pure-data layer; no providers yet.
+ *
+ * Pin the wire shape so v2 sinks can't drift the contract.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  AuditConfigSchema,
+  AuditConfigurationError,
+  AuditError,
+  AuditTransportError,
+  DEFAULT_AUDIT_CONFIG,
+  type AuditConfig,
+  type AuditEvent,
+  type AuditQuery,
+} from '../src/audit/index.js'
+
+describe('AuditConfigSchema (Cut 1)', () => {
+  it('accepts the minimal history-provider config', () => {
+    const r = AuditConfigSchema.safeParse({ provider: 'history' })
+    expect(r.success).toBe(true)
+  })
+
+  it('accepts retention.events + maxAgeMonths', () => {
+    const r = AuditConfigSchema.safeParse({
+      provider: 'history',
+      retention: { events: 10000, maxAgeMonths: 72 },
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('accepts retention.maxAgeMonths: null (no time limit)', () => {
+    const r = AuditConfigSchema.safeParse({
+      provider: 'history',
+      retention: { maxAgeMonths: null },
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('accepts strict mode', () => {
+    expect(AuditConfigSchema.safeParse({ provider: 'history', strict: true }).success).toBe(true)
+  })
+
+  it('accepts pseudonymization modes', () => {
+    expect(AuditConfigSchema.safeParse({ provider: 'history', actorPseudonym: 'none' }).success).toBe(true)
+    expect(AuditConfigSchema.safeParse({ provider: 'history', actorPseudonym: 'sha256' }).success).toBe(true)
+    expect(AuditConfigSchema.safeParse({ provider: 'history', actorPseudonym: 'invalid' }).success).toBe(false)
+  })
+
+  it('accepts sourceIp recording modes', () => {
+    for (const mode of ['none', 'raw', 'hashed', 'truncated']) {
+      expect(AuditConfigSchema.safeParse({ provider: 'history', recordSourceIp: mode }).success).toBe(true)
+    }
+    expect(AuditConfigSchema.safeParse({ provider: 'history', recordSourceIp: 'unknown' }).success).toBe(false)
+  })
+
+  it('accepts userAgent recording modes', () => {
+    for (const mode of ['none', 'raw', 'truncated']) {
+      expect(AuditConfigSchema.safeParse({ provider: 'history', recordUserAgent: mode }).success).toBe(true)
+    }
+    // 'hashed' is intentionally NOT a userAgent mode (low entropy);
+    // schema rejects it.
+    expect(AuditConfigSchema.safeParse({ provider: 'history', recordUserAgent: 'hashed' }).success).toBe(false)
+  })
+
+  it('rejects unknown provider name', () => {
+    const r = AuditConfigSchema.safeParse({ provider: 'cloudwatch' })
+    expect(r.success).toBe(false)
+  })
+
+  it('rejects extra unknown fields (strict mode)', () => {
+    const r = AuditConfigSchema.safeParse({ provider: 'history', extra: 'nope' })
+    expect(r.success).toBe(false)
+  })
+
+  it('rejects retention with negative or zero counts', () => {
+    expect(AuditConfigSchema.safeParse({ provider: 'history', retention: { events: 0 } }).success).toBe(false)
+    expect(AuditConfigSchema.safeParse({ provider: 'history', retention: { events: -1 } }).success).toBe(false)
+  })
+
+  it('DEFAULT_AUDIT_CONFIG parses cleanly through the schema', () => {
+    expect(AuditConfigSchema.safeParse(DEFAULT_AUDIT_CONFIG).success).toBe(true)
+  })
+})
+
+describe('Error taxonomy (Cut 1)', () => {
+  it('AuditConfigurationError extends AuditError + httpStatus 500', () => {
+    const err = new AuditConfigurationError('bad config')
+    expect(err).toBeInstanceOf(AuditError)
+    expect(err.httpStatus).toBe(500)
+    expect(err.name).toBe('AuditConfigurationError')
+  })
+
+  it('AuditTransportError extends AuditError + carries category', () => {
+    const err = new AuditTransportError('connection refused', 'transport')
+    expect(err).toBeInstanceOf(AuditError)
+    expect(err.category).toBe('transport')
+    expect(err.name).toBe('AuditTransportError')
+  })
+
+  it('AuditTransportError category is closed enum', () => {
+    // Type-level check: TS rejects 'unknown' at compile time.
+    // Runtime: the constructor accepts what callers pass; the
+    // closed type guards against typos at the consumer site.
+    expect(new AuditTransportError('x', 'serialize').category).toBe('serialize')
+    expect(new AuditTransportError('x', 'quota').category).toBe('quota')
+  })
+})
+
+describe('Type-level shape (Cut 1)', () => {
+  it('AuditEvent shape compiles with required + optional fields', () => {
+    const minimal: AuditEvent = {
+      timestamp: '2026-05-07T15:00:00Z',
+      actor: { id: 'alice', role: 'editor', trustMode: 'cloudflare-access' },
+      action: 'save',
+      outcome: 'success',
+      scope: { kind: 'page', name: 'home' },
+    }
+    expect(minimal.actor.id).toBe('alice')
+
+    const full: AuditEvent = {
+      timestamp: '2026-05-07T15:00:00Z',
+      actor: { id: 'alice', email: 'alice@example.com', role: 'editor', trustMode: 'cloudflare-access' },
+      action: 'publish',
+      outcome: 'success',
+      scope: { kind: 'page', name: 'home' },
+      sourceIp: '203.0.113.1',
+      userAgent: 'Chrome/119',
+      metadata: { destinationTarget: 'production' },
+    }
+    expect(full.metadata?.destinationTarget).toBe('production')
+  })
+
+  it('AuditQuery accepts every documented filter', () => {
+    const q: AuditQuery = {
+      actor: 'alice',
+      action: 'save',
+      outcome: 'success',
+      scope: { kind: 'page', name: 'home' },
+      since: '2026-01-01T00:00:00Z',
+      until: '2026-12-31T00:00:00Z',
+      limit: 50,
+    }
+    expect(q.limit).toBe(50)
+  })
+
+  it('AuditConfig is the schema-inferred type', () => {
+    // Compile-time check: parsed config matches the AuditConfig type.
+    const cfg: AuditConfig = AuditConfigSchema.parse({ provider: 'history' })
+    expect(cfg.provider).toBe('history')
+  })
+})

--- a/packages/gazetta/tests/auth-capabilities.test.ts
+++ b/packages/gazetta/tests/auth-capabilities.test.ts
@@ -21,10 +21,35 @@ describe('capabilityGrants (Cut 6)', () => {
     expect(capabilityGrants(['*'], '@my-org/search:rebuild-index')).toBe(true)
   })
 
-  it('prefix wildcard read:* grants any read capability', () => {
+  it('prefix wildcard read:* grants ordinary read capabilities', () => {
     expect(capabilityGrants(['read:*'], 'read:pages')).toBe(true)
     expect(capabilityGrants(['read:*'], 'read:fragments')).toBe(true)
-    expect(capabilityGrants(['read:*'], 'read:audit-log')).toBe(true)
+    expect(capabilityGrants(['read:*'], 'read:assets')).toBe(true)
+  })
+
+  // Wildcard-exempt capabilities — privacy-sensitive reads that
+  // don't auto-grant via prefix wildcards (Cut 9). Per
+  // design-auth-rbac.md "Audit-log read access is its own capability
+  // — viewers don't see audit by default" + design-audit.md's
+  // "read:audit-log capability gates the drawer entirely".
+  describe('wildcard-exempt capabilities (Cut 9)', () => {
+    it('read:* does NOT grant read:audit-log', () => {
+      expect(capabilityGrants(['read:*'], 'read:audit-log')).toBe(false)
+    })
+
+    it('exact grant of read:audit-log works', () => {
+      expect(capabilityGrants(['read:audit-log'], 'read:audit-log')).toBe(true)
+    })
+
+    it('combined read:* + read:audit-log grants both ordinary reads + audit', () => {
+      const granted = ['read:*', 'read:audit-log']
+      expect(capabilityGrants(granted, 'read:pages')).toBe(true)
+      expect(capabilityGrants(granted, 'read:audit-log')).toBe(true)
+    })
+
+    it('root wildcard * still grants read:audit-log (admin escape hatch)', () => {
+      expect(capabilityGrants(['*'], 'read:audit-log')).toBe(true)
+    })
   })
 
   it('prefix wildcard does NOT cross prefixes', () => {
@@ -62,19 +87,30 @@ describe('capabilityGrants (Cut 6)', () => {
     expect(capabilityGrants(BUILT_IN_ROLES.admin, 'publish:production')).toBe(true)
   })
 
-  it('editor role grants read + edit + non-prod publish but NOT prod publish', () => {
+  it('editor role grants read + edit + non-prod publish but NOT prod publish or audit', () => {
     expect(capabilityGrants(BUILT_IN_ROLES.editor, 'read:pages')).toBe(true)
     expect(capabilityGrants(BUILT_IN_ROLES.editor, 'edit:pages')).toBe(true)
     expect(capabilityGrants(BUILT_IN_ROLES.editor, 'publish:non-production')).toBe(true)
     expect(capabilityGrants(BUILT_IN_ROLES.editor, 'publish:production')).toBe(false)
     expect(capabilityGrants(BUILT_IN_ROLES.editor, 'delete:pages')).toBe(false)
     expect(capabilityGrants(BUILT_IN_ROLES.editor, 'configure:site')).toBe(false)
+    // Cut 9: read:* does not grant read:audit-log; editors don't see audit by default
+    expect(capabilityGrants(BUILT_IN_ROLES.editor, 'read:audit-log')).toBe(false)
   })
 
-  it('viewer role grants only reads', () => {
+  it('viewer role grants only ordinary reads (no audit)', () => {
     expect(capabilityGrants(BUILT_IN_ROLES.viewer, 'read:pages')).toBe(true)
     expect(capabilityGrants(BUILT_IN_ROLES.viewer, 'edit:pages')).toBe(false)
     expect(capabilityGrants(BUILT_IN_ROLES.viewer, 'publish:non-production')).toBe(false)
+    // Cut 9: viewers don't see audit by default
+    expect(capabilityGrants(BUILT_IN_ROLES.viewer, 'read:audit-log')).toBe(false)
+  })
+
+  it('admin role grants read:audit-log via root wildcard', () => {
+    // Sanity check the design-locked invariant: admin is the only
+    // built-in role with audit access; custom roles need explicit
+    // grant.
+    expect(capabilityGrants(BUILT_IN_ROLES.admin, 'read:audit-log')).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary

Phase 1 foundation #5 — audit log. Records every save / publish / delete / restore / configure-roles attempt with actor + outcome. Composes with auth/RBAC's `Principal` (just shipped in PR #257) for actor identity. Per `design-audit.md` + `design-audit-implementation.md`.

This PR will ship **all 10 cuts** on the same branch (per recent precedent: PR #257 shipped 11 auth cuts). Each cut is a separate commit + independently rollback-able.

## Cut sequence

| # | Cut | Status | Tests |
|---|---|---|---|
| 1 | `audit/` infrastructure: types, schema, errors | ✓ | 17 |
| 2 | `AuditProvider` + `HistoryAuditProvider` | ☐ | — |
| 3 | Recorder (parallel fan-out, sync fail-open) | ☐ | — |
| 4 | Pseudonymization + sourceIp / userAgent | ☐ | — |
| 5 | Wire write handlers (save/publish/delete/restore) | ☐ | — |
| 6 | `GET /api/audit` + admin drawer | ☐ | — |
| 7 | `queryUrl()` drawer UX states | ☐ | — |
| 8 | Retention pruner | ☐ | — |
| 9 | `read:audit-log` capability gate | ☐ | — |
| 10 | Docs | ☐ | — |

## Scope

- v1 in-tree provider: `HistoryAuditProvider` (extends existing `Revision` shape with `actor` + `outcome` fields)
- v2 external sinks (webhook, file, OTel, CloudWatch, Azure Monitor, syslog) reserved; provider interface stays open

## Test plan

- [ ] All 10 cuts merged
- [ ] Audit drawer renders events under admin role
- [ ] Failure outcomes (forbidden / validation-failed / unauthenticated) recorded with full context
- [ ] Retention pruner respects audit-only vs content-bearing distinction
- [ ] `read:audit-log` capability gates the drawer (viewer can't see audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)