### PR TITLE
feat(bots): transparency layer — JSONL transcripts, decision logs, replay

### DIFF
--- a/.github/workflows/flake-watcher.yml
+++ b/.github/workflows/flake-watcher.yml
@@ -60,3 +60,16 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           LOOKBACK_HOURS: ${{ inputs.lookback_hours || '48' }}
         run: npm run flake-watcher -w @gazetta/bots
+
+      # Per-investigation JSONL transcripts. A future agent can `gh run download
+      # <run-id> -n flake-watcher-transcripts` to read every tool call and
+      # decision from past runs — feeds the prompt-improvement loop documented
+      # in bots/README.md.
+      - name: Upload transcripts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: flake-watcher-transcripts
+          path: bots/transcripts/
+          if-no-files-found: ignore
+          retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ reports/
 **/targets/**/index.html
 **/targets/**/site.json
 **/targets/**/index/
+
+# Bot transcripts — uploaded as workflow artifact in CI; locally accumulate after
+# real bot runs or replays. Don't commit.
+bots/transcripts/

--- a/bots/README.md
+++ b/bots/README.md
@@ -13,9 +13,11 @@ Repo-scoped bots that run on GitHub Actions cron schedules. Each bot:
 bots/
 ├── package.json              # one workspace, one entry per bot
 ├── tsconfig.json
-├── _lib/                     # shared modules — github, claude, etc.
+├── _lib/                     # shared modules — github, claude, replay
 │   ├── github.ts
-│   └── claude.ts
+│   ├── claude.ts             # claude -p wrapper; writes JSONL transcript
+│   └── replay.ts             # rerun past investigations against current prompt
+├── transcripts/              # JSONL transcripts (gitignored; CI uploads as artifact)
 └── <bot-name>/
     ├── index.ts              # entry point
     └── prompt.md             # Claude prompt template
@@ -60,3 +62,49 @@ GITHUB_REPOSITORY=gazetta-studio/gazetta-studio GH_TOKEN=$(gh auth token) \
 | Bot | Trigger | Purpose | Workflow |
 |---|---|---|---|
 | `flake-watcher` | Daily 12:00 UTC | Detects CI flakes (run_attempt >= 2), files / comments on issues | `.github/workflows/flake-watcher.yml` |
+
+## Improving a bot
+
+Bots are designed for an agent (you, in a future session) to improve over time.
+Three signals make the loop work:
+
+1. **JSONL transcripts** — every Claude invocation writes one line per event
+   (tool call, tool result, assistant text) to `bots/transcripts/`. CI uploads
+   them as the `<bot-name>-transcripts` artifact (90-day retention). To read a
+   past run's transcripts: `gh run download <run-id> -n flake-watcher-transcripts`.
+2. **Decision-log convention** — bot prompts ask Claude to articulate
+   load-bearing decisions inline (`> Decision: ...`). The transcript captures
+   the WHY, not just the WHAT.
+3. **Outcome tags** — every comment / new issue ends with
+   `<!-- flake-watcher: run=$RUN_ID -->`. Lets you query
+   `gh issue list --search "flake-watcher: run=12345"` to find what the bot
+   touched in any past run, joining intent (transcript) with outcome (issue
+   activity).
+
+### Replay loop (the actual improvement workflow)
+
+```bash
+# 1. Pick a recent workflow run
+gh run list --workflow=flake-watcher.yml --limit 5
+
+# 2. Read transcripts to find quality issues — over-eager dedup, missed
+#    root-cause class, etc. Outcome tags let you cross-check what each
+#    investigation actually produced on the issue tracker.
+gh run download <run-id> -n flake-watcher-transcripts -D /tmp/transcripts
+
+# 3. Edit the prompt (bots/<bot-name>/prompt.md)
+
+# 4. Replay the same flakes against the new prompt — writes side-by-side
+#    transcripts to bots/transcripts/<bot>/replay-from-<source-run>/.
+npm run replay -w @gazetta/bots <bot-name> <source-run-id>
+
+# 5. Diff <run-id>-original.jsonl vs <run-id>-replay.jsonl per investigation;
+#    decide if the change is an improvement.
+
+# 6. Open a PR with the prompt change; cite which past runs replay improved.
+```
+
+**Replay safety**: replays invoke real Claude with real tools. The current
+prompt may instruct Claude to file/comment on issues — replays will too.
+Always inspect transcripts before shipping a prompt change. Future work:
+add a `REPLAY=1` env that the prompt can read to suppress side effects.

