### PR TITLE
Editor breadcrumb: replace template-name jargon with user-set path

### DIFF
--- a/apps/admin/src/client/components/EditorBreadcrumb.vue
+++ b/apps/admin/src/client/components/EditorBreadcrumb.vue
@@ -1,0 +1,177 @@
+<script setup lang="ts">
+/**
+ * Breadcrumb shown above the editor body in edit mode (#82).
+ *
+ * Replaces the previous `<h3>{{ editing.template }}</h3>` header which
+ * showed developer-jargon template names like "hero" or "feature-card"
+ * — content authors don't know what those mean. The breadcrumb shows
+ * the user-set component names that match what they see in the
+ * ComponentTree, with each segment clickable to navigate up.
+ *
+ * Examples:
+ *   - Page root selected:                 home
+ *   - Top-level component on page:        home  >  hero
+ *   - Nested inline component:            home  >  features  >  fast
+ *   - Fragment edit (root):               @header
+ *   - Component inside fragment:          @header  >  nav  >  link-list
+ *
+ * Click behavior:
+ *   - Last segment is non-clickable (current position)
+ *   - Earlier segments push to the corresponding URL hash. The router
+ *     beforeEach guard runs the standard unsaved-changes flow if the
+ *     navigation would discard pending edits — same as ComponentTree
+ *     row clicks, no new guard surface.
+ *
+ * Locale awareness: the active locale is already shown in the top-bar
+ * locale picker; the breadcrumb stays simple and doesn't duplicate it.
+ *
+ * Truncation: at the operating envelope (depth typically < 5), the
+ * full breadcrumb fits. Long paths hit the parent's overflow:hidden
+ * ellipsis at v1; middle-segment truncation lands when concrete
+ * pain surfaces.
+ *
+ * # SOLID lenses
+ *
+ *   - SRP: this component renders one breadcrumb derived from the
+ *     editing store + selection store. Navigation through a hash
+ *     change is delegated to vue-router; the unsaved-changes guard
+ *     is delegated to the router beforeEach.
+ *   - DIP: depends on the typed editing/selection stores; doesn't
+ *     reach into manifest-walking code.
+ */
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useEditingStore } from '../stores/editing.js'
+import { useSelectionStore } from '../stores/selection.js'
+
+interface Segment {
+  /** Display label (component name or @fragmentName or page name). */
+  label: string
+  /**
+   * Hash to navigate to when clicked. `null` for the current
+   * (last) segment, which renders as plain text.
+   */
+  hash: string | null
+}
+
+const editing = useEditingStore()
+const selection = useSelectionStore()
+const router = useRouter()
+
+const segments = computed<Segment[]>(() => {
+  const sel = selection.selection
+  if (!sel) return []
+
+  const out: Segment[] = []
+
+  // First segment: the page or fragment itself. Fragment context
+  // shows `@name` to match the syntax used in component manifests +
+  // ComponentTree rendering.
+  const rootLabel = sel.type === 'page' ? sel.name : `@${sel.name}`
+  // Root is clickable when we're not currently AT the root (i.e.,
+  // there's at least one component segment after it). Three "root"
+  // shapes:
+  //   - page root: editing.path === '_root'
+  //   - fragment root: editing.path === '@<name>'
+  //   - no editor open: editing.path null/empty
+  const path = editing.path
+  const onFragmentRoot = sel.type === 'fragment' && path === `@${sel.name}`
+  const atRoot = path === '_root' || path === null || path === '' || onFragmentRoot
+  out.push({
+    label: rootLabel,
+    hash: atRoot ? null : '', // empty hash = root selection
+  })
+
+  // Component path: 'features/fast' → ['features', 'fast'], each
+  // clickable except the last. _root is excluded from segments
+  // (it's the root marker, already rendered above). Fragment-edit
+  // path '@name' is also excluded (the fragment itself IS root).
+  if (path && path !== '_root' && !path.startsWith('@')) {
+    const parts = path.split('/').filter(Boolean)
+    let acc = ''
+    for (let i = 0; i < parts.length; i++) {
+      acc = acc ? `${acc}/${parts[i]}` : parts[i]
+      const isLast = i === parts.length - 1
+      out.push({
+        label: parts[i],
+        hash: isLast ? null : `#${acc}`,
+      })
+    }
+  }
+
+  return out
+})
+
+function navigate(hash: string) {
+  // Plain string hash form — vue-router's withPersistentQuery wrapper
+  // (router.ts) parses + preserves locale/target query params. The
+  // beforeEach guard handles unsaved edits via useUnsavedGuardStore.
+  // Empty string = navigate to current path with no hash (root).
+  router.push({ path: router.currentRoute.value.path, hash, query: router.currentRoute.value.query })
+}
+</script>
+
+<template>
+  <nav v-if="segments.length > 0" class="editor-breadcrumb" aria-label="Editor location" data-testid="editor-breadcrumb">
+    <template v-for="(seg, idx) in segments" :key="idx">
+      <span v-if="idx > 0" class="separator" aria-hidden="true">›</span>
+      <button
+        v-if="seg.hash !== null"
+        type="button"
+        class="segment segment-link"
+        :data-testid="`breadcrumb-segment-${seg.label}`"
+        @click="navigate(seg.hash)">
+        {{ seg.label }}
+      </button>
+      <span v-else class="segment segment-current" :data-testid="`breadcrumb-segment-${seg.label}`" aria-current="location">
+        {{ seg.label }}
+      </span>
+    </template>
+  </nav>
+</template>
+
+<style scoped>
+.editor-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.8125rem;
+  line-height: 1.25;
+  color: var(--color-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 0;
+  min-width: 0;
+}
+.separator {
+  color: var(--color-muted);
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+.segment {
+  background: transparent;
+  border: none;
+  font: inherit;
+  color: inherit;
+  padding: 0.125rem 0.25rem;
+  border-radius: var(--p-border-radius-sm);
+  cursor: default;
+}
+.segment-link {
+  cursor: pointer;
+  color: var(--color-muted);
+}
+.segment-link:hover {
+  background: var(--color-hover-bg);
+  color: var(--color-fg);
+}
+.segment-link:focus-visible {
+  outline: 2px solid var(--p-primary-color);
+  outline-offset: 1px;
+}
+.segment-current {
+  color: var(--color-fg);
+  font-weight: 600;
+}
+</style>

--- a/apps/admin/src/client/components/EditorPanel.vue
+++ b/apps/admin/src/client/components/EditorPanel.vue
@@ -14,6 +14,7 @@ import FragmentBlastRadius from './FragmentBlastRadius.vue'
 import PageMetadataEditor from './PageMetadataEditor.vue'
 import ValidationBanner from './ValidationBanner.vue'
 import ConflictBanner from './ConflictBanner.vue'
+import EditorBreadcrumb from './EditorBreadcrumb.vue'
 import { useLocaleStore } from '../stores/locale.js'
 import { manifestPath } from '../stores/editorEtags.js'
 import { useConflictDiscard } from '../composables/useConflictDiscard.js'
@@ -140,8 +141,12 @@ async function handleConflictDiscard() {
       <p>Select a component to edit</p>
     </div>
     <div v-else class="editor-active">
+      <!-- #82 — breadcrumb shows the user-set component name path
+           ("home > features > fast") instead of the template-name
+           jargon ("feature-card") that authors don't understand.
+           Each non-current segment is clickable to navigate up. -->
       <div class="editor-header">
-        <h3>{{ editing.template }}</h3>
+        <EditorBreadcrumb />
         <FragmentBlastRadius v-if="fragmentName" :fragmentName="fragmentName" />
       </div>
       <div v-if="hasProperties" ref="containerRef" class="editor-container" data-testid="editor-container" :key="editing.path" />
@@ -152,7 +157,6 @@ async function handleConflictDiscard() {
 </template>
 
 <style scoped>
-.editor-panel h3 { font-size: 0.75rem; text-transform: uppercase; color: var(--color-muted); letter-spacing: 0.05em; margin: 0; }
 .editor-header { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; margin-bottom: 1rem; flex-wrap: wrap; }
 .editor-error { color: var(--color-danger-fg); font-size: 0.875rem; display: flex; flex-direction: column; align-items: center; padding-top: 3rem; gap: 0.5rem; text-align: center; }
 .editor-error .pi { font-size: 2rem; }

--- a/apps/admin/tests/EditorBreadcrumb.test.ts
+++ b/apps/admin/tests/EditorBreadcrumb.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for EditorBreadcrumb.vue (#82).
+ *
+ * Drive the breadcrumb's two inputs:
+ *   - selection store (page or fragment + name)
+ *   - editing store's path (`_root` | name path | `@fragmentName`)
+ *
+ * Verify the rendered segments + the click-navigation hashes. The
+ * router beforeEach guard for unsaved edits is exercised via the
+ * existing UnsavedDialog test suite — this file pins the breadcrumb's
+ * own contract.
+ */
+import { beforeEach, describe, expect, it, beforeAll } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import PrimeVue from 'primevue/config'
+import EditorBreadcrumb from '../src/client/components/EditorBreadcrumb.vue'
+import { useSelectionStore } from '../src/client/stores/selection.js'
+import { useEditorContentStore } from '../src/client/stores/editorContent.js'
+import type { EditingTarget } from '../src/client/stores/editorContent.js'
+import type { PageDetail, FragmentDetail } from '../src/client/api/client.js'
+
+beforeAll(() => {
+  if (typeof window.matchMedia !== 'function') {
+    window.matchMedia = (q: string) =>
+      ({
+        matches: false,
+        media: q,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList
+  }
+})
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: { template: '<div />' } },
+      { path: '/pages/:name/edit', component: { template: '<div />' }, name: 'page-edit' },
+      { path: '/fragments/:name/edit', component: { template: '<div />' }, name: 'fragment-edit' },
+    ],
+  })
+}
+
+/**
+ * Mount the breadcrumb with the stores in a known state. `editingPath`
+ * sets `editorContent.target.path` (the breadcrumb's primary input);
+ * setSelection() seeds the selection store.
+ */
+async function mountAt(opts: {
+  selection: 'page' | 'fragment'
+  selectionName: string
+  editingPath: string | null
+  startUrl?: string
+}) {
+  const router = makeRouter()
+  await router.push(opts.startUrl ?? `/${opts.selection === 'page' ? 'pages' : 'fragments'}/${opts.selectionName}/edit`)
+
+  const sel = useSelectionStore()
+  if (opts.selection === 'page') {
+    sel.selection = {
+      type: 'page',
+      name: opts.selectionName,
+      detail: {
+        name: opts.selectionName,
+        route: '/',
+        template: 'page-default',
+        dir: `pages/${opts.selectionName}`,
+        components: [],
+      } as PageDetail,
+    }
+  } else {
+    sel.selection = {
+      type: 'fragment',
+      name: opts.selectionName,
+      detail: {
+        name: opts.selectionName,
+        template: 'header-layout',
+        dir: `fragments/${opts.selectionName}`,
+      } as FragmentDetail,
+    }
+  }
+
+  const ec = useEditorContentStore()
+  if (opts.editingPath !== null) {
+    ec.target = {
+      template: 'x',
+      path: opts.editingPath,
+      content: {},
+      schema: {},
+      save: async () => {},
+    } as EditingTarget
+  }
+
+  const w = mount(EditorBreadcrumb, {
+    global: { plugins: [PrimeVue, router] },
+  })
+  await w.vm.$nextTick()
+  return { wrapper: w, router }
+}
+
+describe('EditorBreadcrumb — page context', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('shows just the page name when at root', async () => {
+    const { wrapper } = await mountAt({
+      selection: 'page',
+      selectionName: 'home',
+      editingPath: '_root',
+    })
+    const segments = wrapper.findAll('[data-testid^="breadcrumb-segment-"]')
+    expect(segments).toHaveLength(1)
+    expect(segments[0].text()).toBe('home')
+    // At root, the only segment is the current — non-clickable.
+    expect(segments[0].element.tagName).toBe('SPAN')
+  })
+
+  it('shows page name > component when editing a top-level component', async () => {
+    const { wrapper } = await mountAt({
+      selection: 'page',
+      selectionName: 'home',
+      editingPath: 'hero',
+    })
+    const segments = wrapper.findAll('[data-testid^="breadcrumb-segment-"]')
+    expect(segments).toHaveLength(2)
+    expect(segments[0].text()).toBe('home')
+    expect(segments[1].text()).toBe('hero')
+    // Page name is clickable (not at root); component is current.
+    expect(segments[0].element.tagName).toBe('BUTTON')
+    expect(segments[1].element.tagName).toBe('SPAN')
+  })
+
+  it('shows full nested path for inline composite children', async () => {
+    const { wrapper } = await mountAt({
+      selection: 'page',
+      selectionName: 'home',
+      editingPath: 'features/fast',
+    })
+    const segments = wrapper.findAll('[data-testid^="breadcrumb-segment-"]')
+    expect(segments).toHaveLength(3)
+    expect(segments.map(s => s.text())).toEqual(['home', 'features', 'fast'])
+    // home + features clickable; fast is current
+    expect(segments[0].element.tagName).toBe('BUTTON')
+    expect(segments[1].element.tagName).toBe('BUTTON')
+    expect(segments[2].element.tagName).toBe('SPAN')
+  })
+
+  it('separator is rendered between segments and is hidden from screen readers', async () => {
+    const { wrapper } = await mountAt({
+      selection: 'page',
+      selectionName: 'home',
+      editingPath: 'features/fast',
+    })
+    const seps = wrapper.findAll('.separator')
+    expect(seps).toHaveLength(2) // 3 segments → 2 separators
+    expect(seps[0].attributes('aria-hidden')).toBe('true')
+  })
+
+  it('the current segment carries aria-current="location"', async () => {
+    const { wrapper } = await mountAt({
+      selection: 'page',
+      selectionName: 'home',
+      editingPath: 'hero',
+    })
+    const current = wrapper.find('.segment-current')
+    expect(current.exists()).toBe(true)
+    expect(current.attributes('aria-current')).toBe('location')
+    expect(current.text()).toBe('hero')
+  })
+})
+
+describe('EditorBreadcrumb — fragment context', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('shows @fragmentName when editing the fragment root', async () => {
+    const { wrapper } = await mountAt({
+      selection: 'fragment',
+      selectionName: 'header',
+      editingPath: '@header',
+    })
+    const segments = wrapper.findAll('[data-testid^="breadcrumb-segment-"]')
+    expect(segments).toHaveLength(1)
+    expect(segments[0].text()).toBe('@header')
+    // Editing path === @header is treated as root for the fragment;
+    // single segment, non-clickable.
+    expect(segments[0].element.tagName).toBe('SPAN')
+  })
+
+  it('shows @fragmentName > component when editing a child', async () => {
+    const { wrapper } = await mountAt({
+      selection: 'fragment',
+      selectionName: 'header',
+      editingPath: 'nav',
+    })
+    const segments = wrapper.findAll('[data-testid^="breadcrumb-segment-"]')
+    expect(segments).toHaveLength(2)
+    expect(segments.map(s => s.text())).toEqual(['@header', 'nav'])
+    expect(segments[0].element.tagName).toBe('BUTTON') // root clickable
+    expect(segments[1].element.tagName).toBe('SPAN') // current
+  })
+
+  it('shows nested fragment children: @header > nav > link-list', async () => {
+    const { wrapper } = await mountAt({
+      selection: 'fragment',
+      selectionName: 'header',
+      editingPath: 'nav/link-list',
+    })
+    const segments = wrapper.findAll('[data-testid^="breadcrumb-segment-"]')
+    expect(segments).toHaveLength(3)
+    expect(segments.map(s => s.text())).toEqual(['@header', 'nav', 'link-list'])
+  })
+})
+
+describe('EditorBreadcrumb — navigation on click', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('clicking the page name segment from a component navigates to the page root (empty hash)', async () => {
+    const { wrapper, router } = await mountAt({
+      selection: 'page',
+      selectionName: 'home',
+      editingPath: 'features/fast',
+      startUrl: '/pages/home/edit#features/fast',
+    })
+    await wrapper.find('[data-testid="breadcrumb-segment-home"]').trigger('click')
+    await router.isReady()
+    await new Promise(r => setTimeout(r, 0))
+    expect(router.currentRoute.value.hash).toBe('')
+  })
+
+  it('clicking an intermediate segment navigates to that level', async () => {
+    const { wrapper, router } = await mountAt({
+      selection: 'page',
+      selectionName: 'home',
+      editingPath: 'features/fast',
+      startUrl: '/pages/home/edit#features/fast',
+    })
+    await wrapper.find('[data-testid="breadcrumb-segment-features"]').trigger('click')
+    await router.isReady()
+    await new Promise(r => setTimeout(r, 0))
+    expect(router.currentRoute.value.hash).toBe('#features')
+  })
+
+  it('clicking the current segment is a no-op (it renders as a span, not a button)', async () => {
+    const { wrapper, router } = await mountAt({
+      selection: 'page',
+      selectionName: 'home',
+      editingPath: 'hero',
+      startUrl: '/pages/home/edit#hero',
+    })
+    const current = wrapper.find('[data-testid="breadcrumb-segment-hero"]')
+    expect(current.element.tagName).toBe('SPAN')
+    // The hash should remain unchanged; verify by attempting a click
+    // and asserting no navigation. Span has no click handler, so this
+    // is mostly a structural assertion — pin it explicitly.
+    await current.trigger('click')
+    expect(router.currentRoute.value.hash).toBe('#hero')
+  })
+})
+
+describe('EditorBreadcrumb — empty / edge states', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders nothing when there is no selection', async () => {
+    const router = makeRouter()
+    await router.push('/')
+    const w = mount(EditorBreadcrumb, {
+      global: { plugins: [PrimeVue, router] },
+    })
+    await w.vm.$nextTick()
+    expect(w.find('[data-testid="editor-breadcrumb"]').exists()).toBe(false)
+  })
+})

