### PR TITLE
admin-api: shared error-response schema (audit cycle 1, recommendation 1)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,17 +2,12 @@
   "mcpServers": {
     "dev": {
       "command": "npx",
-      "args": [
-        "tsx",
-        "tools/mcp-dev/src/index.ts"
-      ]
+      "args": ["tsx", "tools/mcp-dev/src/index.ts"]
     },
     "playwright": {
       "type": "stdio",
       "command": "npx",
-      "args": [
-        "@playwright/mcp@latest"
-      ],
+      "args": ["@playwright/mcp@latest"],
       "env": {}
     }
   }

--- a/packages/gazetta/src/admin-api/schemas/error.ts
+++ b/packages/gazetta/src/admin-api/schemas/error.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared shape for admin-API error responses.
+ *
+ * Most error responses follow `{ code: ErrorCode, message: string }`.
+ * Error classes that carry typed extras (`STALE` carries `current` +
+ * `currentEtag`; `VALIDATION_FAILED` carries `issues`) declare their
+ * own schema in the relevant route module — those schemas extend the
+ * base shape, they don't replace it.
+ *
+ * # Why this exists
+ *
+ * Per `docs/audits/test-quality-with-ai.md` cycle 1: error-shape
+ * tautology was the highest-leverage finding. Tests asserted on
+ * status code only; mutation testing showed `code: 'BAD_REQUEST'`
+ * survives mutation to `code: ''` because no test asserts on the
+ * body's `code` field. The fix is structural — assert against the
+ * schema, not the observed shape.
+ *
+ * # Usage
+ *
+ * Tests assert on error responses through `ErrorResponseSchema`:
+ *
+ *   const body = ErrorResponseSchema.parse(await res.json())
+ *   expect(body.code).toBe('BAD_REQUEST')
+ *
+ * `parse` (not `safeParse`) is intentional — a malformed error body
+ * is itself a regression. Failing to round-trip through the schema
+ * is the assertion.
+ *
+ * # Extending
+ *
+ * Routes that emit a typed error variant declare a discriminated
+ * schema in their own module (e.g. `StaleResponseSchema` in
+ * `pages.ts`). The base `ErrorCodeSchema` enum lists every code
+ * the admin-API may emit; extend it when new error classes ship.
+ */
+import { z } from 'zod'
+
+/**
+ * Closed enum of every error code the admin-API emits.
+ *
+ * Adding a new error class = one new entry here + a route-module
+ * extension if the error carries typed extras. Keeping the enum
+ * closed prevents drift: a route that returns `code: 'NEW_THING'`
+ * without updating this enum fails schema validation in tests, which
+ * surfaces the missing entry before it ships.
+ */
+export const ErrorCodeSchema = z.enum([
+  'AI_ADAPTER_FAILED',
+  'AI_ADAPTER_UNAVAILABLE',
+  'ARCHIVED_NAME_CONFLICT',
+  'ASSET_MANIFEST_NOT_FOUND',
+  'BAD_REQUEST',
+  'FORBIDDEN',
+  'HOOK_CANCELLED',
+  'NOT_FOUND',
+  'PUBLISH_AUDIT_FAILED',
+  'STALE',
+  'UNAUTHENTICATED',
+  'VALIDATION_FAILED',
+])
+export type ErrorCode = z.infer<typeof ErrorCodeSchema>
+
+/**
+ * Base error-response shape. Every admin-API error response
+ * round-trips through this OR a route-specific extension of it.
+ *
+ * Optional fields:
+ *   - `message` — human-readable; present on every error today, but
+ *     marked optional because the closed-enum `code` is the stable
+ *     contract; future error classes might omit `message` if the
+ *     code alone carries enough information.
+ *   - `missing` — `FORBIDDEN` responses carry the missing capability
+ *     list per `design-auth-rbac.md` Q3 lock; reserved at the base
+ *     so test assertions don't have to discriminate by code first.
+ */
+export const ErrorResponseSchema = z.object({
+  code: ErrorCodeSchema,
+  message: z.string().optional(),
+  missing: z.array(z.string()).optional(),
+})
+export type ErrorResponse = z.infer<typeof ErrorResponseSchema>

