### PR TITLE
stryker: extend mutate glob to src/alt/route-handler.ts

### DIFF
--- a/.claude/rules/testing-plan.md
+++ b/.claude/rules/testing-plan.md
@@ -93,11 +93,15 @@ tests slip most easily where assertions match observed response shapes ("expect 
 the route returned"). Rule 31's failure mode lives most often at this tier; mutation
 testing is the discovery tool. Sequence:
 
-1. `packages/gazetta/src/admin-api/routes/suggest-alt.ts` — smallest route; one
-   real tautology already fixed (cross-foundation gap #4); methodology calibration.
-2. `archive.ts` — recent feature, AI-paired cuts, concentrated seam.
-3. `publish.ts` — highest blast radius; tackle once triage workflow stable.
-4. Remaining routes (`pages.ts`, `fragments.ts`, `assets.ts`, `history.ts`, …) on demand.
+1. `packages/gazetta/src/admin-api/routes/assets.ts` (where suggest-alt lives —
+   no separate `suggest-alt.ts` file as the original Q4 lock assumed) — first
+   cycle complete; see [`docs/audits/test-quality-with-ai.md`](../../docs/audits/test-quality-with-ai.md).
+2. `src/alt/route-handler.ts` — adjacent finding from cycle 1; suggest-alt
+   orchestration lives here, NOT in `admin-api/routes/assets.ts`. Added to the
+   Stryker `mutate` glob; cycle 2 audits the next nightly run.
+3. `archive.ts` — recent feature, AI-paired cuts, concentrated seam.
+4. `publish.ts` — highest blast radius; tackle once triage workflow stable.
+5. Remaining routes (`pages.ts`, `fragments.ts`, `history.ts`, …) on demand.
 
 Same smallest-first discipline as the internal-module list. Routes calling internal
 modules already covered by mutation testing produce some redundant signal; document

--- a/packages/gazetta/stryker.config.json
+++ b/packages/gazetta/stryker.config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/stryker-mutator/stryker-js/master/packages/core/schema/stryker-schema.json",
-  "_comment": "Mutation testing for high-stakes modules — history + admin-api + publish. See testing-plan.md Priority 3.1.",
+  "_comment": "Mutation testing for high-stakes modules — history + admin-api + publish + alt/route-handler. alt/route-handler.ts added per docs/audits/test-quality-with-ai.md cycle 1's adjacent finding (suggest-alt orchestration lives there, not in admin-api/routes/assets.ts). See testing-plan.md.",
   "packageManager": "npm",
   "reporters": ["html", "clear-text", "progress"],
   "testRunner": "vitest",
@@ -15,7 +15,8 @@
     "src/history-restorer.ts",
     "src/publish.ts",
     "src/publish-rendered.ts",
-    "src/admin-api/**/*.ts"
+    "src/admin-api/**/*.ts",
+    "src/alt/route-handler.ts"
   ],
   "thresholds": {
     "high": 80,


### PR DESCRIPTION
## Summary

Implements cycle 1's adjacent finding from [`docs/audits/test-quality-with-ai.md`](https://github.com/gazetta-studio/gazetta-studio/blob/main/docs/audits/test-quality-with-ai.md): suggest-alt orchestration logic lives in `src/alt/route-handler.ts`, NOT in `admin-api/routes/assets.ts`. The orchestrator was outside the Stryker `mutate` glob (`src/admin-api/**/*.ts` only) the whole time — zero mutation coverage despite being the load-bearing piece of the suggest-alt feature.

Adding the file to the glob lets the next nightly run produce mutation data for the orchestration layer; cycle 2's audit doc (separate PR) reads the result.

## What ships

- **`packages/gazetta/stryker.config.json`** — adds `"src/alt/route-handler.ts"` to the `mutate` array (single line addition)
- **`.claude/rules/testing-plan.md`** — admin-API track sequence updated:
  - s/`suggest-alt.ts`/`assets.ts`/ (the original Q4 lock named a file that doesn't exist; suggest-alt is a route inside `assets.ts`)
  - adds `route-handler.ts` as cycle 2's target
- **`packages/gazetta/stryker.config.json`** — leading `_comment` updated to reference the audit doc

## What this does NOT do

- Doesn't expand to other `src/alt/*.ts` files (anthropic, ollama, openai, suggester, config, etc.). Surgical addition matches the smallest-first discipline; broader expansion is a separate decision after triaging route-handler's survived mutants.
- Doesn't gate mutation score yet. `thresholds.break: 0` stays — observational metric until baseline stabilizes per `testing-plan.md`.

## Test plan

- [x] Stryker config still parses (no JSON syntax error)
- [x] No production code touched — config-only change
- [ ] CI green
- [ ] Merge with `gh pr merge --rebase --delete-branch`
- [ ] Next nightly mutation run picks up the new file (CI runs on schedule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)