--- a/bots/_lib/claude.ts
+++ b/bots/_lib/claude.ts
@@ -8,8 +8,18 @@
  * Auth: CLAUDE_CODE_OAUTH_TOKEN env var. The Claude Code CLI reads it
  * automatically — no flag needed. Bills against the Claude account's
  * subscription rather than per-token API spend.
+ *
+ * Transparency: Claude is invoked with `--output-format stream-json --verbose`
+ * so every tool call, tool result, and assistant message lands as one JSON
+ * event per line. The wrapper writes the raw JSONL to a transcript file (for
+ * a future agent to read) AND renders a human-readable summary to stdout
+ * (for live workflow log viewing). See `bots/README.md` "Improving the bot"
+ * for how the transcripts feed the replay loop.
  */
-import { spawnSync } from 'node:child_process'
+import { spawn } from 'node:child_process'
+import { createWriteStream } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
 
 export interface ClaudeOptions {
   /** The prompt content (system + user combined). */
@@ -24,6 +34,12 @@ export interface ClaudeOptions {
    * Working directory for tool calls. Default `process.cwd()`.
    */
   cwd?: string
+  /**
+   * Path to write the raw JSONL transcript to. Required — agents replaying
+   * past investigations read transcripts; if you don't want one, you don't
+   * want this wrapper.
+   */
+  transcriptPath: string
 }
 
 export interface ClaudeResult {
@@ -31,30 +47,182 @@ export interface ClaudeResult {
   exitCode: number
   /** True when claude exited 0. */
   success: boolean
+  /** Path the JSONL transcript was written to. */
+  transcriptPath: string
 }
 
 /**
- * Run `claude -p` headless. Streams stdout/stderr to the parent process so
- * the bot's logs show Claude's tool-call output inline.
+ * Stream-json event shapes (only the fields we read).
+ *
+ * The schema isn't documented as stable — we use the minimum surface that
+ * survives version bumps. Anything we don't recognise just falls through to
+ * the raw transcript file.
+ */
+interface StreamEventBase {
+  type: string
+}
+interface AssistantMessage extends StreamEventBase {
+  type: 'assistant'
+  message: {
+    content: Array<
+      { type: 'text'; text: string } | { type: 'tool_use'; name: string; input: Record<string, unknown>; id: string }
+    >
+  }
+}
+interface UserMessage extends StreamEventBase {
+  type: 'user'
+  message: {
+    content: Array<
+      | { type: 'tool_result'; tool_use_id: string; content: string | Array<{ type: string; text?: string }> }
+      | { type: 'text'; text: string }
+    >
+  }
+}
+interface ResultEvent extends StreamEventBase {
+  type: 'result'
+  is_error: boolean
+  result?: string
+  duration_ms?: number
+  num_turns?: number
+}
+
+/**
+ * Run `claude -p` headless. Writes raw JSONL transcript to disk; renders a
+ * human-readable summary to stdout in real time.
  *
  * Flag rationale:
- *   --print               : non-interactive, exit after response
- *   --allowedTools <list> : restrict to the tools the prompt actually needs
- *   --dangerously-skip-permissions : no human in CI to approve tool calls;
- *                           --allowedTools is the safety boundary
+ *   --print                       : non-interactive, exit after response
+ *   --output-format stream-json   : emit one JSON event per line — required
+ *                                   for the transcript + summary split
+ *   --verbose                     : required alongside stream-json (CLI
+ *                                   refuses without it)
+ *   --allowedTools <list>         : restrict to tools the prompt needs
+ *   --dangerously-skip-permissions: no human in CI to approve tool calls;
+ *                                   --allowedTools is the safety boundary
  *
  * Do NOT pass --bare — it disables OAuth token reading per the CLI docs.
  */
-export function runClaude(opts: ClaudeOptions): ClaudeResult {
+export async function runClaude(opts: ClaudeOptions): Promise<ClaudeResult> {
   const tools = opts.allowedTools ?? ['Bash']
-  const result = spawnSync(
-    'claude',
-    ['--print', '--allowedTools', tools.join(','), '--dangerously-skip-permissions', opts.prompt],
-    {
-      stdio: 'inherit',
-      cwd: opts.cwd ?? process.cwd(),
-      env: process.env,
-    },
-  )
-  return { exitCode: result.status ?? 1, success: result.status === 0 }
+  await mkdir(dirname(opts.transcriptPath), { recursive: true })
+  const transcript = createWriteStream(opts.transcriptPath, { flags: 'w' })
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      'claude',
+      [
+        '--print',
+        '--output-format',
+        'stream-json',
+        '--verbose',
+        '--allowedTools',
+        tools.join(','),
+        '--dangerously-skip-permissions',
+        opts.prompt,
+      ],
+      { cwd: opts.cwd ?? process.cwd(), env: process.env, stdio: ['ignore', 'pipe', 'inherit'] },
+    )
+
+    // Buffer stdout to handle JSONL events split across chunks. Each complete
+    // line is parsed for the human summary AND written verbatim to the
+    // transcript. Anything we can't parse is still preserved in the transcript.
+    let stdoutBuffer = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdoutBuffer += chunk.toString('utf-8')
+      let nlIndex = stdoutBuffer.indexOf('\n')
+      while (nlIndex !== -1) {
+        const line = stdoutBuffer.slice(0, nlIndex)
+        stdoutBuffer = stdoutBuffer.slice(nlIndex + 1)
+        if (line.trim()) {
+          transcript.write(`${line}\n`)
+          renderSummaryLine(line)
+        }
+        nlIndex = stdoutBuffer.indexOf('\n')
+      }
+    })
+
+    child.on('error', err => {
+      transcript.end()
+      reject(err)
+    })
+    child.on('close', code => {
+      // Flush any tail without trailing newline.
+      if (stdoutBuffer.trim()) {
+        transcript.write(`${stdoutBuffer}\n`)
+        renderSummaryLine(stdoutBuffer)
+      }
+      transcript.end()
+      const exitCode = code ?? 1
+      resolve({ exitCode, success: exitCode === 0, transcriptPath: opts.transcriptPath })
+    })
+  })
+}
+
+/**
+ * Render one stream-json line to a human-readable summary on stdout.
+ *
+ * Format conventions:
+ *   - Tool calls:   "→ Bash: gh issue list ..."  (truncated args)
+ *   - Tool results: "  ← (123 chars)"            (size only — full content
+ *                                                 is in the transcript)
+ *   - Text output:  "▸ ..."                     (Claude's natural-language
+ *                                                 reasoning, decision logs)
+ *   - Final result: "✓ done in 12s, 5 turns"     OR "✗ error after Ns"
+ *
+ * Anything unrecognised is silently skipped from the summary; raw is in the
+ * transcript regardless.
+ */
+function renderSummaryLine(line: string): void {
+  let event: StreamEventBase
+  try {
+    event = JSON.parse(line) as StreamEventBase
+  } catch {
+    return // Non-JSON line; raw is in transcript.
+  }
+
+  if (event.type === 'assistant') {
+    const msg = event as AssistantMessage
+    for (const block of msg.message.content) {
+      if (block.type === 'text') {
+        // Render multi-line text with each line prefixed for readability.
+        for (const textLine of block.text.split('\n')) {
+          if (textLine.trim()) console.log(`  ▸ ${textLine}`)
+        }
+      } else if (block.type === 'tool_use') {
+        console.log(`  → ${block.name}: ${summarizeToolInput(block.name, block.input)}`)
+      }
+    }
+  } else if (event.type === 'user') {
+    const msg = event as UserMessage
+    for (const block of msg.message.content) {
+      if (block.type === 'tool_result') {
+        const size = typeof block.content === 'string' ? block.content.length : JSON.stringify(block.content).length
+        console.log(`    ← (${size} chars)`)
+      }
+    }
+  } else if (event.type === 'result') {
+    const r = event as ResultEvent
+    const seconds = r.duration_ms ? Math.round(r.duration_ms / 1000) : '?'
+    if (r.is_error) {
+      console.log(`  ✗ Claude reported error after ${seconds}s`)
+    } else {
+      console.log(`  ✓ done in ${seconds}s, ${r.num_turns ?? '?'} turns`)
+    }
+  }
+}
+
+/**
+ * Trim a tool-call's input to a one-line summary. The full input is in the
+ * transcript; this is for the live log skim.
+ */
+function summarizeToolInput(name: string, input: Record<string, unknown>): string {
+  if (name === 'Bash' && typeof input.command === 'string') {
+    return truncate(input.command, 120)
+  }
+  // Generic fallback: stringify, truncate.
+  return truncate(JSON.stringify(input), 120)
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s
 }