--- a/packages/gazetta/src/admin-api/schemas/index.ts
+++ b/packages/gazetta/src/admin-api/schemas/index.ts
@@ -22,6 +22,7 @@
  *
  * Add new endpoint modules here as they move to schema-validated contracts.
  */
+export * from './error.js'
 export * from './pages.js'
 export * from './fragments.js'
 export * from './archive.js'

--- a/packages/gazetta/tests/admin-api-error-schema.test.ts
+++ b/packages/gazetta/tests/admin-api-error-schema.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Schema-level coverage for `ErrorResponseSchema` and `ErrorCodeSchema`.
+ *
+ * The schema is now the contract every admin-API error test asserts
+ * against (per `docs/audits/test-quality-with-ai.md` cycle 1
+ * recommendation 1). Validating the schema's own shape protects the
+ * downstream tests from silent contract drift.
+ *
+ * Per rule 26 (test-isolation paranoia): no shared state; every test
+ * works against literal payloads.
+ */
+import { describe, expect, it } from 'vitest'
+import { ErrorCodeSchema, ErrorResponseSchema } from '../src/admin-api/schemas/error.js'
+
+describe('ErrorCodeSchema — closed enum of admin-API error codes', () => {
+  it('accepts every documented error code', () => {
+    const codes = [
+      'AI_ADAPTER_FAILED',
+      'AI_ADAPTER_UNAVAILABLE',
+      'ARCHIVED_NAME_CONFLICT',
+      'ASSET_MANIFEST_NOT_FOUND',
+      'BAD_REQUEST',
+      'FORBIDDEN',
+      'HOOK_CANCELLED',
+      'NOT_FOUND',
+      'PUBLISH_AUDIT_FAILED',
+      'STALE',
+      'UNAUTHENTICATED',
+      'VALIDATION_FAILED',
+    ]
+    for (const code of codes) {
+      expect(() => ErrorCodeSchema.parse(code)).not.toThrow()
+    }
+  })
+
+  it('rejects unknown codes (closed-enum invariant)', () => {
+    // Closed enum prevents drift: a route emitting an undocumented
+    // code fails schema validation in tests, surfacing the missing
+    // entry before it ships.
+    expect(() => ErrorCodeSchema.parse('NEW_CODE')).toThrow()
+    expect(() => ErrorCodeSchema.parse('bad_request')).toThrow() // case-sensitive
+    expect(() => ErrorCodeSchema.parse('')).toThrow() // empty rejected
+  })
+})
+
+describe('ErrorResponseSchema — shape of admin-API error responses', () => {
+  it('accepts the canonical { code, message } shape', () => {
+    const body = ErrorResponseSchema.parse({
+      code: 'BAD_REQUEST',
+      message: 'Invalid locale code: NOT_A_LOCALE',
+    })
+    expect(body.code).toBe('BAD_REQUEST')
+    expect(body.message).toBe('Invalid locale code: NOT_A_LOCALE')
+  })
+
+  it('accepts FORBIDDEN with a missing-capabilities list', () => {
+    // Per design-auth-rbac.md Q3 lock: FORBIDDEN responses carry the
+    // missing capability list. The base schema reserves this field so
+    // tests don't have to discriminate by code first.
+    const body = ErrorResponseSchema.parse({
+      code: 'FORBIDDEN',
+      message: 'Missing capability',
+      missing: ['edit:pages'],
+    })
+    expect(body.code).toBe('FORBIDDEN')
+    expect(body.missing).toEqual(['edit:pages'])
+  })
+
+  it('accepts code without message (forward-compat for terse error classes)', () => {
+    // `message` is optional — future error classes might omit it if
+    // the code alone carries enough information. Schema must allow it.
+    const body = ErrorResponseSchema.parse({ code: 'NOT_FOUND' })
+    expect(body.code).toBe('NOT_FOUND')
+    expect(body.message).toBeUndefined()
+  })
+
+  it('rejects responses missing the code field', () => {
+    expect(() => ErrorResponseSchema.parse({ message: 'oops' })).toThrow()
+  })
+
+  it('rejects responses with an unknown code (closed-enum)', () => {
+    expect(() => ErrorResponseSchema.parse({ code: 'WHO_KNOWS', message: 'oops' })).toThrow()
+  })
+
+  it('rejects empty body', () => {
+    // The textbook tautology survivor from cycle 1: assets.ts:404
+    // mutated `c.json({ code: 'BAD_REQUEST', message: '...' }, 400)`
+    // to `c.json({}, 400)` and tests stayed green because they only
+    // checked status. Schema parse on the body would have caught it.
+    expect(() => ErrorResponseSchema.parse({})).toThrow()
+  })
+
+  it('rejects responses with empty-string code (the cycle 1 mutation)', () => {
+    // assets.ts:61 survived `code: 'BAD_REQUEST'` → `code: ''`. Empty
+    // string isn't a valid enum member; schema parse rejects it.
+    expect(() => ErrorResponseSchema.parse({ code: '', message: 'oops' })).toThrow()
+  })
+
+  it('rejects responses with non-string code', () => {
+    expect(() => ErrorResponseSchema.parse({ code: 400, message: 'oops' })).toThrow()
+  })
+
+  it('rejects missing as non-array', () => {
+    // Forward-compat: if a future error class accidentally emits
+    // `missing: 'edit:pages'` instead of `['edit:pages']`, schema
+    // parse rejects it before consumers see the malformed shape.
+    expect(() =>
+      ErrorResponseSchema.parse({
+        code: 'FORBIDDEN',
+        message: 'oops',
+        missing: 'edit:pages',
+      }),
+    ).toThrow()
+  })
+})

