### PR TITLE
refactor(bots): label-driven pipeline replaces chain-dispatch

### DIFF
--- a/.claude/rules/dev-glossary.md
+++ b/.claude/rules/dev-glossary.md
@@ -296,6 +296,26 @@ The bot's lean (if any) goes in the comment body, not the label —
 applying a category guess in the label would defeat the "trust labels
 to mean confident classification" UX.
 
+**`ready-for-human` (label)**:
+Project-specific overload of the skill-canonical `ready-for-human` state
+role. Used in two contexts:
+
+- **discovery-prep-bot output**: "Discovery research posted as a comment;
+  design grilling can start whenever the maintainer is ready."
+- **fix-bot output (when stuck)**: "Tried but couldn't capture the bug as
+  a failing test; needs human to write the test or close as wontfix."
+
+Disambiguate by reading the latest bot comment's outcome tag
+(`<!-- discovery-prep-bot:` vs `<!-- fix-bot:`). The skill's canonical
+"needs human implementation" usage is preserved — maintainer-applied
+`ready-for-human` via `/triage` keeps that meaning. Three contexts on
+one label is the trade-off accepted to avoid a new label per bot.
+
+The label is also a pipeline gate: once applied, the issue is excluded
+from triage-bot's and discovery-prep-bot's input queries. Maintainer
+intervention is required to re-enter the bot pipeline (remove the
+label).
+
 **`flake` (label)**:
 CI test-flake classification — intermittent failure, not a real bug until
 proven otherwise via triage. Applied by flake-watcher to every issue it

--- a/.github/workflows/discovery-prep-bot.yml
+++ b/.github/workflows/discovery-prep-bot.yml
@@ -1,28 +1,35 @@
 name: Discovery prep bot
 
-# Researches a single confident-enhancement issue. NOT cron-driven —
-# triggered either by triage-bot (chained dispatch when triage classifies
-# an issue as `enhancement`) or manually for re-research / prompt iteration.
+# Researches confident-enhancement issues. Two trigger modes:
+#   - Cron (daily): scans `enhancement` issues lacking `ready-for-human`,
+#     `ready-for-agent`, `wontfix`, `needs-info`. Per-run budget bounds work;
+#     backlog converges over multiple days.
+#   - workflow_dispatch with `issue` input: research one specific issue
+#     (manual override for re-research after prompt iteration).
 #
-# Output is a SINGLE ISSUE COMMENT — no PR, no repo file. The bot needs
-# only `issues: write` permission. Idempotent: skips if discovery-prep-bot
-# has already commented on the issue (delete the prior comment to force
-# re-research).
+# Output: single issue comment + `ready-for-human` label. No PR, no repo
+# file. The label is the idempotency contract.
 on:
+  schedule:
+    # 10:00 UTC daily — one hour before triage-bot's 11:00 UTC. Discovery
+    # picks up enhancements triage-bot classified yesterday; downstream
+    # actor (maintainer) sees `ready-for-human` issues during their
+    # workday.
+    - cron: '0 10 * * *'
   workflow_dispatch:
     inputs:
       issue:
-        description: 'Issue number to research (must be a confident-enhancement issue, open)'
-        required: true
+        description: 'Optional: research one specific issue (otherwise scans all candidates)'
+        required: false
 
 jobs:
   research:
     runs-on: ubuntu-latest
     continue-on-error: true
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
-      # Read code (for repo grep + bot source) + read/write issues (for the
-      # research comment). NO `contents: write` and NO `pull-requests`
+      # Read code (for repo grep) + read/write issues (research comment +
+      # ready-for-human label). No `contents: write`, no `pull-requests`
       # — bot doesn't write any files or open PRs.
       contents: read
       issues: write
@@ -46,6 +53,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
+          # Empty when input not provided — the bot treats empty as "cron
+          # mode" (scan candidates) and treats a numeric value as "manual
+          # one-issue mode."
           ISSUE_NUMBER: ${{ inputs.issue }}
         run: npm run discovery-prep-bot -w @gazetta/bots
 

--- a/bots/README.md
+++ b/bots/README.md
@@ -59,31 +59,54 @@ GITHUB_REPOSITORY=gazetta-studio/gazetta-studio GH_TOKEN=$(gh auth token) \
 
 ## Active bots
 
-| Bot | Trigger | Purpose | Workflow |
+| Bot | Trigger | Input (label-driven) | Output |
 |---|---|---|---|
