### PR TITLE
testing-plan: add admin-API route track + test-quality research scope

### DIFF
--- a/.claude/rules/testing-plan.md
+++ b/.claude/rules/testing-plan.md
@@ -88,6 +88,31 @@ batch — survived mutants from one module need triage before adding the next.
 Don't gate on score yet — observational metric until each module's baseline
 stabilises. Treat survived mutants as test-quality bugs.
 
+**Admin-API route track (parallel to the internal-module list above).** Tautological
+tests slip most easily where assertions match observed response shapes ("expect what
+the route returned"). Rule 31's failure mode lives most often at this tier; mutation
+testing is the discovery tool. Sequence:
+
+1. `packages/gazetta/src/admin-api/routes/suggest-alt.ts` — smallest route; one
+   real tautology already fixed (cross-foundation gap #4); methodology calibration.
+2. `archive.ts` — recent feature, AI-paired cuts, concentrated seam.
+3. `publish.ts` — highest blast radius; tackle once triage workflow stable.
+4. Remaining routes (`pages.ts`, `fragments.ts`, `assets.ts`, `history.ts`, …) on demand.
+
+Same smallest-first discipline as the internal-module list. Routes calling internal
+modules already covered by mutation testing produce some redundant signal; document
+equivalent mutants per route in the audit notes rather than skipping the route.
+
+**Test-quality-with-AI research (next session).** Locked scope: B-primary
+(test quality, signal-to-noise) + A-secondary (agent-loop ergonomics that
+compose with B's findings). C (coverage gaps) deferred — wait for the next
+escape. Methodology: mutation testing per the admin-API track above,
+suggest-alt first. Outputs: audit doc at `docs/audits/test-quality-with-ai.md`
+(per rule 21) + rule/plan updates as patterns generalize. Sequencing:
+measurement-first — write the audit doc from triage notes, layer in
+external-source framing (Anthropic PBT post, ThoughtWorks Vol 34+, recent
+StrykerJS releases) after.
+
 **Property-test scope expansion (next):** `fast-check` is installed and used
 in 1 file. Targets where round-trip / fallback chain semantics matter:
 - `archive/` filename codec round-trip (alias-targets sidecar names)


### PR DESCRIPTION
## Summary

Outcome of a `/grill-with-docs` scoping pass on improving testing approach with Claude Code + test automation. Two additions to `testing-plan.md`'s existing "Mutation scope expansion (next)" subsection:

1. **Admin-API route track** in parallel to the existing internal-module mutation priority list. Sequence: `suggest-alt.ts` → `archive.ts` → `publish.ts` → remaining routes. Smallest-first discipline matches the internal-module track.
2. **Test-quality-with-AI research scope**: B-primary (test quality / signal-to-noise) + A-secondary (agent-loop ergonomics). C (coverage gaps) deferred — wait for the next escape. Measurement-first sequencing; audit doc at `docs/audits/test-quality-with-ai.md` as deliverable.

The actual research happens in a separate session — this PR is the scoping artifact (per rule 21: research is durable + design absorbs the conclusions).

## Locked decisions (Q1-Q6)

- Q1: B primary, A secondary, C deferred
- Q2: Admin-API route tests as the first investigation surface
- Q3: Mutation testing (StrykerJS) as the measurement primitive
- Q4: One route at a time; `suggest-alt.ts` first
- Q5: Audit doc + rule/plan updates as outputs
- Q6: Measurement-first sequencing; scoping captured here

## Test plan

- [x] Addendum extends the existing subsection (terse, command-style match)
- [x] Doesn't override the internal-module priority — both tracks run in parallel
- [x] Forward-compat: equivalent-mutant note covers redundancy between tracks
- [ ] CI green
- [ ] Merge with `gh pr merge --rebase --delete-branch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)