### PR TITLE
MCP wiring + CLAUDE.md commands + rule 32 (test-iteration loop)

### DIFF
--- a/.claude/rules/team-preferences.md
+++ b/.claude/rules/team-preferences.md
@@ -257,3 +257,17 @@ Validated approaches and things to avoid. Each entry: rule, then why.
    - Mutation testing nightly (StrykerJS, already shipped per [`testing-plan.md`](testing-plan.md)) catches the residual tautological tests that slip through TDD ordering.
 
    Example: validation Cut 1's save-delta orchestrator — failing test landed first (`save returns 409 with the introduced ref's issue, not pre-existing issues`), then the diff implementation. Reverting the implementation re-fails the test; the TDD ordering proved the diff logic was load-bearing, not vestigial. Without the ordering, the agent would have written `expect(response.status).toBeOneOf([200, 409])` — passing whether or not the diff worked.
+
+32. **Read all failures before editing; iterate on a single file via vitest watch mode.** Two complementary patterns for the test-error inner loop:
+
+   **Pattern A — when a single run produces N independent failures, fix all N in one edit pass before rerunning.** Common case in API/contract work: different routes, different validator surfaces, different return shapes — each failure has its own root cause, none caused by another. Sequential single-fix-per-run is a heuristic for *coupled* changes (where the second failure might be caused by the first fix). Applied to independent contract mismatches, it just multiplies run cost by N. Reading two types and editing two call sites in one pass is the same cognitive cost as four serialized read-then-edit-then-rerun cycles, but one test run instead of four.
+
+   **Pattern B — when iterating on a single test file (refining assertions, narrowing a flake, exploring a behavior), use `vitest` (watch mode), not `vitest run`.** Each subsequent edit reruns the changed file in ~10-50ms instead of paying the ~400ms-1.2s cold-start tax per `vitest run` invocation. Background it via `Bash run_in_background` if conversational visibility matters; otherwise run inline and read output between edits.
+
+   **When NOT to apply A:** when failures are genuinely coupled (a state-machine transition test where fixing the first transition might cascade into the second). Read the failure messages and judge — if each failure names a different file/route/type, they're independent.
+
+   **When NOT to apply B:** one-shot verification ("did my fix work?") — `vitest run path/to/file.test.ts` is fine; the cold-start tax pays once. Watch mode earns its keep on the third-or-later invocation against the same file.
+
+   **Why:** the iterate-on-test loop is one of the highest-frequency activities in any session. A 3-failure sequence costs 4× a 1-pass fix; a 5-edit watch loop costs 1× the watch startup vs 5× the run cold-start. Both compound across sessions.
+
+   Example: cross-foundation gap #3 produced 3 independent surface failures at once (validator scope shape wrong, publish/audit body shape wrong, consistency check cascading from #4). I fixed them sequentially across 3 runs (~3.6s total). Pattern A would have fixed all 3 in one edit pass and one rerun (~1.2s) — same diagnostic effort, one-third the runs.

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,18 @@
   "mcpServers": {
     "dev": {
       "command": "npx",
-      "args": ["tsx", "tools/mcp-dev/src/index.ts"]
+      "args": [
+        "tsx",
+        "tools/mcp-dev/src/index.ts"
+      ]
+    },
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest"
+      ],
+      "env": {}
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,11 +61,46 @@ Stateless CMS that structures websites as composable fragments. All state lives 
 
 ## Build & Test
 
+All commands run from the repo root unless noted.
+
 ```bash
-npm install        # install dependencies (from root)
-npm run build      # build all packages
-npm run dev        # start dev server (examples/starter on localhost:3000)
-npm test           # run all tests
+npm install                              # install all workspace deps
+npm run build                            # build all packages
+npm run dev                              # examples/starter on localhost:3000
+npm test                                 # all workspace tests (~65s for gazetta)
+npm test -w packages/gazetta             # one workspace's tests
+```
+
+**Single test file / pattern** — run from the package directory:
+
+```bash
+cd packages/gazetta && npx vitest run tests/some-file.test.ts
+cd packages/gazetta && npx vitest run -t "test name pattern"
+```
+
+**Type-check** — no repo-level script; per-package:
+
+```bash
+cd packages/gazetta && npx tsc --noEmit
+```
+
+**Format** — Biome; rule 30 says run before tests, not after (post-test format thrash forces a re-run):
+
+```bash
+npm run format                           # write
+npm run format:check                     # CI gate
+```
+
+**E2e** — Playwright; no wrapping npm script:
+
+```bash
+npx playwright test
+```
+
+**Mutation** — StrykerJS, opt-in (per `testing-plan.md`); slow:
+
+```bash
+npm run test:mutation -w packages/gazetta
 ```
 
 **Note:** Page and fragment manifests use JSON (`page.json`, `fragment.json`). Site config is TypeScript (`site.config.ts`) using `defineSite()` from the `gazetta` package. Components are inline in the page manifest — no separate component files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,12 @@ cd packages/gazetta && npx vitest run tests/some-file.test.ts
 cd packages/gazetta && npx vitest run -t "test name pattern"
 ```
 
+**Iterating on one file** — use watch mode (per rule 32 Pattern B); each edit reruns in ~10-50ms instead of the ~1.2s cold-start of `vitest run`:
+
+```bash
+cd packages/gazetta && npx vitest tests/some-file.test.ts
+```
+
 **Type-check** — no repo-level script; per-package:
 
 ```bash


### PR DESCRIPTION
## Summary

Two commits that previously sat on local main; rebased onto a branch to follow rule 33 (PR-only flow).

- **`1a2493c`** — Wire Playwright MCP at project scope (`.mcp.json`); expand CLAUDE.md `Build & Test` with single-file vitest, per-package tsc, format ordering, e2e, mutation
- **`b332826`** — Add rule 32 (read all failures before editing; vitest watch mode for single-file iteration); cross-reference watch invocation in CLAUDE.md

## Test plan

- [x] `.mcp.json` loads — `claude mcp list` shows `playwright: ✓ Connected`
- [x] CLAUDE.md commands all reference scripts that actually exist in `package.json`
- [x] Rule 32 follows the existing format (rule + Why + How to apply + Example)
- [ ] CI green
- [ ] Merge with `gh pr merge --rebase --delete-branch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)