### PR TITLE
fix(triage-bot): treat empty-string LOOKBACK_HOURS as unset

### DIFF
--- a/bots/triage-bot/index.ts
+++ b/bots/triage-bot/index.ts
@@ -58,10 +58,19 @@ const RUN_TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$
 const PER_RUN_BUDGET_MS = Number(process.env.BUDGET_MS ?? 50 * 60 * 1000)
 
 // Optional manual override: set LOOKBACK_HOURS to force a wider scan.
-//   LOOKBACK_HOURS=720  → scan last 30 days (good for a periodic full sweep)
-//   LOOKBACK_HOURS=0    → scan ALL open issues (no since filter — backlog mode)
-//   unset (default)     → auto-detect via the last successful workflow run
-const LOOKBACK_HOURS_OVERRIDE = process.env.LOOKBACK_HOURS
+//   LOOKBACK_HOURS=720    → scan last 30 days (good for a periodic full sweep)
+//   LOOKBACK_HOURS=0      → scan ALL open issues (no since filter — backlog mode)
+//   unset / empty string  → auto-detect via the last successful workflow run
+//
+// Empty string handling: workflow_dispatch inputs always coerce to strings
+// in the env block. With `LOOKBACK_HOURS: ${{ inputs.lookback_hours || '' }}`
+// in the YAML, an unset input arrives here as "" (empty string), NOT
+// undefined. We treat empty as equivalent to unset to preserve the auto-
+// detect default for cron AND default-input manual triggers. Without this,
+// empty string would coerce via Number('') === 0 into the "full backlog"
+// branch and silently re-walk all issues every manual trigger.
+const rawLookback = process.env.LOOKBACK_HOURS
+const LOOKBACK_HOURS_OVERRIDE = rawLookback !== undefined && rawLookback !== '' ? rawLookback : undefined
 
 async function main(): Promise<void> {
   const repo = repoFromEnv()


### PR DESCRIPTION
## Summary

Caught live from the validation run of #295 + #296 stacked: manual `workflow_dispatch` with the default empty `lookback_hours` input silently triggers full backlog scan instead of the intended auto-detect.

## Root cause

The workflow YAML emits `LOOKBACK_HOURS: \${{ inputs.lookback_hours || '' }}` — an empty string when the input is unset. In TS, \`process.env.LOOKBACK_HOURS === ''\` is NOT undefined. The previous check fell into the override branch on empty string, then \`Number('') === 0\` silently triggered the "full backlog scan" branch.

## Fix

Treat empty string equivalently to undefined:

\`\`\`ts
const rawLookback = process.env.LOOKBACK_HOURS
const LOOKBACK_HOURS_OVERRIDE =
  rawLookback !== undefined && rawLookback !== '' ? rawLookback : undefined
\`\`\`

## Verified locally

| Scenario | Before fix | After fix |
|---|---|---|
| \`LOOKBACK_HOURS=\` (empty, manual default) | full backlog (52) ❌ | auto-detect ✓ |
| Unset (cron) | auto-detect ✓ | auto-detect ✓ |
| \`LOOKBACK_HOURS=0\` (explicit) | full backlog ✓ | full backlog ✓ |
| \`LOOKBACK_HOURS=24\` | last 24h ✓ | last 24h ✓ |

Cron path is unaffected (the YAML doesn't set \`LOOKBACK_HOURS\` at all on cron, so \`process.env.LOOKBACK_HOURS\` is genuinely undefined). Only manual triggers with default input were broken.

## Why not also use `LOOKBACK_HOURS: \${{ inputs.lookback_hours }}` directly

Tested — that emits the literal string \`null\` when the input is unset. Empty-string-as-fallback in the YAML is the lesser evil; the TS-side normalization handles it cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)