### PR TITLE
fix(bots): add lookback_hours workflow input to discovery + fix bots

### DIFF
--- a/.github/workflows/discovery-prep-bot.yml
+++ b/.github/workflows/discovery-prep-bot.yml
@@ -21,6 +21,9 @@ on:
       issue:
         description: 'Optional: research one specific issue (otherwise scans all candidates)'
         required: false
+      lookback_hours:
+        description: 'Optional: scan window. 0 = full backlog (no since-filter); N>0 = last N hours; empty = auto-detect from last successful run'
+        required: false
 
 jobs:
   research:
@@ -57,6 +60,10 @@ jobs:
           # mode" (scan candidates) and treats a numeric value as "manual
           # one-issue mode."
           ISSUE_NUMBER: ${{ inputs.issue }}
+          # Empty on cron (auto-detect since-anchor); set to "0" via manual
+          # trigger to force a full backlog scan; set to "N" to scan last
+          # N hours.
+          LOOKBACK_HOURS: ${{ inputs.lookback_hours }}
         run: npm run discovery-prep-bot -w @gazetta/bots
 
       - name: Upload transcripts

--- a/.github/workflows/fix-bot.yml
+++ b/.github/workflows/fix-bot.yml
@@ -21,6 +21,9 @@ on:
       issue:
         description: 'Optional: fix one specific issue (otherwise scans all candidates)'
         required: false
+      lookback_hours:
+        description: 'Optional: scan window. 0 = full backlog (no since-filter); N>0 = last N hours; empty = auto-detect from last successful run'
+        required: false
 
 jobs:
   fix:
@@ -74,6 +77,10 @@ jobs:
           # mode (scan candidates) and treats a numeric value as manual
           # one-issue mode.
           ISSUE_NUMBER: ${{ inputs.issue }}
+          # Empty on cron (auto-detect since-anchor); set to "0" via manual
+          # trigger to force a full backlog scan; set to "N" to scan last
+          # N hours.
+          LOOKBACK_HOURS: ${{ inputs.lookback_hours }}
         run: npm run fix-bot -w @gazetta/bots
 
       - name: Upload transcripts


### PR DESCRIPTION
## Summary

Caught while explaining what tomorrow's discovery-prep-bot cron would actually do: the since-filter + label-driven exclusion combine to strand the 29 existing enhancements. Cron will return 0 candidates and exit in <30s. Backlog never drains.

Same gap exists for fix-bot's 6 producer-bot bugs.

## Root cause

Discovery-prep-bot and fix-bot inherited the since-filter pattern from triage-bot during the label-driven refactor (#301), but didn't expose `lookback_hours` as a `workflow_dispatch` input. Without it, the only way to run a full-backlog scan is to edit code or trigger per-issue manually (47-50 separate workflow runs to clear the backlog).

The bots' `index.ts` already supports `LOOKBACK_HOURS=0` for full-backlog scan; the workflow YAMLs just need to wire input → env.

## Fix

Add `lookback_hours` input to both workflows (mirrors triage-bot's existing input).

Usage to drain a backlog:

```bash
# Drain 29 enhancement backlog through discovery-prep-bot
gh workflow run discovery-prep-bot.yml -f lookback_hours=0

# Drain 6 bug backlog through fix-bot
gh workflow run fix-bot.yml -f lookback_hours=0
```

After the one-time backlog clear, daily cron uses the since-filter (narrow window) as designed.

## Verified

```
LOOKBACK_HOURS=0 → full backlog scan (no since filter) ✓
LOOKBACK_HOURS=  → auto-detect from last successful run ✓
```

## Test plan

- [x] Type-check clean
- [x] Local dry-run with both env values
- [ ] After merge: `gh workflow run discovery-prep-bot.yml -f lookback_hours=0` to drain the 29-enhancement backlog (~30 min wall-clock estimated; per-run budget bounds it)
- [ ] Subsequent cron tomorrow at 10:00 UTC: should return 0 candidates (since-anchor on this manual run; no new enhancements since)

🤖 Generated with [Claude Code](https://claude.com/claude-code)