--- a/packages/gazetta/tests/admin-api-suggest-alt.test.ts
+++ b/packages/gazetta/tests/admin-api-suggest-alt.test.ts
@@ -11,12 +11,28 @@ import { Hono } from 'hono'
 import sharp from 'sharp'
 import { assetRoutes } from '../src/admin-api/routes/assets.js'
 import { staticSourceResolver, createSourceContext } from '../src/admin-api/source-context.js'
+import { ErrorResponseSchema } from '../src/admin-api/schemas/error.js'
 import { anthropicProvider } from '../src/alt/anthropic.js'
 import { ollamaProvider } from '../src/alt/ollama.js'
 import { principalMiddleware } from '../src/admin-api/middleware/principal.js'
 import { auditMiddleware } from '../src/admin-api/middleware/audit.js'
 import type { SiteManifest } from '../src/types.js'
 import { memoryStorage, type MemoryStorage } from './_helpers/memory-storage.js'
+
+/**
+ * Assert that an error response round-trips through the shared
+ * error-response schema AND carries a non-empty `message`. Per
+ * `docs/audits/test-quality-with-ai.md` cycle 1: status-only
+ * assertions left `code: ''` and `message: ''` mutations alive.
+ * The schema parse pins `code` to the closed enum; the explicit
+ * `message.length` assertion pins the human-readable side.
+ */
+async function expectErrorResponse(res: Response, expectedCode: string): Promise<void> {
+  const body = ErrorResponseSchema.parse(await res.json())
+  expect(body.code).toBe(expectedCode)
+  expect(body.message).toBeDefined()
+  expect(body.message!.length).toBeGreaterThan(0)
+}
 
 const ENV_KEYS = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'OLLAMA_BASE_URL'] as const
 const savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {}
@@ -219,8 +235,7 @@ describe('POST /api/assets/:name/suggest-alt — locale parameter', () => {
     const { app } = buildApp(site)
     const res = await app.request('/api/assets/hero/suggest-alt?locale=NOT_A_LOCALE!!!', { method: 'POST' })
     expect(res.status).toBe(400)
-    const body = await res.json()
-    expect(body.code).toBe('BAD_REQUEST')
+    await expectErrorResponse(res, 'BAD_REQUEST')
   })
 })
 
