### PR TITLE
refactor(bots): drop since-filter from all bots — pure label-driven inputs

### DIFF
--- a/.github/workflows/triage-bot.yml
+++ b/.github/workflows/triage-bot.yml
@@ -19,15 +19,10 @@ on:
     - cron: '0 11 * * *'
   workflow_dispatch:
     # Manual trigger for testing prompt changes or one-off triage passes.
-    inputs:
-      lookback_hours:
-        description: |
-          How many hours back to scan. Empty = auto-detect via last
-          successful run (default cron behavior; incremental). Set to a
-          number to force a wider scan (720 = monthly sweep). Set to 0
-          to scan all open issues regardless of update time.
-        required: false
-        default: ''
+    # No inputs — bot's input is purely label-driven (open issues without
+    # any classification or terminal-state label). To re-enqueue an
+    # already-classified issue, manually remove the classification label
+    # from it; next cron picks it up.
 
 jobs:
   triage:
@@ -66,9 +61,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
-          # Empty on cron (auto-detect via last-successful-run); set on
-          # manual trigger to override (720 = 30d sweep, 0 = all open).
-          LOOKBACK_HOURS: ${{ inputs.lookback_hours || '' }}
         run: npm run triage-bot -w @gazetta/bots
 
       # Per-issue JSONL transcripts. Same loop as flake-watcher: a future