--- a/bots/_lib/replay.ts
+++ b/bots/_lib/replay.ts
@@ -1,0 +1,163 @@
+/**
+ * Replay harness — re-investigate a past flake against the current prompt.
+ *
+ * Use case: an agent improving a bot's prompt wants to know whether the new
+ * prompt produces better output than the old one. This module:
+ *
+ *   1. Pulls the transcripts artifact from a past workflow run via gh CLI
+ *   2. Reads each transcript to recover (a) the original prompt, (b) the
+ *      flake's RUN_ID input, (c) the original outcome
+ *   3. Re-invokes the current prompt against each flake's RUN_ID, writing a
+ *      new transcript next to the old one
+ *   4. The agent reads both old + new transcripts and decides whether to
+ *      keep the prompt change
+ *
+ * Storage layout:
+ *   bots/transcripts/<bot-name>/<replay-source>/
+ *     <past-run-id>-original.jsonl    (recovered from artifact)
+ *     <past-run-id>-replay.jsonl      (current prompt against same flake)
+ *
+ * Usage:
+ *   npx tsx bots/_lib/replay.ts <bot-name> <past-workflow-run-id>
+ *   # e.g. npx tsx bots/_lib/replay.ts flake-watcher 25627966006
+ *
+ * The new transcripts are written to disk only — no issue/comment side
+ * effects — because replay's purpose is evaluation, not action. The agent
+ * is expected to read the new transcripts and decide if a real run with the
+ * updated prompt is warranted.
+ *
+ * Note: actually preventing side effects in replayed Claude calls would
+ * require the prompt to know about replay mode AND for Claude to honour it.
+ * Today we rely on the agent running replay to inspect output before
+ * shipping — replay isn't safe to run unattended.
+ */
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { runClaude } from './claude.js'
+
+interface PastInvestigation {
+  runId: string
+  originalTranscriptPath: string
+}
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..')
+const BOTS_DIR = resolve(HERE, '..')
+const REPO_ROOT = resolve(BOTS_DIR, '..')
+
+async function main(): Promise<void> {
+  const [, , botName, sourceRunId] = process.argv
+  if (!botName || !sourceRunId) {
+    console.error('Usage: tsx bots/_lib/replay.ts <bot-name> <past-workflow-run-id>')
+    console.error('Example: tsx bots/_lib/replay.ts flake-watcher 25627966006')
+    process.exit(2)
+  }
+
+  const botDir = resolve(BOTS_DIR, botName)
+  const promptPath = resolve(botDir, 'prompt.md')
+  if (!existsSync(promptPath)) {
+    console.error(`No prompt.md found at ${promptPath} — is "${botName}" a real bot?`)
+    process.exit(2)
+  }
+
+  // Stage transcripts under bots/transcripts/<bot>/replay-from-<source-run>/
+  const stagingDir = resolve(BOTS_DIR, 'transcripts', botName, `replay-from-${sourceRunId}`)
+  if (existsSync(stagingDir)) {
+    console.log(`Cleaning previous staging at ${stagingDir}`)
+    rmSync(stagingDir, { recursive: true, force: true })
+  }
+  mkdirSync(stagingDir, { recursive: true })
+
+  // Step 1: download artifact from past run.
+  console.log(`Downloading transcripts artifact from run ${sourceRunId}...`)
+  const dl = spawnSync('gh', ['run', 'download', sourceRunId, '-n', `${botName}-transcripts`, '-D', stagingDir], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+  })
+  if (dl.status !== 0) {
+    console.error(`Failed to download artifact "${botName}-transcripts" from run ${sourceRunId}.`)
+    console.error('Is the artifact still available (90-day default retention)? Was the bot named correctly?')
+    process.exit(1)
+  }
+
+  // Step 2: enumerate the past investigations.
+  const past = enumeratePastInvestigations(stagingDir)
+  if (past.length === 0) {
+    console.error(`No transcripts found in ${stagingDir} after download.`)
+    process.exit(1)
+  }
+  console.log(`\nFound ${past.length} past investigation(s) to replay:`)
+  for (const p of past) console.log(`  run=${p.runId}`)
+
+  // Step 3: rename originals so replays land beside them.
+  for (const p of past) {
+    const originalRenamed = resolve(stagingDir, `${p.runId}-original.jsonl`)
+    spawnSync('mv', [p.originalTranscriptPath, originalRenamed], { stdio: 'inherit' })
+    p.originalTranscriptPath = originalRenamed
+  }
+
+  // Step 4: load the CURRENT prompt and replay.
+  const promptTemplate = readFileSync(promptPath, 'utf-8')
+  for (const p of past) {
+    console.log(`\n=== Replaying run ${p.runId} against current prompt ===`)
+    const replayPath = resolve(stagingDir, `${p.runId}-replay.jsonl`)
+    const prompt = `${promptTemplate}
+
+RUN_ID=${p.runId}
+LOOKBACK_HOURS=replay`
+    try {
+      const result = await runClaude({ prompt, transcriptPath: replayPath })
+      if (!result.success) {
+        console.log(`Warning: replay of ${p.runId} exited ${result.exitCode}; continuing.`)
+      }
+    } catch (err) {
+      console.log(`Warning: replay of ${p.runId} threw: ${err}; continuing.`)
+    }
+  }
+
+  console.log(`\nReplay complete. Compare transcripts in: ${stagingDir}`)
+  console.log('Per past investigation: <run-id>-original.jsonl vs <run-id>-replay.jsonl')
+  console.log('\nWARNING: replays may have produced real side effects (issue comments, new')
+  console.log('issues) if the current prompt instructs Claude to do so. Inspect before shipping.')
+}
+
+/**
+ * Find every JSONL transcript downloaded from the source artifact and
+ * recover its RUN_ID by parsing the original system event.
+ *
+ * Transcript filenames follow the pattern written by the bot:
+ *   <iso-timestamp>-run-<run-id>.jsonl
+ * but we also extract from the JSONL contents as a fallback.
+ */
+function enumeratePastInvestigations(stagingDir: string): PastInvestigation[] {
+  const out: PastInvestigation[] = []
+  for (const entry of readdirSync(stagingDir)) {
+    if (!entry.endsWith('.jsonl')) continue
+    const fullPath = resolve(stagingDir, entry)
+    const runId = extractRunIdFromFilename(entry) ?? extractRunIdFromContents(fullPath)
+    if (!runId) {
+      console.warn(`Could not recover RUN_ID from ${entry}; skipping.`)
+      continue
+    }
+    out.push({ runId, originalTranscriptPath: fullPath })
+  }
+  return out
+}
+
+function extractRunIdFromFilename(name: string): string | null {
+  const m = name.match(/run-(\d+)\.jsonl$/)
+  return m ? m[1] : null
+}
+
+function extractRunIdFromContents(path: string): string | null {
+  // The user-prompt event includes the RUN_ID=N line we appended.
+  const contents = readFileSync(path, 'utf-8')
+  const m = contents.match(/RUN_ID=(\d+)/)
+  return m ? m[1] : null
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err)
+  process.exit(1)
+})

