### PR TITLE
feat(triage-bot): autonomous classification + auto-advance for confident bugs

### DIFF
--- a/.claude/rules/dev-glossary.md
+++ b/.claude/rules/dev-glossary.md
@@ -273,16 +273,28 @@ Two label dimensions per the
 [`triage` skill](https://github.com/anthropics/claude-skills/tree/main/skills/triage).
 **Category roles**: `bug` | `enhancement`. **State roles**: `needs-triage`
 | `needs-info` | `ready-for-agent` | `ready-for-human` | `wontfix`. Every
-triaged issue carries exactly one of each. The triage-bot may apply category
-roles + `needs-triage` only; advancing past `needs-triage` is reserved for
-maintainers via `/triage`.
+triaged issue carries exactly one of each. The triage-bot applies category
+roles autonomously; advances confident bugs to `ready-for-agent` for
+fix-bot to pick up; never advances to `needs-info` / `ready-for-human` /
+`wontfix` (those require maintainer judgment via `/triage`).
 
 **`needs-triage` (label)**:
-Default state for any issue not yet maintainer-evaluated. Applied by the
-triage-bot after first-pass enrichment. The interactive `/triage` skill
-queries this label to find work. Spelled with a hyphen per the skill's
-canonical name (the project briefly used `needs triage` with a space —
-migrated 2026-05-10).
+Skill-canonical "no bot or human has looked yet" state. The bot does NOT
+apply this label — once the bot has classified, the bot HAS looked. The
+interactive `/triage` skill queries this label for issues the bot
+hasn't gotten to (rare; typically only for issues filed before the bot
+existed). Spelled with a hyphen per the skill's canonical name (the
+project briefly used `needs triage` with a space — migrated 2026-05-10).
+
+**`triage-uncertain` (label)**:
+Bot looked but couldn't classify confidently. Applied by triage-bot when
+the issue body has both bug-language AND enhancement-language, or
+neither. The maintainer's primary morning queue:
+`gh issue list --label triage-uncertain`. Steady-state target: 1-3 per
+week. Distinct from `needs-triage` (which means "never been looked at").
+The bot's lean (if any) goes in the comment body, not the label —
+applying a category guess in the label would defeat the "trust labels
+to mean confident classification" UX.
 
 **`flake` (label)**:
 CI test-flake classification — intermittent failure, not a real bug until