-| `flake-watcher` | Daily 12:00 UTC | Detects CI flakes (run_attempt >= 2), files / comments on issues | `.github/workflows/flake-watcher.yml` |
-| `triage-bot` | Daily 11:00 UTC + workflow_dispatch | Classifies incoming issues (`bug` / `enhancement` / `triage-uncertain`); auto-advances reproducible bugs to `ready-for-agent`; chain-dispatches discovery-prep-bot for confident enhancements | `.github/workflows/triage-bot.yml` |
-| `discovery-prep-bot` | workflow_dispatch (chained from triage-bot, OR manual) | Researches a single confident-enhancement issue; opens a draft PR with `docs/audits/issue-NNN-discovery.md` | `.github/workflows/discovery-prep-bot.yml` |
+| `flake-watcher` | Daily 12:00 UTC + workflow_dispatch | (CI events, not labels) | New issue with `bug`, `flake`, `area: X`, `recurring-flake?` |
+| `triage-bot` | Daily 11:00 UTC + workflow_dispatch | Open issue lacking all of `ready-for-agent`, `ready-for-human`, `wontfix`, `needs-info` | One of `bug` / `enhancement` / `triage-uncertain` + `area: X`. Reproducible bug also gets `ready-for-agent`. |
+| `discovery-prep-bot` | Daily 10:00 UTC + workflow_dispatch | `enhancement` AND lacks all of `ready-for-human`, `ready-for-agent`, `wontfix`, `needs-info` | Research comment + `ready-for-human` label |
 
-### Pipeline shape
+### Pipeline shape (label-driven)
 
 ```
 flake-watcher (cron 12:00 UTC)
-    ↓ files issue with flake + bug
-triage-bot (cron 11:00 UTC next day)
-    ├─→ confident bug + reproducible → applies ready-for-agent
-    │       ↓ (future: fix-bot opens PR; maintainer merges)
-    ├─→ confident enhancement → dispatches discovery-prep-bot
+    ↓ files issue (auto-classified `bug`)
+triage-bot (cron 11:00 UTC next day) — input: open + no terminal-state label
+    ├─→ confident bug + reproducible → applies `ready-for-agent`
+    │       ↓ (future: fix-bot picks up bug + ready-for-agent)
+    ├─→ confident enhancement → no extra label (handed off via the
+    │   `enhancement` label itself)
     │       ↓
-    │   discovery-prep-bot → opens draft PR with audit doc
-    │       ↓
-    │   maintainer reviews PR, starts grilling at their pace
+    │   discovery-prep-bot (cron 10:00 UTC) — input: enhancement + no
+    │   ready-for-human / ready-for-agent / wontfix / needs-info
+    │       ↓ posts research comment + applies `ready-for-human`
+    │   maintainer reads comment, starts grilling at their pace
     │
     └─→ triage-uncertain → maintainer's morning queue
             gh issue list --label triage-uncertain
 ```
 
-Each bot is independent. Failures are isolated (per-bot try/catch + workflow `continue-on-error`). Each dispatched downstream bot runs on its own GitHub Actions run with its own transcript artifact.
+**Pipeline state lives in labels, not in code or workflow runs.** Each bot's input is a label query; each bot's output is a label mutation. To re-run any bot on an issue, remove its output label — the next cron picks it up. To opt-out an issue, apply a terminal-state label (`wontfix` / `ready-for-human`).
+
+**Maintainer queries:**
+
+```bash
+# What did the bot flag for me?
+gh issue list --label triage-uncertain
+
+# What's in design-grilling territory? (read the latest comment to know
+# whether it's discovery-prep-bot's research or fix-bot's stuck case)
+gh issue list --label ready-for-human
+
+# What's queued for fix-bot?
+gh issue list --label ready-for-agent
+
+# What needs reporter clarification?
+gh issue list --label needs-info
+```
+
+`ready-for-human` is shared between discovery-prep-bot ("research done, grilling can start") and fix-bot ("stuck — needs human"). Disambiguate by reading the most recent bot comment's outcome tag.
+
+Each bot is independent. Failures are isolated (per-bot try/catch + workflow `continue-on-error`). No chained workflow_dispatch — each bot's cron is the trigger, the issue's label state is the input.
 
 ## Improving a bot
 

