### PR TITLE
Validation Cut 2: background scanner + admin UI surfaces

### DIFF
--- a/apps/admin/src/client/App.vue
+++ b/apps/admin/src/client/App.vue
@@ -5,6 +5,7 @@ import { useThemeStore } from './stores/theme.js'
 import { useToastStore } from './stores/toast.js'
 import { useActiveTargetStore } from './stores/activeTarget.js'
 import { useSyncStatusStore } from './stores/syncStatus.js'
+import { useValidationScannerStore } from './stores/validationScanner.js'
 import { setActiveTargetProvider } from './api/client.js'
 import { useWorkspaceChrome } from './composables/useWorkspaceChrome.js'
 import { useAssetLibraryShortcut } from './composables/useAssetLibraryShortcut.js'
@@ -21,6 +22,7 @@ const theme = useThemeStore()
 const toast = useToastStore()
 const activeTarget = useActiveTargetStore()
 const syncStatus = useSyncStatusStore()
+const validationScanner = useValidationScannerStore()
 
 // Apply workspace-wide chrome when the active target is an editable
 // production target. Kept out of App.vue's inline setup so the rule has
@@ -71,6 +73,11 @@ watch(
 onMounted(() => {
   theme.init()
   activeTarget.load()
+  // Background validation scanner: fetch current issues + subscribe to
+  // SSE updates so site-tree dots + Site Health drawer reflect the
+  // scanner's state without per-component polling.
+  void validationScanner.refresh()
+  validationScanner.subscribe()
 })
 </script>
 

--- a/apps/admin/src/client/components/CmsToolbar.vue
+++ b/apps/admin/src/client/components/CmsToolbar.vue
@@ -9,11 +9,13 @@ import { useEditingStore } from '../stores/editing.js'
 import { useThemeStore } from '../stores/theme.js'
 import { useUiModeStore } from '../stores/uiMode.js'
 import { useActiveTargetStore } from '../stores/activeTarget.js'
+import { useValidationScannerStore } from '../stores/validationScanner.js'
 import { saveButtonLabel, saveButtonSeverity } from '../composables/saveButtonBinding.js'
 import PublishPanel from './PublishPanel.vue'
 import ActiveTargetIndicator from './ActiveTargetIndicator.vue'
 import SyncIndicators from './SyncIndicators.vue'
 import LocalePicker from './LocalePicker.vue'
+import SiteHealthDrawer from './SiteHealthDrawer.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -25,8 +27,25 @@ const editing = useEditingStore()
 const theme = useThemeStore()
 const uiMode = useUiModeStore()
 const activeTarget = useActiveTargetStore()
+const validationScanner = useValidationScannerStore()
 
 const showPublish = ref(false)
+const showSiteHealth = ref(false)
+const healthBadgeSeverity = computed(() => {
+  if (validationScanner.itemsWithErrors.size > 0) return 'danger'
+  if (validationScanner.itemsWithWarnings.size > 0) return 'warn'
+  return 'info'
+})
+const healthIconClass = computed(() => {
+  if (validationScanner.itemsWithErrors.size > 0) return 'pi pi-exclamation-circle'
+  if (validationScanner.itemsWithWarnings.size > 0) return 'pi pi-exclamation-triangle'
+  return 'pi pi-shield'
+})
+const healthTitle = computed(() => {
+  const total = validationScanner.total
+  if (total === 0) return 'Site health — no issues'
+  return `Site health — ${total} issue${total === 1 ? '' : 's'}`
+})
 /** Destination to preselect in the panel (set by sync chip clicks). */
 const publishInitialDestination = ref<string | undefined>(undefined)
 
@@ -101,6 +120,13 @@ function handleBack() {
         :title="theme.dark ? 'Switch to light mode' : 'Switch to dark mode'"
         :aria-label="theme.dark ? 'Switch to light mode' : 'Switch to dark mode'"
         data-testid="theme-toggle" @click="theme.toggle()" size="small" class="cms-btn" />
+      <Button v-if="validationScanner.total > 0"
+        :icon="healthIconClass" text rounded
+        :title="healthTitle" :aria-label="healthTitle"
+        :severity="healthBadgeSeverity"
+        data-testid="site-health-btn" @click="showSiteHealth = true" size="small"
+        :badge="String(validationScanner.total)"
+        class="cms-btn" />
       <Button v-if="uiMode.mode === 'edit'" :label="saveLabel" icon="pi pi-save" :severity="saveSeverity" :loading="editing.saving"
         data-testid="save-btn" :title="saveTitle" :disabled="!editing.hasPendingEdits" @click="editing.save()" size="small" class="cms-btn" />
       <Button label="Publish" icon="pi pi-cloud-upload" severity="success"
@@ -109,6 +135,7 @@ function handleBack() {
   </Toolbar>
 
   <PublishPanel v-model:visible="showPublish" :initialDestination="publishInitialDestination" />
+  <SiteHealthDrawer v-model:visible="showSiteHealth" />
 </template>
 
 <style scoped>

--- a/apps/admin/src/client/components/SiteHealthDrawer.vue
+++ b/apps/admin/src/client/components/SiteHealthDrawer.vue
@@ -1,0 +1,242 @@
+<script setup lang="ts">
+/**
+ * Site Health drawer (Validation Cut 2).
+ *
+ * Lists current issues from the background scanner, grouped by item.
+ * Click an issue → navigate to the affected item; in-editor banner
+ * shows the issue inline (Cut 1 surface).
+ *
+ * Per design-validation.md "Surfaces" + Krug rule 23: absence is the
+ * state. The drawer shows only when opened from the toolbar; the
+ * toolbar icon shows a count badge only when issues > 0.
+ */
+import { computed } from 'vue'
+import Dialog from 'primevue/dialog'
+import Button from 'primevue/button'
+import { useRouter } from 'vue-router'
+import { useValidationScannerStore } from '../stores/validationScanner.js'
+import type { ValidationIssue } from '../api/client.js'
+
+defineProps<{ visible: boolean }>()
+const emit = defineEmits<{ (e: 'update:visible', v: boolean): void }>()
+
+const router = useRouter()
+const store = useValidationScannerStore()
+
+interface ItemGroup {
+  itemPath: string
+  issues: readonly ValidationIssue[]
+  worstSeverity: 'error' | 'warn' | 'info'
+}
+
+const SEVERITY_RANK: Record<'error' | 'warn' | 'info', number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+}
+
+/** Issues grouped by item, sorted by worst severity. */
+const groups = computed<ItemGroup[]>(() => {
+  const out: ItemGroup[] = []
+  for (const [itemPath, issues] of Object.entries(store.byItem)) {
+    let worst: 'error' | 'warn' | 'info' = 'info'
+    for (const issue of issues) {
+      if (SEVERITY_RANK[issue.severity] < SEVERITY_RANK[worst]) worst = issue.severity
+    }
+    out.push({ itemPath, issues, worstSeverity: worst })
+  }
+  out.sort((a, b) => SEVERITY_RANK[a.worstSeverity] - SEVERITY_RANK[b.worstSeverity])
+  return out
+})
+
+function close() {
+  emit('update:visible', false)
+}
+
+function severityIcon(severity: 'error' | 'warn' | 'info'): string {
+  if (severity === 'error') return 'pi pi-exclamation-circle'
+  if (severity === 'warn') return 'pi pi-exclamation-triangle'
+  return 'pi pi-info-circle'
+}
+
+/**
+ * Map an item path (e.g., `pages/home/page.json` or
+ * `fragments/header/fragment.json`) to a router-link route. Locale
+ * variants (`page.fr.json`) navigate to the same item with the locale
+ * pre-selected.
+ */
+function navigateToItem(itemPath: string) {
+  const m = itemPath.match(/^pages\/(.+?)\/page(?:\.([a-zA-Z-]+))?\.json$/)
+  if (m) {
+    const [, name, locale] = m
+    router.push({
+      path: `/pages/${name}`,
+      query: locale ? { locale } : undefined,
+    })
+    close()
+    return
+  }
+  const f = itemPath.match(/^fragments\/(.+?)\/fragment(?:\.([a-zA-Z-]+))?\.json$/)
+  if (f) {
+    const [, name, locale] = f
+    router.push({
+      path: `/fragments/${name}`,
+      query: locale ? { locale } : undefined,
+    })
+    close()
+    return
+  }
+  // Unrecognized path shape — leave the drawer open so the operator can copy it
+}
+</script>
+
+<template>
+  <Dialog
+    :visible="visible"
+    @update:visible="emit('update:visible', $event)"
+    modal
+    header="Site health"
+    :style="{ width: '720px', maxHeight: '80vh' }"
+    :closable="true"
+    data-testid="site-health-drawer"
+  >
+    <div v-if="store.fetchError" class="health-error">
+      <i class="pi pi-exclamation-triangle"></i>
+      Couldn't fetch issues: {{ store.fetchError }}
+      <Button text size="small" label="Retry" @click="store.refresh()" />
+    </div>
+    <div v-else-if="groups.length === 0" class="health-empty">
+      <i class="pi pi-check-circle health-clean-icon"></i>
+      No issues found.
+    </div>
+    <div v-else class="health-list">
+      <div
+        v-for="group in groups"
+        :key="group.itemPath"
+        class="health-item"
+        :data-testid="`health-item-${group.itemPath}`"
+      >
+        <button
+          class="health-item-header"
+          @click="navigateToItem(group.itemPath)"
+          :aria-label="`Open ${group.itemPath} (${group.issues.length} issue${group.issues.length === 1 ? '' : 's'})`"
+        >
+          <i :class="severityIcon(group.worstSeverity)" :data-severity="group.worstSeverity"></i>
+          <span class="health-item-path">{{ group.itemPath }}</span>
+          <span class="health-item-count">{{ group.issues.length }}</span>
+        </button>
+        <ul class="health-issue-list">
+          <li
+            v-for="(issue, i) in group.issues"
+            :key="i"
+            :class="`health-issue health-issue-${issue.severity}`"
+          >
+            <i :class="severityIcon(issue.severity)" :data-severity="issue.severity"></i>
+            <span class="health-issue-message">{{ issue.message }}</span>
+            <code v-if="issue.contentPath" class="health-issue-path">{{ issue.contentPath }}</code>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </Dialog>
+</template>
+
+<style scoped>
+.health-error {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  color: var(--p-red-600);
+}
+
+.health-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 2rem;
+  color: var(--p-text-muted-color);
+}
+
+.health-clean-icon {
+  font-size: 2rem;
+  color: var(--p-green-500);
+}
+
+.health-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.health-item {
+  border: 1px solid var(--p-content-border-color);
+  border-radius: var(--p-border-radius-md);
+  overflow: hidden;
+}
+
+.health-item-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--p-content-hover-background);
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  color: inherit;
+  font-size: 0.875rem;
+}
+
+.health-item-header:hover {
+  background: var(--p-content-background);
+}
+
+.health-item-path {
+  flex: 1;
+  font-family: ui-monospace, monospace;
+  color: var(--p-text-color);
+}
+
+.health-item-count {
+  color: var(--p-text-muted-color);
+  font-size: 0.75rem;
+}
+
+.health-issue-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.health-issue {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid var(--p-content-border-color);
+  font-size: 0.875rem;
+}
+
+.health-issue-message {
+  flex: 1;
+}
+
+.health-issue-path {
+  color: var(--p-text-muted-color);
+  font-size: 0.75rem;
+}
+
+i[data-severity='error'] {
+  color: var(--p-red-500);
+}
+i[data-severity='warn'] {
+  color: var(--p-amber-500);
+}
+i[data-severity='info'] {
+  color: var(--p-blue-500);
+}
+</style>

--- a/apps/admin/src/client/components/SiteTree.vue
+++ b/apps/admin/src/client/components/SiteTree.vue
@@ -7,6 +7,7 @@ import { useSelectionStore } from '../stores/selection.js'
 import { useEditingStore } from '../stores/editing.js'
 import { useToastStore } from '../stores/toast.js'
 import { usePublishStatusStore } from '../stores/publishStatus.js'
+import { useValidationScannerStore } from '../stores/validationScanner.js'
 import { usePagesApi, useFragmentsApi } from '../composables/api.js'
 import CreatePageDialog from './CreatePageDialog.vue'
 import CreateFragmentDialog from './CreateFragmentDialog.vue'
@@ -27,6 +28,7 @@ const selection = useSelectionStore()
 const editing = useEditingStore()
 const toast = useToastStore()
 const publishStatus = usePublishStatusStore()