--- a/bots/_lib/github.ts
+++ b/bots/_lib/github.ts
@@ -92,13 +92,20 @@ export interface IssueSummary {
 
 /**
  * State roles that indicate an issue has been advanced past the triage bot's
- * scope. The bot enriches; humans decide. Any issue carrying one of these
- * has had a maintainer judgment applied — bot stays out.
+ * re-investigation scope. Any issue carrying one of these is excluded from
+ * future bot scans:
+ *
+ *   - `needs-info` / `ready-for-human` / `wontfix` — applied by maintainer
+ *     via the `/triage` skill; bot stays out
+ *   - `ready-for-agent` — may be applied by the maintainer OR by the bot
+ *     itself (per prompt step 8e auto-advance). Either way, the next bot
+ *     surface is fix-bot, not re-triage. Triage-bot stays out.
  *
  * Mirrors the five state roles from the `/triage` skill
  * (~/.claude/skills/triage/SKILL.md). `needs-triage` is intentionally NOT
- * in this list — it's the bot's "default state" and the bot may re-enrich
- * issues sitting there.
+ * in this list — that label is reserved for the skill-canonical
+ * "no bot or human has looked yet" state, distinct from `triage-uncertain`
+ * (bot looked, couldn't classify).
  */
 const ADVANCED_STATE_ROLES = ['needs-info', 'ready-for-agent', 'ready-for-human', 'wontfix'] as const
 

--- a/bots/triage-bot/index.ts
+++ b/bots/triage-bot/index.ts
@@ -1,20 +1,26 @@
 /**
- * triage-bot — daily autonomous enrichment of incoming issues.
+ * triage-bot — daily autonomous classification of incoming issues.
  *
- * Scope: every open issue that's either labeled `needs-triage` OR completely
- * unlabeled. Per-issue, the bot reads the body + comments + linked code,
- * categorizes (bug / enhancement), applies area + needs-triage labels, runs
- * the reproducer for bugs when possible, posts findings, and (for high-
- * confidence reproduced bugs) drafts an agent brief comment.
+ * Per-issue, the bot reads the body + comments + linked code, classifies
+ * confidently as `bug` or `enhancement` when the body has concrete
+ * evidence, OR escalates as `triage-uncertain` when the body is ambiguous.
+ * For confident bugs that reproduce locally (or are producer-bot-filed),
+ * the bot also auto-advances state to `ready-for-agent` so fix-bot picks
+ * up the issue on its next cron.
  *
- * The bot NEVER advances issue state past `needs-triage` (no `ready-for-agent`,
- * no `wontfix`, no closing). Those decisions stay with maintainers via the
- * interactive `/triage` skill, which sees the bot's enrichment as starting
- * research, not as a verdict.
+ * Maintainer UX target: morning view = `gh issue list --label triage-uncertain`
+ * shows ONLY the issues the bot couldn't classify (target: 1-3 per week
+ * in steady state). Confident classifications carry no maintainer-attention
+ * label; the maintainer reviews fix-bot's PRs as the irreducible gate.
  *
- * Conventions shared with the `/triage` skill (see `bots/_lib/triage.ts`):
+ * The bot does NOT apply `needs-triage` (that label is skill-canonical
+ * "no bot or human has looked yet"). The bot does NOT advance state past
+ * `ready-for-agent` — `wontfix` / `needs-info` / `ready-for-human` are
+ * maintainer-only via the interactive `/triage` skill.
+ *
+ * Conventions shared with the `/triage` skill (~/.claude/skills/triage/):
  *   - AI disclaimer prefix on every comment
- *   - Two category roles: bug | enhancement
+ *   - Category roles: bug | enhancement (+ project-specific triage-uncertain)
  *   - Outcome-tag suffix per flake-watcher convention
  *
  * Run locally:

--- a/bots/triage-bot/prompt.md
+++ b/bots/triage-bot/prompt.md
@@ -1,12 +1,26 @@
 # Triage bot — investigation prompt
 
-You are doing first-pass triage on an open GitHub issue. The bot has already
-identified this issue as needing triage (either labeled `needs-triage` or
-unlabeled). Your job: enrich the issue with classification + context so a
-maintainer running the interactive `/triage` skill can decide state in
-seconds rather than minutes.
+You are doing first-pass triage on an open GitHub issue. Your job: classify
+the issue confidently when the evidence is concrete; flag it for the
+maintainer when ambiguous.
 
-You are NOT the decider. You enrich and recommend; humans advance state.
+**Maintainer UX target (load-bearing):** the maintainer's morning view is
+`gh issue list --label triage-uncertain` — they want to see ONLY the
+issues you couldn't classify. Confident classifications carry no
+maintainer-attention label; the classification IS the visible signal.
+
+So:
+
+- **Confident classification** → apply `bug` or `enhancement` + `area: X`.
+  No `triage-uncertain`. No `needs-triage`. The classification stands.
+- **Confident `bug` AND reproducible OR producer-bot-filed** → also apply
+  `ready-for-agent` so fix-bot picks it up next cron. (Fix-bot has its
+  own TDD-first guard: it must write a failing test first or it exits.)
+- **Uncertain** → apply `triage-uncertain` + `area: X` (skip category
+  label; you don't have one). Maintainer decides via `/triage`.
+
+You ARE the decider on category. The maintainer is the decider on state
+advancement past `ready-for-agent` (they merge the fix-bot PR or not).
 
 ## Inputs (appended below this prompt)
 
@@ -148,21 +162,51 @@ Read the full body and every comment. If prior triage notes exist (any
 comment containing "Triage Notes" or "AI during triage"), parse them so you
 don't re-do completed work.
 
-### 2. Categorize: bug or enhancement
+### 2. Categorize: bug, enhancement, or uncertain
 
-Apply EXACTLY ONE of:
-- `bug` — something is broken (reporter describes unexpected behavior, an
-  error, a regression, a failing test)
-- `enhancement` — new feature or improvement request
+Apply the **concrete-evidence rule** to decide. LLMs are over-confident
+by default — this rule keeps you grounded in the issue body's text.
 
-If unclassifiable (e.g. a question, a discussion, a meta issue), apply
-neither and explain in your comment.
+**Producer-bot recognition (check FIRST):** if the issue body contains an
+outcome tag from a known producer bot — e.g.
+`<!-- flake-watcher: run=` — classify per the producer's domain WITHOUT
+running the body-language analysis. The producer already validated the
+issue's domain by filing it. Currently:
+
+| Producer-bot tag | Classification |
+|---|---|
+| `<!-- flake-watcher: run=` | confident `bug` (CI test-flake) |
+
+Future producer bots get added here as they ship.
+
+**Body-language rule (for everything else):**
+
+| If body contains | And LACKS | → Result |
+|---|---|---|
+| Stack trace OR explicit error message OR "doesn't work" / "got X expected Y" / reproducer steps OR "broken" / "regression" | Words like "wishlist" / "would be nice" / "feature request" / "support for X" / "could we" | confident `bug` |
+| "Add X" / "support for Y" / "would be nice" / "feature request" / "could we" / "wishlist" | Stack trace / explicit error message / "broken" / "regression" / "doesn't work" | confident `enhancement` |
+| BOTH bug-language AND enhancement-language | — | `triage-uncertain` |
+| NEITHER (question, discussion, meta) | — | `triage-uncertain` |
+
+**Apply the label:**
 
 ```
+# Confident bug
 gh issue edit $ISSUE_NUMBER --add-label bug
-# or
+
+# Confident enhancement
 gh issue edit $ISSUE_NUMBER --add-label enhancement
+
+# Uncertain — DO NOT guess at category in the label; the lean goes in
+# the comment, not the label
+gh issue edit $ISSUE_NUMBER --add-label triage-uncertain
 ```
+
+**On uncertainty, the bot's lean goes in the comment, not the label.**
+Maintainers query `gh issue list --label triage-uncertain` for issues
+that need their judgment; the comment they read explains your lean and
+why the body was ambiguous. See the escalation comment template in
+step 7 below.
 
 ### 3. Apply `area:` label
 
@@ -182,13 +226,19 @@ match by reading the issue body for file paths or feature names:
 If the issue spans multiple areas, pick the most specific one and explain
 via Decision log. Don't apply multiple `area:` labels.
 
-### 4. Apply `needs-triage`
+### 4. NEVER apply `needs-triage`
 
-Always apply `needs-triage` after enrichment — it signals "bot has done
-first pass, maintainer should decide state":
+`needs-triage` is the skill-canonical "no bot or human has looked yet"
+state. Do NOT apply it — once you've classified (confidently or as
+`triage-uncertain`), the bot HAS looked. The label means something
+different from "bot finished triage."
+
+If you encounter an issue that already has `needs-triage` AND nothing
+else (filed before the bot existed, or filed by a maintainer expecting
+manual triage), REMOVE it after applying your own labels:
 
 ```
-gh issue edit $ISSUE_NUMBER --add-label needs-triage
+gh issue edit $ISSUE_NUMBER --remove-label needs-triage
 ```
 
 ### 5. Search for duplicates
@@ -269,11 +319,39 @@ appears novel. Maintainer: design decision needed."]
 ```
 
 **If `bug`** — continue to step 8 (reproduction). This is the bot's
-highest-leverage contribution.
+highest-leverage contribution. If repro succeeds OR if this is a
+producer-bot-filed issue (e.g., flake-watcher output), advance state
+to `ready-for-agent` per step 8e so fix-bot picks it up next cron.
 
-**If unclassifiable** — STOP. Post a brief comment noting the
-classification ambiguity and what specifically is missing. Maintainer
-clarifies via `/triage`.
+**If `triage-uncertain`** — STOP. Post the escalation comment below,
+exit. Do NOT proceed to repro / agent brief / further investigation.
+The maintainer will decide via `/triage`.
+
+Escalation comment format:
+
+```
+> *This was generated by AI during triage.*
+
+⚠ **Triage uncertain — maintainer please classify.**
+
+The body contains [describe what made you uncertain — e.g., "both
+bug-language ('X doesn't work') AND enhancement-language ('would be
+nice if also Y')" OR "neither bug nor enhancement language — appears
+to be a question about Z"].
+
+**My lean:** [`bug` | `enhancement` | "no lean"], because [one-sentence
+reasoning]. But I'm not confident enough to apply that label.
+
+[If duplicate-of link from step 5, include it here]
+[If non-goals match from step 6, include it here]
+
+Maintainer: classify category + advance state via `/triage`.
+
+<!-- triage-bot: run=$RUN_ID -->
+```
+
+Apply: `triage-uncertain` + `area: X` (the area is usually unambiguous
+even when category is). NO `bug`, NO `enhancement`, NO `needs-triage`.
 
 ### 8. For BUGS only: pre-flight, then conditional reproduction
 
@@ -352,10 +430,36 @@ Emit `> Decision: classified as <class> because <signal>` before proceeding.
 
 | Outcome | Source | Action |
 |---|---|---|
-| **Confirmed** | 8c — bug reproduces locally | Post repro details + (if confident) draft agent brief (step 9) |
-| **Code analysis** | 8a — flake or 8b CI-only / env-specific | Post root-cause hypothesis + supporting code excerpts; skip step 9 |
-| **Could not reproduce** | 8c — ran the test, it passed | Post what you tried + flag as needs-info-from-reporter |
-| **Insufficient detail** | 8b — no actionable steps | Note specifically what's missing so the maintainer can ask |
+| **Confirmed** | 8c — bug reproduces locally | Post repro details + investigation notes (step 9) + auto-advance (step 8e) |
+| **Code analysis** | 8a — flake or 8b CI-only / env-specific | Post root-cause hypothesis + supporting code excerpts; skip step 9; auto-advance per 8e (producer-bot path) |
+| **Could not reproduce** | 8c — ran the test, it passed | Post what you tried + flag as needs-info-from-reporter; do NOT auto-advance |
+| **Insufficient detail** | 8b — no actionable steps | Note specifically what's missing so the maintainer can ask; do NOT auto-advance |
+
+**8e. Auto-advance to `ready-for-agent` (when warranted).**
+
+After posting investigation notes, advance state to `ready-for-agent` so
+fix-bot picks up the issue on its next cron. Apply when EITHER:
+
+- Outcome is "Confirmed" (8c — you ran the test, saw it fail), OR
+- Issue is producer-bot-filed (e.g., flake-watcher output — the producer
+  validated the failure exists by filing the issue)
+
+```
+gh issue edit $ISSUE_NUMBER --add-label ready-for-agent
+```
+
+Do NOT auto-advance when:
+- Outcome is "Could not reproduce" — fix-bot would PR fixes that don't
+  match a verified bug
+- Outcome is "Insufficient detail" — needs reporter input first
+- Issue is `triage-uncertain` — never reaches step 8
+
+**Safety net (fix-bot side):** fix-bot has a TDD-first hard rule — its
+first commit MUST be a failing test that captures the bug. If fix-bot
+can't write a failing test, it stops and posts "unable to capture this
+bug as a test" on the issue. So `ready-for-agent` is a hint, not a
+guarantee — fix-bot self-polices when the bug isn't actually
+test-capturable. This makes auto-advance safe even on flake-labeled bugs.
 
 ### 9. Post investigation notes — ONLY if repro succeeded
 
@@ -393,11 +497,12 @@ Investigation notes structure:
 
 ## Investigation notes
 
-**Note:** These are research findings for the maintainer running `/triage`,
-not a durable agent brief. File paths and line numbers below are valid as
-of this comment but may go stale. If this issue advances to
-`ready-for-agent`, the maintainer should write a behavioral agent brief
-per `~/.claude/skills/triage/AGENT-BRIEF.md`.
+**Note:** These are research findings for fix-bot AND the maintainer.
+File paths and line numbers below are valid as of this comment but may
+go stale. Fix-bot will treat the "Suspected fix locus" as a hint, not
+a contract — its TDD-first rule means it must independently confirm
+the bug via a failing test before changing code. Maintainer reviews
+the resulting PR.
 
 ## Reproduction
 
@@ -418,20 +523,39 @@ per `~/.claude/skills/triage/AGENT-BRIEF.md`.
 <!-- triage-bot: run=$RUN_ID -->
 ```
 
-## Apply all labels in one call
+## Apply labels in one call
 
-After deciding category + area + needs-triage, apply them in one gh edit
-to avoid multiple roundtrips:
+Apply all labels for the category in a single gh edit to avoid multiple
+roundtrips:
 
 ```
-gh issue edit $ISSUE_NUMBER --add-label "bug,area: cms,needs-triage"
+# Confident bug, repro succeeded → auto-advances to ready-for-agent
+gh issue edit $ISSUE_NUMBER --add-label "bug,area: cms,ready-for-agent"
+
+# Confident bug, repro deferred (CI-only / env-specific / non-flake)
+gh issue edit $ISSUE_NUMBER --add-label "bug,area: cms"
+
+# Confident enhancement
+gh issue edit $ISSUE_NUMBER --add-label "enhancement,area: cms"
+
+# Uncertain (no category guess in label; lean is in the comment)
+gh issue edit $ISSUE_NUMBER --add-label "triage-uncertain,area: cms"
 ```
 
 ## Rules
 
-- **Don't advance state.** You may apply `needs-triage`, `bug`, `enhancement`,
-  and `area:` labels. You may NOT apply `needs-info`, `ready-for-agent`,
-  `ready-for-human`, or `wontfix`. You may NOT close issues.
+- **State-advancement rules.**
+  - You MAY apply `bug`, `enhancement`, `triage-uncertain`, `area: X`,
+    `flake`, and `recurring-flake`.
+  - You MAY apply `ready-for-agent` ONLY when (8e auto-advance
+    condition): outcome is "Confirmed" via local repro OR issue is
+    producer-bot-filed.
+  - You MAY NOT apply `needs-info`, `ready-for-human`, or `wontfix` —
+    those require maintainer judgment.
+  - You MAY NOT close issues.
+  - You MAY NOT apply `needs-triage` (per step 4 — that label is
+    skill-canonical "no bot or human has looked"; bot finishing means
+    bot HAS looked).
 - **Don't reassign or @mention people.** Don't ping anyone except the
   reporter, and only when their input is genuinely needed.
 - **Quote logs and code verbatim.** Don't paraphrase test output or code


### PR DESCRIPTION
## Summary

Implements step **A** of the multi-bot pipeline locked via grilling (Q1-Q10 across 12 questions). Other steps are separate PRs:
- **C** — discovery-prep-bot for enhancements (next)
- **B** — fix-bot for confident bugs (last; highest risk; benefits from upstream maturity first)

## What changed

The bot is now THE category decider, not a "first-pass enricher." Maintainer's morning view (`gh issue list --label triage-uncertain`) shows ONLY ambiguous cases.

### New label scheme

| State | Label | Source |
|---|---|---|
| Never been looked at | `needs-triage` (rare) | filer / pre-bot legacy |
| Bot uncertain | `triage-uncertain` + `area: X` | triage-bot |
| Bot confident | `bug` / `enhancement` + `area: X` | triage-bot |
| Bug, repro succeeded | + `ready-for-agent` (auto) | triage-bot step 8e |
| Maintainer-advanced | `ready-for-human` / `wontfix` / etc. | maintainer via `/triage` |

### Concrete-evidence classification rule

LLMs are over-confident by default. The rule keeps the bot grounded in what the issue body actually says:

- **Producer-bot recognition (check FIRST):** `<!-- flake-watcher: run=` in body → confident `bug`
- Body has stack trace / "doesn't work" / explicit error AND lacks enhancement-language → confident `bug`
- Body has "would be nice" / "support for" AND lacks bug-language → confident `enhancement`
- Body has BOTH → `triage-uncertain` (lean goes in comment, not label)
- Body has NEITHER → `triage-uncertain` (no lean)

### Auto-advance to `ready-for-agent` (step 8e)

When outcome is "Confirmed" via local repro OR issue is producer-bot-filed, bot also applies `ready-for-agent` so fix-bot picks up the issue on its next cron.

Safety: fix-bot (separate PR) has a TDD-first hard rule — its first commit MUST be a failing test that captures the bug, OR it stops and posts \"unable to capture this bug as a test.\" So `ready-for-agent` from triage-bot is a hint, not a guarantee — fix-bot self-polices when the bug isn't actually test-capturable.

## Pre-merge migration done out-of-band

- Created `triage-uncertain` label (color #fbca04)
- Stripped `needs-triage` from 50 issues that already had `bug` or `enhancement` (the bot put it on every issue under the old prompt)
- Verified migration: only 2 issues still carry `needs-triage` (the genuinely-untouched ones)

## Maintainer UX after this PR

```bash
# What needs me?
gh issue list --label triage-uncertain     # ~1-3 per week target
gh issue list --label needs-triage         # ~0 in steady state (just legacy)

# What's going to fix-bot?
gh issue list --label ready-for-agent      # bot-advanced, awaiting fix-bot

# What did the bot do?
gh issue list --label bug                  # all confident bug classifications
gh issue list --label enhancement          # all confident enhancement classifications
```

## Skill divergence (documented)

The `/triage` skill's bucket 2 (\"evaluation in progress\") expects `needs-triage` to mean \"human is actively triaging.\" This project uses it strictly for \"never been looked at.\" Documented in the dev-glossary's `needs-triage` entry. Matters for multi-maintainer workflows but accepted as a project-specific deviation.

## Test plan

- [x] Type-check clean
- [x] Dry-run shows the right candidate list (52, oldest-first)
- [x] Migration script verified before commit (50 issues stripped, 2 legitimate `needs-triage` remain)
- [ ] After merge: manually trigger triage-bot, verify per-issue behavior:
  - 6 producer-bot bugs (#268, #284-290) get `ready-for-agent` applied
  - 47 enhancements get re-confirmed (no new comment via the dedup rule)
  - Watch for any false-positive `triage-uncertain` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)