--- a/bots/_lib/github.ts
+++ b/bots/_lib/github.ts
@@ -107,41 +107,55 @@ export interface IssueSummary {
  * "no bot or human has looked yet" state, distinct from `triage-uncertain`
  * (bot looked, couldn't classify).
  */
-const ADVANCED_STATE_ROLES = ['needs-info', 'ready-for-agent', 'ready-for-human', 'wontfix'] as const
-
 /**
- * List open issues the triage bot may enrich.
+ * List open issues matching label-driven criteria.
  *
- * Scope: every open issue that has NOT been advanced past `needs-triage` by
- * a maintainer. Concretely, any open issue lacking ALL of `needs-info`,
- * `ready-for-agent`, `ready-for-human`, `wontfix`. Includes:
+ * Each bot in the pipeline declares its input as "issues with ALL of
+ * `requireAll` AND NONE of `excludeAny`." This is the universal contract
+ * — pipeline state lives in labels, not in code or transcripts.
  *
- *   - Unlabeled issues (newly filed, never touched)
- *   - Issues labeled `needs-triage` (the bot's primary surface)
- *   - Issues partially labeled by maintainers (`bug` only, `area: cms` only,
- *     `flake` only, etc.) but never advanced past triage
+ * Concrete bot inputs:
+ *
+ *   triage-bot:
+ *     requireAll: []
+ *     excludeAny: ['bug', 'enhancement', 'triage-uncertain',
+ *                  'ready-for-agent', 'ready-for-human',
+ *                  'wontfix', 'needs-info']
+ *     (the absence of any category role + absence of any state advancement)
+ *
+ *   discovery-prep-bot:
+ *     requireAll: ['enhancement']
+ *     excludeAny: ['ready-for-human', 'ready-for-agent',
+ *                  'wontfix', 'needs-info']
+ *     (an enhancement that hasn't been handed off downstream)
+ *
+ *   fix-bot (future):
+ *     requireAll: ['bug', 'ready-for-agent']
+ *     excludeAny: ['wontfix', 'needs-info', 'ready-for-human']
+ *     (a bug ready for an agent, no maintainer escalation in flight)
+ *
+ * `sinceIso` (optional) lets the daily cron scan only what changed since
+ * the last successful run. Without it (or with a since from before the
+ * project began), behaves as a full scan — the manual "wide lookback"
+ * path uses no since.
  *
  * Excludes pull requests — Octokit returns PRs in this endpoint by default
  * because GitHub treats them as a kind of issue. Filtered out here.
- *
- * Per-issue dedup (skip if the bot has already enriched and has no new
- * findings) lives in the bot's prompt, not here. This function is intent-
- * neutral — it returns every candidate that's ever eligible.
  */
-export async function findTriageCandidates(
+export async function findIssuesByLabels(
   octokit: Octokit,
   repo: RepoIdentity,
-  options: { sinceIso?: string } = {},
+  options: { requireAll?: readonly string[]; excludeAny: readonly string[]; sinceIso?: string },
 ): Promise<IssueSummary[]> {
-  // `since` server-side filters to issues whose ANY-FIELD (labels, comments,
-  // body, state) changed after that timestamp. Lets daily runs scan only
-  // what actually changed, instead of re-walking the full backlog. Without
-  // it (or with a `since` from before the project began), behaves as full
-  // scan — the manual "wide lookback" path uses no since.
+  const requireAll = options.requireAll ?? []
   const { data } = await octokit.issues.listForRepo({
     ...repo,
     state: 'open',
     per_page: 100,
+    // Server-side prefilter when at least one required label exists. Octokit
+    // takes a comma-separated string. Issues here have ALL of these labels
+    // (intersection), which matches our requireAll semantics.
+    ...(requireAll.length > 0 ? { labels: requireAll.join(',') } : {}),
     ...(options.sinceIso ? { since: options.sinceIso } : {}),
   })
 
@@ -149,7 +163,7 @@ export async function findTriageCandidates(
   for (const issue of data) {
     if (issue.pull_request) continue // skip PRs
     const labels = issue.labels.map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean)
-    if (labels.some(l => (ADVANCED_STATE_ROLES as readonly string[]).includes(l))) continue
+    if (labels.some(l => (options.excludeAny as readonly string[]).includes(l))) continue
     out.push({
       number: issue.number,
       title: issue.title,
@@ -256,32 +270,22 @@ export async function hasPriorCommentFromBot(
 }
 
 /**
- * Trigger another workflow via the workflow_dispatch event with inputs.
+ * Apply a label to an issue. Idempotent — adding an already-present label
+ * is a no-op on the GitHub side.
  *
- * Used for chained handoffs between bots (e.g., triage-bot dispatching
- * discovery-prep-bot when an issue is classified as enhancement). The
- * dispatched workflow runs as its own GH Actions run; the caller doesn't
- * wait for completion — that's the whole point of async dispatch.
- *
- * `workflowFileName` is the filename in `.github/workflows/`, e.g.
- * `"discovery-prep-bot.yml"`. `inputs` are the workflow's `inputs:` keys
- * defined in its `workflow_dispatch:` block.
- *
- * Default ref is `main` because pipeline handoffs should always run the
- * latest production code, not whatever branch the caller is on. Pass
- * `ref` to override (rare).
+ * Used by bots to mark pipeline progress: e.g., discovery-prep-bot adds
+ * `ready-for-human` to signal "research done, maintainer's grilling phase
+ * starts now."
  */
-export async function dispatchWorkflow(
+export async function addLabel(
   octokit: Octokit,
   repo: RepoIdentity,
-  workflowFileName: string,
-  inputs: Record<string, string>,
-  ref = 'main',
+  issueNumber: number,
+  label: string,
 ): Promise<void> {
-  await octokit.actions.createWorkflowDispatch({
+  await octokit.issues.addLabels({
     ...repo,
-    workflow_id: workflowFileName,
-    ref,
-    inputs,
+    issue_number: issueNumber,
+    labels: [label],
   })
 }

--- a/bots/discovery-prep-bot/index.ts
+++ b/bots/discovery-prep-bot/index.ts
@@ -1,13 +1,16 @@
 /**
- * discovery-prep-bot — researches a confident-enhancement issue once.
+ * discovery-prep-bot — researches confident-enhancement issues.
  *
- * Triggered ONLY by workflow_dispatch (no cron). Two callers:
+ * Two trigger modes:
  *
- *   1. triage-bot (chained, automatic): when triage-bot classifies an issue
- *      as a confident `enhancement` AND no prior discovery comment exists,
- *      it dispatches this bot for that one issue.
- *   2. Maintainer (manual): `gh workflow run discovery-prep-bot.yml -f issue=N`
- *      to re-research a single issue (e.g., after prompt iteration).
+ *   1. Cron (default): scans for issues matching the input contract
+ *      (label `enhancement`, lacks any of `ready-for-human`,
+ *      `ready-for-agent`, `wontfix`, `needs-info`). Processes oldest-first
+ *      with a per-run budget. Backlog converges over multiple daily runs.
+ *
+ *   2. workflow_dispatch with `issue` input: researches one specific
+ *      issue, regardless of label state. Useful for re-research after
+ *      prompt iteration.
  *
  * Per-issue, the bot:
  *   1. Reads the issue body + comments
@@ -15,16 +18,19 @@
  *      related project ADRs/design-docs/audits, actor-scenario mapping
  *      (per docs/actor-scenarios.md), foundational-dimensions checklist,
  *      open questions for grilling
- *   3. Posts the findings as a single issue comment (the research doc body)
+ *   3. Posts findings as a single issue comment
+ *   4. Adds `ready-for-human` label (signals: research done, design
+ *      grilling can start)
  *
- * Output is an ISSUE COMMENT, not a PR or repo file. Reasons:
- *   - Research lives where the conversation lives
- *   - No PR spam if the chain-dispatch fires N times in a backlog scenario
- *   - Idempotency check is just "do I have a prior comment with my outcome
- *     tag here?" — same pattern as flake-watcher / triage-bot
- *   - Maintainer reads the comment when starting grilling; copies the
- *     useful parts into a real design doc (which they would have done from
- *     a draft PR audit doc anyway, so no value lost)
+ * Output is an ISSUE COMMENT plus the `ready-for-human` label. No PR,
+ * no repo file. The label is the bot's idempotency contract — once
+ * applied, future cron runs skip the issue (since the label is in the
+ * exclude-set of the input query).
+ *
+ * The `ready-for-human` label is shared with fix-bot's "stuck — needs
+ * human" state. Maintainer disambiguates by reading the comment thread:
+ * a discovery-prep-bot outcome tag means "research done"; a fix-bot
+ * outcome tag means "fix-bot stuck."
  *
  * The bot does NOT write a design doc. Per `feature-design-process.md`,
  * design docs are the OUTPUT of grilling — bot can't substitute. Discovery
@@ -32,16 +38,26 @@
  * the design doc themselves.
  *
  * Run locally:
+ *   # Cron mode — scan all open enhancements:
+ *   GITHUB_REPOSITORY=gazetta-studio/gazetta-studio \
+ *     GH_TOKEN=$(gh auth token) npm run discovery-prep-bot -w @gazetta/bots
+ *   # Manual one-issue mode:
  *   ISSUE_NUMBER=192 GITHUB_REPOSITORY=gazetta-studio/gazetta-studio \
  *     GH_TOKEN=$(gh auth token) npm run discovery-prep-bot -w @gazetta/bots
  * Run in CI:
- *   .github/workflows/discovery-prep-bot.yml (workflow_dispatch only)
+ *   .github/workflows/discovery-prep-bot.yml (cron + workflow_dispatch)
  */
 import { mkdirSync, readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { runClaude } from '../_lib/claude.js'
-import { hasPriorCommentFromBot, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
+import {
+  findIssuesByLabels,
+  findLastSuccessfulRunIso,
+  hasPriorCommentFromBot,
+  octokitFromEnv,
+  repoFromEnv,
+} from '../_lib/github.js'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const PROMPT_PATH = resolve(HERE, 'prompt.md')
@@ -50,27 +66,142 @@ const DRY_RUN = process.env.DRY_RUN === '1'
 const TRANSCRIPTS_DIR = resolve(HERE, '../transcripts')
 const RUN_TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')
 
+// Per-run budget. Discovery is expensive (~5-10 min per issue: web search,
+// fact-check, multi-doc grep). Workflow timeout is 60 min; exit gracefully
+// at 50 min for the upload-artifacts step + any in-flight per-issue work.
+// Override via env for local manual runs.
+const PER_RUN_BUDGET_MS = Number(process.env.BUDGET_MS ?? 50 * 60 * 1000)
+
+// Optional manual override: set LOOKBACK_HOURS to force a wider scan than
+// the auto-detected since-anchor. Same shape as triage-bot's override.
+const rawLookback = process.env.LOOKBACK_HOURS
+const LOOKBACK_HOURS_OVERRIDE = rawLookback !== undefined && rawLookback !== '' ? rawLookback : undefined
+
 async function main(): Promise<void> {
   const repo = repoFromEnv()
   const octokit = octokitFromEnv()
 
+  // Manual one-issue mode short-circuits the cron scan.
   const issueNumberStr = process.env.ISSUE_NUMBER
-  if (!issueNumberStr || !/^\d+$/.test(issueNumberStr)) {
-    console.error('ISSUE_NUMBER env var is required and must be a positive integer')
-    console.error(
-      'Usage: ISSUE_NUMBER=192 GITHUB_REPOSITORY=owner/repo GH_TOKEN=... npm run discovery-prep-bot -w @gazetta/bots',
-    )
-    process.exit(2)
+  if (issueNumberStr) {
+    if (!/^\d+$/.test(issueNumberStr)) {
+      console.error(`ISSUE_NUMBER='${issueNumberStr}' must be a positive integer`)
+      process.exit(2)
+    }
+    await researchOneIssue(octokit, repo, Number(issueNumberStr))
+    return
   }
-  const issueNumber = Number(issueNumberStr)
 
-  console.log(`Discovery prep bot: researching issue #${issueNumber} in ${repo.owner}/${repo.repo}`)
+  // Cron mode: scan candidates and process per-run-budget.
+  const sinceIso = await resolveSinceIso(octokit, repo)
+  console.log(`Discovery prep bot: scanning ${repo.owner}/${repo.repo} for confident-enhancement candidates`)
 
-  // Verify the issue exists, is open, and is classified as enhancement.
+  const allCandidates = await findIssuesByLabels(octokit, repo, {
+    requireAll: ['enhancement'],
+    excludeAny: ['ready-for-human', 'ready-for-agent', 'wontfix', 'needs-info'],
+    sinceIso,
+  })
+
+  if (allCandidates.length === 0) {
+    console.log('No discovery-prep candidates found. Inbox zero — nothing to do.')
+    return
+  }
+
+  // Oldest-first so longest-waiting enhancements get research first.
+  const candidates = [...allCandidates].sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+
+  console.log(`Discovery candidates (${candidates.length}, oldest-first):`)
+  for (const c of candidates) {
+    console.log(`  #${c.number} "${c.title}"`)
+  }
+
+  if (DRY_RUN) {
+    console.log(`DRY_RUN=1 — exiting before invoking Claude (${candidates.length} would be processed).`)
+    return
+  }
+
+  const runStart = Date.now()
+  let processed = 0
+  for (const candidate of candidates) {
+    const elapsed = Date.now() - runStart
+    if (elapsed > PER_RUN_BUDGET_MS) {
+      const remaining = candidates.length - processed
+      console.log(
+        `\nPer-run budget exhausted (${Math.round(elapsed / 1000)}s elapsed > ${Math.round(PER_RUN_BUDGET_MS / 1000)}s budget).`,
+      )
+      console.log(`Stopping with ${remaining} candidate(s); tomorrow's run picks them up (oldest-first sort holds).`)
+      for (const skipped of candidates.slice(processed)) {
+        console.log(`  #${skipped.number} "${skipped.title}"`)
+      }
+      break
+    }
+
+    console.log(
+      `\n=== Researching #${candidate.number}: "${candidate.title}" (${processed + 1}/${candidates.length}, ${Math.round(elapsed / 1000)}s elapsed) ===`,
+    )
+    try {
+      await researchOneIssue(octokit, repo, candidate.number)
+    } catch (err) {
+      console.log(`Warning: research of #${candidate.number} threw: ${err}; continuing.`)
+    }
+    processed++
+  }
+
+  console.log(`\nDiscovery prep bot complete. Processed ${processed}/${candidates.length}.`)
+}
+
+/**
+ * Resolve the "since" anchor for incremental scanning.
+ *
+ *   - LOOKBACK_HOURS=0           → no since filter (full backlog scan)
+ *   - LOOKBACK_HOURS=N (N > 0)   → since = now - N hours
+ *   - unset (cron default)       → since = last successful discovery-prep-bot
+ *                                  run minus 1h overlap
+ */
+async function resolveSinceIso(
+  octokit: ReturnType<typeof octokitFromEnv>,
+  repo: ReturnType<typeof repoFromEnv>,
+): Promise<string | undefined> {
+  if (LOOKBACK_HOURS_OVERRIDE !== undefined) {
+    const hours = Number(LOOKBACK_HOURS_OVERRIDE)
+    if (hours === 0) {
+      console.log('LOOKBACK_HOURS=0 — full backlog scan (no since filter)')
+      return undefined
+    }
+    const sinceIso = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()
+    console.log(`LOOKBACK_HOURS=${hours} — scanning issues updated since ${sinceIso}`)
+    return sinceIso
+  }
+  const currentRunId = process.env.GITHUB_RUN_ID ? Number(process.env.GITHUB_RUN_ID) : undefined
+  const lastRun = await findLastSuccessfulRunIso(octokit, repo, 'discovery-prep-bot.yml', currentRunId)
+  if (!lastRun) {
+    console.log('No prior successful run — full backlog scan (first ever invocation)')
+    return undefined
+  }
+  const lastRunMs = new Date(lastRun).getTime()
+  const sinceIso = new Date(lastRunMs - 60 * 60 * 1000).toISOString()
+  console.log(`Auto-detected last successful run completed at ${lastRun}; scanning since ${sinceIso} (1h overlap)`)
+  return sinceIso
+}
+
+/**
+ * Research one issue. Used by both cron mode (per-candidate loop) and
+ * manual mode (single ISSUE_NUMBER input).
+ *
+ * Validates the issue is open + enhancement + not already commented on
+ * by discovery-prep-bot. The label-driven cron candidate query already
+ * applies these filters — but a manual `gh workflow run -f issue=N` can
+ * target any issue, so the per-issue checks are defense-in-depth.
+ */
+async function researchOneIssue(
+  octokit: ReturnType<typeof octokitFromEnv>,
+  repo: ReturnType<typeof repoFromEnv>,
+  issueNumber: number,
+): Promise<void> {
   const { data: issue } = await octokit.issues.get({ ...repo, issue_number: issueNumber })
   if (issue.pull_request) {
-    console.error(`#${issueNumber} is a pull request, not an issue. Aborting.`)
-    process.exit(1)
+    console.log(`#${issueNumber} is a pull request, not an issue. Skipping.`)
+    return
   }
   if (issue.state !== 'open') {
     console.log(`#${issueNumber} is ${issue.state}; nothing to research.`)
@@ -82,13 +213,14 @@ async function main(): Promise<void> {
     return
   }
 
-  // Idempotency: skip if discovery-prep-bot has already commented on this
-  // issue. The chained dispatch from triage-bot does this check too, but
-  // a manual invocation might not — defensive check here.
+  // Idempotency: skip if discovery-prep-bot has already commented. The
+  // label-driven input check would catch this for cron-mode candidates
+  // (because we'd have applied `ready-for-human` after the prior comment),
+  // but a manual one-issue invocation can target any issue.
   const alreadyCommented = await hasPriorCommentFromBot(octokit, repo, issueNumber, 'discovery-prep-bot')
   if (alreadyCommented) {
     console.log(`#${issueNumber}: discovery-prep-bot has already commented; nothing to do.`)
-    console.log('To re-research, manually delete the prior comment first, then re-run.')
+    console.log('To re-research, manually delete the prior comment AND remove `ready-for-human`, then re-run.')
     return
   }
 
@@ -110,26 +242,14 @@ ISSUE_NUMBER=${issueNumber}
 ISSUE_TITLE=${issue.title}
 RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
 
-  // Discovery needs broad tool access: gh CLI for issue comment, web
-  // fetch for competitor research, repo grep + read for project context.
-  // No Write tool — bot doesn't write any files; output goes via gh
-  // issue comment.
-  try {
-    const result = await runClaude({
-      prompt,
-      transcriptPath,
-      allowedTools: ['Bash', 'Read', 'Grep', 'Glob', 'WebFetch', 'WebSearch'],
-    })
-    if (!result.success) {
-      console.log(`Warning: discovery for #${issueNumber} exited ${result.exitCode}`)
-      process.exit(result.exitCode)
-    }
-  } catch (err) {
-    console.error(`Discovery for #${issueNumber} threw:`, err)
-    process.exit(1)
+  const result = await runClaude({
+    prompt,
+    transcriptPath,
+    allowedTools: ['Bash', 'Read', 'Grep', 'Glob', 'WebFetch', 'WebSearch'],
+  })
+  if (!result.success) {
+    console.log(`Warning: discovery for #${issueNumber} exited ${result.exitCode}`)
   }
-
-  console.log(`\nDiscovery prep bot complete. Transcript: ${transcriptPath}`)
 }
 
 main().catch(err => {

--- a/bots/discovery-prep-bot/prompt.md
+++ b/bots/discovery-prep-bot/prompt.md
@@ -254,19 +254,40 @@ revisit", or "this overlaps with existing in-flight work in #other".]
 \`\`\`
 
 The trailing outcome tag (`<!-- discovery-prep-bot: run=$RUN_ID -->`) is
-load-bearing — the orchestrator and triage-bot use it for idempotency
+load-bearing — the orchestrator and bots use it for idempotency
 checks. Don't omit.
+
+### 8. Apply `ready-for-human` label
+
+After posting the comment, apply the `ready-for-human` label. This is
+the bot's pipeline-handoff signal — it tells the maintainer "research
+done, design grilling can start" AND it removes the issue from this
+bot's future cron candidates (the input contract excludes
+`ready-for-human`).
+
+```bash
+gh issue edit $ISSUE_NUMBER --add-label ready-for-human
+```
+
+The label is shared with fix-bot's "stuck — needs human" state. The
+maintainer disambiguates by reading the comment thread:
+- discovery-prep-bot outcome tag in the latest comment → "research done,
+  start grilling"
+- fix-bot outcome tag in the latest comment → "fix-bot stuck on this
+  bug; decide whether to take it on or close as wontfix"
 
 ## Rules
 
 - **Don't write a design doc.** No "Distinctive choices," no "Foundational
   checks" (those belong in design docs after grilling), no committed
   decisions on architecture / data model / API shape.
-- **Don't write any files.** Output is a single issue comment. No PR.
-  No `docs/audits/...` artifact. No edits to any repo file.
-- **Don't advance issue state.** No `ready-for-agent`, no `wontfix`, no
-  closing. No new labels (the `enhancement` + `area:` labels triage-bot
-  applied are fine; don't add or remove anything).
+- **Don't write any files.** Output is a single issue comment + the
+  `ready-for-human` label. No PR. No `docs/audits/...` artifact. No
+  edits to any repo file.
+- **Don't advance issue state past `ready-for-human`.** No `ready-for-agent`,
+  no `wontfix`, no closing. The `enhancement` + `area:` labels triage-bot
+  applied are fine; don't remove them. The ONLY new label you may apply
+  is `ready-for-human`.
 - **Don't @mention anyone.** Issue comment notification is enough.
 - **Quote sources verbatim.** Don't paraphrase competitor docs.
 - **Distinguish verified from unverified.** Per rule 20: if you can't find

--- a/bots/triage-bot/index.ts
+++ b/bots/triage-bot/index.ts
@@ -34,11 +34,9 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { runClaude } from '../_lib/claude.js'
 import {
-  dispatchWorkflow,
+  findIssuesByLabels,
   findLastSuccessfulRunIso,
-  findTriageCandidates,
   hasPriorBotComment,
-  hasPriorCommentFromBot,
   octokitFromEnv,
   repoFromEnv,
 } from '../_lib/github.js'
@@ -109,7 +107,18 @@ async function main(): Promise<void> {
 
   console.log(`Triage bot: scanning ${repo.owner}/${repo.repo} for triage candidates`)
 
-  const allCandidates = await findTriageCandidates(octokit, repo, { sinceIso })
+  // Triage-bot's input contract: any open issue NOT yet advanced to a
+  // terminal state. Re-visits already-classified issues so that:
+  //   - New reporter activity can trigger reclassification suggestions
+  //   - Auto-advance can fire on bugs the bot classified before the
+  //     auto-advance rule existed
+  // The bot's prompt handles dedup (skip if no new findings) and the
+  // append-only rule (don't change labels on re-investigation, except
+  // for ready-for-agent auto-advance).
+  const allCandidates = await findIssuesByLabels(octokit, repo, {
+    excludeAny: ['ready-for-agent', 'ready-for-human', 'wontfix', 'needs-info'],
+    sinceIso,
+  })
 
   if (allCandidates.length === 0) {
     console.log('No triage candidates found. Inbox zero — nothing to do.')
@@ -218,66 +227,16 @@ RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
       console.log(`Warning: triage of #${candidate.number} threw: ${err}; continuing.`)
     }
 
-    // Pipeline handoff: if Claude classified this as a confident
-    // `enhancement` AND no discovery doc exists yet, dispatch
-    // discovery-prep-bot for this one issue. Per Q6 lock — discovery is
-    // one-time per issue, not periodic, so we trigger event-driven (here)
-    // rather than via cron.
-    //
-    // Failure isolation: dispatch is best-effort. If it fails (rate limit,
-    // transient API error), the issue still has its `enhancement` label;
-    // a maintainer can re-trigger via workflow_dispatch on demand.
-    try {
-      await maybeDispatchDiscovery(octokit, repo, candidate.number)
-    } catch (err) {
-      console.log(`Warning: discovery dispatch for #${candidate.number} failed: ${err}; continuing.`)
-    }
+    // No chain-dispatch: discovery-prep-bot now runs on its own cron and
+    // reads `enhancement` issues without `ready-for-human` (its label-
+    // driven input). Triage-bot's job ends at classification; pipeline
+    // hand-off happens via the issue tracker's label state, not via
+    // workflow_dispatch.
 
     processed++
   }
 
   console.log(`\nTriage bot complete. Processed ${processed}/${candidates.length}. Transcripts: ${TRANSCRIPTS_DIR}`)
-}
-
-/**
- * Decide whether to dispatch discovery-prep-bot for this issue.
- *
- * Fires the dispatch when ALL hold:
- *   - The issue is now labeled `enhancement` (triage-bot classified it as
- *     a confident enhancement — either this run or a prior one)
- *   - The issue is NOT labeled `triage-uncertain` (would be a contradiction
- *     but defensive check)
- *   - discovery-prep-bot has NOT already commented on this issue (detected
- *     via the bot's outcome-tag `<!-- discovery-prep-bot: run=` in any
- *     prior comment)
- *
- * The outcome-tag check is the load-bearing idempotency guard. Without it,
- * triage-bot would re-dispatch discovery-prep-bot for every existing
- * enhancement on every run — N PRs of CI burn for no work. The tag is
- * persistent (lives forever in the issue thread), so dedup survives across
- * any number of triage-bot runs.
- *
- * Discovery-prep-bot also performs its own outcome-tag check at startup as
- * a defensive measure (catches manual re-dispatches that bypass triage-bot).
- */
-async function maybeDispatchDiscovery(
-  octokit: ReturnType<typeof octokitFromEnv>,
-  repo: ReturnType<typeof repoFromEnv>,
-  issueNumber: number,
-): Promise<void> {
-  const { data: issue } = await octokit.issues.get({ ...repo, issue_number: issueNumber })
-  const labels = issue.labels.map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean)
-  if (!labels.includes('enhancement')) return
-  if (labels.includes('triage-uncertain')) return
-
-  const alreadyCommented = await hasPriorCommentFromBot(octokit, repo, issueNumber, 'discovery-prep-bot')
-  if (alreadyCommented) {
-    console.log(`#${issueNumber}: discovery-prep-bot has already commented; skipping dispatch.`)
-    return
-  }
-
-  console.log(`#${issueNumber}: dispatching discovery-prep-bot.yml (issue=${issueNumber})`)
-  await dispatchWorkflow(octokit, repo, 'discovery-prep-bot.yml', { issue: String(issueNumber) })
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary

Per the user re-architecture: every bot's input is a label query, every bot's output is a label mutation. **Pipeline state lives in the issue tracker's labels, not in code or workflow runs.**

## Bot contracts

| Bot | Input (lacks ALL) | Input (has ALL) | Output |
|---|---|---|---|
| flake-watcher | (CI events, not labels) | — | New issue: `bug, flake, area:X, recurring-flake?` |
| triage-bot | `ready-for-agent`, `ready-for-human`, `wontfix`, `needs-info` | open | One of `bug` / `enhancement` / `triage-uncertain` + `area: X`. Reproducible bug also gets `ready-for-agent` |
| discovery-prep-bot | `ready-for-human`, `ready-for-agent`, `wontfix`, `needs-info` | `enhancement` | Research comment + `ready-for-human` label |

## Architectural changes

- **Drop chain-dispatch from triage-bot.** Removed `maybeDispatchDiscovery()` + the `dispatchWorkflow()` helper. Pipeline handoff happens via labels, not workflow_dispatch events.
- **Generalize** `findTriageCandidates()` into `findIssuesByLabels()` — same shape but takes `requireAll` + `excludeAny`. Both bots use it. Server-side prefilter via Octokit's `labels` parameter when at least one required label exists.
- **Add** `addLabel()` helper. Discovery-prep-bot calls it to apply `ready-for-human` after posting research.
- **Discovery-prep-bot becomes cron-driven** (daily 10:00 UTC + workflow_dispatch with optional `issue` input). Cron mode scans candidates per the input contract; manual mode processes one specific issue.

## Label semantic decision: `ready-for-human` is shared

discovery-prep-bot and fix-bot (future) both apply `ready-for-human`:
- discovery-prep-bot: \"research done, grilling can start\"
- fix-bot (future): \"stuck — needs human to write test or close\"

Maintainer disambiguates by reading the latest bot comment's outcome tag. Documented in `dev-glossary.md`'s new `ready-for-human` entry.

Three reasons we accepted the label overload over adding a new label:
1. Three label uses on one label is tolerable; adding 1-2 new labels per bot would proliferate
2. Comment outcome tags already disambiguate at the issue level
3. The skill's canonical state-role set stays unchanged

## Why label-driven over chain-dispatch

| Property | Chain-dispatch | Label-driven |
|---|---|---|
| Discoverable | Read bot's index.ts to know what it watches | `gh issue list --label X` from README |
| Reversible | Code change | Remove bot's output label; next cron picks up |
| Maintainer override | Edit code + push | Add/remove labels |
| Pipeline tracing | Read transcripts + workflow runs | `gh issue view N --json labels` |
| Adding a new bot | Touch upstream's code | Don't touch upstream; add cron + label query |
| Failure recovery | Hope dispatch fired | Missing output label → next cron retries |
| State location | Code + transcripts | Issue tracker (single source of truth) |

## Migration

No data migration needed. Today's 6 \`bug + ready-for-agent\` issues are excluded from triage-bot scope (already past triage). Today's 46 \`enhancement\` issues (without `ready-for-human`) become discovery-prep-bot's first cron candidates — backlog converges over multiple days per the per-run budget.

## Test plan

- [x] Type-check clean
- [x] Triage-bot dry-run: 46 candidates (52 total minus 6 ready-for-agent bugs) ✓
- [x] Discovery-prep-bot dry-run: 46 candidates (all open enhancements; same set since none have ready-for-human yet) ✓
- [ ] After merge: discovery-prep-bot's first daily cron processes the backlog oldest-first; per-run budget bounds work. Backlog convergence over multiple days.
- [ ] Manual trigger validation: \`gh workflow run discovery-prep-bot.yml -f issue=192\` validates one-issue mode end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)