+const validationScanner = useValidationScannerStore()
 const pagesApi = usePagesApi()
 const fragmentsApi = useFragmentsApi()
 const selectedKey = ref<string | null>(null)
@@ -49,6 +51,24 @@ function dirtyTitle(): string {
   if (!publishStatus.target) return ''
   if (publishStatus.isFirstPublish) return `Not yet published to ${publishStatus.target}`
   return `Has unpublished changes (${publishStatus.target})`
+}
+
+/**
+ * Map a tree node to the scanner's `itemPath` to look up issue severity.
+ * Cut 2 keys off the default-locale manifest path; locale-variant issues
+ * surface separately when the editor opens a specific locale.
+ */
+function nodeItemPath(node: SiteNode): string {
+  return node.type === 'page' ? `pages/${node.name}/page.json` : `fragments/${node.name}/fragment.json`
+}
+function issueSeverity(node: SiteNode): 'error' | 'warn' | 'info' | null {
+  return validationScanner.severityFor(nodeItemPath(node))
+}
+function issueTitle(node: SiteNode): string {
+  const path = nodeItemPath(node)
+  const issues = validationScanner.issuesFor(path)
+  if (issues.length === 0) return ''
+  return `${issues.length} validation issue${issues.length === 1 ? '' : 's'} — open Site health for details`
 }
 
 // Sync selection when changed externally (e.g. preview link click)
@@ -138,6 +158,10 @@ async function handleDelete(node: SiteNode, e: Event) {
       </span>
       <span v-if="isDirty(node)" class="node-dirty-dot" :title="dirtyTitle()"
         :data-testid="`dirty-${node.type}-${node.name}`" />
+      <span v-if="issueSeverity(node)"
+        :class="['node-issue-dot', `node-issue-${issueSeverity(node)}`]"
+        :title="issueTitle(node)"
+        :data-testid="`issue-${node.type}-${node.name}`" />
       <Button icon="pi pi-trash" text rounded size="small" severity="danger"
         class="node-delete" :data-testid="`delete-${node.type}-${node.name}`"
         :aria-label="`Delete ${node.type} ${node.name}`"
@@ -173,6 +197,10 @@ async function handleDelete(node: SiteNode, e: Event) {
       <FragmentBlastRadius :fragmentName="node.name" compact />
       <span v-if="isDirty(node)" class="node-dirty-dot" :title="dirtyTitle()"
         :data-testid="`dirty-${node.type}-${node.name}`" />
+      <span v-if="issueSeverity(node)"
+        :class="['node-issue-dot', `node-issue-${issueSeverity(node)}`]"
+        :title="issueTitle(node)"
+        :data-testid="`issue-${node.type}-${node.name}`" />
       <Button icon="pi pi-trash" text rounded size="small" severity="danger"
         class="node-delete" :data-testid="`delete-${node.type}-${node.name}`"
         :aria-label="`Delete ${node.type} ${node.name}`"
@@ -211,6 +239,10 @@ async function handleDelete(node: SiteNode, e: Event) {
 .node-item.selected .node-label,
 .node-item:hover .node-label { color: var(--color-fg); }
 .node-dirty-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--color-warning-fg); flex-shrink: 0; margin-right: 2px; }
+.node-issue-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; margin-right: 2px; }
+.node-issue-error { background: var(--p-red-500); }
+.node-issue-warn { background: var(--p-amber-500); }
+.node-issue-info { background: var(--p-blue-500); }
 .node-delete { opacity: 0; transition: opacity 0.1s; flex-shrink: 0; }
 .node-item:hover .node-delete { opacity: 1; }
 .new-btns { display: flex; gap: 0.5rem; margin-top: 8px; padding: 0 6px; }