--- a/tests/e2e/deep-linking.spec.ts
+++ b/tests/e2e/deep-linking.spec.ts
@@ -112,9 +112,9 @@ test.describe('Deep linking - component hash', () => {
   test('hash #hero opens hero editor on page load', async ({ page }) => {
     await page.goto('/admin/pages/home/edit#hero')
     await page.waitForSelector('[data-testid="editor-container"]', { timeout: 10000 })
-    // Hero template header should be visible
-    const header = page.locator('[data-testid="editor-panel"] h3')
-    await expect(header).toContainText('hero', { ignoreCase: true })
+    // Breadcrumb's current segment shows the component name (#82
+    // replaced the template-name jargon h3 with a user-set-name path).
+    await expect(page.locator('[data-testid="breadcrumb-segment-hero"]')).toBeVisible()
     // Hero should be selected in tree
     await expect(page.locator('[data-testid="component-hero"].selected')).toBeVisible()
   })
@@ -131,8 +131,7 @@ test.describe('Deep linking - component hash', () => {
     await page.reload()
     // After reload, hero editor should still be open
     await page.waitForSelector('[data-testid="editor-container"]', { timeout: 10000 })
-    const header = page.locator('[data-testid="editor-panel"] h3')
-    await expect(header).toContainText('hero', { ignoreCase: true })
+    await expect(page.locator('[data-testid="breadcrumb-segment-hero"]')).toBeVisible()
   })
 
   test('fragment link hash #@header/logo shows fragment link with logo selected', async ({ page }) => {
@@ -146,17 +145,17 @@ test.describe('Deep linking - component hash', () => {
   test('hash on fragment page #logo opens logo editor', async ({ page }) => {
     await page.goto('/admin/fragments/header/edit#logo')
     await page.waitForSelector('[data-testid="editor-container"]', { timeout: 10000 })
-    const header = page.locator('[data-testid="editor-panel"] h3')
-    await expect(header).toContainText('logo', { ignoreCase: true })
+    await expect(page.locator('[data-testid="breadcrumb-segment-logo"]')).toBeVisible()
     await expect(page.locator('[data-testid="component-logo"].selected')).toBeVisible()
   })
 
   test('no hash opens root editor by default', async ({ page }) => {
     await page.goto('/admin/pages/home/edit')
     await page.waitForSelector('[data-testid^="component-"]', { timeout: 10000 })
-    // Root should be selected — page-default template header + SEO metadata editor
-    const header = page.locator('[data-testid="editor-panel"] h3').first()
-    await expect(header).toContainText('page-default', { ignoreCase: true })
+    // Root selected — breadcrumb shows just the page name `home`
+    // (#82 replaced the template-name jargon h3 with the user-set
+    // page name; the SEO metadata editor still renders below).
+    await expect(page.locator('[data-testid="breadcrumb-segment-home"]')).toBeVisible()
   })
 })
 

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -85,6 +85,37 @@ test.describe('Custom field', () => {
   })
 })
 
+test.describe('Editor breadcrumb (#82)', () => {
+  test('shows page-name > component-name when editing a top-level component', async ({ page }) => {
+    await openEditor(page, 'home')
+    const tree = new ComponentTreePom(page)
+    await tree.open('hero')
+    await page.waitForSelector('[data-testid="editor-breadcrumb"]', { timeout: 10000 })
+
+    const breadcrumb = page.locator('[data-testid="editor-breadcrumb"]')
+    await expect(breadcrumb.locator('[data-testid="breadcrumb-segment-home"]')).toBeVisible()
+    await expect(breadcrumb.locator('[data-testid="breadcrumb-segment-hero"]')).toBeVisible()
+
+    // page-name segment is a button (clickable); current segment is a span.
+    const homeSeg = breadcrumb.locator('[data-testid="breadcrumb-segment-home"]')
+    const heroSeg = breadcrumb.locator('[data-testid="breadcrumb-segment-hero"]')
+    await expect(homeSeg).toHaveJSProperty('tagName', 'BUTTON')
+    await expect(heroSeg).toHaveJSProperty('tagName', 'SPAN')
+  })
+
+  test('clicking the page-name segment navigates back to root (clears the hash)', async ({ page }) => {
+    await openEditor(page, 'home')
+    const tree = new ComponentTreePom(page)
+    await tree.open('hero')
+    await page.waitForSelector('[data-testid="editor-breadcrumb"]', { timeout: 10000 })
+
+    // We're on /pages/home/edit#hero; click home segment.
+    expect(new URL(page.url()).hash).toBe('#hero')
+    await page.locator('[data-testid="breadcrumb-segment-home"]').click()
+    await expect.poll(() => new URL(page.url()).hash).toBe('')
+  })
+})
+
 test.describe('Rapid selection', () => {
   test('last click wins when rapidly switching pages', { retry: 1 }, async ({ page }) => {
     await page.goto('/admin')


### PR DESCRIPTION
Closes #82. Replaces the editor header's developer-jargon template name (\`<h3>{{ editing.template }}</h3>\`) with a clickable breadcrumb that uses user-set component names matching what they see in ComponentTree.

## Summary

Daily authors don't know that \"hero\" is a template name. They DO recognize the component name they themselves set in the manifest. The breadcrumb shows the path of names from the page or fragment root down to the current edit position, with each non-current segment clickable to navigate up.

| Editing position | Breadcrumb |
|---|---|
| Page root | \`home\` |
| Top-level component | \`home > hero\` |
| Nested inline composite | \`home > features > fast\` |
| Fragment root | \`@header\` |
| Component inside fragment | \`@header > nav > link-list\` |

## Implementation notes

- New \`EditorBreadcrumb.vue\` consumes \`useSelectionStore()\` (page/fragment + name) + \`useEditingStore()\` (\`editing.path\`); renders one segment per path level
- Each non-current segment is a \`<button>\` that pushes the corresponding URL hash. The existing router \`beforeEach\` guard handles unsaved-changes via \`useUnsavedGuardStore\` — no new guard surface.
- The current segment is a \`<span>\` with \`aria-current=\"location\"\`
- Separators (\`›\`) are \`aria-hidden\`
- \`@\` prefix on fragment names matches the syntax in the manifest + ComponentTree rendering
- Locale awareness: the active locale already lives in the top-bar locale picker; the breadcrumb doesn't duplicate it
- Long-path truncation is overflow ellipsis at v1; middle-segment truncation deferred until concrete pain (operating envelope is depth typically <5)

## Test plan

- [x] gazetta tests — \`npx vitest run --root packages/gazetta\` (no changes)
- [x] admin tests — \`npx vitest run --root apps/admin\` (810 passing; +12 new in \`EditorBreadcrumb.test.ts\` covering page + fragment context, root + nested paths, separators, aria-current, click navigation, empty state)
- [x] e2e — \`npx playwright test tests/e2e/editor.spec.ts --project=dev\` (7 passing; +2 new for breadcrumb rendering + click-back navigation in the real running admin)
- [x] Typecheck — \`npx tsc --noEmit\` clean
- [x] Format — \`npm run format\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)