--- a/bots/_lib/github.ts
+++ b/bots/_lib/github.ts
@@ -121,7 +121,7 @@ export interface IssueSummary {
  *     excludeAny: ['bug', 'enhancement', 'triage-uncertain',
  *                  'ready-for-agent', 'ready-for-human',
  *                  'wontfix', 'needs-info']
- *     (the absence of any category role + absence of any state advancement)
+ *     (no classification yet AND no state advancement)
  *
  *   discovery-prep-bot:
  *     requireAll: ['enhancement']
@@ -129,23 +129,26 @@ export interface IssueSummary {
  *                  'wontfix', 'needs-info']
  *     (an enhancement that hasn't been handed off downstream)
  *
- *   fix-bot (future):
+ *   fix-bot:
  *     requireAll: ['bug', 'ready-for-agent']
  *     excludeAny: ['wontfix', 'needs-info', 'ready-for-human']
  *     (a bug ready for an agent, no maintainer escalation in flight)
  *
- * `sinceIso` (optional) lets the daily cron scan only what changed since
- * the last successful run. Without it (or with a since from before the
- * project began), behaves as a full scan — the manual "wide lookback"
- * path uses no since.
- *
  * Excludes pull requests — Octokit returns PRs in this endpoint by default
  * because GitHub treats them as a kind of issue. Filtered out here.
+ *
+ * No since-filter: the label-driven exclude-set already narrows candidates
+ * to "issues that need work this run." Re-checking already-processed
+ * issues at the API level is cheap (one bounded list call per cron); the
+ * since-filter would save ~30s per cron at the cost of a stranded-backlog
+ * failure mode. Not worth the complexity. Maintainer who wants to
+ * re-enqueue an issue removes its completion label — the next cron picks
+ * it up because the exclude-set no longer matches.
  */
 export async function findIssuesByLabels(
   octokit: Octokit,
   repo: RepoIdentity,
-  options: { requireAll?: readonly string[]; excludeAny: readonly string[]; sinceIso?: string },
+  options: { requireAll?: readonly string[]; excludeAny: readonly string[] },
 ): Promise<IssueSummary[]> {
   const requireAll = options.requireAll ?? []
   const { data } = await octokit.issues.listForRepo({
@@ -156,7 +159,6 @@ export async function findIssuesByLabels(
     // takes a comma-separated string. Issues here have ALL of these labels
     // (intersection), which matches our requireAll semantics.
     ...(requireAll.length > 0 ? { labels: requireAll.join(',') } : {}),
-    ...(options.sinceIso ? { since: options.sinceIso } : {}),
   })
 
   const out: IssueSummary[] = []
@@ -173,45 +175,6 @@ export async function findIssuesByLabels(
     })
   }
   return out
-}
-
-/**
- * Find when the most recent successful workflow run COMPLETED (not started).
- *
- * Used by triage-bot to determine "what's changed since I last finished
- * looking" without persistent state — the workflow run history IS the state.
- *
- * Returns the run's `updated_at` ISO timestamp (which equals `completed_at`
- * for finished runs). Returns null when no prior successful run exists.
- *
- * Why `updated_at` not `created_at`: the bot's own comments happen DURING
- * a run, between `created_at` and `updated_at`. If we anchored to
- * `created_at`, the next run's incremental scan would see all those
- * comments as "new activity since last run" and re-investigate every
- * issue the bot just touched. Anchoring to `updated_at` (when the bot
- * stopped writing) means only genuinely-new activity since then triggers
- * re-investigation.
- *
- * Excludes the current in-progress run so the bot doesn't pick its own
- * start as the anchor.
- */
-export async function findLastSuccessfulRunIso(
-  octokit: Octokit,
-  repo: RepoIdentity,
-  workflowFileName: string,
-  excludeRunId?: number,
-): Promise<string | null> {
-  const { data } = await octokit.actions.listWorkflowRuns({
-    ...repo,
-    workflow_id: workflowFileName, // Octokit accepts file path here, e.g. "triage-bot.yml"
-    status: 'success',
-    per_page: 10,
-  })
-  for (const run of data.workflow_runs) {
-    if (excludeRunId !== undefined && run.id === excludeRunId) continue
-    return run.updated_at
-  }
-  return null
 }
 
 /**

--- a/bots/discovery-prep-bot/index.ts
+++ b/bots/discovery-prep-bot/index.ts
@@ -51,13 +51,7 @@ import { mkdirSync, readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { runClaude } from '../_lib/claude.js'
-import {
-  findIssuesByLabels,
-  findLastSuccessfulRunIso,
-  hasPriorCommentFromBot,
-  octokitFromEnv,
-  repoFromEnv,
-} from '../_lib/github.js'
+import { findIssuesByLabels, hasPriorCommentFromBot, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const PROMPT_PATH = resolve(HERE, 'prompt.md')
@@ -71,11 +65,6 @@ const RUN_TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$
 // at 50 min for the upload-artifacts step + any in-flight per-issue work.
 // Override via env for local manual runs.
 const PER_RUN_BUDGET_MS = Number(process.env.BUDGET_MS ?? 50 * 60 * 1000)
-
-// Optional manual override: set LOOKBACK_HOURS to force a wider scan than
-// the auto-detected since-anchor. Same shape as triage-bot's override.
-const rawLookback = process.env.LOOKBACK_HOURS
-const LOOKBACK_HOURS_OVERRIDE = rawLookback !== undefined && rawLookback !== '' ? rawLookback : undefined
 
 async function main(): Promise<void> {
   const repo = repoFromEnv()
@@ -92,14 +81,15 @@ async function main(): Promise<void> {
     return
   }
 
-  // Cron mode: scan candidates and process per-run-budget.
-  const sinceIso = await resolveSinceIso(octokit, repo)
   console.log(`Discovery prep bot: scanning ${repo.owner}/${repo.repo} for confident-enhancement candidates`)
 
+  // Label-driven input: every enhancement that hasn't been handed off
+  // downstream. Once `ready-for-human` is applied (after research is
+  // posted), the issue is excluded forever — the label IS the
+  // completion signal. Maintainer re-enqueues by removing the label.
   const allCandidates = await findIssuesByLabels(octokit, repo, {
     requireAll: ['enhancement'],
     excludeAny: ['ready-for-human', 'ready-for-agent', 'wontfix', 'needs-info'],
-    sinceIso,
   })
 
   if (allCandidates.length === 0) {
@@ -148,40 +138,6 @@ async function main(): Promise<void> {
   }
 
   console.log(`\nDiscovery prep bot complete. Processed ${processed}/${candidates.length}.`)
-}
-
-/**
- * Resolve the "since" anchor for incremental scanning.
- *
- *   - LOOKBACK_HOURS=0           → no since filter (full backlog scan)
- *   - LOOKBACK_HOURS=N (N > 0)   → since = now - N hours
- *   - unset (cron default)       → since = last successful discovery-prep-bot
- *                                  run minus 1h overlap
- */
-async function resolveSinceIso(
-  octokit: ReturnType<typeof octokitFromEnv>,
-  repo: ReturnType<typeof repoFromEnv>,
-): Promise<string | undefined> {
-  if (LOOKBACK_HOURS_OVERRIDE !== undefined) {
-    const hours = Number(LOOKBACK_HOURS_OVERRIDE)
-    if (hours === 0) {
-      console.log('LOOKBACK_HOURS=0 — full backlog scan (no since filter)')
-      return undefined
-    }
-    const sinceIso = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()
-    console.log(`LOOKBACK_HOURS=${hours} — scanning issues updated since ${sinceIso}`)
-    return sinceIso
-  }
-  const currentRunId = process.env.GITHUB_RUN_ID ? Number(process.env.GITHUB_RUN_ID) : undefined
-  const lastRun = await findLastSuccessfulRunIso(octokit, repo, 'discovery-prep-bot.yml', currentRunId)
-  if (!lastRun) {
-    console.log('No prior successful run — full backlog scan (first ever invocation)')
-    return undefined
-  }
-  const lastRunMs = new Date(lastRun).getTime()
-  const sinceIso = new Date(lastRunMs - 60 * 60 * 1000).toISOString()
-  console.log(`Auto-detected last successful run completed at ${lastRun}; scanning since ${sinceIso} (1h overlap)`)
-  return sinceIso
 }
 
 /**

--- a/bots/fix-bot/index.ts
+++ b/bots/fix-bot/index.ts
@@ -47,13 +47,7 @@ import { mkdirSync, readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { runClaude } from '../_lib/claude.js'
-import {
-  findIssuesByLabels,
-  findLastSuccessfulRunIso,
-  hasPriorCommentFromBot,
-  octokitFromEnv,
-  repoFromEnv,
-} from '../_lib/github.js'
+import { findIssuesByLabels, hasPriorCommentFromBot, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const PROMPT_PATH = resolve(HERE, 'prompt.md')
@@ -67,11 +61,6 @@ const RUN_TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$
 // take 15-30 min per issue. Budget at 50 min (10 min margin from
 // workflow's 60 min timeout) means roughly 1-2 fixes per cron.
 const PER_RUN_BUDGET_MS = Number(process.env.BUDGET_MS ?? 50 * 60 * 1000)
-
-// Optional manual override: set LOOKBACK_HOURS to force a wider scan than
-// the auto-detected since-anchor. Same shape as triage-bot / discovery-prep-bot.
-const rawLookback = process.env.LOOKBACK_HOURS
-const LOOKBACK_HOURS_OVERRIDE = rawLookback !== undefined && rawLookback !== '' ? rawLookback : undefined
 
 async function main(): Promise<void> {
   const repo = repoFromEnv()
@@ -88,14 +77,17 @@ async function main(): Promise<void> {
     return
   }
 
-  // Cron mode: scan candidates.
-  const sinceIso = await resolveSinceIso(octokit, repo)
   console.log(`Fix bot: scanning ${repo.owner}/${repo.repo} for bug+ready-for-agent candidates`)
 
+  // Label-driven input: every bug ready-for-agent that hasn't escalated
+  // to a maintainer-only state. The `ready-for-agent` label is the
+  // upstream signal (applied by triage-bot or by maintainer); fix-bot's
+  // own completion is "ready-for-human" (when stuck) or PR existence
+  // (when fix attempted). The hasPriorCommentFromBot check below catches
+  // the PR-attempted path; ready-for-human catches the stuck path.
   const allCandidates = await findIssuesByLabels(octokit, repo, {
     requireAll: ['bug', 'ready-for-agent'],
     excludeAny: ['ready-for-human', 'wontfix', 'needs-info'],
-    sinceIso,
   })
 
   if (allCandidates.length === 0) {
@@ -143,32 +135,6 @@ async function main(): Promise<void> {
   }
 
   console.log(`\nFix bot complete. Processed ${processed}/${candidates.length}.`)
-}
-
-async function resolveSinceIso(
-  octokit: ReturnType<typeof octokitFromEnv>,
-  repo: ReturnType<typeof repoFromEnv>,
-): Promise<string | undefined> {
-  if (LOOKBACK_HOURS_OVERRIDE !== undefined) {
-    const hours = Number(LOOKBACK_HOURS_OVERRIDE)
-    if (hours === 0) {
-      console.log('LOOKBACK_HOURS=0 — full backlog scan (no since filter)')
-      return undefined
-    }
-    const sinceIso = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()
-    console.log(`LOOKBACK_HOURS=${hours} — scanning issues updated since ${sinceIso}`)
-    return sinceIso
-  }
-  const currentRunId = process.env.GITHUB_RUN_ID ? Number(process.env.GITHUB_RUN_ID) : undefined
-  const lastRun = await findLastSuccessfulRunIso(octokit, repo, 'fix-bot.yml', currentRunId)
-  if (!lastRun) {
-    console.log('No prior successful run — full backlog scan (first ever invocation)')
-    return undefined
-  }
-  const lastRunMs = new Date(lastRun).getTime()
-  const sinceIso = new Date(lastRunMs - 60 * 60 * 1000).toISOString()
-  console.log(`Auto-detected last successful run completed at ${lastRun}; scanning since ${sinceIso} (1h overlap)`)
-  return sinceIso
 }
 
 /**

--- a/bots/triage-bot/index.ts
+++ b/bots/triage-bot/index.ts
@@ -33,13 +33,7 @@ import { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { runClaude } from '../_lib/claude.js'
-import {
-  findIssuesByLabels,
-  findLastSuccessfulRunIso,
-  hasPriorBotComment,
-  octokitFromEnv,
-  repoFromEnv,
-} from '../_lib/github.js'
+import { findIssuesByLabels, hasPriorBotComment, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const PROMPT_PATH = resolve(HERE, 'prompt.md')
@@ -57,67 +51,31 @@ const RUN_TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$
 // days for one-time spikes). Override via env for local manual runs.
 const PER_RUN_BUDGET_MS = Number(process.env.BUDGET_MS ?? 50 * 60 * 1000)
 
-// Optional manual override: set LOOKBACK_HOURS to force a wider scan.
-//   LOOKBACK_HOURS=720    → scan last 30 days (good for a periodic full sweep)
-//   LOOKBACK_HOURS=0      → scan ALL open issues (no since filter — backlog mode)
-//   unset / empty string  → auto-detect via the last successful workflow run
-//
-// Empty string handling: workflow_dispatch inputs always coerce to strings
-// in the env block. With `LOOKBACK_HOURS: ${{ inputs.lookback_hours || '' }}`
-// in the YAML, an unset input arrives here as "" (empty string), NOT
-// undefined. We treat empty as equivalent to unset to preserve the auto-
-// detect default for cron AND default-input manual triggers. Without this,
-// empty string would coerce via Number('') === 0 into the "full backlog"
-// branch and silently re-walk all issues every manual trigger.
-const rawLookback = process.env.LOOKBACK_HOURS
-const LOOKBACK_HOURS_OVERRIDE = rawLookback !== undefined && rawLookback !== '' ? rawLookback : undefined
-
 async function main(): Promise<void> {
   const repo = repoFromEnv()
   const octokit = octokitFromEnv()
 
-  // Resolve the "since" anchor for incremental scanning.
-  //   - LOOKBACK_HOURS=0           → no since filter (full backlog scan)
-  //   - LOOKBACK_HOURS=N (N > 0)   → since = now - N hours
-  //   - unset (cron default)       → since = last successful triage-bot run
-  //                                  minus 1h overlap (handles edge cases
-  //                                  where an issue was updated mid-run)
-  let sinceIso: string | undefined
-  if (LOOKBACK_HOURS_OVERRIDE !== undefined) {
-    const hours = Number(LOOKBACK_HOURS_OVERRIDE)
-    if (hours === 0) {
-      console.log('LOOKBACK_HOURS=0 — full backlog scan (no since filter)')
-      sinceIso = undefined
-    } else {
-      sinceIso = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()
-      console.log(`LOOKBACK_HOURS=${hours} — scanning issues updated since ${sinceIso}`)
-    }
-  } else {
-    const currentRunId = process.env.GITHUB_RUN_ID ? Number(process.env.GITHUB_RUN_ID) : undefined
-    const lastRun = await findLastSuccessfulRunIso(octokit, repo, 'triage-bot.yml', currentRunId)
-    if (lastRun) {
-      const lastRunMs = new Date(lastRun).getTime()
-      sinceIso = new Date(lastRunMs - 60 * 60 * 1000).toISOString()
-      console.log(`Auto-detected last successful run completed at ${lastRun}; scanning since ${sinceIso} (1h overlap)`)
-    } else {
-      console.log('No prior successful run — full backlog scan (first ever invocation)')
-      sinceIso = undefined
-    }
-  }
-
   console.log(`Triage bot: scanning ${repo.owner}/${repo.repo} for triage candidates`)
 
-  // Triage-bot's input contract: any open issue NOT yet advanced to a
-  // terminal state. Re-visits already-classified issues so that:
-  //   - New reporter activity can trigger reclassification suggestions
-  //   - Auto-advance can fire on bugs the bot classified before the
-  //     auto-advance rule existed
-  // The bot's prompt handles dedup (skip if no new findings) and the
-  // append-only rule (don't change labels on re-investigation, except
-  // for ready-for-agent auto-advance).
+  // Triage-bot's input contract: any open issue with NO classification
+  // yet (no `bug` / `enhancement` / `triage-uncertain`) AND no terminal-
+  // state label (no `ready-for-agent` / `ready-for-human` / `wontfix` /
+  // `needs-info`). Once classified, the issue is excluded forever — the
+  // label IS the completion signal.
+  //
+  // Reclassification path: maintainer removes the existing classification
+  // label to re-enqueue. Re-investigation across runs is the maintainer's
+  // explicit gesture, not the bot's default.
   const allCandidates = await findIssuesByLabels(octokit, repo, {
-    excludeAny: ['ready-for-agent', 'ready-for-human', 'wontfix', 'needs-info'],
-    sinceIso,
+    excludeAny: [
+      'bug',
+      'enhancement',
+      'triage-uncertain',
+      'ready-for-agent',
+      'ready-for-human',
+      'wontfix',
+      'needs-info',
+    ],
   })
 
   if (allCandidates.length === 0) {

--- a/bots/triage-bot/index.ts
+++ b/bots/triage-bot/index.ts
@@ -33,7 +33,7 @@ import { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { runClaude } from '../_lib/claude.js'
-import { findIssuesByLabels, hasPriorBotComment, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
+import { findIssuesByLabels, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const PROMPT_PATH = resolve(HERE, 'prompt.md')
@@ -153,17 +153,14 @@ ${roadmap}
       `\n=== Triaging #${candidate.number}: "${candidate.title}" (${processed + 1}/${candidates.length}, ${Math.round(elapsed / 1000)}s elapsed) ===`,
     )
 
-    // Pre-compute "is this a first investigation" at the orchestrator level.
-    // Saves Claude one tool call (gh issue view --json comments) and removes
-    // an ambiguity (Claude sometimes mis-classified maintainer comments
-    // mentioning "triage" as prior bot output).
-    const isFirstInvestigation = !(await hasPriorBotComment(octokit, repo, candidate.number))
-
+    // Every investigation is fresh — the candidate query already excludes
+    // classified issues, so any candidate we see is either brand-new or
+    // explicitly re-enqueued by a maintainer (who removed the prior
+    // classification label). In both cases, classify from scratch.
     const prompt = `${promptTemplate}${referenceDocsBlock}
 
 ISSUE_NUMBER=${candidate.number}
 ISSUE_TITLE=${candidate.title}
-IS_FIRST_INVESTIGATION=${isFirstInvestigation}
 RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
 
     const transcriptPath = resolve(TRANSCRIPTS_DIR, `${RUN_TIMESTAMP}-issue-${candidate.number}.jsonl`)

--- a/bots/triage-bot/prompt.md
+++ b/bots/triage-bot/prompt.md
@@ -26,10 +26,14 @@ advancement past `ready-for-agent` (they merge the fix-bot PR or not).
 
 - `ISSUE_NUMBER` — the GitHub issue number to triage
 - `ISSUE_TITLE` — for context (the issue body has the full content)
-- `IS_FIRST_INVESTIGATION` — `true` when no prior bot comment exists on this
-  issue, `false` otherwise. Pre-computed by the orchestrator. Trust this
-  value — do NOT re-check via `gh issue view --json comments`.
 - `RUN_ID` — the workflow run ID (used for outcome tags); `local` if running outside CI
+
+Every investigation is FRESH. The candidate query already excludes
+classified issues — if you're seeing this issue, it's either brand-new
+or explicitly re-enqueued by a maintainer who removed the prior
+classification label. In both cases, classify from scratch. If a prior
+bot comment exists, append your new comment as a new entry; the prior
+one stands as history.
 
 The prompt also includes a **Reference docs** block at the bottom containing
 the full text of `docs/non-goals.md` and `ROADMAP.md`. Match against that
@@ -568,47 +572,13 @@ gh issue edit $ISSUE_NUMBER --add-label "triage-uncertain,area: cms"
 - **Don't ask the user questions** — you're running headless. If reporter
   input is needed, surface that in your comment ("Maintainer: this needs
   reporter clarification on X before agent-ready") and stop.
-- **Skip if already advanced.** The bot's selection logic already excludes
-  issues with any of `ready-for-agent`, `ready-for-human`, `wontfix`,
-  `needs-info` — but verify defensively at start of investigation. If any of
-  those four labels is present, emit a Decision line and exit immediately;
-  do not re-classify.
-- **Auto-advance is idempotent and runs unconditionally** (when its
-  conditions match). Even when `IS_FIRST_INVESTIGATION=false` and
-  you're about to dedup-skip, FIRST check whether auto-advance applies
-  (per step 8e: confident bug + reproducible-locally OR producer-bot-
-  filed). If yes, apply `ready-for-agent` BEFORE exiting. The label is
-  idempotent — a no-op when already present — so it's safe to apply on
-  every investigation. Without this carve-out, any bug classified
-  before auto-advance was a rule (PR #296) would never receive
-  `ready-for-agent` because the dedup-skip would fire first. Order:
-  read prior comments → check auto-advance conditions → apply
-  `ready-for-agent` if applicable → THEN apply the dedup-skip rule
-  below.
-- **Skip if no new findings vs prior bot comment.** When
-  `IS_FIRST_INVESTIGATION=false` (the orchestrator pre-computed this for
-  you — trust it; do NOT re-fetch comments), read the existing bot
-  comments first to understand what was already said. Only post a new
-  comment if you have meaningfully new findings — e.g. you ran a repro
-  this time and the prior comment hadn't, or new reporter/maintainer
-  activity has surfaced fresh information. If you have nothing new, emit
-  `> Decision: prior bot comment covers this; nothing new to add` and
-  exit. Labels are still applied idempotently (no-op when already there).
-- **Append-only after first investigation.** Labels are the bot's opening
-  hand. When `IS_FIRST_INVESTIGATION=true`, apply category + area +
-  needs-triage. When `false`, append new comments but do NOT change
-  labels (even labels the bot itself applied) and do NOT edit prior bot
-  comments. **Exception:** `ready-for-agent` may be applied on subsequent
-  investigations when the auto-advance conditions match (per the
-  preceding rule). This is the one label triage-bot adds during dedup-
-  skip; all others stay frozen after first investigation. If new evidence
-  (reporter follow-up, new failures, etc.) suggests reclassifying —
-  e.g. an `enhancement` that the reporter has now clarified is happening
-  in production — append a comment surfacing the suggested
-  reclassification and let the maintainer decide via `/triage`. Format:
-  "Reporter follow-up suggests reclassifying as `<X>` — maintainer
-  please confirm." Bot never retracts its own labels or edits its own
-  comments.
+- **Defensive label check before classifying.** The bot's selection
+  logic excludes issues with any of `bug`, `enhancement`,
+  `triage-uncertain`, `ready-for-agent`, `ready-for-human`, `wontfix`,
+  `needs-info` — but verify defensively at start of investigation. If
+  any of those labels is unexpectedly present (e.g., a manual workflow
+  run targeting an already-classified issue), emit a Decision line
+  and exit immediately. Do not re-classify a labeled issue.
 - **Comment-action consistency.** The body of any `gh issue comment` MUST
   match the labels you actually applied and the actions you actually took.
   When drafting your comment text, re-read your prior `gh issue edit`


### PR DESCRIPTION
## Summary

User insight: **if all bots produce completion labels, the since-filter is redundant.** The label query already excludes done work at the API level. Re-checking already-done issues is impossible.

This PR makes triage-bot use the same pattern discovery-prep-bot and fix-bot already use: classification labels in `excludeAny`. Then drops the since-filter plumbing from all three bots. Plus a follow-up commit removing the now-unreachable `IS_FIRST_INVESTIGATION` / dedup-skip rules from triage-bot.

## Bot contracts after this PR

| Bot | requireAll | excludeAny |
|---|---|---|
| triage-bot | — | `bug`, `enhancement`, `triage-uncertain`, `ready-for-agent`, `ready-for-human`, `wontfix`, `needs-info` |
| discovery-prep-bot | `enhancement` | `ready-for-human`, `ready-for-agent`, `wontfix`, `needs-info` |
| fix-bot | `bug`, `ready-for-agent` | `ready-for-human`, `wontfix`, `needs-info` |

Once a bot produces its completion label, the candidate query never returns the issue again. Same gesture maintainer-side: remove the completion label to re-enqueue.

## Commits in this PR

### 1. Drop since-filter from all bots

- `findLastSuccessfulRunIso()` helper from `_lib/github.ts`
- `sinceIso` parameter from `findIssuesByLabels()`
- `resolveSinceIso()` function from discovery-prep-bot and fix-bot
- `LOOKBACK_HOURS_OVERRIDE` parsing from all three bots
- `lookback_hours` workflow input from triage-bot.yml

### 2. Drop IS_FIRST_INVESTIGATION + dedup-skip rules from triage-bot

Now that the candidate query excludes classified issues, the dedup-skip path is unreachable. Removed:

- `hasPriorBotComment()` call in triage-bot (saves one Octokit call per candidate)
- `IS_FIRST_INVESTIGATION` input
- 3 prompt rules totalling ~40 lines:
  - \"Skip if no new findings vs prior bot comment\"
  - \"Append-only after first investigation\"
  - \"Auto-advance is idempotent and runs unconditionally\" (the carve-out for dedup-skip — now unreachable)

Auto-advance step 8e still fires during fresh classification when bug is reproducible OR producer-bot-filed — that's normal classification flow, not a dedup-skip carve-out.

## Net change

~120 LOC less; mental model: \"label-driven completion across all bots, every investigation is fresh.\"

## What stays

- **Per-run budget** in all three bots (still bounds wall-clock per cron)
- **Oldest-first sort** (backlog convergence over multiple cron days when budget bounds work)
- **Per-bot outcome-tag check** (`hasPriorCommentFromBot`) for stuck-path detection — fix-bot and discovery-prep-bot use it for defense-in-depth on manual one-issue triggers
- **flake-watcher's `lookback_hours`** input — different purpose (CI run window, not issue tracker since-filter); not affected

## Verified locally

```
triage-bot dry-run:        0 candidates (everything already classified) ✓
discovery-prep-bot dry-run: 45 candidates (46 enhancements minus #192's ready-for-human) ✓
fix-bot dry-run:           6 candidates (producer-bot bugs) ✓
```

## Supersedes

Closed PR #303 (which added `lookback_hours` input to discovery + fix bots — the simpler answer turned out to be \"don't need it at all\").

🤖 Generated with [Claude Code](https://claude.com/claude-code)