--- a/apps/admin/src/client/stores/validationScanner.ts
+++ b/apps/admin/src/client/stores/validationScanner.ts
@@ -76,7 +76,9 @@ export const useValidationScannerStore = defineStore('validationScanner', () => 
   /** Refresh from the server. Called on boot, on SSE event, on explicit retry. */
   async function refresh(): Promise<void> {
     try {
-      const res = await fetch(apiUrl('/api/validation/issues'), {
+      // `apiUrl()` already prefixes API_BASE (which contains `/api`); the path
+      // arg is relative to that base. Convention from sibling api modules.
+      const res = await fetch(apiUrl('/validation/issues'), {
         headers: authHeaders(),
       })
       if (!res.ok) {
@@ -100,10 +102,11 @@ export const useValidationScannerStore = defineStore('validationScanner', () => 
    */
   function subscribe(): void {
     if (eventSource) return
-    // /__validation lives at the admin root, not under /api. Strip the
-    // trailing /api segment from API_BASE to get the admin root.
-    const adminBase = API_BASE.replace(/\/api$/, '')
-    const url = `${adminBase}/__validation`
+    // /__validation is mounted on the OUTER Hono app at the site root
+    // (matching `/__reload`'s placement) so dev-mode browsers reach it
+    // without going through Vite's middleware. URL is the bare absolute
+    // path; no admin or api prefix.
+    const url = '/__validation'
     try {
       eventSource = new EventSource(url, { withCredentials: false })
       eventSource.addEventListener('validation-issues-updated', () => {

--- a/apps/admin/src/client/stores/validationScanner.ts
+++ b/apps/admin/src/client/stores/validationScanner.ts
@@ -1,0 +1,145 @@
+/**
+ * Background scanner issues store (Validation Cut 2).
+ *
+ * Holds the current accumulated issues across the site, populated from
+ * `GET /api/validation/issues`. Subscribes to the SSE channel
+ * `/__validation` to receive `validation-issues-updated` events emitted
+ * by the scanner; on each event, the store re-fetches the issues list.
+ *
+ * Distinct from `useValidationIssuesStore` (save-time banner): the
+ * banner shows issues from THIS save; the scanner store shows
+ * accumulated state across the entire site, surfaced as site-tree
+ * dots + Site Health drawer per design-validation.md.
+ */
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import type { ValidationIssue } from '../api/client.js'
+import { API_BASE, apiUrl, authHeaders } from '../api/_request.js'
+
+interface IssuesByItem {
+  [itemPath: string]: ValidationIssue[]
+}
+
+export const useValidationScannerStore = defineStore('validationScanner', () => {
+  const issues = ref<readonly ValidationIssue[]>([])
+  const lastFetchedAt = ref<number | null>(null)
+  const fetchError = ref<string | null>(null)
+
+  /** Total issue count — drives the toolbar badge. */
+  const total = computed(() => issues.value.length)
+
+  /** Issues grouped by `itemPath`. Drives the drawer's per-item lists. */
+  const byItem = computed<IssuesByItem>(() => {
+    const out: IssuesByItem = {}
+    for (const issue of issues.value) {
+      const list = out[issue.itemPath] ?? []
+      list.push(issue)
+      out[issue.itemPath] = list
+    }
+    return out
+  })
+
+  /** Items that have at least one error-severity issue. Drives red dots. */
+  const itemsWithErrors = computed(() => {
+    const set = new Set<string>()
+    for (const issue of issues.value) {
+      if (issue.severity === 'error') set.add(issue.itemPath)
+    }
+    return set
+  })
+
+  /** Items that have warn-severity issues but no errors. Drives amber dots. */
+  const itemsWithWarnings = computed(() => {
+    const set = new Set<string>()
+    for (const issue of issues.value) {
+      if (issue.severity !== 'warn') continue
+      if (itemsWithErrors.value.has(issue.itemPath)) continue
+      set.add(issue.itemPath)
+    }
+    return set
+  })
+
+  /** Issues for one specific item (drawer click + editor banner integration). */
+  function issuesFor(itemPath: string): readonly ValidationIssue[] {
+    return byItem.value[itemPath] ?? []
+  }
+
+  /** Highest severity for an item — drives dot color. Returns null when clean. */
+  function severityFor(itemPath: string): 'error' | 'warn' | 'info' | null {
+    if (itemsWithErrors.value.has(itemPath)) return 'error'
+    if (itemsWithWarnings.value.has(itemPath)) return 'warn'
+    const list = byItem.value[itemPath]
+    if (list && list.length > 0) return 'info'
+    return null
+  }
+
+  /** Refresh from the server. Called on boot, on SSE event, on explicit retry. */
+  async function refresh(): Promise<void> {
+    try {
+      const res = await fetch(apiUrl('/api/validation/issues'), {
+        headers: authHeaders(),
+      })
+      if (!res.ok) {
+        fetchError.value = `HTTP ${res.status}`
+        return
+      }
+      const body = (await res.json()) as { issues: ValidationIssue[]; total: number }
+      issues.value = body.issues
+      fetchError.value = null
+      lastFetchedAt.value = Date.now()
+    } catch (err) {
+      fetchError.value = (err as Error).message
+    }
+  }
+
+  let eventSource: EventSource | null = null
+
+  /**
+   * Open the SSE stream. Idempotent — repeated calls reuse the existing
+   * connection. Reconnects automatically via EventSource's built-in retry.
+   */
+  function subscribe(): void {
+    if (eventSource) return
+    // /__validation lives at the admin root, not under /api. Strip the
+    // trailing /api segment from API_BASE to get the admin root.
+    const adminBase = API_BASE.replace(/\/api$/, '')
+    const url = `${adminBase}/__validation`
+    try {
+      eventSource = new EventSource(url, { withCredentials: false })
+      eventSource.addEventListener('validation-issues-updated', () => {
+        void refresh()
+      })
+      eventSource.onerror = () => {
+        // EventSource reconnects automatically; nothing to do here. Errors
+        // before the first connect surface as `readyState === CLOSED`.
+      }
+    } catch {
+      // Browser doesn't support EventSource OR the URL is malformed —
+      // store still works via explicit refresh() calls; just no push.
+      eventSource = null
+    }
+  }
+
+  /** Close the SSE stream. Called on store dispose / admin teardown. */
+  function unsubscribe(): void {
+    if (eventSource) {
+      eventSource.close()
+      eventSource = null
+    }
+  }
+
+  return {
+    issues,
+    total,
+    byItem,
+    itemsWithErrors,
+    itemsWithWarnings,
+    lastFetchedAt,
+    fetchError,
+    issuesFor,
+    severityFor,
+    refresh,
+    subscribe,
+    unsubscribe,
+  }
+})

--- a/apps/admin/tests/SiteHealthDrawer.test.ts
+++ b/apps/admin/tests/SiteHealthDrawer.test.ts
@@ -1,0 +1,145 @@
+/**
+ * SiteHealthDrawer.vue — Validation Cut 2 admin surface tests.
+ *
+ * Verifies:
+ *   - Empty state ("No issues found") when scanner is clean
+ *   - Renders one group per item, sorted by worst severity
+ *   - Each issue surfaced with its message + severity icon
+ *   - Click on an item header navigates via the router
+ *   - Locale-variant paths route to the right URL with `?locale=`
+ *   - Fetch error surfaces a Retry control
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import PrimeVue from 'primevue/config'
+import SiteHealthDrawer from '../src/client/components/SiteHealthDrawer.vue'
+import { useValidationScannerStore } from '../src/client/stores/validationScanner.js'
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/pages/:name', component: { template: '<div />' } },
+    { path: '/fragments/:name', component: { template: '<div />' } },
+  ],
+})
+
+async function makeWrapper(visible = true) {
+  await router.push('/')
+  await router.isReady()
+  return mount(SiteHealthDrawer, {
+    props: { visible },
+    global: {
+      plugins: [PrimeVue, router],
+    },
+    attachTo: document.body,
+  })
+}
+
+/**
+ * Find the item header by its `data-testid`. CSS selectors don't escape
+ * forward slashes in attribute values reliably across jsdom; iterate the
+ * NodeList of all health items and match by getAttribute.
+ */
+function findItemHeader(itemPath: string): HTMLButtonElement | null {
+  const items = document.querySelectorAll<HTMLElement>('[data-testid^="health-item-"]')
+  for (const item of items) {
+    if (item.getAttribute('data-testid') === `health-item-${itemPath}`) {
+      return item.querySelector('button')
+    }
+  }
+  return null
+}
+
+describe('SiteHealthDrawer', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    setActivePinia(createPinia())
+  })
+
+  it('renders the empty state when there are no issues', async () => {
+    const wrapper = await makeWrapper(true)
+    await wrapper.vm.$nextTick()
+    const drawer = document.querySelector('[data-testid="site-health-drawer"]')
+    expect(drawer?.textContent).toContain('No issues found')
+    wrapper.unmount()
+  })
+
+  it('renders one group per item with the worst severity', async () => {
+    const wrapper = await makeWrapper(true)
+    const store = useValidationScannerStore()
+    store.issues = [
+      {
+        validator: 'referenced-fragment-exists',
+        severity: 'error',
+        message: 'Fragment "@missing" referenced but not found.',
+        itemPath: 'pages/home/page.json',
+      },
+      {
+        validator: 'unused-fragment',
+        severity: 'info',
+        message: 'Fragment "@orphan" is defined but no page references it.',
+        itemPath: 'fragments/orphan/fragment.json',
+      },
+    ]
+    await wrapper.vm.$nextTick()
+    const items = document.querySelectorAll('[data-testid^="health-item-"]')
+    expect(items.length).toBe(2)
+    // Error sorts before info — pages/home should come first.
+    expect(items[0].getAttribute('data-testid')).toBe('health-item-pages/home/page.json')
+    wrapper.unmount()
+  })
+
+  it('navigates to the item when its header is clicked', async () => {
+    const wrapper = await makeWrapper(true)
+    const store = useValidationScannerStore()
+    store.issues = [
+      {
+        validator: 'referenced-fragment-exists',
+        severity: 'error',
+        message: 'broken',
+        itemPath: 'pages/home/page.json',
+      },
+    ]
+    await wrapper.vm.$nextTick()
+    const header = findItemHeader('pages/home/page.json')
+    expect(header).toBeTruthy()
+    header!.click()
+    await flushPromises()
+    expect(router.currentRoute.value.path).toBe('/pages/home')
+    wrapper.unmount()
+  })
+
+  it('routes locale variants with the locale query', async () => {
+    const wrapper = await makeWrapper(true)
+    const store = useValidationScannerStore()
+    store.issues = [
+      {
+        validator: 'orphaned-locale-file',
+        severity: 'warn',
+        message: 'orphan',
+        itemPath: 'pages/home/page.fr.json',
+      },
+    ]
+    await wrapper.vm.$nextTick()
+    const header = findItemHeader('pages/home/page.fr.json')
+    expect(header).toBeTruthy()
+    header!.click()
+    await flushPromises()
+    expect(router.currentRoute.value.path).toBe('/pages/home')
+    expect(router.currentRoute.value.query.locale).toBe('fr')
+    wrapper.unmount()
+  })
+
+  it('shows a retry control when fetch errored', async () => {
+    const wrapper = await makeWrapper(true)
+    const store = useValidationScannerStore()
+    store.fetchError = 'HTTP 500'
+    await wrapper.vm.$nextTick()
+    const drawer = document.querySelector('[data-testid="site-health-drawer"]')
+    expect(drawer?.textContent).toContain("Couldn't fetch issues")
+    expect(drawer?.textContent).toContain('Retry')
+    wrapper.unmount()
+  })
+})

--- a/packages/gazetta/src/admin-api/index.ts
+++ b/packages/gazetta/src/admin-api/index.ts
@@ -42,6 +42,7 @@ import { historyRoutes } from './routes/history.js'
 import { assetRoutes } from './routes/assets.js'
 import { systemRoutes } from './routes/system.js'
 import { auditRoutes } from './routes/audit.js'
+import { validationRoutes } from './routes/validation.js'
 import { healthRoutes } from './routes/health.js'
 import { HookRegistry, type HookContribution } from '../hooks/index.js'
 
@@ -130,6 +131,14 @@ export interface AdminAppOptions {
    * Tests pass an empty (or pre-populated) registry directly.
    */
   hooks?: HookRegistry
+  /**
+   * Background validation scanner (Cut 2). Constructed by the boot path
+   * via `createValidationScanner({...})` against the resolved source. The
+   * admin app mounts the read-side route + SSE channel against this
+   * instance. When omitted, `/api/validation/issues` returns an empty list
+   * and the SSE channel emits no events.
+   */
+  validationScanner?: import('../validation/scanner.js').ValidationScanner | null
   /**
    * Disable the periodic audit retention pruner. Defaults to false
    * (pruner runs at boot + every 6 hours when audit retention is
@@ -384,8 +393,20 @@ export function createAdminApp(opts: AdminAppOptions): AdminApp {
   )
 
   app.route('/', siteRoutes(resolveSource))
-  app.route('/', pageRoutes(resolveSource, validators, templatesDir, { hooks: opts.hooks }))
-  app.route('/', fragmentRoutes(resolveSource, validators, templatesDir, { hooks: opts.hooks }))
+  app.route(
+    '/',
+    pageRoutes(resolveSource, validators, templatesDir, {
+      hooks: opts.hooks,
+      scanner: opts.validationScanner ?? null,
+    }),
+  )
+  app.route(
+    '/',
+    fragmentRoutes(resolveSource, validators, templatesDir, {
+      hooks: opts.hooks,
+      scanner: opts.validationScanner ?? null,
+    }),
+  )
   app.route('/', templateRoutes(resolveSource, templatesDir, adminDir, opts.production))
   app.route('/', previewRoutes(resolveSource, templatesDir))
   app.route(
@@ -398,6 +419,7 @@ export function createAdminApp(opts: AdminAppOptions): AdminApp {
   app.route('/', assetRoutes(resolveSource, { hooks: opts.hooks }))
   app.route('/', systemRoutes(resolveSource))
   app.route('/', auditRoutes({ providers: auditProviders }))
+  app.route('/', validationRoutes({ scanner: opts.validationScanner ?? null }))
   app.route('/', healthRoutes())
 
   // Periodic cache stats log — fires every 5 minutes against the

--- a/packages/gazetta/src/admin-api/routes/fragments.ts
+++ b/packages/gazetta/src/admin-api/routes/fragments.ts
@@ -27,6 +27,12 @@ import { makeAuditFiringEmitter } from '../hook-audit-emitter.js'
 
 export interface FragmentRoutesOptions {
   hooks?: HookRegistry
+  /**
+   * Background validation scanner. Fragment saves notify the scanner to
+   * re-validate this fragment + every page/fragment that references it
+   * (transitively, via `findDependentsFromSidecars`).
+   */
+  scanner?: import('../../validation/scanner.js').ValidationScanner | null
 }
 
 export function fragmentRoutes(
@@ -308,6 +314,12 @@ export function fragmentRoutes(
     // committed first.
     if (hooks && hookCtx) {
       await dispatchAfterSave(hooks, hookScope, { payload: finalManifest, etag: newEtag }, hookCtx)
+    }
+    // Background validation scanner re-validates this fragment + every
+    // page/fragment that references it (transitively). Fire-and-forget;
+    // SSE event drives the admin UI re-fetch when complete.
+    if (opts.scanner) {
+      void opts.scanner.rescan({ kind: 'fragment', name })
     }
     return c.json({ ok: true, etag: newEtag })
   })

--- a/packages/gazetta/src/admin-api/routes/pages.ts
+++ b/packages/gazetta/src/admin-api/routes/pages.ts
@@ -33,6 +33,13 @@ export interface PageRoutesOptions {
    * `manifest.admin?.hooks` in the admin-api boot path.
    */
   hooks?: HookRegistry
+  /**
+   * Background validation scanner. When provided, save handlers notify
+   * the scanner on commit so background-stage validators re-run for the
+   * affected item. When omitted, save handlers run as today (save-delta
+   * only).
+   */
+  scanner?: import('../../validation/scanner.js').ValidationScanner | null
 }
 
 export function pageRoutes(
@@ -415,6 +422,14 @@ export function pageRoutes(
     // applies; one slow hook bounded by its timeout, not the total.
     if (hooks && hookCtx) {
       await dispatchAfterSave(hooks, hookScope, { payload: finalManifest, etag: newEtag }, hookCtx)
+    }
+    // Background validation scanner re-validates this item + dependents.
+    // Fire-and-forget — the save response shouldn't block on scanner work;
+    // the scanner emits its own SSE event when the pass completes and the
+    // admin UI store re-fetches `/api/validation/issues` on the event.
+    if (opts.scanner) {
+      const itemRef = { kind: 'page' as const, name, itemPath: manifestPath }
+      void opts.scanner.rescan({ kind: 'manifest', item: itemRef })
     }
     return c.json({ ok: true, etag: newEtag })
   })

--- a/packages/gazetta/src/admin-api/routes/validation.ts
+++ b/packages/gazetta/src/admin-api/routes/validation.ts
@@ -1,0 +1,103 @@
+/**
+ * Background validation API + SSE channel (Cut 2).
+ *
+ * - `GET /api/validation/issues` — current accumulated issues from the
+ *   per-instance scanner. Reads from the in-memory store; doesn't trigger
+ *   a scan.
+ * - `GET /__validation` — SSE channel that emits `validation-issues-updated`
+ *   events when the scanner finishes a pass. Dev-only by convention; in
+ *   production (`gazetta serve`) the route is mounted but emits no events
+ *   because the scanner only triggers on saves and the admin store fetches
+ *   `/api/validation/issues` after each save.
+ *
+ * Per `design-validation-implementation.md` Cut 2 + open question 5 (SSE
+ * channel locked to its own path so cache invalidations + validation
+ * events don't share a route).
+ *
+ * # SOLID lenses
+ *
+ * - SRP: route maps scanner state to HTTP. Doesn't run validators, doesn't
+ *   trigger scans.
+ * - DIP: depends on `ValidationScanner` interface; tests pass a fake.
+ * - ISP: scanner exposes a narrow read surface (`allIssues` + `subscribe`);
+ *   the route consumes only what it needs.
+ */
+import { Hono } from 'hono'
+import { streamSSE } from 'hono/streaming'
+import type { ValidationScanner, ScanEvent } from '../../validation/scanner.js'
+
+export interface ValidationRoutesOptions {
+  /** Scanner instance shared across all routes. May be null when validation isn't enabled. */
+  scanner: ValidationScanner | null
+}
+
+export function validationRoutes(opts: ValidationRoutesOptions) {
+  const app = new Hono()
+
+  /**
+   * GET /api/validation/issues — current issues. Returns an empty list when
+   * no scanner is configured (validation disabled or pre-scan boot).
+   */
+  app.get('/api/validation/issues', c => {
+    if (!opts.scanner) return c.json({ issues: [], total: 0 })
+    const issues = opts.scanner.allIssues()
+    return c.json({ issues, total: issues.length })
+  })
+
+  /**
+   * GET /__validation — SSE stream of `validation-issues-updated` events
+   * when the scanner finishes a pass.
+   *
+   * The drawer subscribes once at admin boot. On every event, it re-fetches
+   * `/api/validation/issues` to pick up the latest set. Two-step (event +
+   * re-fetch) instead of pushing the full diff in the event payload because
+   * the issue set is small (~tens to hundreds of items at envelope) and a
+   * fresh GET is simpler than diff reconciliation client-side.
+   *
+   * When `scanner` is null, the route still mounts but never emits — keeps
+   * the client's EventSource open so it doesn't reconnect-spam.
+   */
+  app.get('/__validation', async c => {
+    return streamSSE(c, async stream => {
+      const queue: ScanEvent[] = []
+      let resolveWaiter: (() => void) | null = null
+
+      const dispose = opts.scanner?.subscribe(event => {
+        queue.push(event)
+        if (resolveWaiter) {
+          const r = resolveWaiter
+          resolveWaiter = null
+          r()
+        }
+      })
+
+      stream.onAbort(() => {
+        dispose?.()
+        if (resolveWaiter) {
+          const r = resolveWaiter
+          resolveWaiter = null
+          r()
+        }
+      })
+
+      // Open-frame: clients (EventSource) transition to OPEN on first byte.
+      await stream.writeSSE({ data: '', event: 'ready' })
+
+      while (!stream.aborted) {
+        if (queue.length === 0) {
+          await new Promise<void>(resolve => {
+            resolveWaiter = resolve
+          })
+          continue
+        }
+        const event = queue.shift()!
+        await stream.writeSSE({
+          event: 'validation-issues-updated',
+          data: JSON.stringify(event),
+        })
+      }
+    })
+  })
+
+  return app
+}

--- a/packages/gazetta/src/admin-api/routes/validation.ts
+++ b/packages/gazetta/src/admin-api/routes/validation.ts
@@ -1,14 +1,15 @@
 /**
- * Background validation API + SSE channel (Cut 2).
+ * Background validation API (Cut 2).
  *
  * - `GET /api/validation/issues` — current accumulated issues from the
  *   per-instance scanner. Reads from the in-memory store; doesn't trigger
  *   a scan.
- * - `GET /__validation` — SSE channel that emits `validation-issues-updated`
- *   events when the scanner finishes a pass. Dev-only by convention; in
- *   production (`gazetta serve`) the route is mounted but emits no events
- *   because the scanner only triggers on saves and the admin store fetches
- *   `/api/validation/issues` after each save.
+ *
+ * The peer SSE channel (`/__validation`) lives at the outer Hono app —
+ * see `mountValidationSse()` below. This mirrors `/__reload`'s placement:
+ * SSE channels sit at the outer app's root so dev-mode browsers reach them
+ * without going through Vite's middleware (which would 404 anything not
+ * matched by Vite's `proxy` config).
  *
  * Per `design-validation-implementation.md` Cut 2 + open question 5 (SSE
  * channel locked to its own path so cache invalidations + validation
@@ -24,7 +25,7 @@
  */
 import { Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
-import type { ValidationScanner, ScanEvent } from '../../validation/scanner.js'
+import type { ScanEvent, ValidationScanner } from '../../validation/scanner.js'
 
 export interface ValidationRoutesOptions {
   /** Scanner instance shared across all routes. May be null when validation isn't enabled. */
@@ -44,25 +45,29 @@ export function validationRoutes(opts: ValidationRoutesOptions) {
     return c.json({ issues, total: issues.length })
   })
 
-  /**
-   * GET /__validation — SSE stream of `validation-issues-updated` events
-   * when the scanner finishes a pass.
-   *
-   * The drawer subscribes once at admin boot. On every event, it re-fetches
-   * `/api/validation/issues` to pick up the latest set. Two-step (event +
-   * re-fetch) instead of pushing the full diff in the event payload because
-   * the issue set is small (~tens to hundreds of items at envelope) and a
-   * fresh GET is simpler than diff reconciliation client-side.
-   *
-   * When `scanner` is null, the route still mounts but never emits — keeps
-   * the client's EventSource open so it doesn't reconnect-spam.
-   */
+  return app
+}
+
+/**
+ * Mount `GET /__validation` SSE channel on the outer Hono app. The browser
+ * EventSource opens this URL at the root (not under `/admin/`), matching
+ * the pattern `/__reload` already follows. Production (`gazetta serve`)
+ * pass `null` for `scanner` to mount a stub that never emits events —
+ * keeps the client's EventSource open so it doesn't reconnect-spam.
+ *
+ * The drawer subscribes once at admin boot. On every event, it re-fetches
+ * `/api/validation/issues` to pick up the latest set. Two-step (event +
+ * re-fetch) instead of pushing the full diff in the event payload because
+ * the issue set is small (~tens to hundreds of items at envelope) and a
+ * fresh GET is simpler than diff reconciliation client-side.
+ */
+export function mountValidationSse(app: Hono, scanner: ValidationScanner | null): void {
   app.get('/__validation', async c => {
     return streamSSE(c, async stream => {
       const queue: ScanEvent[] = []
       let resolveWaiter: (() => void) | null = null
 
-      const dispose = opts.scanner?.subscribe(event => {
+      const dispose = scanner?.subscribe(event => {
         queue.push(event)
         if (resolveWaiter) {
           const r = resolveWaiter
@@ -98,6 +103,4 @@ export function validationRoutes(opts: ValidationRoutesOptions) {
       }
     })
   })
-
-  return app
 }

--- a/packages/gazetta/src/admin-api/schemas/index.ts
+++ b/packages/gazetta/src/admin-api/schemas/index.ts
@@ -18,6 +18,7 @@
  *   - DELETE /api/assets/:name (AssetRef + 409 AssetInUseResponse)
  *   - GET  /api/system/cache/stats (CacheStats snapshot)
  *   - GET  /api/audit (forensic event query + external-sink links)
+ *   - 409 VALIDATION_FAILED on save handlers + GET /api/validation/issues
  *
  * Add new endpoint modules here as they move to schema-validated contracts.
  */
@@ -35,3 +36,4 @@ export * from './fetch.js'
 export * from './assets.js'
 export * from './system.js'
 export * from './audit.js'
+export * from './validation.js'

--- a/packages/gazetta/src/admin-api/schemas/validation.ts
+++ b/packages/gazetta/src/admin-api/schemas/validation.ts
@@ -1,9 +1,8 @@
 /**
  * Zod schemas for the validation response. The save handlers return a 409
- * with this shape when save-delta validation finds error-severity issues.
- *
- * Cut 1: only the response shape ships. Cut 2 will add a separate
- * `/api/validation/issues` route shape; Cut 4 will add a publish-gate shape.
+ * with `ValidationFailedResponseSchema` when save-delta validation finds
+ * error-severity issues. Cut 2 adds the `/api/validation/issues` GET shape
+ * for the background scanner's accumulated state.
  */
 import { z } from 'zod'
 
@@ -31,3 +30,16 @@ export const ValidationFailedResponseSchema = z.object({
   issues: z.array(IssueSchema),
 })
 export type ValidationFailedResponse = z.infer<typeof ValidationFailedResponseSchema>
+
+/**
+ * GET /api/validation/issues — current accumulated issues from the background
+ * scanner (Cut 2). The drawer fetches this on admin load + on save SSE; it
+ * doesn't run scans itself.
+ */
+export const ValidationIssuesResponseSchema = z.object({
+  /** All current issues across the site, flat list. UI groups by `itemPath`. */
+  issues: z.array(IssueSchema),
+  /** Total count (== issues.length) — convenience field for the dot/badge. */
+  total: z.number().int().nonnegative(),
+})
+export type ValidationIssuesResponse = z.infer<typeof ValidationIssuesResponseSchema>

--- a/packages/gazetta/src/cli/index.ts
+++ b/packages/gazetta/src/cli/index.ts
@@ -1136,6 +1136,7 @@ async function runAdmin(siteDir: string, port: number) {
     adminDir,
     targetConfigs,
     hookContributions,
+    manifest,
   )
 
   // SPA fallback for non-API admin routes
@@ -1685,7 +1686,7 @@ async function runDev(siteDir: string, port: number) {
   const hookContributions = readHookContributions(manifest)
   if (isDevMode) {
     // Dev mode: mount CMS API inline (same process = shared template cache)
-    cmsApp = await setupCmsApi(app, source, siteDir, templatesDir, adminDir, targetConfigs, hookContributions)
+    cmsApp = await setupCmsApi(app, source, siteDir, templatesDir, adminDir, targetConfigs, hookContributions, manifest)
   } else if (cmsStaticDir) {
     // Production mode: inline CMS API + static files
     cmsApp = await setupProductionMode(
@@ -1697,6 +1698,7 @@ async function runDev(siteDir: string, port: number) {
       adminDir,
       targetConfigs,
       hookContributions,
+      manifest,
     )
   }
 
@@ -1987,6 +1989,40 @@ function mountUserThemeRoute(cmsApp: Hono, adminDir: string) {
   })
 }
 
+/**
+ * Build the background validation scanner (validation Cut 2). The scanner
+ * is constructed against the resolved source's storage + cache; the boot
+ * path kicks off an initial full-site scan in the background so admin
+ * responses don't block on it.
+ *
+ * Returns null when the manifest is unavailable (site lacks site.config.ts)
+ * — the admin app degrades gracefully (route returns empty issues; SSE
+ * channel idle).
+ */
+async function buildValidationScanner(opts: {
+  source: import('../admin-api/source-context.js').SourceContext
+  templatesDir: string
+  manifest: SiteManifest | null
+}): Promise<import('../validation/scanner.js').ValidationScanner | null> {
+  if (!opts.manifest) return null
+  const { createValidationScanner } = await import('../validation/scanner.js')
+  const { defaultValidatorRegistry } = await import('../validation/default-registry.js')
+  const scanner = createValidationScanner({
+    storage: opts.source.storage,
+    contentRoot: opts.source.contentRoot,
+    registry: defaultValidatorRegistry(),
+    cache: opts.source.cache,
+    siteOptions: { templatesDir: opts.templatesDir, manifest: opts.manifest },
+  })
+  // Boot warm: kick off the initial scan in the background. Errors are
+  // logged but don't block boot — broken validators surface as info-issues
+  // rather than failing the admin process.
+  void scanner.scanAll().catch(err => {
+    console.error('[validation] initial scan failed:', err)
+  })
+  return scanner
+}
+
 async function setupCmsApi(
   app: Hono,
   source: import('../admin-api/source-context.js').SourceContext,
@@ -1995,6 +2031,7 @@ async function setupCmsApi(
   adminDir: string,
   targetConfigs: Record<string, import('../types.js').TargetConfig> | undefined,
   contributions: ReadonlyArray<import('../hooks/index.js').HookContribution> | undefined,
+  manifest: SiteManifest | null,
 ): Promise<
   Hono & {
     invalidateTemplatesCache(): void
@@ -2006,7 +2043,16 @@ async function setupCmsApi(
   // extension surface; sites without `admin.hooks` get an empty
   // registry (no overhead).
   const hooks = await buildHooksRegistry({ contributions })
-  const cmsApp = createAdminApp({ source, siteDir, templatesDir, adminDir, targetConfigs, hooks })
+  const validationScanner = await buildValidationScanner({ source, templatesDir, manifest })
+  const cmsApp = createAdminApp({
+    source,
+    siteDir,
+    templatesDir,
+    adminDir,
+    targetConfigs,
+    hooks,
+    validationScanner,
+  })
   mountUserThemeRoute(cmsApp, adminDir)
   app.route('/admin', cmsApp)
   return cmsApp
@@ -2022,10 +2068,12 @@ async function setupProductionMode(
   adminDir: string,
   targetConfigs: Record<string, import('../types.js').TargetConfig> | undefined,
   contributions: ReadonlyArray<import('../hooks/index.js').HookContribution> | undefined,
+  manifest: SiteManifest | null,
 ) {
   // Same shape as dev mode — `gazetta serve` reads `admin.hooks`
   // factory contributions from the same site config.
   const hooks = await buildHooksRegistry({ contributions })
+  const validationScanner = await buildValidationScanner({ source, templatesDir, manifest })
   // Mount CMS API inline at /admin (production mode — bundled editors/fields)
   const cmsApp = createAdminApp({
     source,
@@ -2035,6 +2083,7 @@ async function setupProductionMode(
     production: true,
     targetConfigs,
     hooks,
+    validationScanner,
   })
   mountUserThemeRoute(cmsApp, adminDir)
   app.route('/admin', cmsApp)

--- a/packages/gazetta/src/cli/index.ts
+++ b/packages/gazetta/src/cli/index.ts
@@ -2044,6 +2044,13 @@ async function setupCmsApi(
   // registry (no overhead).
   const hooks = await buildHooksRegistry({ contributions })
   const validationScanner = await buildValidationScanner({ source, templatesDir, manifest })
+  // Mount SSE on the OUTER Hono app — matches `/__reload`'s placement so
+  // the browser EventSource (which connects without an `/admin/` prefix)
+  // bypasses Vite's middleware and reaches the route. Same in prod for
+  // consistency: a save from one tab updates the badge in every other
+  // tab without polling.
+  const { mountValidationSse } = await import('../admin-api/routes/validation.js')
+  mountValidationSse(app, validationScanner)
   const cmsApp = createAdminApp({
     source,
     siteDir,
@@ -2074,6 +2081,9 @@ async function setupProductionMode(
   // factory contributions from the same site config.
   const hooks = await buildHooksRegistry({ contributions })
   const validationScanner = await buildValidationScanner({ source, templatesDir, manifest })
+  // SSE channel at the outer app's root; see setupCmsApi for rationale.
+  const { mountValidationSse } = await import('../admin-api/routes/validation.js')
+  mountValidationSse(app, validationScanner)
   // Mount CMS API inline at /admin (production mode — bundled editors/fields)
   const cmsApp = createAdminApp({
     source,

--- a/packages/gazetta/src/validation/default-registry.ts
+++ b/packages/gazetta/src/validation/default-registry.ts
@@ -1,14 +1,17 @@
 import { circularFragment } from './validators/circular-fragment.js'
 import { dynamicRouteConflict } from './validators/dynamic-route-conflict.js'
+import { orphanedLocaleFile } from './validators/orphaned-locale-file.js'
 import { referencedAssetExists } from './validators/referenced-asset-exists.js'
 import { referencedFragmentExists } from './validators/referenced-fragment-exists.js'
 import { referencedTemplateExists } from './validators/referenced-template-exists.js'
+import { schemaConformance } from './validators/schema-conformance.js'
+import { unusedFragment } from './validators/unused-fragment.js'
 import { createValidatorRegistry, type ValidatorRegistry } from './registry.js'
 
 /**
- * Default validator registry — populated with the Cut 1 reference-existence
- * validators. Cut 2 will extend this list with background-only validators
- * (orphaned-locale-file, unused-fragment); Cut 3 will add quality validators.
+ * Default validator registry — Cut 1 (ref-existence) + Cut 2 (background-
+ * only validators: schema conformance, orphaned locale files, unused
+ * fragments). Cut 3 will add quality validators.
  *
  * Each validator declares its own stage support, so adding entries here is
  * safe: validators that don't apply to a given stage are filtered out by
@@ -21,5 +24,8 @@ export function defaultValidatorRegistry(): ValidatorRegistry {
     referencedTemplateExists,
     circularFragment,
     dynamicRouteConflict,
+    schemaConformance,
+    orphanedLocaleFile,
+    unusedFragment,
   ])
 }

--- a/packages/gazetta/src/validation/scanner.ts
+++ b/packages/gazetta/src/validation/scanner.ts
@@ -1,0 +1,337 @@
+/**
+ * Background validation scanner — runs all background-stage validators across
+ * the site and exposes the resulting issues to the admin API + admin UI.
+ *
+ * Per design-validation.md "Background scanner (Cut 2)" + the implementation
+ * plan in design-validation-implementation.md:
+ *
+ * - Initial full-site scan on admin boot.
+ * - Incremental rescan after save: affected item + transitive dependents
+ *   (fragment edits invalidate pages via `findDependentsFromSidecars`; asset
+ *   edits invalidate referencing items via `readRefsForAsset`; template edits
+ *   trigger a full-site rescan since no `template-deps` reverse-dep relation
+ *   exists yet).
+ * - Per-item validation cache keyed by content hash (via `AdminCache`).
+ *   Same content = same issues; cache hit short-circuits the validators.
+ * - Result store keyed by item path; reads return current issues.
+ * - SSE subscribers fired when a scan pass completes (admin UI dot updates).
+ *
+ * # Multi-instance discipline
+ *
+ * The scanner is per-instance scope. Each admin instance maintains its own
+ * result store + cache; SSE invalidation isn't broadcast across instances.
+ * Acceptable because: (a) each instance scans independently from the same
+ * source-of-truth storage; (b) save-side invalidation is per-instance via
+ * the same code path that wrote the manifest; (c) external changes (git
+ * pull) flow through `gazetta dev`'s file watcher per-instance.
+ *
+ * # SOLID lenses
+ *
+ * - SRP: scanner orchestrates passes. It doesn't implement validators
+ *   (that's per-validator) and doesn't render UI (that's the admin UI).
+ * - DIP: depends on `AdminCache` interface, not `MemoryCache`; depends on
+ *   the validator registry contract, not specific validators.
+ * - OCP: adding a new background-stage validator means registering it in
+ *   `defaultValidatorRegistry()`; the scanner picks it up automatically
+ *   via `registry.forStage('background')`.
+ */
+import { createHash } from 'node:crypto'
+import type { AdminCache } from '../cache/types.js'
+import type { ContentRoot } from '../content-root.js'
+import { findDependentsFromSidecars } from '../publish.js'
+import type { Site, LoadSiteOptions } from '../site-loader.js'
+import { allFragmentEntries, allPageEntries, loadSite } from '../site-loader.js'
+import type { FragmentManifest, PageManifest, StorageProvider } from '../types.js'
+import type { ValidatorRegistry } from './registry.js'
+import type { Issue, SavedItem } from './types.js'
+
+/**
+ * Source of an incremental rescan. Drives which dependents the scanner
+ * pulls in.
+ */
+export type RescanCause =
+  /** Manifest of a page or fragment was saved/edited. */
+  | { kind: 'manifest'; item: SavedItem }
+  /** Fragment edited — the scanner walks dependents transitively. */
+  | { kind: 'fragment'; name: string }
+  /** Asset edited — the scanner walks the asset's referrers. */
+  | { kind: 'asset'; name: string }
+  /** Template source changed — full-site rescan is the fallback. */
+  | { kind: 'template'; name: string }
+  /** Out-of-band change detected by file watcher; full-site rescan. */
+  | { kind: 'full' }
+
+/**
+ * Event published when a scan pass finishes. SSE consumers receive these.
+ */
+export interface ScanEvent {
+  /** Wall-clock duration of the scan, ms. */
+  durationMs: number
+  /** Number of items the scan touched. 0 means cache-hit-only or no items. */
+  scanned: number
+  /** Total number of issues across the site after this scan. */
+  totalIssues: number
+}
+
+export type ScanSubscriber = (event: ScanEvent) => void
+
+export interface ValidationScanner {
+  /** Run a full-site scan; updates store + cache. Idempotent. */
+  scanAll(): Promise<void>
+  /** Incremental rescan triggered by `cause`. */
+  rescan(cause: RescanCause): Promise<void>
+  /** All current issues. */
+  allIssues(): readonly Issue[]
+  /** Current issues for one item; empty if clean. */
+  issuesFor(itemPath: string): readonly Issue[]
+  /** Subscribe to scan-completed events. Returns disposer. */
+  subscribe(handler: ScanSubscriber): () => void
+}
+
+export interface CreateScannerOptions {
+  storage: StorageProvider
+  contentRoot: ContentRoot
+  registry: ValidatorRegistry
+  cache: AdminCache
+  /** Hook to load the site (extracted so tests can stub). */
+  loadSiteImpl?: (opts: LoadSiteOptions) => Promise<Site>
+  /** Site loader options used at every refresh. */
+  siteOptions: Omit<LoadSiteOptions, 'contentRoot'>
+}
+
+/**
+ * Construct a scanner. The scanner doesn't kick off `scanAll()` automatically;
+ * callers (CLI boot path) call it after constructing.
+ */
+export function createValidationScanner(opts: CreateScannerOptions): ValidationScanner {
+  const { storage, contentRoot, registry, cache, siteOptions } = opts
+  const loadSiteFn = opts.loadSiteImpl ?? loadSite
+
+  const issuesByItem = new Map<string, Issue[]>()
+  const subscribers = new Set<ScanSubscriber>()
+
+  function setIssues(itemPath: string, issues: readonly Issue[]) {
+    if (issues.length === 0) issuesByItem.delete(itemPath)
+    else issuesByItem.set(itemPath, [...issues])
+  }
+
+  function totalIssues(): number {
+    let n = 0
+    for (const arr of issuesByItem.values()) n += arr.length
+    return n
+  }
+
+  function emit(event: ScanEvent) {
+    for (const sub of subscribers) {
+      try {
+        sub(event)
+      } catch {
+        // Subscriber faults isolated; one bad subscriber doesn't block siblings.
+      }
+    }
+  }
+
+  async function loadFreshSite(): Promise<Site> {
+    return loadSiteFn({ contentRoot, ...siteOptions })
+  }
+
+  async function validateItem(
+    site: Site,
+    item: SavedItem,
+    manifest: PageManifest | FragmentManifest,
+  ): Promise<Issue[]> {
+    const hash = hashManifestStable(manifest)
+    const key = cacheKey(item, hash)
+    const cached = await cache.get<Issue[]>(key)
+    if (cached !== null) {
+      // Re-stamp the store from cache (cheap; covers boot warm-up too).
+      setIssues(item.itemPath, cached)
+      return cached
+    }
+    const validators = registry.forStage('background')
+    const issues: Issue[] = []
+    for (const v of validators) {
+      try {
+        const out = await v.validate({
+          stage: 'background',
+          site,
+          contentRoot,
+          storage,
+          scope: { kind: 'background', item, manifest },
+        })
+        issues.push(...out)
+      } catch (err) {
+        // Validator threw — surface as an info issue so the scan finishes.
+        issues.push({
+          validator: v.name,
+          severity: 'info',
+          message: `Validator "${v.name}" failed: ${(err as Error).message}`,
+          itemPath: item.itemPath,
+        })
+      }
+    }
+    await cache.set(key, issues)
+    setIssues(item.itemPath, issues)
+    return issues
+  }
+
+  async function scanAll(): Promise<void> {
+    const start = Date.now()
+    const site = await loadFreshSite()
+    let scanned = 0
+
+    const seen = new Set<string>()
+    for (const entry of allPageEntries(site)) {
+      const item: SavedItem = {
+        kind: 'page',
+        name: entry.name,
+        itemPath: itemPathFor('page', entry.page.dir, entry.locale),
+      }
+      if (seen.has(item.itemPath)) continue
+      seen.add(item.itemPath)
+      await validateItem(site, item, entry.page)
+      scanned++
+    }
+    for (const entry of allFragmentEntries(site)) {
+      const item: SavedItem = {
+        kind: 'fragment',
+        name: entry.name,
+        itemPath: itemPathFor('fragment', entry.fragment.dir, entry.locale),
+      }
+      if (seen.has(item.itemPath)) continue
+      seen.add(item.itemPath)
+      await validateItem(site, item, entry.fragment)
+      scanned++
+    }
+
+    // Stale items in the store (deleted since last scan) get pruned.
+    for (const path of [...issuesByItem.keys()]) {
+      if (!seen.has(path)) issuesByItem.delete(path)
+    }
+
+    emit({ durationMs: Date.now() - start, scanned, totalIssues: totalIssues() })
+  }
+
+  async function rescan(cause: RescanCause): Promise<void> {
+    if (cause.kind === 'template' || cause.kind === 'full') {
+      await scanAll()
+      return
+    }
+    const start = Date.now()
+    const site = await loadFreshSite()
+    let scanned = 0
+
+    const targets = await targetsForCause(cause, site, contentRoot)
+    for (const target of targets) {
+      const manifest = manifestForItem(site, target)
+      if (!manifest) continue // item disappeared between save and rescan
+      await validateItem(site, target, manifest)
+      scanned++
+    }
+
+    emit({ durationMs: Date.now() - start, scanned, totalIssues: totalIssues() })
+  }
+
+  function allIssues(): readonly Issue[] {
+    const out: Issue[] = []
+    for (const arr of issuesByItem.values()) out.push(...arr)
+    return out
+  }
+
+  function issuesFor(itemPath: string): readonly Issue[] {
+    return issuesByItem.get(itemPath) ?? []
+  }
+
+  function subscribe(handler: ScanSubscriber): () => void {
+    subscribers.add(handler)
+    return () => subscribers.delete(handler)
+  }
+
+  return { scanAll, rescan, allIssues, issuesFor, subscribe }
+}
+
+// ---- helpers --------------------------------------------------------------
+
+function itemPathFor(kind: 'page' | 'fragment', dir: string, locale?: string): string {
+  const base = kind === 'page' ? 'page' : 'fragment'
+  const ext = locale ? `${base}.${locale}.json` : `${base}.json`
+  return `${dir}/${ext}`
+}
+
+/**
+ * Stable hash of a manifest for cache keying. Crypto-grade — same content =
+ * same hash across processes. Different from the publish-time
+ * `hashManifest()` (which folds in template + fragment hashes); the scanner
+ * cares only about manifest content for invalidation purposes.
+ *
+ * Canonicalizes nested objects by recursively sorting keys before
+ * serializing. JSON.stringify's replacer-array form only filters top-level
+ * keys, which would silently miss nested mutations.
+ */
+function hashManifestStable(manifest: PageManifest | FragmentManifest): string {
+  return createHash('sha256').update(canonicalJson(manifest)).digest('hex').slice(0, 16)
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  const obj = value as Record<string, unknown>
+  const keys = Object.keys(obj).sort()
+  const parts = keys.map(k => `${JSON.stringify(k)}:${canonicalJson(obj[k])}`)
+  return `{${parts.join(',')}}`
+}
+
+function cacheKey(item: SavedItem, contentHash: string): string {
+  return `validation:${item.kind}:${encodePath(item.itemPath)}:${contentHash}`
+}
+
+function encodePath(path: string): string {
+  return path.replace(/[/]/g, '.').replace(/[^a-zA-Z0-9._-]/g, '_')
+}
+
+async function targetsForCause(
+  cause: Exclude<RescanCause, { kind: 'template' } | { kind: 'full' }>,
+  site: Site,
+  contentRoot: ContentRoot,
+): Promise<readonly SavedItem[]> {
+  if (cause.kind === 'manifest') return [cause.item]
+
+  if (cause.kind === 'fragment') {
+    // Affected: the fragment itself + every page/fragment that references it.
+    const out: SavedItem[] = []
+    const frag = site.fragments.get(cause.name)
+    if (frag) {
+      out.push({ kind: 'fragment', name: cause.name, itemPath: `${frag.dir}/fragment.json` })
+    }
+    const dependents = await findDependentsFromSidecars(contentRoot, { fragment: cause.name })
+    for (const pageName of dependents.pages) {
+      const page = site.pages.get(pageName)
+      if (page) out.push({ kind: 'page', name: pageName, itemPath: `${page.dir}/page.json` })
+    }
+    for (const fragName of dependents.fragments) {
+      const f = site.fragments.get(fragName)
+      if (f) out.push({ kind: 'fragment', name: fragName, itemPath: `${f.dir}/fragment.json` })
+    }
+    return out
+  }
+
+  if (cause.kind === 'asset') {
+    // readRefsForAsset would re-introduce a coupling we don't want here;
+    // for v1, treat asset edits as full-site rescan. The cost is low at
+    // envelope (5K pages x ~10ms validate per item = 50s worst case;
+    // typical scans are <1s thanks to cache hits).
+    const out: SavedItem[] = []
+    for (const entry of allPageEntries(site)) {
+      out.push({ kind: 'page', name: entry.name, itemPath: itemPathFor('page', entry.page.dir, entry.locale) })
+    }
+    return out
+  }
+
+  // Unreachable per type guards above.
+  return []
+}
+
+function manifestForItem(site: Site, item: SavedItem): PageManifest | FragmentManifest | null {
+  if (item.kind === 'page') return site.pages.get(item.name) ?? null
+  return site.fragments.get(item.name) ?? null
+}

--- a/packages/gazetta/src/validation/types.ts
+++ b/packages/gazetta/src/validation/types.ts
@@ -51,7 +51,16 @@ export type ValidatorScope =
       /** The incoming manifest being saved. */
       after: PageManifest | FragmentManifest
     }
-  | { kind: 'background'; item: SavedItem }
+  | {
+      kind: 'background'
+      item: SavedItem
+      /**
+       * The current manifest read by the scanner. Pre-loaded so validators
+       * stay pure functions over (manifest, site) — no per-validator storage
+       * reads.
+       */
+      manifest: PageManifest | FragmentManifest
+    }
   | { kind: 'pre-publish'; items: readonly SavedItem[] }
   | { kind: 'cli' }
 
@@ -93,6 +102,10 @@ export interface ValidatorInput {
 /**
  * The validator contract. One implementation per validation rule.
  *
+ * - `source` — package identity for diagnostics + audit + plugin-promotion.
+ *   In-tree validators use `'gazetta'`; npm-distributed validators use their
+ *   package name (`'@example/link-checker'`); site-local factories use
+ *   `'site-local:{name}'`. Per design-plugins.md "source convention" + ADR-0009.
  * - `name` — stable identifier referenced from issues and registry lookup.
  * - `stages` — which lifecycle stages this validator runs at. Save-delta-only
  *   validators (most ref-existence checks) declare `['save-delta', 'background', 'pre-publish', 'cli']`
@@ -104,6 +117,7 @@ export interface ValidatorInput {
  *   throws are reserved for infrastructure errors (storage failure, etc).
  */
 export interface Validator {
+  readonly source: string
   readonly name: string
   readonly stages: readonly ValidationStage[]
   defaultSeverity(stage: ValidationStage): Severity

--- a/packages/gazetta/src/validation/validators/circular-fragment.ts
+++ b/packages/gazetta/src/validation/validators/circular-fragment.ts
@@ -15,6 +15,7 @@ import type { Issue, Validator, ValidatorInput } from '../types.js'
  * aren't reachable from each other through @ refs).
  */
 export const circularFragment: Validator = {
+  source: 'gazetta',
   name: 'circular-fragment',
   stages: ['save-delta', 'background', 'pre-publish', 'cli'] as const,
 
@@ -25,9 +26,8 @@ export const circularFragment: Validator = {
   async validate(input: ValidatorInput): Promise<Issue[]> {
     const { scope, site } = input
     if (scope.kind !== 'save-delta' && scope.kind !== 'background') return []
-    const manifest = scope.kind === 'save-delta' ? scope.after : null
-    if (!manifest) return []
     if (scope.item.kind !== 'fragment') return [] // only fragments form cycles
+    const manifest = scope.kind === 'save-delta' ? scope.after : scope.manifest
 
     const fragmentName = scope.item.name
     const fragmentsView = scope.kind === 'save-delta' ? withSubstituted(site, fragmentName, manifest) : site.fragments

--- a/packages/gazetta/src/validation/validators/dynamic-route-conflict.ts
+++ b/packages/gazetta/src/validation/validators/dynamic-route-conflict.ts
@@ -17,6 +17,7 @@ import type { Issue, Validator, ValidatorInput } from '../types.js'
  * Only fires for pages.
  */
 export const dynamicRouteConflict: Validator = {
+  source: 'gazetta',
   name: 'dynamic-route-conflict',
   stages: ['save-delta', 'background', 'pre-publish', 'cli'] as const,
 
@@ -27,9 +28,8 @@ export const dynamicRouteConflict: Validator = {
   async validate(input: ValidatorInput): Promise<Issue[]> {
     const { scope, site } = input
     if (scope.kind !== 'save-delta' && scope.kind !== 'background') return []
-    const manifest = scope.kind === 'save-delta' ? scope.after : null
-    if (!manifest) return []
     if (scope.item.kind !== 'page') return []
+    const manifest = scope.kind === 'save-delta' ? scope.after : scope.manifest
 
     const newRoute = (manifest as PageManifest).route
     if (!newRoute) return []

--- a/packages/gazetta/src/validation/validators/orphaned-locale-file.ts
+++ b/packages/gazetta/src/validation/validators/orphaned-locale-file.ts
@@ -1,0 +1,84 @@
+import type { Issue, Validator, ValidatorInput } from '../types.js'
+import { resolveSiteLocales } from '../../locale.js'
+
+/**
+ * Detect locale-variant manifests whose locale isn't supported by the site.
+ *
+ * Concrete cases this catches:
+ *   - `page.fr.json` exists but site config omits `fr` from `locales.supported`
+ *     (typo, removed locale, or copy-paste leftover)
+ *   - Same for `fragment.{loc}.json`
+ *
+ * Doesn't flag missing-default — `page.json` (default locale) absence with
+ * `page.fr.json` present means "French-only page," which is valid (per
+ * `design-i18n.md` "Edge cases" — French-only pages are allowed).
+ *
+ * Background scope only — orphan-locale is a site-wide property of the file
+ * tree; save-delta on `page.fr.json` already runs the standard ref validators
+ * against the saved variant.
+ *
+ * Issues surface on the orphaned variant file itself.
+ */
+export const orphanedLocaleFile: Validator = {
+  source: 'gazetta',
+  name: 'orphaned-locale-file',
+  stages: ['background', 'cli'] as const,
+
+  defaultSeverity() {
+    return 'warn'
+  },
+
+  async validate(input: ValidatorInput): Promise<Issue[]> {
+    const { scope, site } = input
+    if (scope.kind !== 'background' && scope.kind !== 'cli') return []
+
+    const resolved = resolveSiteLocales(site.manifest)
+    if (!resolved) return [] // single-locale site — no locale variants to check
+    const supported = new Set(resolved.supported)
+
+    if (scope.kind === 'background') {
+      // Per-item: only emit if THIS item's locale is unsupported.
+      const item = scope.item
+      const variants = item.kind === 'page' ? site.pageLocales.get(item.name) : site.fragmentLocales.get(item.name)
+      if (!variants) return []
+      const issues: Issue[] = []
+      for (const [locale, manifest] of variants.locales) {
+        if (supported.has(locale)) continue
+        const ext = item.kind === 'page' ? 'page' : 'fragment'
+        issues.push({
+          validator: 'orphaned-locale-file',
+          severity: 'warn',
+          message: `Locale variant "${locale}" exists but is not in site.locales.supported. Add the locale to site.config.ts or remove the file.`,
+          itemPath: `${manifest.dir}/${ext}.${locale}.json`,
+        })
+      }
+      return issues
+    }
+
+    // CLI: enumerate every orphan across the site
+    const issues: Issue[] = []
+    for (const [, entry] of site.pageLocales) {
+      for (const [locale, manifest] of entry.locales) {
+        if (supported.has(locale)) continue
+        issues.push({
+          validator: 'orphaned-locale-file',
+          severity: 'warn',
+          message: `Locale variant "${locale}" exists but is not in site.locales.supported.`,
+          itemPath: `${manifest.dir}/page.${locale}.json`,
+        })
+      }
+    }
+    for (const [, entry] of site.fragmentLocales) {
+      for (const [locale, manifest] of entry.locales) {
+        if (supported.has(locale)) continue
+        issues.push({
+          validator: 'orphaned-locale-file',
+          severity: 'warn',
+          message: `Locale variant "${locale}" exists but is not in site.locales.supported.`,
+          itemPath: `${manifest.dir}/fragment.${locale}.json`,
+        })
+      }
+    }
+    return issues
+  },
+}

--- a/packages/gazetta/src/validation/validators/referenced-asset-exists.ts
+++ b/packages/gazetta/src/validation/validators/referenced-asset-exists.ts
@@ -13,6 +13,7 @@ import { manifestComponents } from '../types.js'
  * scope to introduced refs before invoking).
  */
 export const referencedAssetExists: Validator = {
+  source: 'gazetta',
   name: 'referenced-asset-exists',
   stages: ['save-delta', 'background', 'pre-publish', 'cli'] as const,
 
@@ -23,8 +24,7 @@ export const referencedAssetExists: Validator = {
   async validate(input: ValidatorInput): Promise<Issue[]> {
     const { scope, storage } = input
     if (scope.kind !== 'save-delta' && scope.kind !== 'background') return []
-    const manifest = scope.kind === 'save-delta' ? scope.after : null
-    if (!manifest) return []
+    const manifest = scope.kind === 'save-delta' ? scope.after : scope.manifest
 
     const issues: Issue[] = []
     const refs = collectAssetRefs(manifest.content as Record<string, unknown> | undefined, '')

--- a/packages/gazetta/src/validation/validators/referenced-fragment-exists.ts
+++ b/packages/gazetta/src/validation/validators/referenced-fragment-exists.ts
@@ -9,6 +9,7 @@ import { manifestComponents } from '../types.js'
  * `"@name"`, checks `site.fragments` for the name. Flags missing.
  */
 export const referencedFragmentExists: Validator = {
+  source: 'gazetta',
   name: 'referenced-fragment-exists',
   stages: ['save-delta', 'background', 'pre-publish', 'cli'] as const,
 
@@ -19,8 +20,7 @@ export const referencedFragmentExists: Validator = {
   async validate(input: ValidatorInput): Promise<Issue[]> {
     const { scope, site } = input
     if (scope.kind !== 'save-delta' && scope.kind !== 'background') return []
-    const manifest = scope.kind === 'save-delta' ? scope.after : null
-    if (!manifest) return []
+    const manifest = scope.kind === 'save-delta' ? scope.after : scope.manifest
 
     const issues: Issue[] = []
     const refs = collectFragmentRefs(manifestComponents(manifest), '')

--- a/packages/gazetta/src/validation/validators/referenced-template-exists.ts
+++ b/packages/gazetta/src/validation/validators/referenced-template-exists.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path'
  * checked against the templates directory for an `index.{ts,tsx,js}` entry.
  */
 export const referencedTemplateExists: Validator = {
+  source: 'gazetta',
   name: 'referenced-template-exists',
   stages: ['save-delta', 'background', 'pre-publish', 'cli'] as const,
 
@@ -21,8 +22,7 @@ export const referencedTemplateExists: Validator = {
   async validate(input: ValidatorInput): Promise<Issue[]> {
     const { scope, site } = input
     if (scope.kind !== 'save-delta' && scope.kind !== 'background') return []
-    const manifest = scope.kind === 'save-delta' ? scope.after : null
-    if (!manifest) return []
+    const manifest = scope.kind === 'save-delta' ? scope.after : scope.manifest
 
     const templatesDir = site.templatesDir
     if (!templatesDir) return [] // no templates configured — can't check

--- a/packages/gazetta/src/validation/validators/schema-conformance.ts
+++ b/packages/gazetta/src/validation/validators/schema-conformance.ts
@@ -1,0 +1,123 @@
+import { z } from 'zod'
+import type { ComponentEntry, FragmentManifest, InlineComponent, PageManifest, StorageProvider } from '../../types.js'
+import { loadTemplate } from '../../template-loader.js'
+import type { Issue, Validator, ValidatorInput } from '../types.js'
+import { manifestComponents } from '../types.js'
+
+/**
+ * Parse content against the template's Zod schema. Surfaces `warn` when
+ * content doesn't conform — typically content that bypassed the admin form
+ * (direct file edits, git pulls bringing in old shape, schema migrations
+ * mid-flight).
+ *
+ * Background scope only — save-delta runs the form's own Zod validation
+ * already (the admin UI uses @rjsf which validates before submit). Pre-publish
+ * gate (Cut 4) promotes this to `error`.
+ *
+ * Walks the manifest + recursive inline components. Each component is parsed
+ * against its declared template's schema. Failures emit one issue per zod
+ * error with `contentPath` set to the failing field path.
+ */
+export const schemaConformance: Validator = {
+  source: 'gazetta',
+  name: 'schema-conformance',
+  stages: ['background', 'pre-publish', 'cli'] as const,
+
+  defaultSeverity(stage) {
+    return stage === 'pre-publish' ? 'error' : 'warn'
+  },
+
+  async validate(input: ValidatorInput): Promise<Issue[]> {
+    const { scope, site, storage } = input
+    if (scope.kind !== 'background' && scope.kind !== 'cli') return []
+
+    const templatesDir = site.templatesDir
+    if (!templatesDir) return []
+
+    if (scope.kind === 'background') {
+      const manifest = scope.manifest
+      return await checkManifest(scope.item.itemPath, manifest, storage, templatesDir)
+    }
+
+    // CLI: walk the whole site
+    const issues: Issue[] = []
+    for (const [, page] of site.pages) {
+      issues.push(...(await checkManifest(`${page.dir}/page.json`, page, storage, templatesDir)))
+    }
+    for (const [, frag] of site.fragments) {
+      issues.push(...(await checkManifest(`${frag.dir}/fragment.json`, frag, storage, templatesDir)))
+    }
+    return issues
+  },
+}
+
+async function checkManifest(
+  itemPath: string,
+  manifest: PageManifest | FragmentManifest,
+  storage: StorageProvider,
+  templatesDir: string,
+): Promise<Issue[]> {
+  const issues: Issue[] = []
+  // The manifest itself has a template + content; parse those, then descend.
+  if (manifest.template && manifest.content !== undefined) {
+    issues.push(...(await checkOne(itemPath, manifest.template, manifest.content, '', storage, templatesDir)))
+  }
+  for (const child of manifestComponents(manifest)) {
+    await collectFromEntry(child, '', issues, itemPath, storage, templatesDir)
+  }
+  return issues
+}
+
+async function collectFromEntry(
+  entry: ComponentEntry,
+  parentPath: string,
+  out: Issue[],
+  itemPath: string,
+  storage: StorageProvider,
+  templatesDir: string,
+): Promise<void> {
+  if (typeof entry === 'string') return // fragment ref — schema checked when fragment is scanned
+  const inline = entry as InlineComponent
+  const path = parentPath ? `${parentPath}/${inline.name}` : inline.name
+  if (inline.template && inline.content !== undefined) {
+    out.push(...(await checkOne(itemPath, inline.template, inline.content, path, storage, templatesDir)))
+  }
+  if (inline.components) {
+    for (const child of inline.components) {
+      await collectFromEntry(child, path, out, itemPath, storage, templatesDir)
+    }
+  }
+}
+
+async function checkOne(
+  itemPath: string,
+  templateName: string,
+  content: unknown,
+  contentPath: string,
+  storage: StorageProvider,
+  templatesDir: string,
+): Promise<Issue[]> {
+  const tpl = await safeLoadTemplate(storage, templatesDir, templateName)
+  if (!tpl) return [] // template missing — referenced-template-exists handles this
+  const parsed = (tpl.schema as z.ZodTypeAny).safeParse(content)
+  if (parsed.success) return []
+  return parsed.error.issues.map(issue => ({
+    validator: 'schema-conformance',
+    severity: 'warn' as const,
+    message: `${issue.path.length ? issue.path.join('.') : '<root>'}: ${issue.message}`,
+    itemPath,
+    contentPath: contentPath || undefined,
+  }))
+}
+
+async function safeLoadTemplate(
+  storage: StorageProvider,
+  templatesDir: string,
+  templateName: string,
+): Promise<{ render: unknown; schema: unknown } | null> {
+  try {
+    return await loadTemplate(storage, templatesDir, templateName)
+  } catch {
+    return null
+  }
+}

--- a/packages/gazetta/src/validation/validators/unused-fragment.ts
+++ b/packages/gazetta/src/validation/validators/unused-fragment.ts
@@ -1,0 +1,92 @@
+import type { ComponentEntry } from '../../types.js'
+import type { Site } from '../../site-loader.js'
+import type { Issue, Validator, ValidatorInput } from '../types.js'
+import { manifestComponents } from '../types.js'
+
+/**
+ * A fragment defined in `fragments/` but not referenced by any page or other
+ * fragment is unused. Surfaces as `info` (not `warn`) — operators legitimately
+ * keep work-in-progress fragments around; this is a hint, not a defect.
+ *
+ * Background scope only: requires walking the entire site to know whether
+ * any item references the fragment in question. Per-item save-delta can't
+ * tell — adding the fragment is fine; removing the only ref is what makes
+ * it orphaned.
+ *
+ * One issue per orphaned fragment, surfaced on the fragment itself
+ * (`itemPath: fragments/{name}/fragment.json`).
+ */
+export const unusedFragment: Validator = {
+  source: 'gazetta',
+  name: 'unused-fragment',
+  stages: ['background', 'cli'] as const,
+
+  defaultSeverity() {
+    return 'info'
+  },
+
+  async validate(input: ValidatorInput): Promise<Issue[]> {
+    const { scope, site } = input
+    if (scope.kind !== 'background' && scope.kind !== 'cli') return []
+    // Background scope is per-item; only emit issues from the fragment itself,
+    // so the issue lands on the right tree node. CLI scope is site-wide and
+    // emits all orphans at once.
+    if (scope.kind === 'background' && scope.item.kind !== 'fragment') return []
+
+    const referenced = collectReferencedFragments(site)
+
+    if (scope.kind === 'background') {
+      const fragName = scope.item.name
+      if (referenced.has(fragName)) return []
+      return [
+        {
+          validator: 'unused-fragment',
+          severity: 'info',
+          message: `Fragment "@${fragName}" is defined but no page or fragment references it.`,
+          itemPath: scope.item.itemPath,
+        },
+      ]
+    }
+
+    // CLI: enumerate every orphan
+    const issues: Issue[] = []
+    for (const [name, frag] of site.fragments) {
+      if (referenced.has(name)) continue
+      issues.push({
+        validator: 'unused-fragment',
+        severity: 'info',
+        message: `Fragment "@${name}" is defined but no page or fragment references it.`,
+        itemPath: `${frag.dir}/fragment.json`,
+      })
+    }
+    return issues
+  },
+}
+
+/**
+ * Walk every page and every fragment, collecting the set of fragment names
+ * referenced via `@name` in their components tree (recursively). The result
+ * is the "live" set; anything in `site.fragments` not in this set is orphaned.
+ */
+function collectReferencedFragments(site: Site): Set<string> {
+  const referenced = new Set<string>()
+  for (const page of site.pages.values()) {
+    walkFragmentRefs(manifestComponents(page), referenced)
+  }
+  for (const frag of site.fragments.values()) {
+    walkFragmentRefs(manifestComponents(frag), referenced)
+  }
+  return referenced
+}
+
+function walkFragmentRefs(components: readonly ComponentEntry[], out: Set<string>): void {
+  for (const entry of components) {
+    if (typeof entry === 'string' && entry.startsWith('@')) {
+      out.add(entry.slice(1))
+      continue
+    }
+    if (typeof entry === 'object' && entry !== null && entry.components) {
+      walkFragmentRefs(entry.components, out)
+    }
+  }
+}

--- a/packages/gazetta/tests/validation-scanner.test.ts
+++ b/packages/gazetta/tests/validation-scanner.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Unit tests for the background validation scanner (Validation Cut 2).
+ *
+ * Exercises:
+ *   - Full-site scan populates the issue store
+ *   - Cache hits short-circuit re-validation when content hash unchanged
+ *   - Incremental rescan via `cause: 'manifest'` updates only the affected item
+ *   - Fragment-edit rescan walks dependents (via stub of findDependentsFromSidecars)
+ *   - Subscriber receives ScanEvent on completion
+ *   - Stale items pruned when scan finishes (e.g. after a delete)
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type { FragmentManifest, PageManifest, StorageProvider } from '../src/types.js'
+import type { Site } from '../src/site-loader.js'
+import { createContentRoot } from '../src/content-root.js'
+import { createMemoryCache } from '../src/cache/memory.js'
+import { createValidatorRegistry } from '../src/validation/registry.js'
+import { createValidationScanner } from '../src/validation/scanner.js'
+import type { Issue, Validator } from '../src/validation/types.js'
+
+// ---- helpers --------------------------------------------------------------
+
+function memoryStorage(initial: Record<string, string> = {}): StorageProvider {
+  const files = new Map(Object.entries(initial))
+  return {
+    async readFile(path) {
+      const v = files.get(path)
+      if (v === undefined) throw new Error(`ENOENT: ${path}`)
+      return v
+    },
+    async writeFile(path, content) {
+      files.set(path, content as string)
+    },
+    async readDir() {
+      return []
+    },
+    async exists(path) {
+      return files.has(path)
+    },
+    async mkdir() {},
+    async rm(path) {
+      files.delete(path)
+    },
+    async readBytes() {
+      throw new Error('not used in test')
+    },
+    async writeBytes() {},
+    async readStream() {
+      throw new Error('not used in test')
+    },
+    async writeStream() {
+      throw new Error('not used in test')
+    },
+  }
+}
+
+function buildSite(opts: { pages?: Record<string, PageManifest>; fragments?: Record<string, FragmentManifest> }): Site {
+  const pages = new Map<string, PageManifest & { dir: string }>()
+  for (const [name, p] of Object.entries(opts.pages ?? {})) {
+    pages.set(name, { ...p, dir: `pages/${name}` })
+  }
+  const fragments = new Map<string, FragmentManifest & { dir: string }>()
+  for (const [name, f] of Object.entries(opts.fragments ?? {})) {
+    fragments.set(name, { ...f, dir: `fragments/${name}` })
+  }
+  return {
+    pages,
+    fragments,
+    pageLocales: new Map(),
+    fragmentLocales: new Map(),
+    manifest: { name: 'test-site', targets: { local: {} } } as Site['manifest'],
+    templatesDir: undefined,
+  } as Site
+}
+
+function trackingValidator(name: string): { validator: Validator; getCalls(): number } {
+  let calls = 0
+  const validator: Validator = {
+    source: 'gazetta',
+    name,
+    stages: ['background'],
+    defaultSeverity: () => 'warn',
+    async validate(input) {
+      calls++
+      if (input.scope.kind !== 'background') return []
+      const issue: Issue = {
+        validator: name,
+        severity: 'warn',
+        message: `from ${name}`,
+        itemPath: input.scope.item.itemPath,
+      }
+      return [issue]
+    },
+  }
+  return { validator, getCalls: () => calls }
+}
+
+// ---- tests ----------------------------------------------------------------
+
+describe('validation scanner', () => {
+  it('scans every page + fragment and stores issues per item', async () => {
+    const site = buildSite({
+      pages: { home: { template: 'page-default', content: {} } },
+      fragments: { header: { template: 'header', content: {} } },
+    })
+    const tracker = trackingValidator('test-validator')
+    const scanner = createValidationScanner({
+      storage: memoryStorage(),
+      contentRoot: createContentRoot(memoryStorage()),
+      registry: createValidatorRegistry([tracker.validator]),
+      cache: createMemoryCache(),
+      siteOptions: { templatesDir: '/dev/null', manifest: site.manifest },
+      loadSiteImpl: async () => site,
+    })
+
+    await scanner.scanAll()
+
+    expect(scanner.allIssues()).toHaveLength(2)
+    expect(scanner.issuesFor('pages/home/page.json')).toHaveLength(1)
+    expect(scanner.issuesFor('fragments/header/fragment.json')).toHaveLength(1)
+  })
+
+  it('cache hit short-circuits re-validation on unchanged content', async () => {
+    const site = buildSite({
+      pages: { home: { template: 'page-default', content: {} } },
+    })
+    const tracker = trackingValidator('test-validator')
+    const cache = createMemoryCache()
+    const scanner = createValidationScanner({
+      storage: memoryStorage(),
+      contentRoot: createContentRoot(memoryStorage()),
+      registry: createValidatorRegistry([tracker.validator]),
+      cache,
+      siteOptions: { templatesDir: '/dev/null', manifest: site.manifest },
+      loadSiteImpl: async () => site,
+    })
+
+    await scanner.scanAll()
+    expect(tracker.getCalls()).toBe(1)
+
+    // Second scan with same content should hit cache; calls don't increment.
+    await scanner.scanAll()
+    expect(tracker.getCalls()).toBe(1)
+  })
+
+  it('incremental rescan with manifest cause re-validates only the affected item', async () => {
+    const site = buildSite({
+      pages: {
+        home: { template: 'page-default', content: {} },
+        about: { template: 'page-default', content: {} },
+      },
+    })
+    const tracker = trackingValidator('test-validator')
+    const scanner = createValidationScanner({
+      storage: memoryStorage(),
+      contentRoot: createContentRoot(memoryStorage()),
+      registry: createValidatorRegistry([tracker.validator]),
+      cache: createMemoryCache(),
+      siteOptions: { templatesDir: '/dev/null', manifest: site.manifest },
+      loadSiteImpl: async () => site,
+    })
+
+    await scanner.scanAll()
+    const baseline = tracker.getCalls() // 2 (home + about)
+    expect(baseline).toBe(2)
+
+    // Mutate the home manifest so the cache key changes; rescan only the home item.
+    site.pages.set('home', { ...site.pages.get('home')!, content: { changed: true } })
+    await scanner.rescan({
+      kind: 'manifest',
+      item: { kind: 'page', name: 'home', itemPath: 'pages/home/page.json' },
+    })
+    expect(tracker.getCalls()).toBe(baseline + 1) // only home revalidated
+    expect(scanner.issuesFor('pages/home/page.json')).toHaveLength(1)
+  })
+
+  it('emits ScanEvent to subscribers', async () => {
+    const site = buildSite({
+      pages: { home: { template: 'page-default', content: {} } },
+    })
+    const tracker = trackingValidator('test-validator')
+    const scanner = createValidationScanner({
+      storage: memoryStorage(),
+      contentRoot: createContentRoot(memoryStorage()),
+      registry: createValidatorRegistry([tracker.validator]),
+      cache: createMemoryCache(),
+      siteOptions: { templatesDir: '/dev/null', manifest: site.manifest },
+      loadSiteImpl: async () => site,
+    })
+
+    const events: { scanned: number; totalIssues: number }[] = []
+    scanner.subscribe(e => events.push({ scanned: e.scanned, totalIssues: e.totalIssues }))
+
+    await scanner.scanAll()
+    expect(events).toHaveLength(1)
+    expect(events[0]).toEqual({ scanned: 1, totalIssues: 1 })
+  })
+
+  it('prunes stale items from the store on full rescan', async () => {
+    const site = buildSite({
+      pages: {
+        home: { template: 'page-default', content: {} },
+        about: { template: 'page-default', content: {} },
+      },
+    })
+    const tracker = trackingValidator('test-validator')
+    const scanner = createValidationScanner({
+      storage: memoryStorage(),
+      contentRoot: createContentRoot(memoryStorage()),
+      registry: createValidatorRegistry([tracker.validator]),
+      cache: createMemoryCache(),
+      siteOptions: { templatesDir: '/dev/null', manifest: site.manifest },
+      loadSiteImpl: async () => site,
+    })
+
+    await scanner.scanAll()
+    expect(scanner.allIssues()).toHaveLength(2)
+
+    // Delete a page; rescan should prune its issues.
+    site.pages.delete('about')
+    await scanner.scanAll()
+    expect(scanner.allIssues()).toHaveLength(1)
+    expect(scanner.issuesFor('pages/about/page.json')).toHaveLength(0)
+  })
+
+  it('subscriber faults isolated', async () => {
+    const site = buildSite({
+      pages: { home: { template: 'page-default', content: {} } },
+    })
+    const tracker = trackingValidator('test-validator')
+    const scanner = createValidationScanner({
+      storage: memoryStorage(),
+      contentRoot: createContentRoot(memoryStorage()),
+      registry: createValidatorRegistry([tracker.validator]),
+      cache: createMemoryCache(),
+      siteOptions: { templatesDir: '/dev/null', manifest: site.manifest },
+      loadSiteImpl: async () => site,
+    })
+
+    const goodEvents: number[] = []
+    scanner.subscribe(() => {
+      throw new Error('boom')
+    })
+    scanner.subscribe(e => goodEvents.push(e.scanned))
+
+    await scanner.scanAll()
+    expect(goodEvents).toEqual([1]) // good subscriber still ran
+  })
+
+  it('cache keys differ when nested content changes (regression: hash must canonicalize recursively)', async () => {
+    // Caught during Cut 2 implementation: JSON.stringify(obj, keys.sort()) filters
+    // only top-level keys, silently dropping nested mutations from the hash.
+    // Mutation to `content.title` MUST produce a different cache key, otherwise
+    // the second scan returns stale cached issues.
+    const site = buildSite({
+      pages: { home: { template: 'page-default', content: { title: 'A' } } },
+    })
+    const tracker = trackingValidator('test-validator')
+    const scanner = createValidationScanner({
+      storage: memoryStorage(),
+      contentRoot: createContentRoot(memoryStorage()),
+      registry: createValidatorRegistry([tracker.validator]),
+      cache: createMemoryCache(),
+      siteOptions: { templatesDir: '/dev/null', manifest: site.manifest },
+      loadSiteImpl: async () => site,
+    })
+
+    await scanner.scanAll()
+    expect(tracker.getCalls()).toBe(1)
+
+    site.pages.set('home', { ...site.pages.get('home')!, content: { title: 'B' } })
+    await scanner.rescan({
+      kind: 'manifest',
+      item: { kind: 'page', name: 'home', itemPath: 'pages/home/page.json' },
+    })
+    expect(tracker.getCalls()).toBe(2) // Re-validated; not a cache hit.
+  })
+
+  it('dispose returned by subscribe stops further events', async () => {
+    const site = buildSite({
+      pages: { home: { template: 'page-default', content: {} } },
+    })
+    const tracker = trackingValidator('test-validator')
+    const scanner = createValidationScanner({
+      storage: memoryStorage(),
+      contentRoot: createContentRoot(memoryStorage()),
+      registry: createValidatorRegistry([tracker.validator]),
+      cache: createMemoryCache(),
+      siteOptions: { templatesDir: '/dev/null', manifest: site.manifest },
+      loadSiteImpl: async () => site,
+    })
+
+    const events: number[] = []
+    const dispose = scanner.subscribe(e => events.push(e.scanned))
+    await scanner.scanAll()
+    dispose()
+    await scanner.scanAll()
+    expect(events).toEqual([1]) // second scan didn't fire
+  })
+})

--- a/packages/gazetta/tests/validation.test.ts
+++ b/packages/gazetta/tests/validation.test.ts
@@ -164,9 +164,35 @@ describe('defaultValidatorRegistry', () => {
     expect(names).toContain('dynamic-route-conflict')
   })
 
-  it('every default validator runs at save-delta', () => {
+  it('every Cut 1 ref-existence validator runs at save-delta', () => {
     const reg = defaultValidatorRegistry()
-    expect(reg.forStage('save-delta')).toHaveLength(reg.all().length)
+    const saveDeltaNames = reg
+      .forStage('save-delta')
+      .map(v => v.name)
+      .sort()
+    expect(saveDeltaNames).toEqual([
+      'circular-fragment',
+      'dynamic-route-conflict',
+      'referenced-asset-exists',
+      'referenced-fragment-exists',
+      'referenced-template-exists',
+    ])
+  })
+
+  it('Cut 2 background-only validators are present and tagged background+cli', () => {
+    const reg = defaultValidatorRegistry()
+    const backgroundNames = reg
+      .forStage('background')
+      .map(v => v.name)
+      .sort()
+    expect(backgroundNames).toContain('schema-conformance')
+    expect(backgroundNames).toContain('orphaned-locale-file')
+    expect(backgroundNames).toContain('unused-fragment')
+    // None of the background-only validators leak into save-delta
+    const saveDeltaNames = reg.forStage('save-delta').map(v => v.name)
+    expect(saveDeltaNames).not.toContain('schema-conformance')
+    expect(saveDeltaNames).not.toContain('orphaned-locale-file')
+    expect(saveDeltaNames).not.toContain('unused-fragment')
   })
 })
 


### PR DESCRIPTION
## Summary

- Background validation pipeline shipped per [`design-validation-implementation.md`](.claude/rules/design-validation-implementation.md) Cut 2.
- Per-instance scanner + content-hash cache + 3 new background-only validators + admin API + SSE channel + Pinia store + Site Health drawer + site-tree dots.
- Site Health icon in top toolbar (only visible when issues exist — Krug rule 23: absence is the state).
- 1991 gazetta tests + 752 admin tests pass; 13 net-new tests.

## What ships

| Surface | Files |
|---|---|
| Scanner | [\`packages/gazetta/src/validation/scanner.ts\`](packages/gazetta/src/validation/scanner.ts), [\`tests/validation-scanner.test.ts\`](packages/gazetta/tests/validation-scanner.test.ts) |
| Validator interface | [\`types.ts\`](packages/gazetta/src/validation/types.ts) — \`source\` field added per ADR-0009; \`ValidatorScope.background\` extended with \`manifest\` |
| New validators | [\`schema-conformance.ts\`](packages/gazetta/src/validation/validators/schema-conformance.ts), [\`orphaned-locale-file.ts\`](packages/gazetta/src/validation/validators/orphaned-locale-file.ts), [\`unused-fragment.ts\`](packages/gazetta/src/validation/validators/unused-fragment.ts) |
| Admin API | [\`validation.ts\`](packages/gazetta/src/admin-api/routes/validation.ts) (\`GET /api/validation/issues\` + \`GET /__validation\` SSE), schemas |
| Save-handler integration | [\`pages.ts\`](packages/gazetta/src/admin-api/routes/pages.ts), [\`fragments.ts\`](packages/gazetta/src/admin-api/routes/fragments.ts) — fire-and-forget rescan after success |
| Boot wiring | [\`cli/index.ts\`](packages/gazetta/src/cli/index.ts) \`buildValidationScanner()\` |
| Pinia store | [\`validationScanner.ts\`](apps/admin/src/client/stores/validationScanner.ts) |
| Site Health drawer | [\`SiteHealthDrawer.vue\`](apps/admin/src/client/components/SiteHealthDrawer.vue), [\`SiteHealthDrawer.test.ts\`](apps/admin/tests/SiteHealthDrawer.test.ts) |
| Toolbar trigger | [\`CmsToolbar.vue\`](apps/admin/src/client/components/CmsToolbar.vue) |
| Site tree dots | [\`SiteTree.vue\`](apps/admin/src/client/components/SiteTree.vue) |
| Boot subscribe | [\`App.vue\`](apps/admin/src/client/App.vue) |

## Notable

- **Recursive content-hash regression caught + tested.** JSON.stringify(obj, keys.sort()) filters only top-level keys, silently dropping nested mutations from the scanner's cache key. Switched to recursive canonicalization; pinned with a regression test (per [team-preferences rule 25](.claude/rules/team-preferences.md)).
- **Validator.source field locked durable.** Added per ADR-0009 + plugins design pass. All five Cut 1 validators source-tagged \`gazetta\`; new Cut 2 validators same. Plugin-supplied validators (when shipped) use their npm package name.
- **Three rescan causes**: \`manifest\` (single item), \`fragment\` (item + transitive dependents via existing \`findDependentsFromSidecars\`), \`asset\` (full rescan v1 fallback per implementation doc), \`template\` / \`full\` (full rescan).
- **SSE channel scoped to \`/__validation\`** — separate from \`/__reload\` (preview iframe) per design open-question 5 lock.

## Test plan

- [ ] CI green
- [ ] gazetta package: 1991 tests pass (\`cd packages/gazetta && npx vitest run\`)
- [ ] admin package: 752 tests pass (\`cd apps/admin && npx vitest run\`)
- [ ] Manual: \`gazetta dev\` against \`examples/starter\` → boot triggers scan → \`/api/validation/issues\` returns issues → save a page → SSE event fires → drawer/dots update without reload
- [ ] Manual: introduce a broken \`@missing\` fragment ref via direct file edit → background scan picks it up → tree shows red dot → drawer lists it

🤖 Generated with [Claude Code](https://claude.com/claude-code)