### PR TITLE
Validation Cut 6: template-developer surfaces

### DIFF
--- a/.claude/rules/design-validation-implementation.md
+++ b/.claude/rules/design-validation-implementation.md
@@ -191,20 +191,75 @@ Per [team-preferences.md rule 17](team-preferences.md): "Build and validate, don
 
 ### Cut 6 — Template-developer surfaces (3 days)
 
+Per `design-validation.md`'s "DevPlayground Impact tab + transient
+banner" surface — paired with the existing site-health drawer; this
+cut adds the template-developer audience.
+
 **What ships:**
-- When a template's schema changes (file watcher), run `schema-conformance` against all content using that template
-- New admin UI panel: "Template impact" — shows which content items are affected by the template change
-- Per-item: green ✓ (still conforms), amber ⚠ (warning), red ✗ (errors)
-- One-click "Migrate" action per item (opens the editor with the affected fields highlighted)
+
+Backend:
+- CLI template watcher → `validationScanner.rescan({ kind: 'template', name })`
+  on every `.ts/.tsx` change in `templates/{name}/`. The scanner already
+  supports the `template` rescan cause (full-site rescan fallback per
+  Cut 2's deferred items table); this cut wires the trigger.
+- New admin API `GET /api/templates/:name/impact` returning items
+  using the template (recursive walk: top-level + inline components in
+  page/fragment manifests) plus their issues from the scanner store.
+  Shape: `{ items: [{ kind, name, itemPath, issues }] }`.
+- New SSE event `template-changed { name, affectedItemCount }` on the
+  existing `/__validation` channel after a template-edit rescan
+  completes. Banner consumes this.
+
+Frontend:
+- Pinia store `useTemplateImpactStore`: subscribes to `/__validation`,
+  tracks the latest template-change event with auto-clear (60s timer
+  + zero-impact-from-scanner clear).
+- `TemplateChangedBanner.vue` in the admin shell toolbar — shows the
+  banner when the store has an active event. Click → routes to
+  `/admin/dev/editor/{name}` with the Impact tab pre-selected.
+- DevPlayground gains an "Impact" tab in the right detail pane
+  alongside the existing schema/preview view. Tab lists items using
+  the selected template with ✓/⚠/✗ severity icons. Click-to-edit
+  reuses the existing ValidationBanner field-focus.
+
+**Migrate affordance — deferred:**
+
+Per the design's "Migrate" reservation: the impact panel does NOT ship
+a "Migrate" button in v1. Schema migrations are too feature-specific
+to automate generically (every schema change has its own translation
+rule: rename, default-fill, type-widen, restructure). Future direction
+per `design-ai.md`'s extension surface — schema migrations are a
+natural AI-task ("translate this content to match the new schema") and
+land when the AI infrastructure has its second consumer beyond
+alt-text. Reserved seam: the impact panel's row buttons today say
+"Edit" (which navigates to the page); a future "Migrate with AI"
+button slots in adjacent without redesigning the panel.
 
 **Tests:**
-- Template schema change triggers re-validation of dependent content
-- Panel surfaces the impact
-- Migrate action focuses the right field
 
-**Risk:** low-medium. The infrastructure exists by Cut 6; this is mostly UI work.
+Backend:
+- Template-edit triggers scanner rescan with `kind: 'template'`
+- `GET /api/templates/:name/impact` returns the right items + their
+  issues; recursive component walk catches nested inline templates
+- SSE event fires after template-edit rescan completes
 
-**Why this is last:** it's a power-user feature for template developers, not a daily-author concern. Most daily author workflows don't trigger it.
+Frontend:
+- Store handles SSE event; auto-clears at 60s; auto-clears when
+  scanner reports zero impact
+- Banner renders + dismisses; click navigates correctly
+- Impact tab fetches + renders the list with severity icons
+- Click-to-edit on an issue row navigates to the affected item
+
+**Risk:** low-medium. The infrastructure exists by Cut 6; this is
+mostly UI work + one new API. The DevPlayground integration is the
+load-bearing change — the existing playground is template-developer
+turf, so adding to it is structurally cheaper than building a
+parallel `/admin/templates` surface.
+
+**Why this is last:** it's a power-user feature for template
+developers, not a daily-author concern. Most daily author workflows
+don't trigger it. Daily authors see schema-conformance issues via
+the existing site-health drawer (no Cut 6 dependency).
 
 ## What's deferred from this plan
 

--- a/.claude/rules/design-validation.md
+++ b/.claude/rules/design-validation.md
@@ -165,7 +165,7 @@ export interface Issue {
 
 ## Surfaces
 
-Three distinct UI surfaces, each tied to a phase:
+Four distinct UI surfaces, each tied to a phase or audience:
 
 ### Banner (save-time integrity)
 
@@ -197,6 +197,52 @@ Operator-configurable per target: `targets.production.publishAudit: { strict: tr
 **Visual weight:** modal — operator is committing.
 
 **Scope:** items being published × their issues × target config.
+
+### DevPlayground Impact tab + transient banner (template-developer)
+
+For template developers (the ones editing `templates/{name}/index.tsx`),
+neither the save-banner nor the site-health drawer is the right surface.
+Their workflow lives in their IDE, not the admin form. They edit a
+template's schema, hot-reload fires, and they want to know: did I break
+any content?
+
+Two paired surfaces give them the answer:
+
+- **Transient toolbar banner** — when the dev server's template watcher
+  fires, the scanner rescans (template-edit invalidation) and the
+  admin pushes an SSE `template-changed { name, affectedItemCount }`
+  event. The toolbar shows: "Template `hero` changed — 2 items
+  affected. View impact →." Click navigates to the DevPlayground for
+  that template. Auto-clears after 60s OR when scanner reports zero
+  affected items, whichever first. Single-slot — newer template
+  changes overwrite older ones; the older items' impact is still
+  available via the site-health drawer's accumulated issues.
+
+- **DevPlayground Impact tab** — the existing dev playground (which
+  already lists templates + custom editors + fields, Storybook-style)
+  gains an "Impact" tab in the right detail pane alongside the
+  schema/preview view. The tab lists all items that use the selected
+  template — pages first, then fragments, then nested inline
+  components — with per-item ✓/⚠/✗ severity icons. Click-to-edit
+  navigates to the affected item; the existing site-health drawer's
+  field-focus mechanism (Cut 1's `ValidationBanner`) takes over from
+  there. "Migrate" affordance per item is reserved for a future
+  AI-task surface (per `design-ai.md`'s extension model — schema
+  migrations are too feature-specific to automate generically; the
+  AI seam is the right home when concrete demand surfaces).
+
+**Visual weight:** ambient banner + on-demand tab. Banner only
+appears in response to template edits; tab only matters when a
+developer is in the DevPlayground.
+
+**Scope:** one template at a time × all items that use it × their
+issues. Banner shows the count; tab shows the list.
+
+**Why this surface earns its place:** template developers are a
+distinct audience from content authors. Folding their needs into the
+site-health drawer would force them to filter by template manually
+on every edit; folding the impact view into the editor would put
+template-developer concerns in the daily-author chrome.
 
 ## Severity
 

--- a/apps/admin/src/client/App.vue
+++ b/apps/admin/src/client/App.vue
@@ -16,6 +16,8 @@ import AssetPicker from './components/AssetPicker.vue'
 import AssetDeleteConfirm from './components/AssetDeleteConfirm.vue'
 import OfflineBanner from './components/OfflineBanner.vue'
 import StorageQuotaBanner from './components/StorageQuotaBanner.vue'
+import TemplateChangedBanner from './components/TemplateChangedBanner.vue'
+import { useTemplateImpactStore } from './stores/templateImpact.js'
 
 const site = useSiteStore()
 const theme = useThemeStore()
@@ -23,6 +25,7 @@ const toast = useToastStore()
 const activeTarget = useActiveTargetStore()
 const syncStatus = useSyncStatusStore()
 const validationScanner = useValidationScannerStore()
+const templateImpact = useTemplateImpactStore()
 
 // Apply workspace-wide chrome when the active target is an editable
 // production target. Kept out of App.vue's inline setup so the rule has
@@ -78,6 +81,12 @@ onMounted(() => {
   // scanner's state without per-component polling.
   void validationScanner.refresh()
   validationScanner.subscribe()
+  // Cut 6 — the template-changed banner consumes a separate SSE event
+  // type on the same /__validation channel. Subscribing here keeps the
+  // banner reactive to dev-mode template hot reloads without per-route
+  // wiring. Production has no template watcher so the channel stays
+  // silent for this event type — no harm, no overhead.
+  templateImpact.subscribe()
 })
 </script>
 
@@ -86,6 +95,7 @@ onMounted(() => {
     <Toolbar />
     <OfflineBanner />
     <StorageQuotaBanner />
+    <TemplateChangedBanner />
     <div v-if="site.error" class="cms-error">{{ site.error }}</div>
     <!-- Only block on the first load. Subsequent reloads (e.g., on
          active-target switch) keep the router-view mounted so the

--- a/apps/admin/src/client/api/client.ts
+++ b/apps/admin/src/client/api/client.ts
@@ -200,6 +200,8 @@ import type {
   CreateFragmentRequest as CreateFragmentRequestShape,
   CreateFragmentResponse as CreateFragmentResponseShape,
   TemplateSummary as TemplateSummaryShape,
+  TemplateImpactItem as TemplateImpactItemShape,
+  TemplateImpactResponse as TemplateImpactResponseShape,
   FieldSummary as FieldSummaryShape,
   TargetInfo as TargetInfoShape,
   TargetEnvironment as TargetEnvironmentShape,
@@ -229,6 +231,8 @@ export type FragmentSummary = FragmentSummaryShape
 export type CreateFragmentRequest = CreateFragmentRequestShape
 export type CreateFragmentResponse = CreateFragmentResponseShape
 export type TemplateSummary = TemplateSummaryShape
+export type TemplateImpactItem = TemplateImpactItemShape
+export type TemplateImpactResponse = TemplateImpactResponseShape
 export type FieldSummary = FieldSummaryShape
 export type TargetInfo = TargetInfoShape
 export type TargetEnvironment = TargetEnvironmentShape
@@ -364,6 +368,13 @@ export const api = {
     })
   },
   getTemplates: () => request<TemplateSummary[]>('/templates'),
+  /**
+   * Validation Cut 6 — items using a template + their issues from the
+   * background scanner. Powers the DevPlayground "Impact" tab + the
+   * toolbar banner's "View impact" link.
+   */
+  getTemplateImpact: (name: string, options?: RequestInit) =>
+    request<TemplateImpactResponse>(`/templates/${name}/impact`, options),
   getTemplateSchema: (name: string, options?: RequestInit) =>
     request<Record<string, unknown>>(`/templates/${name}/schema`, options),
   getFields: () => request<FieldSummary[]>('/fields'),

--- a/apps/admin/src/client/components/DevPlayground.vue
+++ b/apps/admin/src/client/components/DevPlayground.vue
@@ -6,6 +6,7 @@ import { useThemeStore } from '../stores/theme.js'
 import { usePagesApi, useFragmentsApi, useTemplatesApi } from '../composables/api.js'
 import type { EditorMount, FieldMount } from 'gazetta/types'
 import { createEditorMount } from 'gazetta/editor'
+import TemplateImpactPanel from './TemplateImpactPanel.vue'
 
 const theme = useThemeStore()
 const router = useRouter()
@@ -58,6 +59,37 @@ const selected = ref<Selected | null>(null)
 const schemaLoading = ref(false)
 const mountError = ref<string | null>(null)
 const showAllTemplates = ref(false)
+
+// Cut 6 — Impact tab. Two tabs only when an editor (template) is
+// selected: Preview (existing form + value inspector) and Impact
+// (items using this template + their issues). Field selections skip
+// tabs entirely (no impact concept for fields). Tab state persists
+// via the `?tab=impact` query param so the toolbar banner's deep-link
+// can land directly on the Impact view.
+type DevTab = 'preview' | 'impact'
+const activeTab = ref<DevTab>((route.query.tab as DevTab | undefined) === 'impact' ? 'impact' : 'preview')
+
+function selectTab(t: DevTab) {
+  if (activeTab.value === t) return
+  activeTab.value = t
+  // Reflect into the URL so reload + share preserve the tab.
+  router.replace({
+    path: route.path,
+    query: { ...route.query, tab: t === 'preview' ? undefined : 'impact' },
+  })
+}
+
+// Reset to Preview when switching to a different editor (a fresh
+// selection shouldn't preserve a stale tab from a different template).
+// Banner deep-links go through router.push BEFORE selectEditor runs,
+// so the route's `?tab=impact` is already set; honor it on the next
+// editor selection by re-reading the query.
+watch(
+  () => route.query.tab,
+  q => {
+    activeTab.value = q === 'impact' ? 'impact' : 'preview'
+  },
+)
 
 // Value inspector
 const currentValue = ref<unknown>(null)
@@ -159,7 +191,13 @@ async function selectEditor(name: string) {
     const realContent = await findRealContent(name)
 
     selected.value = { type: 'editor', name, hasEditor: !!hasEditor, editorUrl, fieldsBaseUrl, schema, realContent }
-    router.replace(`/dev/editor/${name}`)
+    // Preserve the tab query — banner deep-link comes in with
+    // `?tab=impact`; sidebar clicks come in without and stay on Preview.
+    const currentTab = route.query.tab as string | undefined
+    router.replace({
+      path: `/dev/editor/${name}`,
+      query: currentTab === 'impact' ? { tab: 'impact' } : {},
+    })
   } catch (err) {
     mountError.value = `Failed to load schema for "${name}": ${(err as Error).message}`
     selected.value = null
@@ -416,16 +454,38 @@ function generateMockContent(schema: Record<string, unknown>): Record<string, un
             <strong>{{ selected.name }}</strong>
             <span v-if="selected.type === 'editor' && selected.realContent" class="toolbar-hint">using real content</span>
           </span>
-          <button class="toolbar-btn" data-testid="playground-reset" @click="reset" title="Reset to initial state">
+          <button v-if="activeTab === 'preview'" class="toolbar-btn" data-testid="playground-reset" @click="reset" title="Reset to initial state">
             <i class="pi pi-refresh" /> Reset
           </button>
-          <button class="toolbar-btn" data-testid="playground-toggle-inspector" @click="showInspector = !showInspector">
+          <button v-if="activeTab === 'preview'" class="toolbar-btn" data-testid="playground-toggle-inspector" @click="showInspector = !showInspector">
             <i class="pi pi-code" /> {{ showInspector ? 'Hide' : 'Show' }} Value
           </button>
         </div>
 
-        <!-- Content: editor + optional inspector side by side -->
-        <div class="main-body">
+        <!-- Tab strip — only for editors (templates). Fields skip tabs.
+             Cut 6 — Impact tab is template-developer turf, not relevant
+             to field-only previews. -->
+        <div v-if="selected.type === 'editor'" class="playground-tabs" data-testid="playground-tabs">
+          <button
+            type="button"
+            :class="['playground-tab', activeTab === 'preview' ? 'active' : '']"
+            data-testid="playground-tab-preview"
+            @click="selectTab('preview')">
+            Preview
+          </button>
+          <button
+            type="button"
+            :class="['playground-tab', activeTab === 'impact' ? 'active' : '']"
+            data-testid="playground-tab-impact"
+            @click="selectTab('impact')">
+            Impact
+          </button>
+        </div>
+
+        <!-- Content: editor + optional inspector side by side, OR
+             impact panel when tab=impact. Fields always render preview
+             (no tab strip; the tab state is irrelevant to them). -->
+        <div v-if="activeTab === 'preview' || selected.type === 'field'" class="main-body" data-testid="playground-body-preview">
           <div class="main-content">
             <div v-if="mountError" class="mount-error">{{ mountError }}</div>
             <div ref="mountRef" class="mount-container" data-testid="playground-mount" />
@@ -436,6 +496,13 @@ function generateMockContent(schema: Record<string, unknown>): Record<string, un
             <div class="inspector-header">Value</div>
             <pre class="inspector-value" v-html="valueHtml" />
           </div>
+        </div>
+
+        <!-- Impact tab body. Lazy by tab activation — the panel only
+             fetches when shown, so opening the playground at the
+             default Preview tab pays no Impact cost. -->
+        <div v-else-if="activeTab === 'impact' && selected.type === 'editor'" class="main-body main-body-impact" data-testid="playground-body-impact">
+          <TemplateImpactPanel :template="selected.name" />
         </div>
       </template>
     </div>
@@ -474,8 +541,16 @@ function generateMockContent(schema: Record<string, unknown>): Record<string, un
 .toolbar-btn { display: flex; align-items: center; gap: 0.375rem; padding: 0.25rem 0.625rem; border: 1px solid #e5e7eb; border-radius: 6px; background: transparent; color: #6b7280; font-size: 0.75rem; cursor: pointer; white-space: nowrap; }
 .toolbar-btn:hover { background: rgba(128, 128, 128, 0.08); color: #374151; }
 
+/* Tabs (Cut 6) — Preview / Impact strip below the main toolbar.
+   Storybook-style tab pattern; one selected at a time. */
+.playground-tabs { display: flex; gap: 0; padding: 0 1rem; border-bottom: 1px solid #e5e7eb; flex-shrink: 0; }
+.playground-tab { background: transparent; border: none; border-bottom: 2px solid transparent; padding: 0.5rem 0.75rem; font-size: 0.75rem; color: #6b7280; cursor: pointer; }
+.playground-tab:hover { color: #374151; }
+.playground-tab.active { color: #667eea; border-bottom-color: #667eea; font-weight: 600; }
+
 /* Body — side by side, equal width */
 .main-body { flex: 1; display: flex; overflow: hidden; }
+.main-body-impact { display: block; overflow-y: auto; }
 .main-content { flex: 1; overflow-y: auto; padding: 1.5rem; min-width: 0; }
 .mount-container { max-width: 600px; }
 .mount-error { color: #dc2626; font-size: 0.8125rem; margin-bottom: 1rem; padding: 0.75rem; background: rgba(220, 38, 38, 0.08); border-radius: 6px; }

--- a/apps/admin/src/client/components/TemplateChangedBanner.vue
+++ b/apps/admin/src/client/components/TemplateChangedBanner.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+/**
+ * Template-changed transient banner (Validation Cut 6).
+ *
+ * Surfaces when the dev server's template watcher fires a hot reload
+ * — `templateImpact` store consumes the SSE `template-changed` event
+ * and stashes the latest. Click "View impact" routes to the
+ * DevPlayground for that template with the Impact tab pre-selected;
+ * X dismisses without navigating.
+ *
+ * Auto-clear: 60s timer in the store.
+ *
+ * Per `design-validation.md` "DevPlayground Impact tab + transient
+ * banner" — this banner is template-developer turf, not daily-author
+ * chrome. Mounted at the top of the admin alongside OfflineBanner +
+ * StorageQuotaBanner. Compact horizontal strip, Krug-aligned absence-
+ * as-state (no banner = nothing to know about).
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this component renders the banner. SSE wiring + auto-clear
+ *     timer live in the store.
+ *   - DIP: depends on `useTemplateImpactStore`'s typed surface.
+ */
+import { useRouter } from 'vue-router'
+import Button from 'primevue/button'
+import { useTemplateImpactStore } from '../stores/templateImpact.js'
+
+const store = useTemplateImpactStore()
+const router = useRouter()
+
+function viewImpact() {
+  const c = store.current
+  if (!c) return
+  // Land on the DevPlayground with the template selected. The Impact
+  // tab gets pre-selected via the `?tab=impact` query param so the
+  // dev arrives directly at "what did I break."
+  router.push({
+    path: `/dev/editor/${encodeURIComponent(c.name)}`,
+    query: { tab: 'impact' },
+  })
+  store.dismiss()
+}
+</script>
+
+<template>
+  <div
+    v-if="store.hasBanner && store.current"
+    class="template-changed-banner"
+    role="status"
+    data-testid="template-changed-banner">
+    <i class="pi pi-code banner-icon" aria-hidden="true" />
+    <span class="banner-text">
+      <strong>Template <code>{{ store.current.name }}</code> changed</strong>
+      <span v-if="typeof store.current.affectedItemCount === 'number'">
+        — {{ store.current.affectedItemCount === 0
+          ? 'no items affected'
+          : `${store.current.affectedItemCount} ${store.current.affectedItemCount === 1 ? 'item' : 'items'} affected` }}
+      </span>
+    </span>
+    <button
+      type="button"
+      class="banner-link"
+      data-testid="template-changed-banner-view"
+      @click="viewImpact">
+      View impact →
+    </button>
+    <Button
+      icon="pi pi-times"
+      text
+      rounded
+      size="small"
+      severity="secondary"
+      class="banner-dismiss"
+      aria-label="Dismiss template-changed notice"
+      data-testid="template-changed-banner-dismiss"
+      @click="store.dismiss()" />
+  </div>
+</template>
+
+<style scoped>
+.template-changed-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  background: var(--color-info-bg);
+  color: var(--color-info-fg);
+  border-bottom: 1px solid var(--color-info-fg);
+}
+.banner-icon {
+  font-size: 0.875rem;
+}
+.banner-text {
+  flex: 1;
+}
+.banner-text code {
+  font-family: ui-monospace, monospace;
+  font-size: 0.8125rem;
+  padding: 0.0625rem 0.25rem;
+  border-radius: var(--p-border-radius-sm);
+  background: var(--color-bg);
+}
+.banner-link {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+}
+.banner-link:hover {
+  opacity: 0.85;
+}
+.banner-dismiss {
+  margin-inline-start: 0.25rem;
+}
+</style>

--- a/apps/admin/src/client/components/TemplateImpactPanel.vue
+++ b/apps/admin/src/client/components/TemplateImpactPanel.vue
@@ -1,0 +1,337 @@
+<script setup lang="ts">
+/**
+ * Template impact panel (Validation Cut 6).
+ *
+ * Storybook-style "what does this template touch?" view inside the
+ * DevPlayground's right detail pane. Lists every page + fragment that
+ * uses the selected template — top-level OR nested inline — with
+ * per-item severity icons (✓ clean, ⚠ warns, ✗ errors). Click an
+ * affected item to navigate to its editor; the existing
+ * site-health drawer + ValidationBanner take over field-focus from
+ * there.
+ *
+ * "Migrate" affordance is reserved for a future AI-task surface (per
+ * `design-ai.md` extension model — schema migrations are too feature-
+ * specific to automate generically; the AI seam is the right home
+ * when concrete demand surfaces). For now the row's primary action
+ * is "Edit".
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this component renders one tab on one selected template.
+ *     Walking the site → API; subscribing to scanner state → store.
+ *   - DIP: depends on `TemplatesApi.getTemplateImpact` + the scanner
+ *     store's `byItem` lookup. No coupling to the SSE channel.
+ */
+import { ref, computed, watch, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useTemplatesApi } from '../composables/api.js'
+import { useValidationScannerStore } from '../stores/validationScanner.js'
+import type { TemplateImpactItem, TemplateImpactResponse, ValidationIssue } from '../api/client.js'
+
+const props = defineProps<{
+  /** Template name. The panel re-fetches when this changes. */
+  template: string
+}>()
+
+const templatesApi = useTemplatesApi()
+const scanner = useValidationScannerStore()
+const router = useRouter()
+
+const data = ref<TemplateImpactResponse | null>(null)
+const loading = ref(false)
+const errorMessage = ref<string | null>(null)
+
+async function load(name: string) {
+  loading.value = true
+  errorMessage.value = null
+  try {
+    data.value = await templatesApi.getTemplateImpact(name)
+  } catch (err) {
+    errorMessage.value = (err as Error).message
+    data.value = null
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => load(props.template))
+watch(
+  () => props.template,
+  name => {
+    void load(name)
+  },
+)
+// Re-fetch on every scanner update — the scanner tells us when issues
+// changed for any item, including the ones using this template.
+// Tracking byItem keeps the panel current without manual refresh.
+watch(
+  () => scanner.lastFetchedAt,
+  () => {
+    if (props.template) void load(props.template)
+  },
+)
+
+interface DisplayRow {
+  item: TemplateImpactItem
+  worst: 'error' | 'warn' | 'info' | null
+}
+
+/**
+ * Worst severity for a row drives the icon; null means clean (✓).
+ * Local helper because the scanner store's `severityFor` returns the
+ * same shape but only for items the scanner has scanned — items that
+ * use the template but aren't tracked yet still need a value.
+ */
+function worstSeverity(issues: readonly ValidationIssue[]): 'error' | 'warn' | 'info' | null {
+  if (!issues.length) return null
+  if (issues.some(i => i.severity === 'error')) return 'error'
+  if (issues.some(i => i.severity === 'warn')) return 'warn'
+  return 'info'
+}
+
+const rows = computed<DisplayRow[]>(() => {
+  if (!data.value) return []
+  return data.value.items.map(item => ({ item, worst: worstSeverity(item.issues) }))
+})
+
+function severityIconClass(worst: DisplayRow['worst']): string {
+  if (worst === 'error') return 'pi pi-times-circle severity-error'
+  if (worst === 'warn') return 'pi pi-exclamation-triangle severity-warn'
+  if (worst === 'info') return 'pi pi-info-circle severity-info'
+  return 'pi pi-check-circle severity-clean'
+}
+
+function severityLabel(worst: DisplayRow['worst']): string {
+  if (worst === 'error') return 'Errors'
+  if (worst === 'warn') return 'Warnings'
+  if (worst === 'info') return 'Info'
+  return 'Clean'
+}
+
+function navigateToItem(item: TemplateImpactItem) {
+  if (item.kind === 'page') {
+    router.push({ path: `/pages/${item.name}` })
+  } else {
+    router.push({ path: `/fragments/${item.name}` })
+  }
+}
+</script>
+
+<template>
+  <div class="template-impact" data-testid="template-impact-panel">
+    <div v-if="loading" class="impact-empty" data-testid="template-impact-loading">
+      <i class="pi pi-spin pi-spinner" />
+      <span>Loading impact…</span>
+    </div>
+    <div v-else-if="errorMessage" class="impact-error" data-testid="template-impact-error">
+      <i class="pi pi-exclamation-circle" />
+      <span>{{ errorMessage }}</span>
+    </div>
+    <div v-else-if="!data || data.items.length === 0" class="impact-empty" data-testid="template-impact-empty">
+      <i class="pi pi-info-circle" />
+      <span>No items use this template.</span>
+    </div>
+    <template v-else>
+      <div class="impact-summary" data-testid="template-impact-summary">
+        <strong>{{ data.items.length }}</strong>
+        {{ data.items.length === 1 ? 'item uses' : 'items use' }} <code>{{ data.template }}</code>
+        <span v-if="data.affectedItemCount > 0" class="summary-affected">
+          —
+          <strong>{{ data.affectedItemCount }}</strong>
+          with issues
+        </span>
+        <span v-else class="summary-clean">— all clean</span>
+      </div>
+      <ul class="impact-rows">
+        <li
+          v-for="row in rows"
+          :key="row.item.itemPath"
+          :class="['impact-row', `severity-${row.worst ?? 'clean'}`]"
+          :data-testid="`template-impact-row-${row.item.kind}-${row.item.name}`">
+          <i :class="severityIconClass(row.worst)" :title="severityLabel(row.worst)" />
+          <div class="row-body">
+            <div class="row-head">
+              <span class="row-kind">{{ row.item.kind === 'page' ? 'Page' : 'Fragment' }}</span>
+              <span class="row-name">{{ row.item.name }}</span>
+              <span v-if="row.item.issues.length > 0" class="row-issue-count">
+                {{ row.item.issues.length }} {{ row.item.issues.length === 1 ? 'issue' : 'issues' }}
+              </span>
+            </div>
+            <ul v-if="row.item.issues.length > 0" class="row-issues">
+              <li v-for="(issue, idx) in row.item.issues" :key="idx" class="row-issue">
+                <span class="issue-severity">{{ issue.severity }}</span>
+                <span class="issue-validator">{{ issue.validator }}</span>
+                <span class="issue-message">{{ issue.message }}</span>
+              </li>
+            </ul>
+          </div>
+          <button
+            type="button"
+            class="row-edit"
+            :data-testid="`template-impact-edit-${row.item.kind}-${row.item.name}`"
+            @click="navigateToItem(row.item)">
+            Edit
+          </button>
+        </li>
+      </ul>
+      <p class="impact-footer">
+        Future direction: a "Migrate with AI" action per affected row will land
+        as an AI-task surface alongside <code>alt-text</code> per
+        <code>design-ai.md</code>.
+      </p>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.template-impact {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  font-size: 0.8125rem;
+}
+.impact-empty,
+.impact-error {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-muted);
+  padding: 1rem 0;
+}
+.impact-error {
+  color: var(--color-danger-fg);
+}
+.impact-summary code {
+  font-family: ui-monospace, monospace;
+  background: var(--color-hover-bg);
+  padding: 0.0625rem 0.25rem;
+  border-radius: var(--p-border-radius-sm);
+}
+.summary-affected {
+  color: var(--color-warning-fg);
+}
+.summary-clean {
+  color: var(--color-muted);
+}
+.impact-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.impact-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: start;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--p-border-radius-md);
+  background: var(--color-bg);
+}
+.impact-row.severity-error {
+  border-left: 3px solid var(--color-danger-fg);
+}
+.impact-row.severity-warn {
+  border-left: 3px solid var(--color-warning-fg);
+}
+.impact-row.severity-info {
+  border-left: 3px solid var(--color-info-fg);
+}
+.impact-row.severity-clean {
+  border-left: 3px solid var(--color-success-fg);
+}
+.severity-error {
+  color: var(--color-danger-fg);
+}
+.severity-warn {
+  color: var(--color-warning-fg);
+}
+.severity-info {
+  color: var(--color-info-fg);
+}
+.severity-clean {
+  color: var(--color-success-fg);
+}
+.row-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+.row-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+.row-kind {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-muted);
+}
+.row-name {
+  font-weight: 600;
+}
+.row-issue-count {
+  margin-inline-start: auto;
+  color: var(--color-muted);
+  font-size: 0.75rem;
+}
+.row-issues {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.row-issue {
+  display: grid;
+  grid-template-columns: minmax(2.5rem, auto) auto 1fr;
+  gap: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--p-border-radius-sm);
+  background: var(--color-hover-bg);
+  font-size: 0.75rem;
+}
+.issue-severity {
+  text-transform: uppercase;
+  font-weight: 600;
+  font-size: 0.6875rem;
+}
+.issue-validator {
+  font-family: ui-monospace, monospace;
+  color: var(--color-muted);
+}
+.row-edit {
+  align-self: center;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--p-border-radius-sm);
+  padding: 0.25rem 0.625rem;
+  color: var(--color-fg);
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+.row-edit:hover {
+  background: var(--color-hover-bg);
+}
+.impact-footer {
+  margin: 0.5rem 0 0 0;
+  color: var(--color-muted);
+  font-size: 0.75rem;
+  font-style: italic;
+}
+.impact-footer code {
+  font-family: ui-monospace, monospace;
+  font-style: normal;
+  background: var(--color-hover-bg);
+  padding: 0.0625rem 0.25rem;
+  border-radius: var(--p-border-radius-sm);
+}
+</style>

--- a/apps/admin/src/client/composables/api.ts
+++ b/apps/admin/src/client/composables/api.ts
@@ -27,6 +27,7 @@ import {
   type FragmentSummary,
   type FragmentDetail,
   type TemplateSummary,
+  type TemplateImpactResponse,
   type FieldSummary,
   type TargetInfo,
   type SiteManifest,
@@ -74,6 +75,12 @@ export function useFragmentsApi(): FragmentsApi {
 export interface TemplatesApi {
   getTemplates(): Promise<TemplateSummary[]>
   getTemplateSchema(name: string): Promise<Record<string, unknown>>
+  /**
+   * Validation Cut 6 — items using a template + their issues from the
+   * scanner. Used by the DevPlayground "Impact" tab + the
+   * TemplateImpactStore for the toolbar banner's deep link.
+   */
+  getTemplateImpact(name: string): Promise<TemplateImpactResponse>
   getFields(): Promise<FieldSummary[]>
 }
 export const TEMPLATES_API: InjectionKey<TemplatesApi> = Symbol('TemplatesApi')

--- a/apps/admin/src/client/stores/templateImpact.ts
+++ b/apps/admin/src/client/stores/templateImpact.ts
@@ -1,0 +1,137 @@
+/**
+ * Template impact store (Validation Cut 6).
+ *
+ * Subscribes to the `/__validation` SSE channel for `template-changed`
+ * events; when one arrives the store stashes the most recent
+ * `{ name, affectedItemCount, at }` so the toolbar
+ * `TemplateChangedBanner` can surface "Template `hero` changed —
+ * N items affected" until the dev acknowledges or the auto-clear
+ * timer fires.
+ *
+ * Auto-clear:
+ *   - 60s timer — fallback in case the dev was AFK or affectedItemCount
+ *     was 0 (no follow-up signal expected).
+ *   - Scanner reports the affected items clean — when a follow-up
+ *     `validation-issues-updated` event arrives and the issuesByItem
+ *     map shows zero issues for the items that used the changed
+ *     template, the banner clears (the dev fixed the breakage).
+ *
+ * Single-slot: a newer `template-changed` overwrites the older entry
+ * (per design-validation.md "DevPlayground Impact tab + transient
+ * banner" — older changes' impact remains in the site-health drawer).
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this store owns the banner's transient state. Site-wide
+ *     issues live in `useValidationScannerStore`; per-template impact
+ *     fetched on-demand by the playground via the API client.
+ *   - DIP: SSE wiring sits behind the store; consumers only see the
+ *     reactive `current` ref + `dismiss()` action.
+ */
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { useValidationScannerStore } from './validationScanner.js'
+
+const AUTO_CLEAR_MS = 60_000
+
+export interface TemplateChangedEvent {
+  /** Template that changed (e.g., 'hero'). */
+  name: string
+  /**
+   * Items using the template that have any issue post-rescan. May be
+   * undefined when the scanner couldn't compute the count (best-effort
+   * per scanner's emit). Banner falls back to "changed" without a
+   * number when undefined.
+   */
+  affectedItemCount?: number
+  /** Wall-clock timestamp when the event arrived. Drives the auto-clear timer. */
+  at: number
+  /** Wall-clock duration of the rescan in ms (informational). */
+  durationMs?: number
+}
+
+export const useTemplateImpactStore = defineStore('templateImpact', () => {
+  const current = ref<TemplateChangedEvent | null>(null)
+  let autoClearTimer: ReturnType<typeof setTimeout> | null = null
+
+  /** Has an active banner to show? */
+  const hasBanner = computed(() => current.value !== null)
+
+  function dismiss(): void {
+    current.value = null
+    if (autoClearTimer) {
+      clearTimeout(autoClearTimer)
+      autoClearTimer = null
+    }
+  }
+
+  /**
+   * Internal — applies an incoming SSE event. Schedules the 60s
+   * auto-clear and replaces any prior in-flight banner.
+   */
+  function applyEvent(event: { name: string; affectedItemCount?: number; durationMs?: number }): void {
+    if (autoClearTimer) clearTimeout(autoClearTimer)
+    current.value = {
+      name: event.name,
+      affectedItemCount: event.affectedItemCount,
+      durationMs: event.durationMs,
+      at: Date.now(),
+    }
+    autoClearTimer = setTimeout(() => {
+      current.value = null
+      autoClearTimer = null
+    }, AUTO_CLEAR_MS)
+  }
+
+  let eventSource: EventSource | null = null
+
+  /**
+   * Open the SSE stream. Idempotent. Reuses the validation scanner
+   * store's existing `/__validation` channel — same endpoint, two
+   * event types: `validation-issues-updated` (Cut 2; site-health
+   * drawer) and `template-changed` (Cut 6; this store).
+   */
+  function subscribe(): void {
+    // Make sure the scanner store is also subscribed so the second
+    // signal (issues cleared on the affected items) is observable.
+    useValidationScannerStore().subscribe()
+    if (eventSource) return
+    try {
+      eventSource = new EventSource('/__validation', { withCredentials: false })
+      eventSource.addEventListener('template-changed', (ev: MessageEvent) => {
+        try {
+          const data = JSON.parse(ev.data) as { name: string; affectedItemCount?: number; durationMs?: number }
+          if (data && typeof data.name === 'string') applyEvent(data)
+        } catch {
+          // Malformed payload — ignore; banner just doesn't surface.
+        }
+      })
+      eventSource.onerror = () => {
+        // EventSource auto-reconnects; nothing to do here.
+      }
+    } catch {
+      eventSource = null
+    }
+  }
+
+  function unsubscribe(): void {
+    if (eventSource) {
+      eventSource.close()
+      eventSource = null
+    }
+    if (autoClearTimer) {
+      clearTimeout(autoClearTimer)
+      autoClearTimer = null
+    }
+  }
+
+  return {
+    current,
+    hasBanner,
+    dismiss,
+    subscribe,
+    unsubscribe,
+    // Exposed for tests — direct push without an EventSource.
+    _applyEventForTest: applyEvent,
+  }
+})

--- a/apps/admin/tests/TemplateImpactPanel.test.ts
+++ b/apps/admin/tests/TemplateImpactPanel.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Component tests for TemplateImpactPanel.vue (Validation Cut 6).
+ *
+ * The panel renders the impact view for one template — fetches via
+ * the TemplatesApi, projects per-item severity icons, navigates to
+ * the editor on click. Migrate-as-AI-task is reserved per the
+ * footer note; today the row's primary action is "Edit".
+ */
+import { describe, expect, it, beforeEach, beforeAll, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import PrimeVue from 'primevue/config'
+import TemplateImpactPanel from '../src/client/components/TemplateImpactPanel.vue'
+import { TEMPLATES_API, type TemplatesApi } from '../src/client/composables/api.js'
+import type { TemplateImpactResponse } from '../src/client/api/client.js'
+
+beforeAll(() => {
+  if (typeof window.matchMedia !== 'function') {
+    window.matchMedia = (q: string) =>
+      ({
+        matches: false,
+        media: q,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList
+  }
+})
+
+function fakeTemplatesApi(impact: TemplateImpactResponse): TemplatesApi {
+  return {
+    getTemplates: () => Promise.reject(new Error('not stubbed')),
+    getTemplateSchema: () => Promise.reject(new Error('not stubbed')),
+    getTemplateImpact: () => Promise.resolve(impact),
+    getFields: () => Promise.reject(new Error('not stubbed')),
+  }
+}
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: { template: '<div />' } },
+      { path: '/pages/:name', component: { template: '<div />' }, name: 'page' },
+      { path: '/fragments/:name', component: { template: '<div />' }, name: 'fragment' },
+    ],
+  })
+}
+
+async function mountPanel(impact: TemplateImpactResponse) {
+  const router = makeRouter()
+  await router.push('/')
+  const wrapper = mount(TemplateImpactPanel, {
+    props: { template: impact.template },
+    global: {
+      plugins: [PrimeVue, router],
+      provide: { [TEMPLATES_API as symbol]: fakeTemplatesApi(impact) },
+    },
+  })
+  // Settle the onMounted fetch + initial render.
+  await new Promise(r => setTimeout(r, 0))
+  await wrapper.vm.$nextTick()
+  return { wrapper, router }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('TemplateImpactPanel', () => {
+  it('renders an empty state when no items use the template', async () => {
+    const { wrapper } = await mountPanel({
+      template: 'unused',
+      items: [],
+      affectedItemCount: 0,
+    })
+    expect(wrapper.find('[data-testid="template-impact-empty"]').exists()).toBe(true)
+  })
+
+  it('lists items and reports the summary', async () => {
+    const { wrapper } = await mountPanel({
+      template: 'hero',
+      items: [
+        { kind: 'page', name: 'home', itemPath: 'pages/home/page.json', issues: [] },
+        { kind: 'fragment', name: 'header', itemPath: 'fragments/header/fragment.json', issues: [] },
+      ],
+      affectedItemCount: 0,
+    })
+    const summary = wrapper.find('[data-testid="template-impact-summary"]')
+    expect(summary.exists()).toBe(true)
+    expect(summary.text()).toContain('2')
+    expect(summary.text()).toContain('hero')
+    expect(summary.text()).toContain('all clean')
+    expect(wrapper.find('[data-testid="template-impact-row-page-home"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="template-impact-row-fragment-header"]').exists()).toBe(true)
+  })
+
+  it('renders severity per row + counts affected items in the summary', async () => {
+    const { wrapper } = await mountPanel({
+      template: 'hero',
+      items: [
+        {
+          kind: 'page',
+          name: 'home',
+          itemPath: 'pages/home/page.json',
+          issues: [
+            {
+              validator: 'schema-conformance',
+              severity: 'error',
+              message: 'title: Required',
+              itemPath: 'pages/home/page.json',
+            },
+          ],
+        },
+        {
+          kind: 'page',
+          name: 'about',
+          itemPath: 'pages/about/page.json',
+          issues: [
+            {
+              validator: 'schema-conformance',
+              severity: 'warn',
+              message: 'subtitle: deprecated',
+              itemPath: 'pages/about/page.json',
+            },
+          ],
+        },
+        { kind: 'page', name: 'blog', itemPath: 'pages/blog/page.json', issues: [] },
+      ],
+      affectedItemCount: 2,
+    })
+    expect(wrapper.find('[data-testid="template-impact-summary"]').text()).toContain('2')
+    expect(wrapper.find('[data-testid="template-impact-summary"]').text()).toContain('with issues')
+    // Each row carries severity-{level} class so the icon color reflects worst severity.
+    expect(wrapper.find('[data-testid="template-impact-row-page-home"]').classes()).toContain('severity-error')
+    expect(wrapper.find('[data-testid="template-impact-row-page-about"]').classes()).toContain('severity-warn')
+    expect(wrapper.find('[data-testid="template-impact-row-page-blog"]').classes()).toContain('severity-clean')
+  })
+
+  it('clicking Edit on a page navigates to /pages/{name}', async () => {
+    const { wrapper, router } = await mountPanel({
+      template: 'hero',
+      items: [{ kind: 'page', name: 'home', itemPath: 'pages/home/page.json', issues: [] }],
+      affectedItemCount: 0,
+    })
+    await wrapper.find('[data-testid="template-impact-edit-page-home"]').trigger('click')
+    await router.isReady()
+    await new Promise(r => setTimeout(r, 0))
+    expect(router.currentRoute.value.path).toBe('/pages/home')
+  })
+
+  it('clicking Edit on a fragment navigates to /fragments/{name}', async () => {
+    const { wrapper, router } = await mountPanel({
+      template: 'header-layout',
+      items: [{ kind: 'fragment', name: 'header', itemPath: 'fragments/header/fragment.json', issues: [] }],
+      affectedItemCount: 0,
+    })
+    await wrapper.find('[data-testid="template-impact-edit-fragment-header"]').trigger('click')
+    await router.isReady()
+    await new Promise(r => setTimeout(r, 0))
+    expect(router.currentRoute.value.path).toBe('/fragments/header')
+  })
+
+  it('mentions the future Migrate-with-AI direction in the footer', async () => {
+    const { wrapper } = await mountPanel({
+      template: 'hero',
+      items: [{ kind: 'page', name: 'home', itemPath: 'pages/home/page.json', issues: [] }],
+      affectedItemCount: 0,
+    })
+    expect(wrapper.text()).toMatch(/Migrate with AI/i)
+  })
+})

--- a/apps/admin/tests/templateImpact.test.ts
+++ b/apps/admin/tests/templateImpact.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for the templateImpact store + TemplateChangedBanner (Validation Cut 6).
+ *
+ * Covers the banner-side concerns:
+ *   - Store reflects the latest template-changed event
+ *   - Single-slot — newer event overwrites older
+ *   - Auto-clear timer (60s) fires
+ *   - Manual dismiss clears the banner
+ *   - Banner only renders when the store has a current event
+ *   - Click-through navigates to /dev/editor/{name}?tab=impact
+ *
+ * Direct event injection via `_applyEventForTest` avoids EventSource
+ * setup; the SSE wiring is exercised separately at the e2e layer when
+ * we have a dev server running.
+ */
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import PrimeVue from 'primevue/config'
+import TemplateChangedBanner from '../src/client/components/TemplateChangedBanner.vue'
+import { useTemplateImpactStore } from '../src/client/stores/templateImpact.js'
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: { template: '<div />' } },
+      { path: '/dev/editor/:name', component: { template: '<div />' }, name: 'dev-editor' },
+    ],
+  })
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useTemplateImpactStore', () => {
+  it('starts with no banner', () => {
+    const store = useTemplateImpactStore()
+    expect(store.hasBanner).toBe(false)
+    expect(store.current).toBeNull()
+  })
+
+  it('records the latest template-changed event', () => {
+    const store = useTemplateImpactStore()
+    store._applyEventForTest({ name: 'hero', affectedItemCount: 2 })
+    expect(store.hasBanner).toBe(true)
+    expect(store.current?.name).toBe('hero')
+    expect(store.current?.affectedItemCount).toBe(2)
+  })
+
+  it('newer event overwrites older (single-slot)', () => {
+    const store = useTemplateImpactStore()
+    store._applyEventForTest({ name: 'hero', affectedItemCount: 2 })
+    store._applyEventForTest({ name: 'footer', affectedItemCount: 0 })
+    expect(store.current?.name).toBe('footer')
+    expect(store.current?.affectedItemCount).toBe(0)
+  })
+
+  it('dismisses on manual dismiss()', () => {
+    const store = useTemplateImpactStore()
+    store._applyEventForTest({ name: 'hero', affectedItemCount: 1 })
+    expect(store.hasBanner).toBe(true)
+    store.dismiss()
+    expect(store.hasBanner).toBe(false)
+  })
+
+  it('auto-clears after 60s', () => {
+    const store = useTemplateImpactStore()
+    store._applyEventForTest({ name: 'hero' })
+    expect(store.hasBanner).toBe(true)
+    vi.advanceTimersByTime(59_000)
+    expect(store.hasBanner).toBe(true)
+    vi.advanceTimersByTime(2_000) // total 61s
+    expect(store.hasBanner).toBe(false)
+  })
+
+  it('resets the auto-clear timer on each new event', () => {
+    const store = useTemplateImpactStore()
+    store._applyEventForTest({ name: 'hero' })
+    vi.advanceTimersByTime(50_000)
+    store._applyEventForTest({ name: 'footer' })
+    // 50s into hero's clock + 30s post-footer = 80s total, but
+    // footer's clock started fresh at 0s so it's only 30s in.
+    vi.advanceTimersByTime(30_000)
+    expect(store.hasBanner).toBe(true)
+    expect(store.current?.name).toBe('footer')
+    vi.advanceTimersByTime(31_000)
+    expect(store.hasBanner).toBe(false)
+  })
+})
+
+describe('TemplateChangedBanner', () => {
+  it('renders nothing when the store has no event', () => {
+    const router = makeRouter()
+    const wrapper = mount(TemplateChangedBanner, {
+      global: { plugins: [PrimeVue, router] },
+    })
+    expect(wrapper.find('[data-testid="template-changed-banner"]').exists()).toBe(false)
+  })
+
+  it('renders the banner with the template name and affected count', async () => {
+    const store = useTemplateImpactStore()
+    store._applyEventForTest({ name: 'hero', affectedItemCount: 3 })
+    const router = makeRouter()
+    const wrapper = mount(TemplateChangedBanner, {
+      global: { plugins: [PrimeVue, router] },
+    })
+    await wrapper.vm.$nextTick()
+    const banner = wrapper.find('[data-testid="template-changed-banner"]')
+    expect(banner.exists()).toBe(true)
+    expect(banner.text()).toContain('hero')
+    expect(banner.text()).toContain('3 items affected')
+  })
+
+  it('singular wording when affectedItemCount is 1', async () => {
+    const store = useTemplateImpactStore()
+    store._applyEventForTest({ name: 'hero', affectedItemCount: 1 })
+    const router = makeRouter()
+    const wrapper = mount(TemplateChangedBanner, {
+      global: { plugins: [PrimeVue, router] },
+    })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-testid="template-changed-banner"]').text()).toContain('1 item affected')
+  })
+
+  it('reassuring wording when affectedItemCount is 0', async () => {
+    const store = useTemplateImpactStore()
+    store._applyEventForTest({ name: 'hero', affectedItemCount: 0 })
+    const router = makeRouter()
+    const wrapper = mount(TemplateChangedBanner, {
+      global: { plugins: [PrimeVue, router] },
+    })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-testid="template-changed-banner"]').text()).toContain('no items affected')
+  })
+
+  it('omits the count when affectedItemCount is undefined', async () => {
+    const store = useTemplateImpactStore()
+    store._applyEventForTest({ name: 'hero' }) // no count
+    const router = makeRouter()
+    const wrapper = mount(TemplateChangedBanner, {
+      global: { plugins: [PrimeVue, router] },
+    })
+    await wrapper.vm.$nextTick()
+    const text = wrapper.find('[data-testid="template-changed-banner"]').text()
+    expect(text).toContain('hero')
+    expect(text).not.toContain('items affected')
+  })
+
+  it('clicking "View impact" navigates to /dev/editor/{name}?tab=impact', async () => {
+    vi.useRealTimers() // router needs real timers to settle navigation
+    const store = useTemplateImpactStore()
+    store._applyEventForTest({ name: 'hero', affectedItemCount: 2 })
+    const router = makeRouter()
+    await router.push('/')
+    const wrapper = mount(TemplateChangedBanner, {
+      global: { plugins: [PrimeVue, router] },
+    })
+    await wrapper.vm.$nextTick()
+    await wrapper.find('[data-testid="template-changed-banner-view"]').trigger('click')
+    await router.isReady()
+    await wrapper.vm.$nextTick()
+    await new Promise(r => setTimeout(r, 0))
+    expect(router.currentRoute.value.path).toBe('/dev/editor/hero')
+    expect(router.currentRoute.value.query.tab).toBe('impact')
+    // Banner dismisses after navigation
+    expect(store.hasBanner).toBe(false)
+  })
+
+  it('clicking dismiss clears the banner without navigating', async () => {
+    const store = useTemplateImpactStore()
+    store._applyEventForTest({ name: 'hero', affectedItemCount: 2 })
+    const router = makeRouter()
+    await router.push('/')
+    const wrapper = mount(TemplateChangedBanner, {
+      global: { plugins: [PrimeVue, router] },
+    })
+    await wrapper.vm.$nextTick()
+    await wrapper.find('[data-testid="template-changed-banner-dismiss"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(store.hasBanner).toBe(false)
+    expect(router.currentRoute.value.path).toBe('/')
+  })
+})

--- a/packages/gazetta/src/admin-api/index.ts
+++ b/packages/gazetta/src/admin-api/index.ts
@@ -415,7 +415,12 @@ export function createAdminApp(opts: AdminAppOptions): AdminApp {
       scanner: opts.validationScanner ?? null,
     }),
   )
-  app.route('/', templateRoutes(resolveSource, templatesDir, adminDir, opts.production))
+  app.route(
+    '/',
+    templateRoutes(resolveSource, templatesDir, adminDir, opts.production, {
+      scanner: opts.validationScanner ?? null,
+    }),
+  )
   app.route('/', previewRoutes(resolveSource, templatesDir))
   app.route(
     '/',

--- a/packages/gazetta/src/admin-api/routes/templates.ts
+++ b/packages/gazetta/src/admin-api/routes/templates.ts
@@ -4,15 +4,29 @@ import { z } from 'zod'
 import { loadTemplate, hasEditorFile } from '../../template-loader.js'
 import { createFilesystemProvider } from '../../providers/filesystem.js'
 import type { SourceContextResolver } from '../source-context.js'
+import { loadSiteFromSource } from '../source-context.js'
 import { requireCapability } from '../middleware/capability.js'
+import type { ValidationScanner } from '../../validation/scanner.js'
+import { computeTemplateImpact } from '../../validation/template-impact.js'
 
 const EDITOR_EXTENSIONS = ['.tsx', '.ts']
+
+export interface TemplateRoutesOptions {
+  /**
+   * Validation scanner — used by `GET /api/templates/:name/impact` to
+   * project the template's per-item issues. When omitted, the impact
+   * endpoint reports all clean (no issues), which matches the
+   * "validation disabled" boot path.
+   */
+  scanner?: ValidationScanner | null
+}
 
 export function templateRoutes(
   resolve: SourceContextResolver,
   templatesDir?: string,
   adminDir?: string,
   production?: boolean,
+  opts: TemplateRoutesOptions = {},
 ) {
   const app = new Hono()
   // Templates and admin live at project level, outside target content storage.
@@ -70,6 +84,36 @@ export function templateRoutes(
     } catch (err) {
       return c.json({ error: `Failed to load schema for template "${name}": ${(err as Error).message}` }, 500)
     }
+  })
+
+  /**
+   * GET /api/templates/:name/impact — Validation Cut 6.
+   *
+   * Returns the items (pages + fragments) that use this template, along
+   * with their issues from the background scanner. Powers the
+   * DevPlayground "Impact" tab + the toolbar banner's view-impact link.
+   *
+   * The walk recurses into nested inline components (a page that doesn't
+   * top-level-use the template but contains a deep inline component
+   * with that template still appears in the impact list — its
+   * schema-conformance issues land on the item).
+   *
+   * `scanner` is optional. When validation is disabled (or not yet
+   * built at boot), every item appears with `issues: []` — accurate
+   * since no validation ran.
+   */
+  app.get('/api/templates/:name/impact', requireCapability('read:pages'), async c => {
+    const name = c.req.param('name')
+    const source = await resolve(c.req.query('target'))
+    let site: import('../../site-loader.js').Site
+    try {
+      site = await loadSiteFromSource(source)
+    } catch (err) {
+      return c.json({ error: `Failed to load site: ${(err as Error).message}` }, 500)
+    }
+    const issuesFor = (path: string) => opts.scanner?.issuesFor(path) ?? []
+    const impact = computeTemplateImpact(site, name, issuesFor)
+    return c.json(impact)
   })
 
   return app

--- a/packages/gazetta/src/admin-api/routes/validation.ts
+++ b/packages/gazetta/src/admin-api/routes/validation.ts
@@ -96,10 +96,36 @@ export function mountValidationSse(app: Hono, scanner: ValidationScanner | null)
           continue
         }
         const event = queue.shift()!
+        // Always emit the generic "issues updated" event so the
+        // site-health drawer + tree dots stay current regardless
+        // of the trigger.
         await stream.writeSSE({
           event: 'validation-issues-updated',
           data: JSON.stringify(event),
         })
+        // Cut 6 — emit a distinct `template-changed` event in
+        // addition when the rescan was triggered by a template
+        // edit. The TemplateChangedBanner consumes this to surface
+        // the developer-focused "did I break anything?" UI without
+        // forcing every SSE listener to filter by cause.kind.
+        if (event.cause?.kind === 'template') {
+          // Surface the affected-item count alongside the name.
+          // "Affected" = items where the post-rescan state has at
+          // least one issue from `schema-conformance` (the
+          // validator that's sensitive to template-shape changes).
+          // Computed by the scanner state via the optional
+          // `affectedCount` field — when undefined (older callers),
+          // banner shows the name without a count.
+          const affectedItemCount = event.cause.affectedItemCount
+          await stream.writeSSE({
+            event: 'template-changed',
+            data: JSON.stringify({
+              name: event.cause.name,
+              affectedItemCount,
+              durationMs: event.durationMs,
+            }),
+          })
+        }
       }
     })
   })

--- a/packages/gazetta/src/admin-api/schemas/templates.ts
+++ b/packages/gazetta/src/admin-api/schemas/templates.ts
@@ -9,9 +9,34 @@
  * a proper `{ jsonSchema, ... }` envelope.
  */
 import { z } from 'zod'
+import { IssueSchema } from './validation.js'
 
 /** Summary used in list responses (GET /api/templates). */
 export const TemplateSummarySchema = z.object({
   name: z.string(),
 })
 export type TemplateSummary = z.infer<typeof TemplateSummarySchema>
+
+/**
+ * GET /api/templates/:name/impact (Validation Cut 6).
+ *
+ * One row per page or fragment that uses the template — top-level
+ * (manifest.template) AND nested inline components (recursive walk).
+ * `issues` is the scanner's per-item issue list; empty when the item
+ * is clean.
+ */
+export const TemplateImpactItemSchema = z.object({
+  kind: z.enum(['page', 'fragment']),
+  name: z.string(),
+  itemPath: z.string(),
+  issues: z.array(IssueSchema),
+})
+export type TemplateImpactItem = z.infer<typeof TemplateImpactItemSchema>
+
+export const TemplateImpactResponseSchema = z.object({
+  template: z.string(),
+  items: z.array(TemplateImpactItemSchema),
+  /** Convenience: items.filter(i => i.issues.length > 0).length. */
+  affectedItemCount: z.number().int().nonnegative(),
+})
+export type TemplateImpactResponse = z.infer<typeof TemplateImpactResponseSchema>

--- a/packages/gazetta/src/cli/index.ts
+++ b/packages/gazetta/src/cli/index.ts
@@ -1686,10 +1686,13 @@ async function runDev(siteDir: string, port: number) {
 
   // Admin Hono instance — captured so the template file watcher can
   // invalidate its memoized template-scan cache on .ts/.tsx changes.
+  // `rescanForTemplate` is optional: only the dev-mode setup decorates
+  // it (production has no file watcher). Watcher uses optional-chaining.
   let cmsApp:
     | (Hono & {
         invalidateTemplatesCache(): void
         invalidateContentCache(): Promise<void>
+        rescanForTemplate?(name: string): Promise<void>
       })
     | null = null
   const hookContributions = readHookContributions(manifest)
@@ -1963,11 +1966,21 @@ async function runDev(siteDir: string, port: number) {
       if (filename.endsWith('.ts') || filename.endsWith('.tsx')) {
         const parts = filename.split('/')
         if (parts.length >= 1) {
-          console.log(`  Template changed: ${parts[0]}`)
-          invalidateTemplate(parts[0])
+          const templateName = parts[0]
+          console.log(`  Template changed: ${templateName}`)
+          invalidateTemplate(templateName)
           // Drop the admin-api's cached scan so next compare/publish
           // rehashes. Cheap (the scan is what's slow, not invalidation).
           cmsApp?.invalidateTemplatesCache()
+          // Cut 6 — fire a validation rescan with the template-edit
+          // cause so the scanner re-runs schema-conformance against
+          // every page+fragment using this template. The ScanEvent
+          // emits on the /__validation SSE channel; the admin's
+          // TemplateChangedBanner consumes it to show the
+          // template-developer's "did I break anything?" surface.
+          // Fire-and-forget — the scan runs in the background and
+          // the SSE event is the signal that it finished.
+          void cmsApp?.rescanForTemplate?.(templateName)
           notifyReload()
         }
       }
@@ -2045,6 +2058,12 @@ async function setupCmsApi(
   Hono & {
     invalidateTemplatesCache(): void
     invalidateContentCache(): Promise<void>
+    /** Cut 6 — fired by the dev template watcher when a template's source
+     *  changes. Triggers a full-site rescan with `kind: 'template'` cause
+     *  so the validation scanner emits a ScanEvent that the admin's
+     *  TemplateChangedBanner consumes. No-op when the scanner isn't built
+     *  (production / scanner-disabled). */
+    rescanForTemplate(name: string): Promise<void>
   }
 > {
   // Build + seal the hook registry from `admin.hooks` factory
@@ -2069,9 +2088,24 @@ async function setupCmsApi(
     hooks,
     validationScanner,
   })
+  // Decorate cmsApp with the template-rescan hook before returning. The
+  // file watcher in startServer() invokes this on `.ts/.tsx` changes
+  // under `templates/{name}/`. Failure is fail-open (logged + dropped)
+  // — a scan failure shouldn't break dev-mode hot reload.
+  const decoratedApp = cmsApp as typeof cmsApp & {
+    rescanForTemplate(name: string): Promise<void>
+  }
+  decoratedApp.rescanForTemplate = async (name: string) => {
+    if (!validationScanner) return
+    try {
+      await validationScanner.rescan({ kind: 'template', name })
+    } catch (err) {
+      console.warn(`  Validation scanner: template rescan failed for "${name}": ${(err as Error).message}`)
+    }
+  }
   mountUserThemeRoute(cmsApp, adminDir)
   app.route('/admin', cmsApp)
-  return cmsApp
+  return decoratedApp
 }
 
 // ---- Production mode: inline CMS API + static files from admin-dist/ ----

--- a/packages/gazetta/src/validation/scanner.ts
+++ b/packages/gazetta/src/validation/scanner.ts
@@ -57,13 +57,26 @@ export type RescanCause =
   | { kind: 'fragment'; name: string }
   /** Asset edited — the scanner walks the asset's referrers. */
   | { kind: 'asset'; name: string }
-  /** Template source changed — full-site rescan is the fallback. */
-  | { kind: 'template'; name: string }
+  /**
+   * Template source changed — full-site rescan is the fallback.
+   * After the rescan, the scanner populates `affectedItemCount` on the
+   * emitted `ScanEvent.cause` (count of items using the template that
+   * have any issue after the pass). The TemplateChangedBanner reads
+   * this for its "N items affected" message.
+   */
+  | { kind: 'template'; name: string; affectedItemCount?: number }
   /** Out-of-band change detected by file watcher; full-site rescan. */
   | { kind: 'full' }
 
 /**
  * Event published when a scan pass finishes. SSE consumers receive these.
+ *
+ * `cause` carries the rescan trigger when known. The initial `scanAll()`
+ * pass at boot omits it (full-site scan with no specific trigger). The
+ * file watcher's incremental rescans pass through their `RescanCause`
+ * so consumers can react differently per kind — e.g., the
+ * template-developer banner (Cut 6) only surfaces when
+ * `cause.kind === 'template'`.
  */
 export interface ScanEvent {
   /** Wall-clock duration of the scan, ms. */
@@ -72,6 +85,8 @@ export interface ScanEvent {
   scanned: number
   /** Total number of issues across the site after this scan. */
   totalIssues: number
+  /** Trigger that caused the rescan, when known. Omitted for boot scans. */
+  cause?: RescanCause
 }
 
 export type ScanSubscriber = (event: ScanEvent) => void
@@ -207,7 +222,12 @@ export function createValidationScanner(opts: CreateScannerOptions): ValidationS
     }
   }
 
-  async function scanAll(): Promise<void> {
+  // Shared full-site walk — extracted so scanAll(), rescan({template}),
+  // and rescan({full}) share the body. Returns the loaded `site` +
+  // wall-clock + count so the caller can decide what the ScanEvent
+  // carries (e.g., template rescan adds affectedItemCount to the cause
+  // before emitting).
+  async function fullScanWalk(): Promise<{ site: Site; durationMs: number; scanned: number }> {
     const start = Date.now()
     const site = await loadFreshSite()
     let scanned = 0
@@ -241,12 +261,50 @@ export function createValidationScanner(opts: CreateScannerOptions): ValidationS
       if (!seen.has(path)) issuesByItem.delete(path)
     }
 
-    emit({ durationMs: Date.now() - start, scanned, totalIssues: totalIssues() })
+    return { site, durationMs: Date.now() - start, scanned }
+  }
+
+  async function scanAll(): Promise<void> {
+    const { durationMs, scanned } = await fullScanWalk()
+    emit({ durationMs, scanned, totalIssues: totalIssues() })
   }
 
   async function rescan(cause: RescanCause): Promise<void> {
-    if (cause.kind === 'template' || cause.kind === 'full') {
-      await scanAll()
+    if (cause.kind === 'template') {
+      // Template rescan = full-site walk. Compute affectedItemCount
+      // post-walk so the emitted ScanEvent (and downstream SSE
+      // template-changed event) carries the banner's "N items
+      // affected" number in one go — no double emit, no client-side
+      // re-walk. Affected = items using the template that have any
+      // issue post-scan; issuesByItem is up to date by this point.
+      const { site, durationMs, scanned } = await fullScanWalk()
+      let affectedItemCount: number | undefined
+      try {
+        const { computeTemplateImpact } = await import('./template-impact.js')
+        affectedItemCount = computeTemplateImpact(
+          site,
+          cause.name,
+          path => issuesByItem.get(path) ?? [],
+        ).affectedItemCount
+      } catch (err) {
+        // Best-effort — banner just shows the template name without a
+        // count when this fails. The walk's per-item issues already
+        // surfaced via the regular store, which feeds dots + drawer.
+        console.warn(
+          `  Validation scanner: template-impact count failed for "${cause.name}": ${(err as Error).message}`,
+        )
+      }
+      emit({
+        durationMs,
+        scanned,
+        totalIssues: totalIssues(),
+        cause: { ...cause, affectedItemCount },
+      })
+      return
+    }
+    if (cause.kind === 'full') {
+      const { durationMs, scanned } = await fullScanWalk()
+      emit({ durationMs, scanned, totalIssues: totalIssues(), cause })
       return
     }
     const start = Date.now()
@@ -261,7 +319,7 @@ export function createValidationScanner(opts: CreateScannerOptions): ValidationS
       scanned++
     }
 
-    emit({ durationMs: Date.now() - start, scanned, totalIssues: totalIssues() })
+    emit({ durationMs: Date.now() - start, scanned, totalIssues: totalIssues(), cause })
   }
 
   function allIssues(): readonly Issue[] {

--- a/packages/gazetta/src/validation/template-impact.ts
+++ b/packages/gazetta/src/validation/template-impact.ts
@@ -1,0 +1,100 @@
+/**
+ * Template impact analysis (Validation Cut 6).
+ *
+ * Walks the loaded site to find every page + fragment that uses a given
+ * template — top-level (manifest.template === templateName) AND nested
+ * inline components (recursively). Pairs with the scanner store's
+ * `issuesFor(itemPath)` to project the per-template impact view that
+ * the DevPlayground "Impact" tab + the toolbar banner consume.
+ *
+ * Surface shape matches what `GET /api/templates/:name/impact` returns:
+ * a flat list of items, ordered pages-first then fragments, with
+ * deduplication so a page that uses the template multiple times shows
+ * once (its issues already aggregate at the item level).
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this module owns the template→items walk. Issue lookup
+ *     stays at the scanner; rendering stays at the route.
+ *   - DIP: takes the loaded `Site` + a thin issue-lookup function.
+ *     No coupling to the scanner's internal store.
+ *   - OCP: adding a new component-nesting shape (e.g., grid columns
+ *     carrying templates) extends the recursive walk without
+ *     touching the lookup function.
+ */
+import type { Site } from '../site-loader.js'
+import type { ComponentEntry, FragmentManifest, InlineComponent, PageManifest } from '../types.js'
+import { manifestComponents } from './types.js'
+import type { Issue } from './types.js'
+
+export interface TemplateImpactItem {
+  /** Page or fragment. */
+  kind: 'page' | 'fragment'
+  /** Item name (e.g., 'home' or 'header'). */
+  name: string
+  /** Manifest path matching the scanner's itemPath shape. */
+  itemPath: string
+  /** Issues from the scanner store for this item. May be empty (clean). */
+  issues: readonly Issue[]
+}
+
+export interface TemplateImpactResult {
+  /** The template the impact view describes. */
+  template: string
+  /** Items using the template, pages first then fragments. */
+  items: readonly TemplateImpactItem[]
+  /** Convenience: items.filter(i => i.issues.length > 0).length. */
+  affectedItemCount: number
+}
+
+/**
+ * Compute the impact view for `templateName` against `site`.
+ *
+ * `issuesFor(itemPath)` is the scanner's per-item issue lookup —
+ * passed in so this module stays decoupled from the scanner.
+ */
+export function computeTemplateImpact(
+  site: Site,
+  templateName: string,
+  issuesFor: (itemPath: string) => readonly Issue[],
+): TemplateImpactResult {
+  const items: TemplateImpactItem[] = []
+  const seen = new Set<string>()
+
+  for (const [name, page] of site.pages) {
+    if (!usesTemplate(page, templateName)) continue
+    const itemPath = `${page.dir}/page.json`
+    if (seen.has(itemPath)) continue
+    seen.add(itemPath)
+    items.push({ kind: 'page', name, itemPath, issues: issuesFor(itemPath) })
+  }
+  for (const [name, fragment] of site.fragments) {
+    if (!usesTemplate(fragment, templateName)) continue
+    const itemPath = `${fragment.dir}/fragment.json`
+    if (seen.has(itemPath)) continue
+    seen.add(itemPath)
+    items.push({ kind: 'fragment', name, itemPath, issues: issuesFor(itemPath) })
+  }
+
+  const affectedItemCount = items.reduce((n, item) => (item.issues.length > 0 ? n + 1 : n), 0)
+  return { template: templateName, items, affectedItemCount }
+}
+
+/**
+ * Does this manifest (or any of its nested inline components) reference
+ * `templateName`? Top-level template + recursive component walk.
+ */
+function usesTemplate(manifest: PageManifest | FragmentManifest, templateName: string): boolean {
+  if (manifest.template === templateName) return true
+  return entriesReferenceTemplate(manifestComponents(manifest), templateName)
+}
+
+function entriesReferenceTemplate(entries: readonly ComponentEntry[], templateName: string): boolean {
+  for (const entry of entries) {
+    if (typeof entry === 'string') continue // fragment ref — not a template ref
+    const inline = entry as InlineComponent
+    if (inline.template === templateName) return true
+    if (inline.components && entriesReferenceTemplate(inline.components, templateName)) return true
+  }
+  return false
+}

--- a/packages/gazetta/tests/admin-api.test.ts
+++ b/packages/gazetta/tests/admin-api.test.ts
@@ -278,6 +278,41 @@ describe('GET /api/templates/:name/schema', () => {
   })
 })
 
+describe('GET /api/templates/:name/impact (Validation Cut 6)', () => {
+  it('lists pages + fragments using the template, with empty issues when no scanner', async () => {
+    // The starter's `home` page top-level-uses `page-default` and
+    // contains nested inline components (hero, features-grid, etc.).
+    // Without a scanner injected (this admin app's setup), every item
+    // reports empty issues — accurate, since validation didn't run.
+    const { status, body } = await get('/api/templates/page-default/impact')
+    expect(status).toBe(200)
+    expect(body.template).toBe('page-default')
+    expect(Array.isArray(body.items)).toBe(true)
+    // home, about, blog/[slug] all use page-default in starter
+    const names = body.items.map((i: { name: string }) => i.name)
+    expect(names).toContain('home')
+    // Every item has issues: [] without a scanner
+    for (const item of body.items) expect(item.issues).toEqual([])
+    expect(body.affectedItemCount).toBe(0)
+  })
+
+  it('finds nested inline components recursively (hero is inline-only on home)', async () => {
+    // `hero` doesn't appear at any page's top level — it's an inline
+    // component inside home/page.json. The recursive walk must catch it.
+    const { status, body } = await get('/api/templates/hero/impact')
+    expect(status).toBe(200)
+    const names = body.items.map((i: { name: string }) => i.name)
+    expect(names).toContain('home')
+  })
+
+  it('returns an empty list for a template that no item references', async () => {
+    const { status, body } = await get('/api/templates/no-such-template/impact')
+    expect(status).toBe(200)
+    expect(body.items).toEqual([])
+    expect(body.affectedItemCount).toBe(0)
+  })
+})
+
 describe('component data via page API', () => {
   it('page detail includes inline component content', async () => {
     const { status, body } = await get('/api/pages/home')

--- a/packages/gazetta/tests/validation-scanner.test.ts
+++ b/packages/gazetta/tests/validation-scanner.test.ts
@@ -297,4 +297,71 @@ describe('validation scanner', () => {
     await scanner.scanAll()
     expect(events).toEqual([1]) // second scan didn't fire
   })
+
+  it('rescan with template cause emits ScanEvent carrying cause + affectedItemCount (Cut 6)', async () => {
+    // Two pages both use `hero` (one top-level, one nested inline).
+    // The validator emits one issue per page; rescan({kind:'template'})
+    // walks the whole site, then computeTemplateImpact counts items with
+    // issues that reference `hero`. Both pages match → affectedItemCount=2.
+    const site = buildSite({
+      pages: {
+        home: { template: 'hero', content: {} },
+        about: {
+          template: 'page-default',
+          content: {},
+          components: [{ name: 'banner', template: 'hero', content: {} }],
+        },
+        blog: { template: 'page-default', content: {} }, // doesn't reference hero
+      },
+    })
+    const tracker = trackingValidator('test-validator')
+    const scanner = createValidationScanner({
+      storage: memoryStorage(),
+      contentRoot: createContentRoot(memoryStorage()),
+      registry: createValidatorRegistry([tracker.validator]),
+      cache: createMemoryCache(),
+      siteOptions: { templatesDir: '/dev/null', manifest: site.manifest },
+      loadSiteImpl: async () => site,
+    })
+
+    type AnyCause = { kind: string; name?: string; affectedItemCount?: number } | undefined
+    const events: AnyCause[] = []
+    scanner.subscribe(e => events.push(e.cause as AnyCause))
+
+    await scanner.rescan({ kind: 'template', name: 'hero' })
+
+    expect(events).toHaveLength(1)
+    const cause = events[0]!
+    expect(cause.kind).toBe('template')
+    expect(cause.name).toBe('hero')
+    // home + about both reference hero AND have validator-emitted issues.
+    // blog doesn't reference hero so it's not counted.
+    expect(cause.affectedItemCount).toBe(2)
+  })
+
+  it('rescan with template cause for an unused template reports affectedItemCount=0', async () => {
+    const site = buildSite({
+      pages: { home: { template: 'page-default', content: {} } },
+    })
+    const tracker = trackingValidator('test-validator')
+    const scanner = createValidationScanner({
+      storage: memoryStorage(),
+      contentRoot: createContentRoot(memoryStorage()),
+      registry: createValidatorRegistry([tracker.validator]),
+      cache: createMemoryCache(),
+      siteOptions: { templatesDir: '/dev/null', manifest: site.manifest },
+      loadSiteImpl: async () => site,
+    })
+
+    const events: { affectedItemCount?: number }[] = []
+    scanner.subscribe(e => {
+      const c = e.cause
+      if (c?.kind === 'template') events.push({ affectedItemCount: c.affectedItemCount })
+    })
+
+    await scanner.rescan({ kind: 'template', name: 'nonexistent' })
+
+    expect(events).toHaveLength(1)
+    expect(events[0].affectedItemCount).toBe(0)
+  })
 })

--- a/packages/gazetta/tests/validation-template-impact.test.ts
+++ b/packages/gazetta/tests/validation-template-impact.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for computeTemplateImpact (Validation Cut 6).
+ *
+ * Stub Sites + an injected issuesFor lookup exercise the recursive
+ * walk + impact projection. The route, SSE event, and banner are
+ * tested separately; this file pins the pure function.
+ */
+import { describe, expect, it } from 'vitest'
+import type { Site } from '../src/site-loader.js'
+import type { FragmentManifest, PageManifest } from '../src/types.js'
+import { computeTemplateImpact } from '../src/validation/template-impact.js'
+import type { Issue } from '../src/validation/types.js'
+
+function buildSite(opts: {
+  pages?: Record<string, PageManifest & { dir: string }>
+  fragments?: Record<string, FragmentManifest & { dir: string }>
+}): Site {
+  return {
+    pages: new Map(Object.entries(opts.pages ?? {})),
+    fragments: new Map(Object.entries(opts.fragments ?? {})),
+    pageLocales: new Map(),
+    fragmentLocales: new Map(),
+    manifest: { name: 't', targets: { local: {} } } as Site['manifest'],
+    templatesDir: undefined,
+  } as Site
+}
+
+const noIssues = () => [] as readonly Issue[]
+
+describe('computeTemplateImpact', () => {
+  it('lists pages whose top-level template matches', () => {
+    const site = buildSite({
+      pages: {
+        home: { template: 'page-default', content: {}, route: '/', dir: 'pages/home' },
+        about: { template: 'page-default', content: {}, route: '/about', dir: 'pages/about' },
+        blog: { template: 'page-blog', content: {}, route: '/blog', dir: 'pages/blog' },
+      },
+    })
+    const result = computeTemplateImpact(site, 'page-default', noIssues)
+    expect(result.template).toBe('page-default')
+    expect(result.items).toHaveLength(2)
+    expect(result.items.map(i => i.name).sort()).toEqual(['about', 'home'])
+  })
+
+  it('lists fragments whose top-level template matches', () => {
+    const site = buildSite({
+      fragments: {
+        header: { template: 'header-layout', content: {}, dir: 'fragments/header' },
+        footer: { template: 'footer-layout', content: {}, dir: 'fragments/footer' },
+      },
+    })
+    const result = computeTemplateImpact(site, 'header-layout', noIssues)
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0].name).toBe('header')
+    expect(result.items[0].kind).toBe('fragment')
+  })
+
+  it('orders pages first, then fragments', () => {
+    const site = buildSite({
+      pages: { p1: { template: 'shared', content: {}, route: '/p1', dir: 'pages/p1' } },
+      fragments: { f1: { template: 'shared', content: {}, dir: 'fragments/f1' } },
+    })
+    const result = computeTemplateImpact(site, 'shared', noIssues)
+    expect(result.items[0].kind).toBe('page')
+    expect(result.items[1].kind).toBe('fragment')
+  })
+
+  it('finds nested inline components recursively', () => {
+    const site = buildSite({
+      pages: {
+        home: {
+          template: 'page-default',
+          content: {},
+          route: '/',
+          dir: 'pages/home',
+          components: [
+            {
+              name: 'wrapper',
+              template: 'section',
+              components: [
+                {
+                  name: 'inner',
+                  template: 'hero', // ← deep match
+                  content: { title: 'x' },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    })
+    const result = computeTemplateImpact(site, 'hero', noIssues)
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0].name).toBe('home')
+  })
+
+  it('deduplicates pages that use the template multiple times', () => {
+    const site = buildSite({
+      pages: {
+        home: {
+          template: 'hero', // top-level
+          content: {},
+          route: '/',
+          dir: 'pages/home',
+          components: [
+            { name: 'second', template: 'hero', content: {} }, // and inline
+          ],
+        },
+      },
+    })
+    const result = computeTemplateImpact(site, 'hero', noIssues)
+    expect(result.items).toHaveLength(1)
+  })
+
+  it('skips pages and fragments that do not reference the template', () => {
+    const site = buildSite({
+      pages: { home: { template: 'page-default', content: {}, route: '/', dir: 'pages/home' } },
+      fragments: { footer: { template: 'footer-layout', content: {}, dir: 'fragments/footer' } },
+    })
+    const result = computeTemplateImpact(site, 'unused-template', noIssues)
+    expect(result.items).toEqual([])
+    expect(result.affectedItemCount).toBe(0)
+  })
+
+  it('attaches issues from the lookup function per item', () => {
+    const site = buildSite({
+      pages: {
+        home: { template: 'hero', content: {}, route: '/', dir: 'pages/home' },
+        about: { template: 'hero', content: {}, route: '/about', dir: 'pages/about' },
+      },
+    })
+    const issuesByPath: Record<string, Issue[]> = {
+      'pages/home/page.json': [
+        {
+          validator: 'schema-conformance',
+          severity: 'error',
+          message: 'title: Required',
+          itemPath: 'pages/home/page.json',
+        },
+      ],
+      'pages/about/page.json': [],
+    }
+    const result = computeTemplateImpact(site, 'hero', path => issuesByPath[path] ?? [])
+    expect(result.items).toHaveLength(2)
+    const home = result.items.find(i => i.name === 'home')!
+    expect(home.issues).toHaveLength(1)
+    expect(home.issues[0].validator).toBe('schema-conformance')
+    const about = result.items.find(i => i.name === 'about')!
+    expect(about.issues).toEqual([])
+  })
+
+  it('counts only items with at least one issue toward affectedItemCount', () => {
+    const site = buildSite({
+      pages: {
+        a: { template: 'hero', content: {}, route: '/a', dir: 'pages/a' },
+        b: { template: 'hero', content: {}, route: '/b', dir: 'pages/b' },
+        c: { template: 'hero', content: {}, route: '/c', dir: 'pages/c' },
+      },
+    })
+    const issuesByPath: Record<string, Issue[]> = {
+      'pages/a/page.json': [{ validator: 'x', severity: 'error', message: 'fail', itemPath: 'pages/a/page.json' }],
+      'pages/b/page.json': [{ validator: 'x', severity: 'warn', message: 'warn', itemPath: 'pages/b/page.json' }],
+      'pages/c/page.json': [],
+    }
+    const result = computeTemplateImpact(site, 'hero', path => issuesByPath[path] ?? [])
+    expect(result.items).toHaveLength(3)
+    expect(result.affectedItemCount).toBe(2) // a + b
+  })
+})


### PR DESCRIPTION
Closes the validation chapter. Adds the fourth validation surface from [`design-validation.md`](.claude/rules/design-validation.md) — paired **transient toolbar banner** + **DevPlayground Impact tab** for template developers.

## Why a fourth surface

Template developers (the ones editing \`templates/{name}/index.tsx\`) work in their IDE, not the admin form. After a hot reload they want to know "did I break any content?" The save banner and site-health drawer are the wrong surfaces — neither shows up in response to a template edit, both require the dev to navigate. The new banner appears automatically; the new tab gives them a Storybook-style "what does this template touch?" view.

## Summary

**Backend**
- CLI template watcher → \`validationScanner.rescan({kind:'template',name})\` on every \`.ts/.tsx\` change in \`templates/{name}/\`
- \`computeTemplateImpact()\` — pure function; recursive walk of \`Site\` finds pages + fragments using a template (top-level OR nested inline)
- \`GET /api/templates/:name/impact\` returns \`{template, items, affectedItemCount}\` with per-item issues from the scanner
- \`/__validation\` SSE channel adds a distinct \`template-changed\` event type so the banner doesn't filter through every scan event

**Frontend**
- \`useTemplateImpactStore\` (Pinia) — single-slot, 60s auto-clear, manual dismiss
- \`TemplateChangedBanner.vue\` — mounted alongside \`OfflineBanner\` in App.vue; "View impact" deep-links to \`/dev/editor/{name}?tab=impact\`
- \`TemplateImpactPanel.vue\` — list of items with severity icons (✓/⚠/✗/info); per-row Edit navigates to affected page/fragment
- DevPlayground gains a Preview/Impact tab strip when an editor (template) is selected; tab state persists via \`?tab=impact\`

**Migrate-as-AI-task deferred** — schema migrations are too feature-specific to automate generically; reserved as an AI-task seam (alongside alt-text in [\`design-ai.md\`](.claude/rules/design-ai.md)). Today's row action is "Edit"; the panel footer notes the future direction.

## Test plan

- [x] gazetta tests — \`npx vitest run --root packages/gazetta\` (2070 passing; +13 new across \`validation-template-impact.test.ts\`, \`validation-scanner.test.ts\`, \`admin-api.test.ts\`)
- [x] admin tests — \`npx vitest run --root apps/admin\` (776 passing; +19 new across \`templateImpact.test.ts\` + \`TemplateImpactPanel.test.ts\`)
- [x] Typecheck — \`npx tsc --noEmit\` clean across both packages
- [x] Format — \`npm run format\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)