--- a/bots/flake-watcher/index.ts
+++ b/bots/flake-watcher/index.ts
@@ -22,7 +22,7 @@
  * Run in CI:
  *   .github/workflows/flake-watcher.yml (daily 12:00 UTC)
  */
-import { readFileSync } from 'node:fs'
+import { mkdirSync, readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { findFlakeCandidates, findWorkflowId, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
@@ -34,6 +34,10 @@ const PROMPT_PATH = resolve(HERE, 'prompt.md')
 const LOOKBACK_HOURS = Number(process.env.LOOKBACK_HOURS ?? '48')
 const WORKFLOW_NAME = process.env.WORKFLOW_NAME ?? 'CI'
 const DRY_RUN = process.env.DRY_RUN === '1'
+// Transcripts are uploaded as a workflow artifact. One JSONL per investigated
+// run, named by the run ID + ISO date so a future agent can browse them.
+const TRANSCRIPTS_DIR = resolve(HERE, '../transcripts')
+const RUN_TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')
 
 async function main(): Promise<void> {
   const repo = repoFromEnv()
@@ -63,22 +67,30 @@ async function main(): Promise<void> {
   }
 
   const promptTemplate = readFileSync(PROMPT_PATH, 'utf-8')
+  mkdirSync(TRANSCRIPTS_DIR, { recursive: true })
 
   for (const flake of flakes) {
-    console.log(`\n=== Investigating run ${flake.runId} ===`)
+    console.log(`\n=== Investigating run ${flake.runId} (sha ${flake.headSha.slice(0, 8)}) ===`)
     const prompt = `${promptTemplate}
 
 RUN_ID=${flake.runId}
 LOOKBACK_HOURS=${LOOKBACK_HOURS}`
 
-    const result = runClaude({ prompt })
-    if (!result.success) {
-      // Don't let one failed investigation kill the whole job. Log and move on.
-      console.log(`Warning: investigation of run ${flake.runId} exited ${result.exitCode}; continuing.`)
+    const transcriptPath = resolve(TRANSCRIPTS_DIR, `${RUN_TIMESTAMP}-run-${flake.runId}.jsonl`)
+    console.log(`(transcript: ${transcriptPath})`)
+
+    try {
+      const result = await runClaude({ prompt, transcriptPath })
+      if (!result.success) {
+        // Don't let one failed investigation kill the whole job.
+        console.log(`Warning: investigation of run ${flake.runId} exited ${result.exitCode}; continuing.`)
+      }
+    } catch (err) {
+      console.log(`Warning: investigation of run ${flake.runId} threw: ${err}; continuing.`)
     }
   }
 
-  console.log('\nFlake watcher complete.')
+  console.log(`\nFlake watcher complete. Transcripts: ${TRANSCRIPTS_DIR}`)
 }
 
 main().catch(err => {

--- a/bots/flake-watcher/prompt.md
+++ b/bots/flake-watcher/prompt.md
@@ -149,10 +149,19 @@ workflow logs.
 
    | Label | When | gh command |
    |---|---|---|
-   | `flake` | Always — every issue you file or comment on | `gh issue edit <N> --add-label flake` |
+   | `flake` | Default on every issue (see note below) | `gh issue edit <N> --add-label flake` |
    | `needs triage` | Always on NEW issues. Skip if a human has already commented on the issue (signals they've started triaging). | `gh issue edit <N> --add-label "needs triage"` |
    | `area: <X>` | Always — pick from path → area mapping below | `gh issue edit <N> --add-label "area: cms"` |
    | `recurring-flake` | When the issue has 3+ occurrences across distinct days | `gh issue edit <N> --add-label recurring-flake` |
+
+   **`flake` label semantics.** The `flake` label classifies an issue as "CI
+   test-flake — intermittent failure, not a real bug until proven otherwise
+   via triage." Apply it by default on every issue you file. Skip ONLY if
+   your hypothesis section concludes the failure is structurally a real
+   bug masquerading as a flake (e.g. an equal-millisecond ordering race in
+   a test, a permanently-wrong assertion that happens to pass under timing
+   coincidence). In that case, say so in the body and let humans decide
+   whether to add the label.
 
    **Path → area mapping:**
 

--- a/bots/flake-watcher/prompt.md
+++ b/bots/flake-watcher/prompt.md
@@ -14,6 +14,42 @@ existing issue or file a new one.
   need the failed attempt(s) specifically.
 - `LOOKBACK_HOURS` — the window the watcher scanned (for context in issue bodies)
 
+## Decision-log convention
+
+Your transcript (the JSONL stream of every tool call and message) is the
+audit trail a future agent will read to improve this bot. The transcript
+captures WHAT you did automatically; you must also articulate WHY.
+
+Before each non-trivial decision (new tool call, choosing comment-vs-file,
+applying a label, deciding evidence is insufficient), emit a one-line
+text block in the form:
+
+> Decision: <one sentence — what choice and why>
+
+Examples:
+
+> Decision: searching open issues for "publish.spec.ts" because the failed test path matches that file.
+> Decision: this run ID already appears in #268's latest comment; skipping to avoid duplicate noise.
+> Decision: filing a new issue rather than commenting on #268 because this is the test name "first-publish destination" which #268 doesn't cover.
+
+Do NOT narrate every tool call (e.g. don't say "running gh issue list now").
+Only call out load-bearing choices — the ones a reviewer would want to
+see explained.
+
+## Outcome tag convention
+
+Every comment you post AND every new issue body you file MUST end with
+this exact line:
+
+```
+<!-- flake-watcher: run=$RUN_ID -->
+```
+
+(Substitute the actual run ID.) This lets a future agent query "which
+issues did the bot touch in run X?" via `gh issue list --search
+"flake-watcher: run=12345"` without timestamp-correlating against
+workflow logs.
+
 ## Process
 
 1. **Find the failed attempt(s).** GitHub stores each retry as a numbered

--- a/bots/flake-watcher/prompt.md
+++ b/bots/flake-watcher/prompt.md
@@ -93,9 +93,24 @@ workflow logs.
    ```
 
    Use the test file name (e.g. `publish.spec.ts`, `admin-api-archive-review.test.ts`)
-   as the search term. Match conservatively — the same test file may host both a
-   tracked flake and a real bug; read the issue body to confirm the failure
-   pattern matches.
+   as the search term. **Match grain: per failure mode, NOT per test file.**
+
+   - The same test file can host multiple distinct flakes (different test cases
+     with different root causes — e.g. one timing race in a tree-render test,
+     a separate state-leak in a theme test in the same file). File a separate
+     issue per failure mode.
+   - "Failure mode" = same test path + same line (or same locator + same
+     symptom). Two failures of `publish.spec.ts:33` are the same mode; a
+     failure of `:33` and a failure of `:199` are different modes.
+   - When deciding "match or new":
+     - **Match (comment)** if the existing issue's title/body describes
+       the same test path and the same symptom you're seeing
+     - **New issue** if the existing issue covers a different test or a
+       different symptom in the same file
+   - Read the existing issue's body to verify, don't title-match. The bot
+     filed both #286 and #290 against `publish.spec.ts` because they're
+     different tests (`:33` vs `:199`) with different root causes — that's
+     the right call.
 
 3. **Dedup against this run.** If you find a matching open issue, search its
    comments for the run ID:
@@ -128,17 +143,43 @@ workflow logs.
      uncertainty — distinguish "flake" (timing race) from "structural bug
      hiding as flake" (the test is wrong).
 
-5. **Recurring-flake label.** If the matched issue has 3+ historical
-   occurrences across different days (count distinct dates in the comment
-   thread), apply the `recurring-flake` label:
+5. **Labelling.** Apply labels per the table below. New issues get the full
+   set; commenting on an existing issue, ADD any missing labels (don't
+   remove ones humans applied during triage).
+
+   | Label | When | gh command |
+   |---|---|---|
+   | `flake` | Always — every issue you file or comment on | `gh issue edit <N> --add-label flake` |
+   | `needs triage` | Always on NEW issues. Skip if a human has already commented on the issue (signals they've started triaging). | `gh issue edit <N> --add-label "needs triage"` |
+   | `area: <X>` | Always — pick from path → area mapping below | `gh issue edit <N> --add-label "area: cms"` |
+   | `recurring-flake` | When the issue has 3+ occurrences across distinct days | `gh issue edit <N> --add-label recurring-flake` |
+
+   **Path → area mapping:**
+
+   | Test path prefix | Area label |
+   |---|---|
+   | `tests/e2e/` | `area: cms` (admin frontend exercised end-to-end) |
+   | `apps/admin/tests/` | `area: cms` |
+   | `packages/gazetta/tests/cli*` or `tests/cli-*` | `area: cli` |
+   | `packages/gazetta/tests/admin-api*` | `area: cms` (admin API is the CMS server side) |
+   | `packages/gazetta/tests/` (anything else — render, hash, sidecars, validators) | `area: renderer` |
+   | `packages/gazetta/tests/` involving storage providers | `area: storage` |
+   | `packages/gazetta/tests/` involving template loading | `area: templates` |
+
+   When a test path doesn't fit the mapping cleanly, pick the closest area
+   and note your reasoning via a `> Decision: ...` line. Don't apply
+   multiple `area:` labels to one issue — pick one.
+
+   **Apply all labels in one call** to avoid multiple API roundtrips:
 
    ```
-   gh label create recurring-flake --color "fbca04" --description "Same flake observed 3+ times across different days" --force
-   gh issue edit <NUMBER> --add-label recurring-flake
+   gh issue edit <N> --add-label "flake,needs triage,area: cms"
    ```
 
-   The label is the signal that root-cause work should be prioritized over
-   continued tracking.
+   For a recurring flake on an existing issue:
+   ```
+   gh issue edit <N> --add-label "flake,recurring-flake,area: cms"
+   ```
 
 ## New-issue template
 
@@ -196,8 +237,9 @@ distinction for whoever picks this up.>
 - **Link related issues.** If the new failure looks like an existing issue's
   cousin (same root-cause class, different test), link it: "Possibly related:
   see issue #<N>'s discussion of <root cause>."
-- **Don't apply the `bug` label.** Issue templates already include it via
-  workflow defaults; let humans triage real bug-vs-flake classification.
+- **Don't apply the `bug` label** — that's a triage decision (real-bug vs
+  flake-vs-test-quality-issue) reserved for humans. Apply only the labels in
+  the Labelling section above.
 - **Stay terse.** Issue bodies should fit on one screen. The pattern + one
   hypothesis + fix options. No preamble, no summary.
 - **Do not ask the user questions** — you're running headless in CI. If

--- a/bots/package.json
+++ b/bots/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "description": "Repo-scoped bots that run on GitHub Actions cron schedules. Each bot lives in its own subdirectory and shares helpers from _lib/.",
   "scripts": {
-    "flake-watcher": "tsx flake-watcher/index.ts"
+    "flake-watcher": "tsx flake-watcher/index.ts",
+    "replay": "tsx _lib/replay.ts"
   },
   "dependencies": {
     "@octokit/rest": "^22.0.0"


### PR DESCRIPTION
## Summary

- JSONL transcript per Claude investigation, uploaded as `flake-watcher-transcripts` artifact (90-day retention) — every tool call, tool result, and assistant message captured as structured events
- Live human-readable summary streams to stdout in parallel for workflow log skim (→ tool call, ← result size, ▸ assistant text, ✓/✗ result)
- Decision-log convention in the prompt — Claude emits `> Decision: <why>` before load-bearing choices so transcripts capture reasoning, not just actions
- Outcome tags on every bot-authored comment / new issue (`<!-- flake-watcher: run=$RUN_ID -->`) — lets a future agent query which issues the bot touched in any past run via `gh issue list --search`
- Replay harness (`npm run replay -w @gazetta/bots <bot> <run-id>`) — re-invokes the current prompt against past flakes, writes new transcripts beside originals for side-by-side diffing

## Why

Goal stated by the user: let Claude Code improve the bot over time. The transparency target is an agent reading transcripts, not a human scrolling logs. Each mechanism answers a distinct question a future agent will ask:

| Question | Answered by |
|---|---|
| What did the bot do? | JSONL transcript |
| Why did it do that? | Decision-log convention |
| Did it produce useful output? | Outcome tags (joins to issue tracker) |
| Would my proposed prompt change be an improvement? | Replay harness |

## Test plan

- [x] Type-check clean
- [x] Dry-run unchanged (same 6 flakes detected in 48h window)
- [x] JSONL parser tested offline against synthetic stream (renders as designed)
- [ ] After merge: manually trigger workflow, verify the artifact uploads and contains parseable JSONL
- [ ] After 1-2 real runs accumulate, try the replay loop end-to-end

## Notes

- Replay safety: replays may produce real side effects (issue comments) because the current prompt instructs Claude to do so. Documented in README; future work to add a `REPLAY=1` env the prompt can read to suppress side effects.
- `bots/transcripts/` added to `.gitignore` — local accumulation from real bot runs / replays shouldn't be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)