### PR TITLE
fix(triage-bot): auto-advance fires even on dedup-skip investigations

### DIFF
--- a/bots/triage-bot/prompt.md
+++ b/bots/triage-bot/prompt.md
@@ -573,6 +573,18 @@ gh issue edit $ISSUE_NUMBER --add-label "triage-uncertain,area: cms"
   `needs-info` — but verify defensively at start of investigation. If any of
   those four labels is present, emit a Decision line and exit immediately;
   do not re-classify.
+- **Auto-advance is idempotent and runs unconditionally** (when its
+  conditions match). Even when `IS_FIRST_INVESTIGATION=false` and
+  you're about to dedup-skip, FIRST check whether auto-advance applies
+  (per step 8e: confident bug + reproducible-locally OR producer-bot-
+  filed). If yes, apply `ready-for-agent` BEFORE exiting. The label is
+  idempotent — a no-op when already present — so it's safe to apply on
+  every investigation. Without this carve-out, any bug classified
+  before auto-advance was a rule (PR #296) would never receive
+  `ready-for-agent` because the dedup-skip would fire first. Order:
+  read prior comments → check auto-advance conditions → apply
+  `ready-for-agent` if applicable → THEN apply the dedup-skip rule
+  below.
 - **Skip if no new findings vs prior bot comment.** When
   `IS_FIRST_INVESTIGATION=false` (the orchestrator pre-computed this for
   you — trust it; do NOT re-fetch comments), read the existing bot
@@ -586,13 +598,17 @@ gh issue edit $ISSUE_NUMBER --add-label "triage-uncertain,area: cms"
   hand. When `IS_FIRST_INVESTIGATION=true`, apply category + area +
   needs-triage. When `false`, append new comments but do NOT change
   labels (even labels the bot itself applied) and do NOT edit prior bot
-  comments. If new evidence (reporter follow-up, new failures, etc.)
-  suggests reclassifying — e.g. an `enhancement` that the reporter has
-  now clarified is happening in production — append a comment surfacing
-  the suggested reclassification and let the maintainer decide via
-  `/triage`. Format: "Reporter follow-up suggests reclassifying as
-  `<X>` — maintainer please confirm." Bot never retracts its own labels
-  or edits its own comments.
+  comments. **Exception:** `ready-for-agent` may be applied on subsequent
+  investigations when the auto-advance conditions match (per the
+  preceding rule). This is the one label triage-bot adds during dedup-
+  skip; all others stay frozen after first investigation. If new evidence
+  (reporter follow-up, new failures, etc.) suggests reclassifying —
+  e.g. an `enhancement` that the reporter has now clarified is happening
+  in production — append a comment surfacing the suggested
+  reclassification and let the maintainer decide via `/triage`. Format:
+  "Reporter follow-up suggests reclassifying as `<X>` — maintainer
+  please confirm." Bot never retracts its own labels or edits its own
+  comments.
 - **Comment-action consistency.** The body of any `gh issue comment` MUST
   match the labels you actually applied and the actions you actually took.
   When drafting your comment text, re-read your prior `gh issue edit`


### PR DESCRIPTION
## Summary

Caught from validation run [25634216891 attempt 2](https://github.com/gazetta-studio/gazetta-studio/actions/runs/25634216891/attempts/2): the 6 producer-bot bugs (#268, #284, #285, #286, #288, #290) should have received \`ready-for-agent\` per #296's step 8e, but none did. All exited via the \"skip if no new findings\" dedup rule before reaching step 8.

## Root cause

Prompt rules are ordered such that the \"exit if dedup-skip\" rule fires before the auto-advance check. Step 8e (auto-advance to \`ready-for-agent\`) lives inside the bug-investigation flow at step 8. For an issue the bot has already commented on (\`IS_FIRST_INVESTIGATION=false\`), the dedup rule short-circuits before step 8 runs.

This made auto-advance permanently broken for any bug the bot had already touched — which was every bug in the current backlog.

## Fix

Two prompt-rule changes:

1. **New rule:** \"Auto-advance is idempotent and runs unconditionally.\" Carves out the auto-advance check as the first thing the bot does on subsequent investigations (after reading prior comments, before deciding whether to dedup-skip).
2. **Updated rule:** \"Append-only after first investigation\" now calls out \`ready-for-agent\` as the one exception — the only label triage-bot may apply during dedup-skip.

The label is idempotent (no-op when already present) so applying it on every investigation is safe.

## Out-of-band one-time fix (before this commit)

The 6 producer-bot bugs needed \`ready-for-agent\` regardless of when the prompt fix lands. Done manually:

- Created \`ready-for-agent\` repo label (color \`#0e8a16\`)
- Applied to #268, #284, #285, #286, #288, #290

Side effect: those 6 now match \`ADVANCED_STATE_ROLES\` and are excluded from future triage-bot scans. Dry-run candidate count drops 52 → 46. Tomorrow's cron won't validate the prompt fix on these specific issues (they've moved past triage's scope) — fix becomes load-bearing the next time a confident bug is filed and re-investigated.

## Test plan

- [x] Type-check clean
- [x] Dry-run shows 46 candidates (52 minus the 6 backfilled)
- [ ] After merge: next time a confident bug filing arrives + a subsequent triage-bot run sees it, verify \`ready-for-agent\` is applied even on dedup-skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)