@@ -232,8 +247,7 @@ describe('POST /api/assets/:name/suggest-alt — unavailable', () => {
     await seedAsset(storage)
     const res = await app.request('/api/assets/hero/suggest-alt', { method: 'POST' })
     expect(res.status).toBe(503)
-    const body = await res.json()
-    expect(body.code).toBe('AI_ADAPTER_UNAVAILABLE')
+    await expectErrorResponse(res, 'AI_ADAPTER_UNAVAILABLE')
   })
 
   it('503s when site manifest is unavailable on source', async () => {
@@ -242,8 +256,7 @@ describe('POST /api/assets/:name/suggest-alt — unavailable', () => {
     await seedAsset(storage)
     const res = await app.request('/api/assets/hero/suggest-alt', { method: 'POST' })
     expect(res.status).toBe(503)
-    const body = await res.json()
-    expect(body.code).toBe('AI_ADAPTER_UNAVAILABLE')
+    await expectErrorResponse(res, 'AI_ADAPTER_UNAVAILABLE')
   })
 
   it('502s when the adapter is configured but the SDK call fails (no msw stub)', async () => {
@@ -284,8 +297,7 @@ describe('POST /api/assets/:name/suggest-alt — failed', () => {
     try {
       const res = await app.request('/api/assets/hero/suggest-alt', { method: 'POST' })
       expect(res.status).toBe(502)
-      const body = await res.json()
-      expect(body.code).toBe('AI_ADAPTER_FAILED')
+      await expectErrorResponse(res, 'AI_ADAPTER_FAILED')
     } finally {
       globalThis.fetch = originalFetch
     }
@@ -303,7 +315,6 @@ describe('POST /api/assets/:name/suggest-alt — not found', () => {
     // No asset seeded.
     const res = await app.request('/api/assets/missing/suggest-alt', { method: 'POST' })
     expect(res.status).toBe(404)
-    const body = await res.json()
-    expect(body.code).toBe('ASSET_MANIFEST_NOT_FOUND')
+    await expectErrorResponse(res, 'ASSET_MANIFEST_NOT_FOUND')
   })
 })


### PR DESCRIPTION
## Summary

Implements recommendation 1 from [`docs/audits/test-quality-with-ai.md`](https://github.com/gazetta-studio/gazetta-studio/blob/main/docs/audits/test-quality-with-ai.md). Cuts pattern 1 (error-shape tautology) on `assets.ts` as a proof-of-concept; the same migration applies to every other admin-api route in follow-ups.

## What ships

- **`packages/gazetta/src/admin-api/schemas/error.ts`** — `ErrorResponseSchema` + `ErrorCodeSchema` (closed enum of 12 documented error codes)
- **Migration of `admin-api-suggest-alt.test.ts`** — 5 error-path assertions now go through `expectErrorResponse(res, 'CODE')`, which parses the body through the schema and checks both `code` and `message`
- **`packages/gazetta/tests/admin-api-error-schema.test.ts`** — pins the schema's own shape including the cycle 1 tautology survivors (empty code, empty body, unknown code, non-array missing)

## What this kills

- ✅ `code: 'BAD_REQUEST'` → `code: ''` mutation now fails the schema parse
- ✅ `message: 'Invalid locale code'` → `message: ''` mutation now fails the `length > 0` assertion
- ✅ `c.json({ code, message }, 400)` → `c.json({}, 400)` mutation now fails the schema parse

These are the exact survivors documented at `assets.ts:61`, `assets.ts:152`, `assets.ts:404` in the cycle 1 audit doc.

## What this does NOT do

- Doesn't migrate the other ~14 admin-api test files. Each lands as a separate cut — same smallest-first discipline as the audit cycles themselves.
- Doesn't model `STALE` or `VALIDATION_FAILED` typed extras. Those have their own schemas in `pages.ts` / `validation.ts`; future work composes them with `ErrorResponseSchema` via discriminated union.
- Doesn't gate mutation score yet. That's recommendation 4 — lands after the migration sweep produces measurable improvement.

## Adjacent cleanup

Biome reformatted `.mcp.json` to its preferred single-line arrays. Kept per rule 19 (Boy Scout — small, obviously correct, adjacent to the work).

## Test plan

- [x] All schema tests green (10 cases pinning the cycle 1 mutations)
- [x] Migrated suggest-alt tests green (9 cases — no behavior change, just stricter assertions)
- [x] Full package suite clean (3 pre-existing `cli-history.test.ts` flakes unrelated to this change)
- [x] `npx tsc --noEmit` clean
- [x] `npm run format:check` clean
- [ ] CI green
- [ ] Merge with `gh pr merge --rebase --delete-branch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)