### PR TITLE
Add mutation-watcher + friendlier orchestrator output

### DIFF
--- a/.github/workflows/mutation-watcher.yml
+++ b/.github/workflows/mutation-watcher.yml
@@ -1,0 +1,68 @@
+name: Mutation watcher
+
+# Daily review of Stryker mutation results. Pairs with the Mutation
+# workflow (mutation.yml) which runs at 03:00 UTC and uploads an HTML
+# report. This watcher runs at 03:30 UTC, fetches that artifact, and
+# files issues for surviving mutants worth investigating.
+#
+# Producer-bot pattern: self-classifies output as `bug` + `area: X` +
+# `ready-for-agent`, bypassing triage-bot. Surviving mutants are
+# self-validating gaps — they go straight to fix-bot's queue.
+#
+# This workflow's failure doesn't block anything (continue-on-error) —
+# monitoring infrastructure, not a gate.
+on:
+  schedule:
+    # 03:30 UTC daily — 30 min after the Mutation workflow's nightly
+    # run. Mutation runs ~1-3h on the current target set; the artifact
+    # is ready well before our 30-min lag, but the lag absorbs delays.
+    - cron: '30 3 * * *'
+  workflow_dispatch:
+    # Manual trigger — useful for testing prompt changes against the
+    # latest Mutation artifact without waiting for the next cron.
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 30
+    permissions:
+      # Read CI run history (download Mutation artifact) + read/write
+      # issues. No code/contents access needed.
+      actions: read
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install workspace deps
+        run: npm ci
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run mutation watcher
+        env:
+          # Auth via Claude Code OAuth token — see flake-watcher.yml for
+          # the same pattern.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: npm run mutation-watcher -w @gazetta/bots
+
+      # Per-investigation JSONL transcripts. A future agent can run
+      # `gh run download <run-id> -n mutation-watcher-transcripts` to read
+      # every tool call and decision from past runs.
+      - name: Upload transcripts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutation-watcher-transcripts
+          path: bots/transcripts/
+          if-no-files-found: ignore
+          retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ reports/
 # real bot runs or replays. Don't commit.
 bots/transcripts/
 bots/test-outputs/
+# mutation-watcher's per-run artifact staging dir — re-fetched every cron from
+# the latest Mutation workflow run. Never authoritative.
+bots/mutation-report-staging/

--- a/bots/README.md
+++ b/bots/README.md
@@ -59,36 +59,57 @@ GITHUB_REPOSITORY=gazetta-studio/gazetta-studio GH_TOKEN=$(gh auth token) \
 
 ## Active bots
 
-| Bot | Trigger | Input (label-driven) | Output |
-|---|---|---|---|
-| `flake-watcher` | Daily 12:00 UTC + workflow_dispatch | (CI events, not labels) | New issue with `bug`, `flake`, `area: X`, `recurring-flake?` |
-| `triage-bot` | Daily 11:00 UTC + workflow_dispatch | Open issue lacking all of `ready-for-agent`, `ready-for-human`, `wontfix`, `needs-info` | One of `bug` / `enhancement` / `triage-uncertain` + `area: X`. Reproducible bug also gets `ready-for-agent`. |
-| `discovery-prep-bot` | Daily 10:00 UTC + workflow_dispatch | `enhancement` AND lacks all of `ready-for-human`, `ready-for-agent`, `wontfix`, `needs-info` | Research comment + `ready-for-human` label |
-| `fix-bot` | Daily 13:00 UTC + workflow_dispatch | `bug` + `ready-for-agent` AND lacks all of `ready-for-human`, `wontfix`, `needs-info` AND no prior fix-bot comment | EITHER draft PR (two commits: failing test + fix), OR stuck-comment + `ready-for-human` label |
+| Bot | Trigger | Input (label-driven, except producer bots) | Output | Role |
+|---|---|---|---|---|
+| `flake-watcher` | Daily 12:00 UTC + workflow_dispatch | CI events (run_attempt >= 2) — not labels | New issue with `bug` + `flake` + `area: X` + `ready-for-agent` (+ `recurring-flake` when applicable) | **Producer** — self-classifies, bypasses triage |
+| `mutation-watcher` | Daily 03:30 UTC + workflow_dispatch | Latest successful Mutation artifact — not labels | New issue with `bug` + `area: X` + `ready-for-agent` per source file with surviving mutants | **Producer** — self-classifies, bypasses triage |
+| `triage-bot` | Daily 11:00 UTC + workflow_dispatch | Open issue lacking all of `bug`, `enhancement`, `triage-uncertain`, `ready-for-agent`, `ready-for-human`, `wontfix`, `needs-info` | One of `bug` / `enhancement` / `triage-uncertain` + `area: X`. Reproducible bug also gets `ready-for-agent`. | Classifier |
+| `discovery-prep-bot` | Daily 10:00 UTC + workflow_dispatch | `enhancement` AND lacks all of `ready-for-human`, `ready-for-agent`, `wontfix`, `needs-info` | Research comment + `ready-for-human` label | Researcher |
+| `fix-bot` | Daily 13:00 UTC + workflow_dispatch | `bug` + `ready-for-agent` AND lacks all of `ready-for-human`, `wontfix`, `needs-info` AND no prior fix-bot comment | EITHER draft PR (two commits: failing test + fix), OR stuck-comment + `ready-for-human` label | Implementer |
+
+**Producer bots vs triage-bot.** Producer bots (`flake-watcher`,
+`mutation-watcher`) consume CI signal and self-classify their output —
+they apply `bug` + `ready-for-agent` directly, bypassing triage-bot.
+Triage-bot's input contract excludes issues already carrying `bug` /
+`enhancement` / `triage-uncertain`, so producer-bot output flows
+straight into fix-bot's queue. The CI signal IS the validation; no
+triage step adds value.
 
 ### Pipeline shape (label-driven)
 
 ```
-flake-watcher (cron 12:00 UTC)
-    ↓ files issue (auto-classified `bug`)
-triage-bot (cron 11:00 UTC next day) — input: open + no terminal-state label
-    ├─→ confident bug + reproducible → applies `ready-for-agent`
-    │       ↓
-    │   fix-bot (cron 13:00 UTC) — input: bug + ready-for-agent + no
-    │   terminal-state label + no prior fix-bot comment
-    │       ↓ EITHER opens draft PR (failing test + fix), OR posts
-    │         stuck-comment + applies `ready-for-human`
-    │   maintainer reviews PR, merges
+Producer bots — bypass triage-bot, go straight to fix-bot's queue:
+─────────────────────────────────────────────────────────────────
+flake-watcher (cron 12:00 UTC)         mutation-watcher (cron 03:30 UTC)
+    ↓ files issue with                     ↓ files issue with
+      bug + flake + ready-for-agent          bug + ready-for-agent
+                          \           /
+                           \         /
+Human-filed issues — go through triage:
+──────────────────────────────────────
+issue filed by maintainer / contributor (no labels)
+    ↓
+triage-bot (cron 11:00 UTC) — input: open + no classification
+    ├─→ confident bug + reproducible → applies bug + ready-for-agent
     │
-    ├─→ confident enhancement → no extra label
+    ├─→ confident enhancement → applies enhancement
     │       ↓
-    │   discovery-prep-bot (cron 10:00 UTC) — input: enhancement + no
-    │   ready-for-human / ready-for-agent / wontfix / needs-info
-    │       ↓ posts research comment + applies `ready-for-human`
+    │   discovery-prep-bot (cron 10:00 UTC) — input: enhancement + not yet handed off
+    │       ↓ posts research comment + applies ready-for-human
     │   maintainer reads comment, starts grilling at their pace
     │
     └─→ triage-uncertain → maintainer's morning queue
             gh issue list --label triage-uncertain
+
+All confident-bug paths converge here:
+─────────────────────────────────────
+                          ↓
+                          ↓ (bug + ready-for-agent from any source)
+                          ↓
+fix-bot (cron 13:00 UTC) — input: bug + ready-for-agent + no prior fix-bot comment
+    ↓ EITHER opens draft PR (failing test + fix),
+      OR posts stuck-comment + applies ready-for-human
+maintainer reviews PR, merges
 ```
 
 **Pipeline state lives in labels, not in code or workflow runs.** Each bot's input is a label query; each bot's output is a label mutation. To re-run any bot on an issue, remove its output label — the next cron picks it up. To opt-out an issue, apply a terminal-state label (`wontfix` / `ready-for-human`).

--- a/bots/_lib/claude.ts
+++ b/bots/_lib/claude.ts
@@ -21,6 +21,7 @@ import { createWriteStream } from 'node:fs'
 import { mkdir } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { c } from './colors.js'
 
 /**
  * Repo root, derived from this file's location: bots/_lib/claude.ts → ../../
@@ -104,6 +105,27 @@ interface ResultEvent extends StreamEventBase {
  * Run `claude -p` headless. Writes raw JSONL transcript to disk; renders a
  * human-readable summary to stdout in real time.
  *
+ * Live-rendering rules (favors maintainer skim over completeness — full
+ * detail is in the JSONL transcript):
+ *
+ *   - Tool call + result paired on one line:
+ *       "  → Bash (4521 chars in 1.2s) gh issue view 245 ..."
+ *     We track tool_use_id at the call site, then back-fill size + duration
+ *     when the matching tool_result arrives. Avoids the dangling "← (N
+ *     chars)" line that didn't tell you which call it belonged to.
+ *
+ *   - Decisions highlighted with "★ Decision: ..." — the prompts ask Claude
+ *     to articulate WHY before non-trivial actions. Surfacing them means a
+ *     maintainer scanning the log sees the reasoning trail at a glance.
+ *
+ *   - Other Claude text (acknowledgements, narration) is rendered as
+ *     "▸ ..." but only the first line of any multi-line block. The rest
+ *     lives in the transcript.
+ *
+ *   - Final result line summarises duration + turns + counts of tool
+ *     calls and decisions, so a maintainer sees the shape of the
+ *     investigation without scrolling.
+ *
  * Flag rationale:
  *   --print                       : non-interactive, exit after response
  *   --output-format stream-json   : emit one JSON event per line — required
@@ -120,6 +142,12 @@ export async function runClaude(opts: ClaudeOptions): Promise<ClaudeResult> {
   const tools = opts.allowedTools ?? ['Bash']
   await mkdir(dirname(opts.transcriptPath), { recursive: true })
   const transcript = createWriteStream(opts.transcriptPath, { flags: 'w' })
+
+  // Per-call rendering state. Pending tool calls indexed by tool_use_id so
+  // the matching tool_result can backfill duration + size. Counters drive
+  // the final summary line.
+  const pending = new Map<string, { name: string; summary: string; startedAt: number }>()
+  const counters = { toolCalls: 0, decisions: 0 }
 
   return new Promise((resolve, reject) => {
     const child = spawn(
@@ -149,7 +177,7 @@ export async function runClaude(opts: ClaudeOptions): Promise<ClaudeResult> {
         stdoutBuffer = stdoutBuffer.slice(nlIndex + 1)
         if (line.trim()) {
           transcript.write(`${line}\n`)
-          renderSummaryLine(line)
+          renderSummaryLine(line, pending, counters)
         }
         nlIndex = stdoutBuffer.indexOf('\n')
       }
@@ -163,7 +191,7 @@ export async function runClaude(opts: ClaudeOptions): Promise<ClaudeResult> {
       // Flush any tail without trailing newline.
       if (stdoutBuffer.trim()) {
         transcript.write(`${stdoutBuffer}\n`)
-        renderSummaryLine(stdoutBuffer)
+        renderSummaryLine(stdoutBuffer, pending, counters)
       }
       transcript.end()
       const exitCode = code ?? 1
@@ -175,18 +203,36 @@ export async function runClaude(opts: ClaudeOptions): Promise<ClaudeResult> {
 /**
  * Render one stream-json line to a human-readable summary on stdout.
  *
- * Format conventions:
- *   - Tool calls:   "→ Bash: gh issue list ..."  (truncated args)
- *   - Tool results: "  ← (123 chars)"            (size only — full content
- *                                                 is in the transcript)
- *   - Text output:  "▸ ..."                     (Claude's natural-language
- *                                                 reasoning, decision logs)
- *   - Final result: "✓ done in 12s, 5 turns"     OR "✗ error after Ns"
+ * Pairs tool_use with its matching tool_result via tool_use_id, so each
+ * tool call shows on ONE line with backfilled size + duration:
  *
- * Anything unrecognised is silently skipped from the summary; raw is in the
- * transcript regardless.
+ *   🔧 Bash · 1.2s · 4.5KB · gh issue view 245 …
+ *
+ * Highlights "Decision: ..." text from Claude with a star prefix, since
+ * the prompts ask for explicit decisions before non-trivial actions.
+ * Other Claude text gets a quieter prefix so the decisions stand out.
+ *
+ * Format key (also see runClaude's docblock):
+ *   🔧 <Tool> · <duration> · <size> · <args>      — paired tool call
+ *   ★ Decision: <one sentence>                    — explicit decision log
+ *   💬 <text>                                     — Claude narration
+ *   ✅ done · <seconds>s · <turns> turns · ...    — final summary
+ *   ❌ error after <seconds>s                      — final error
+ *
+ * Anything unrecognised is silently skipped from the summary; raw is in
+ * the transcript regardless.
  */
-function renderSummaryLine(line: string): void {
+interface PendingTool {
+  name: string
+  summary: string
+  startedAt: number
+}
+interface RenderCounters {
+  toolCalls: number
+  decisions: number
+}
+
+function renderSummaryLine(line: string, pending: Map<string, PendingTool>, counters: RenderCounters): void {
   let event: StreamEventBase
   try {
     event = JSON.parse(line) as StreamEventBase
@@ -198,29 +244,79 @@ function renderSummaryLine(line: string): void {
     const msg = event as AssistantMessage
     for (const block of msg.message.content) {
       if (block.type === 'text') {
-        // Render multi-line text with each line prefixed for readability.
-        for (const textLine of block.text.split('\n')) {
-          if (textLine.trim()) console.log(`  ▸ ${textLine}`)
-        }
+        renderClaudeText(block.text, counters)
       } else if (block.type === 'tool_use') {
-        console.log(`  → ${block.name}: ${summarizeToolInput(block.name, block.input)}`)
+        // Stash the call; we'll print it when the matching result arrives.
+        pending.set(block.id, {
+          name: block.name,
+          summary: summarizeToolInput(block.name, block.input),
+          startedAt: Date.now(),
+        })
+        counters.toolCalls++
       }
     }
   } else if (event.type === 'user') {
     const msg = event as UserMessage
     for (const block of msg.message.content) {
       if (block.type === 'tool_result') {
+        const call = pending.get(block.tool_use_id)
+        pending.delete(block.tool_use_id)
         const size = typeof block.content === 'string' ? block.content.length : JSON.stringify(block.content).length
-        console.log(`    ← (${size} chars)`)
+        const sizeStr = formatBytes(size)
+        if (call) {
+          const durationMs = Date.now() - call.startedAt
+          const durationStr = formatDuration(durationMs)
+          console.log(
+            `   ${c.cyan('🔧')} ${c.bold(call.name)} ${c.dim('·')} ${c.dim(durationStr)} ${c.dim('·')} ${c.dim(sizeStr)} ${c.dim('·')} ${c.gray(call.summary)}`,
+          )
+        } else {
+          // Result with no matching call — shouldn't happen, but render.
+          console.log(`   ${c.cyan('🔧')} ${c.dim(`(orphaned result, ${sizeStr})`)}`)
+        }
       }
     }
   } else if (event.type === 'result') {
     const r = event as ResultEvent
-    const seconds = r.duration_ms ? Math.round(r.duration_ms / 1000) : '?'
+    const seconds = r.duration_ms ? Math.round(r.duration_ms / 1000) : 0
     if (r.is_error) {
-      console.log(`  ✗ Claude reported error after ${seconds}s`)
+      console.log(`   ${c.red('❌')} Claude error after ${c.bold(`${seconds}s`)}`)
     } else {
-      console.log(`  ✓ done in ${seconds}s, ${r.num_turns ?? '?'} turns`)
+      const turns = r.num_turns ?? 0
+      const stats = `${counters.toolCalls} tool call${counters.toolCalls === 1 ? '' : 's'}, ${counters.decisions} decision${counters.decisions === 1 ? '' : 's'}`
+      console.log(
+        `   ${c.green('✅')} done ${c.dim('·')} ${c.bold(`${seconds}s`)} ${c.dim('·')} ${c.bold(`${turns} turns`)} ${c.dim('·')} ${c.dim(stats)}`,
+      )
+    }
+  }
+}
+
+/**
+ * Render a Claude text block. Decisions get a star and color; other text
+ * is dimmed and folded to its first line (full text is in transcript).
+ */
+function renderClaudeText(text: string, counters: RenderCounters): void {
+  const lines = text.split('\n').filter(l => l.trim())
+  if (lines.length === 0) return
+
+  for (const line of lines) {
+    const decision = line.match(/^>?\s*Decision:\s*(.+)$/i)
+    if (decision) {
+      console.log(`   ${c.yellow('★')} ${c.bold('Decision:')} ${decision[1]}`)
+      counters.decisions++
+      continue
+    }
+    // Skip pure markdown-quote prefixes like "> *This was generated...*"
+    // (the disclaimer that gets posted to issues — not maintainer-facing).
+    if (line.startsWith('> *This was generated by AI')) continue
+
+    // Non-decision narration: render the first non-trivial line, dimmed,
+    // truncated. If Claude has multi-paragraph reasoning, only the lead
+    // shows; the rest is in the transcript.
+    if (!decision) {
+      console.log(`   ${c.dim('💬')} ${c.dim(truncate(line, 140))}`)
+      // Only the first non-decision line per text block — keeps live log
+      // tight. Subsequent narration is captured in the transcript.
+      break
     }
   }
 }
@@ -233,10 +329,37 @@ function summarizeToolInput(name: string, input: Record<string, unknown>): strin
   if (name === 'Bash' && typeof input.command === 'string') {
     return truncate(input.command, 120)
   }
+  if (name === 'Read' && typeof input.file_path === 'string') {
+    return input.file_path
+  }
+  if (name === 'Grep' && typeof input.pattern === 'string') {
+    const path = typeof input.path === 'string' ? ` in ${input.path}` : ''
+    return `${input.pattern}${path}`
+  }
+  if (name === 'Glob' && typeof input.pattern === 'string') {
+    return input.pattern
+  }
+  if (name === 'Write' && typeof input.file_path === 'string') {
+    return input.file_path
+  }
+  if (name === 'Edit' && typeof input.file_path === 'string') {
+    return input.file_path
+  }
   // Generic fallback: stringify, truncate.
   return truncate(JSON.stringify(input), 120)
 }
 
 function truncate(s: string, max: number): string {
   return s.length > max ? `${s.slice(0, max - 1)}…` : s
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n}B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`
+  return `${(n / 1024 / 1024).toFixed(1)}MB`
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(1)}s`
 }

--- a/bots/_lib/colors.ts
+++ b/bots/_lib/colors.ts
@@ -1,0 +1,38 @@
+/**
+ * Tiny ANSI color helper. No external dep.
+ *
+ * Respects:
+ *   - NO_COLOR env var (https://no-color.org) — disables all colors
+ *   - FORCE_COLOR=1 — enables colors even when stdout isn't a TTY
+ *   - GitHub Actions — always renders ANSI in workflow logs (TERM=dumb
+ *     locally is the only realistic non-TTY case)
+ *
+ * Used by orchestrator banners + the Claude stream renderer.
+ */
+
+const ESC = '\x1b['
+
+const enabled = (() => {
+  if (process.env.NO_COLOR) return false
+  if (process.env.FORCE_COLOR === '1') return true
+  // Default: on. GitHub Actions runners render ANSI; local terminals do too.
+  // Only `TERM=dumb` (rare) suppresses; respect it.
+  if (process.env.TERM === 'dumb') return false
+  return true
+})()
+
+function wrap(open: string, close: string) {
+  return (s: string): string => (enabled ? `${ESC}${open}m${s}${ESC}${close}m` : s)
+}
+
+export const c = {
+  bold: wrap('1', '22'),
+  dim: wrap('2', '22'),
+  red: wrap('31', '39'),
+  green: wrap('32', '39'),
+  yellow: wrap('33', '39'),
+  blue: wrap('34', '39'),
+  magenta: wrap('35', '39'),
+  cyan: wrap('36', '39'),
+  gray: wrap('90', '39'),
+}

--- a/bots/_lib/ui.ts
+++ b/bots/_lib/ui.ts
@@ -1,0 +1,139 @@
+/**
+ * Small UI helpers for bot orchestrators — banners, section headers,
+ * summaries. All output goes to stdout.
+ *
+ * Goals:
+ *   - A maintainer scanning a workflow log should see (a) what the bot is
+ *     about to do, (b) per-candidate progress, (c) what got done at the end
+ *     — without reading every Claude tool call
+ *   - Output is also convenient for Claude Code reading past transcripts:
+ *     the JSONL transcript is the source of truth for replay/improvement;
+ *     this module only shapes the live workflow log
+ *   - Colors + emoji for skim-ability; respects NO_COLOR for accessibility
+ *     and `colors.ts` enables the right behavior in workflow logs vs. piped
+ *     output
+ */
+import { c } from './colors.js'
+
+/**
+ * Print a startup banner naming the bot, its job, and its input contract.
+ * Called once at the top of main(). Replaces the ad-hoc one-line "X bot:
+ * scanning Y" message most bots had.
+ */
+export function printBanner(opts: {
+  name: string
+  /** A short tagline shown next to the name (e.g., "producer bot · self-classifies"). */
+  tagline?: string
+  purpose: string
+  /** Lines describing what the bot looks for. */
+  inputs: string[]
+  /** Lines describing what the bot produces. */
+  outputs: string[]
+}): void {
+  const bar = '─'.repeat(72)
+  const name = opts.tagline ? `${c.bold(opts.name)} ${c.dim('·')} ${c.dim(opts.tagline)}` : c.bold(opts.name)
+  console.log()
+  console.log(c.cyan(`╭${bar}╮`))
+  console.log(`${c.cyan('│')} 🤖 ${name}`)
+  console.log(c.cyan(`╰${bar}╯`))
+  console.log(`   ${opts.purpose}`)
+  console.log()
+  console.log(c.dim('   📥 Input'))
+  for (const line of opts.inputs) console.log(`     ${c.dim('•')} ${line}`)
+  console.log(c.dim('   📤 Output'))
+  for (const line of opts.outputs) console.log(`     ${c.dim('•')} ${line}`)
+  console.log()
+}
+
+/**
+ * Print a header for a single candidate being processed. Appears between
+ * each Claude invocation in a multi-candidate run.
+ */
+export function printCandidateHeader(opts: {
+  index: number
+  total: number
+  label: string
+  /** Optional metadata lines (e.g., labels, age). */
+  meta?: string[]
+  /** Seconds since the run started. */
+  elapsedSec: number
+}): void {
+  const counter = c.dim(`[${opts.index}/${opts.total}]`)
+  const elapsed = c.dim(`${opts.elapsedSec}s`)
+  console.log()
+  console.log(`${c.blue('▶')} ${counter} ${c.bold(opts.label)} ${c.dim('·')} ${elapsed}`)
+  if (opts.meta?.length) {
+    for (const m of opts.meta) console.log(`  ${c.dim('└')} ${c.dim(m)}`)
+  }
+}
+
+/**
+ * Print the path of the transcript that's being written for this
+ * candidate. Indented so it sits visually under the candidate header.
+ */
+export function printTranscriptPath(path: string): void {
+  console.log(`  ${c.dim('└ 📝')} ${c.dim(path)}`)
+}
+
+/**
+ * Print the final run summary. Called at the end of main() for every bot
+ * to give a consistent "what did we actually do" report.
+ */
+export function printRunSummary(opts: {
+  /** "Triaged", "Investigated", "Researched", etc. */
+  verb: string
+  processed: number
+  total: number
+  skipped: number
+  /** Optional extra lines (e.g., "Filed 2 new issues, commented on 1"). */
+  notes?: string[]
+  elapsedSec: number
+}): void {
+  const bar = '─'.repeat(72)
+  const summary = `${opts.verb} ${c.bold(`${opts.processed}/${opts.total}`)} in ${c.bold(`${opts.elapsedSec}s`)}`
+  console.log()
+  console.log(c.green(`╭${bar}╮`))
+  console.log(`${c.green('│')} ✅ Run complete · ${summary}`)
+  if (opts.skipped > 0) {
+    console.log(`${c.green('│')} ${c.yellow(`⏭  ${opts.skipped} skipped`)} ${c.dim('— see above')}`)
+  }
+  if (opts.notes?.length) {
+    for (const n of opts.notes) console.log(`${c.green('│')}    ${c.dim(n)}`)
+  }
+  console.log(c.green(`╰${bar}╯`))
+}
+
+/**
+ * Print a short notice (one line) — useful for things like "no candidates
+ * found, exiting" or "DRY_RUN — exiting before Claude."
+ */
+export function printNotice(message: string): void {
+  console.log(`\n${c.cyan('ℹ')} ${message}`)
+}
+
+/**
+ * Print a non-fatal warning. Used when one candidate failed but the run
+ * continues. Stands out from regular log lines without being alarmist.
+ */
+export function printWarning(message: string): void {
+  console.log(`${c.yellow('⚠')} ${message}`)
+}
+
+/**
+ * Print the candidate-list preview after the scan but before processing
+ * starts. Shows what the bot will do this run — the maintainer doesn't
+ * have to wait for the per-candidate output to know the scope.
+ */
+export function printCandidateList(opts: {
+  /** Singular noun: "candidate", "issue", "flake". */
+  noun: string
+  candidates: Array<{ ref: string; label: string; meta?: string }>
+}): void {
+  if (opts.candidates.length === 0) return
+  const plural = opts.candidates.length === 1 ? opts.noun : `${opts.noun}s`
+  console.log(c.dim(`\n📋 ${opts.candidates.length} ${plural} (oldest first):`))
+  for (const candidate of opts.candidates) {
+    const meta = candidate.meta ? c.dim(` ${candidate.meta}`) : ''
+    console.log(`   ${c.dim(candidate.ref)} ${candidate.label}${meta}`)
+  }
+}

--- a/bots/discovery-prep-bot/index.ts
+++ b/bots/discovery-prep-bot/index.ts
@@ -52,6 +52,15 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { runClaude } from '../_lib/claude.js'
 import { findIssuesByLabels, hasPriorCommentFromBot, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
+import {
+  printBanner,
+  printCandidateHeader,
+  printCandidateList,
+  printNotice,
+  printRunSummary,
+  printTranscriptPath,
+  printWarning,
+} from '../_lib/ui.js'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const PROMPT_PATH = resolve(HERE, 'prompt.md')
@@ -81,7 +90,21 @@ async function main(): Promise<void> {
     return
   }
 
-  console.log(`Discovery prep bot: scanning ${repo.owner}/${repo.repo} for confident-enhancement candidates`)
+  printBanner({
+    name: 'discovery-prep-bot',
+    tagline: 'researcher',
+    purpose: 'Research confident-enhancement issues; prepare design grilling.',
+    inputs: [
+      'Open issues with `enhancement`',
+      'AND no `ready-for-human` / `ready-for-agent` / `wontfix` / `needs-info`',
+    ],
+    outputs: [
+      'Research comment (competitor scan, ADRs, scenarios, open questions)',
+      '`ready-for-human` label (signals research done; grilling can start)',
+    ],
+  })
+
+  printNotice(`Scanning ${repo.owner}/${repo.repo} for confident-enhancement candidates`)
 
   // Label-driven input: every enhancement that hasn't been handed off
   // downstream. Once `ready-for-human` is applied (after research is
@@ -93,20 +116,20 @@ async function main(): Promise<void> {
   })
 
   if (allCandidates.length === 0) {
-    console.log('No discovery-prep candidates found. Inbox zero — nothing to do.')
+    printNotice('No discovery-prep candidates found. Inbox zero — nothing to do. ✨')
     return
   }
 
   // Oldest-first so longest-waiting enhancements get research first.
   const candidates = [...allCandidates].sort((a, b) => a.createdAt.localeCompare(b.createdAt))
 
-  console.log(`Discovery candidates (${candidates.length}, oldest-first):`)
-  for (const c of candidates) {
-    console.log(`  #${c.number} "${c.title}"`)
-  }
+  printCandidateList({
+    noun: 'enhancement',
+    candidates: candidates.map(c => ({ ref: `#${c.number}`, label: c.title })),
+  })
 
   if (DRY_RUN) {
-    console.log(`DRY_RUN=1 — exiting before invoking Claude (${candidates.length} would be processed).`)
+    printNotice(`DRY_RUN=1 — exiting before invoking Claude (${candidates.length} would be processed).`)
     return
   }
 
@@ -116,28 +139,38 @@ async function main(): Promise<void> {
     const elapsed = Date.now() - runStart
     if (elapsed > PER_RUN_BUDGET_MS) {
       const remaining = candidates.length - processed
-      console.log(
-        `\nPer-run budget exhausted (${Math.round(elapsed / 1000)}s elapsed > ${Math.round(PER_RUN_BUDGET_MS / 1000)}s budget).`,
+      printWarning(
+        `Per-run budget exhausted (${Math.round(elapsed / 1000)}s > ${Math.round(PER_RUN_BUDGET_MS / 1000)}s). Stopping with ${remaining} un-researched; tomorrow's run picks them up.`,
       )
-      console.log(`Stopping with ${remaining} candidate(s); tomorrow's run picks them up (oldest-first sort holds).`)
       for (const skipped of candidates.slice(processed)) {
-        console.log(`  #${skipped.number} "${skipped.title}"`)
+        console.log(`     ⏭  #${skipped.number} "${skipped.title}"`)
       }
       break
     }
 
-    console.log(
-      `\n=== Researching #${candidate.number}: "${candidate.title}" (${processed + 1}/${candidates.length}, ${Math.round(elapsed / 1000)}s elapsed) ===`,
-    )
+    printCandidateHeader({
+      index: processed + 1,
+      total: candidates.length,
+      label: `#${candidate.number} · ${candidate.title}`,
+      elapsedSec: Math.round(elapsed / 1000),
+    })
+
     try {
       await researchOneIssue(octokit, repo, candidate.number)
     } catch (err) {
-      console.log(`Warning: research of #${candidate.number} threw: ${err}; continuing.`)
+      printWarning(`research of #${candidate.number} threw: ${err}; continuing.`)
     }
     processed++
   }
 
-  console.log(`\nDiscovery prep bot complete. Processed ${processed}/${candidates.length}.`)
+  const totalSec = Math.round((Date.now() - runStart) / 1000)
+  printRunSummary({
+    verb: 'Researched',
+    processed,
+    total: candidates.length,
+    skipped: candidates.length - processed,
+    elapsedSec: totalSec,
+  })
 }
 
 /**
@@ -156,16 +189,16 @@ async function researchOneIssue(
 ): Promise<void> {
   const { data: issue } = await octokit.issues.get({ ...repo, issue_number: issueNumber })
   if (issue.pull_request) {
-    console.log(`#${issueNumber} is a pull request, not an issue. Skipping.`)
+    printNotice(`#${issueNumber} is a pull request, not an issue. Skipping.`)
     return
   }
   if (issue.state !== 'open') {
-    console.log(`#${issueNumber} is ${issue.state}; nothing to research.`)
+    printNotice(`#${issueNumber} is ${issue.state}; nothing to research.`)
     return
   }
   const labels = issue.labels.map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean)
   if (!labels.includes('enhancement')) {
-    console.log(`#${issueNumber} is not labeled 'enhancement' (current: [${labels.join(', ')}]); nothing to research.`)
+    printNotice(`#${issueNumber} is not labeled 'enhancement' (current: [${labels.join(', ')}]); nothing to research.`)
     return
   }
 
@@ -175,22 +208,21 @@ async function researchOneIssue(
   // but a manual one-issue invocation can target any issue.
   const alreadyCommented = await hasPriorCommentFromBot(octokit, repo, issueNumber, 'discovery-prep-bot')
   if (alreadyCommented) {
-    console.log(`#${issueNumber}: discovery-prep-bot has already commented; nothing to do.`)
-    console.log('To re-research, manually delete the prior comment AND remove `ready-for-human`, then re-run.')
+    printNotice(
+      `#${issueNumber}: discovery-prep-bot has already commented. To re-research, delete the prior comment AND remove ready-for-human, then re-run.`,
+    )
     return
   }
 
-  console.log(`#${issueNumber}: "${issue.title}" — labels [${labels.join(', ')}]`)
-
   if (DRY_RUN) {
-    console.log(`DRY_RUN=1 — exiting before invoking Claude.`)
+    printNotice(`DRY_RUN=1 — exiting before invoking Claude.`)
     return
   }
 
   const promptTemplate = readFileSync(PROMPT_PATH, 'utf-8')
   mkdirSync(TRANSCRIPTS_DIR, { recursive: true })
   const transcriptPath = resolve(TRANSCRIPTS_DIR, `${RUN_TIMESTAMP}-discovery-issue-${issueNumber}.jsonl`)
-  console.log(`(transcript: ${transcriptPath})`)
+  printTranscriptPath(transcriptPath)
 
   const prompt = `${promptTemplate}
 
@@ -204,7 +236,7 @@ RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
     allowedTools: ['Bash', 'Read', 'Grep', 'Glob', 'WebFetch', 'WebSearch'],
   })
   if (!result.success) {
-    console.log(`Warning: discovery for #${issueNumber} exited ${result.exitCode}`)
+    printWarning(`discovery for #${issueNumber} exited ${result.exitCode}`)
   }
 }
 

--- a/bots/fix-bot/index.ts
+++ b/bots/fix-bot/index.ts
@@ -48,6 +48,15 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { runClaude } from '../_lib/claude.js'
 import { findIssuesByLabels, hasPriorCommentFromBot, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
+import {
+  printBanner,
+  printCandidateHeader,
+  printCandidateList,
+  printNotice,
+  printRunSummary,
+  printTranscriptPath,
+  printWarning,
+} from '../_lib/ui.js'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const PROMPT_PATH = resolve(HERE, 'prompt.md')
@@ -77,7 +86,19 @@ async function main(): Promise<void> {
     return
   }
 
-  console.log(`Fix bot: scanning ${repo.owner}/${repo.repo} for bug+ready-for-agent candidates`)
+  printBanner({
+    name: 'fix-bot',
+    tagline: 'implementer',
+    purpose: 'Fix `bug + ready-for-agent` issues with TDD-first commit ordering.',
+    inputs: [
+      'Open issues with `bug` AND `ready-for-agent`',
+      'AND no `ready-for-human` / `wontfix` / `needs-info`',
+      'AND no prior fix-bot comment (idempotency)',
+    ],
+    outputs: ['EITHER draft PR (commit 1: failing test, commit 2: fix)', 'OR stuck-comment + `ready-for-human` label'],
+  })
+
+  printNotice(`Scanning ${repo.owner}/${repo.repo} for bug+ready-for-agent candidates`)
 
   // Label-driven input: every bug ready-for-agent that hasn't escalated
   // to a maintainer-only state. The `ready-for-agent` label is the
@@ -91,19 +112,19 @@ async function main(): Promise<void> {
   })
 
   if (allCandidates.length === 0) {
-    console.log('No fix-bot candidates found. Inbox zero — nothing to do.')
+    printNotice('No fix-bot candidates found. Inbox zero — nothing to do. ✨')
     return
   }
 
   const candidates = [...allCandidates].sort((a, b) => a.createdAt.localeCompare(b.createdAt))
 
-  console.log(`Fix candidates (${candidates.length}, oldest-first):`)
-  for (const c of candidates) {
-    console.log(`  #${c.number} "${c.title}"`)
-  }
+  printCandidateList({
+    noun: 'bug',
+    candidates: candidates.map(c => ({ ref: `#${c.number}`, label: c.title })),
+  })
 
   if (DRY_RUN) {
-    console.log(`DRY_RUN=1 — exiting before invoking Claude (${candidates.length} would be processed).`)
+    printNotice(`DRY_RUN=1 — exiting before invoking Claude (${candidates.length} would be processed).`)
     return
   }
 
@@ -113,28 +134,38 @@ async function main(): Promise<void> {
     const elapsed = Date.now() - runStart
     if (elapsed > PER_RUN_BUDGET_MS) {
       const remaining = candidates.length - processed
-      console.log(
-        `\nPer-run budget exhausted (${Math.round(elapsed / 1000)}s elapsed > ${Math.round(PER_RUN_BUDGET_MS / 1000)}s budget).`,
+      printWarning(
+        `Per-run budget exhausted (${Math.round(elapsed / 1000)}s > ${Math.round(PER_RUN_BUDGET_MS / 1000)}s). Stopping with ${remaining} unfixed; tomorrow's run picks them up.`,
       )
-      console.log(`Stopping with ${remaining} candidate(s); tomorrow's run picks them up.`)
       for (const skipped of candidates.slice(processed)) {
-        console.log(`  #${skipped.number} "${skipped.title}"`)
+        console.log(`     ⏭  #${skipped.number} "${skipped.title}"`)
       }
       break
     }
 
-    console.log(
-      `\n=== Fixing #${candidate.number}: "${candidate.title}" (${processed + 1}/${candidates.length}, ${Math.round(elapsed / 1000)}s elapsed) ===`,
-    )
+    printCandidateHeader({
+      index: processed + 1,
+      total: candidates.length,
+      label: `#${candidate.number} · ${candidate.title}`,
+      elapsedSec: Math.round(elapsed / 1000),
+    })
+
     try {
       await fixOneIssue(octokit, repo, candidate.number)
     } catch (err) {
-      console.log(`Warning: fix attempt for #${candidate.number} threw: ${err}; continuing.`)
+      printWarning(`fix attempt for #${candidate.number} threw: ${err}; continuing.`)
     }
     processed++
   }
 
-  console.log(`\nFix bot complete. Processed ${processed}/${candidates.length}.`)
+  const totalSec = Math.round((Date.now() - runStart) / 1000)
+  printRunSummary({
+    verb: 'Fixed',
+    processed,
+    total: candidates.length,
+    skipped: candidates.length - processed,
+    elapsedSec: totalSec,
+  })
 }
 
 /**
@@ -153,20 +184,20 @@ async function fixOneIssue(
 ): Promise<void> {
   const { data: issue } = await octokit.issues.get({ ...repo, issue_number: issueNumber })
   if (issue.pull_request) {
-    console.log(`#${issueNumber} is a pull request, not an issue. Skipping.`)
+    printNotice(`#${issueNumber} is a pull request, not an issue. Skipping.`)
     return
   }
   if (issue.state !== 'open') {
-    console.log(`#${issueNumber} is ${issue.state}; nothing to fix.`)
+    printNotice(`#${issueNumber} is ${issue.state}; nothing to fix.`)
     return
   }
   const labels = issue.labels.map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean)
   if (!labels.includes('bug') || !labels.includes('ready-for-agent')) {
-    console.log(`#${issueNumber} lacks 'bug' + 'ready-for-agent' (current: [${labels.join(', ')}]); skipping.`)
+    printNotice(`#${issueNumber} lacks 'bug' + 'ready-for-agent' (current: [${labels.join(', ')}]); skipping.`)
     return
   }
   if (labels.includes('ready-for-human') || labels.includes('wontfix') || labels.includes('needs-info')) {
-    console.log(`#${issueNumber} has terminal-state label; skipping.`)
+    printNotice(`#${issueNumber} has terminal-state label; skipping.`)
     return
   }
 
@@ -175,22 +206,21 @@ async function fixOneIssue(
   // bot's outcome tag in any prior comment IS the signal.
   const alreadyTried = await hasPriorCommentFromBot(octokit, repo, issueNumber, 'fix-bot')
   if (alreadyTried) {
-    console.log(`#${issueNumber}: fix-bot has already attempted; nothing to do.`)
-    console.log('To re-attempt, manually delete the prior fix-bot comment, then re-run.')
+    printNotice(
+      `#${issueNumber}: fix-bot has already attempted. To re-attempt, delete the prior fix-bot comment, then re-run.`,
+    )
     return
   }
 
-  console.log(`#${issueNumber}: "${issue.title}" — labels [${labels.join(', ')}]`)
-
   if (DRY_RUN) {
-    console.log(`DRY_RUN=1 — exiting before invoking Claude.`)
+    printNotice(`DRY_RUN=1 — exiting before invoking Claude.`)
     return
   }
 
   const promptTemplate = readFileSync(PROMPT_PATH, 'utf-8')
   mkdirSync(TRANSCRIPTS_DIR, { recursive: true })
   const transcriptPath = resolve(TRANSCRIPTS_DIR, `${RUN_TIMESTAMP}-fix-issue-${issueNumber}.jsonl`)
-  console.log(`(transcript: ${transcriptPath})`)
+  printTranscriptPath(transcriptPath)
 
   const branchName = `fix/issue-${issueNumber}`
   const prompt = `${promptTemplate}
@@ -209,7 +239,7 @@ RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
     allowedTools: ['Bash', 'Read', 'Grep', 'Glob', 'Write', 'Edit'],
   })
   if (!result.success) {
-    console.log(`Warning: fix attempt for #${issueNumber} exited ${result.exitCode}`)
+    printWarning(`fix attempt for #${issueNumber} exited ${result.exitCode}`)
   }
 }
 

--- a/bots/flake-watcher/index.ts
+++ b/bots/flake-watcher/index.ts
@@ -14,8 +14,8 @@
  * When a flake is found, hand the run to `claude -p` with the prompt in
  * `prompt.md`. Claude reads failed-attempt logs, searches existing open
  * issues for a match, and either comments on the existing issue (with
- * dedup against the run ID) or files a new one following the templates
- * established in #268.
+ * dedup against the run ID) or files a new one per the producer-bot
+ * pattern (self-classifies as bug + applies ready-for-agent).
  *
  * Run locally:
  *   DRY_RUN=1 LOOKBACK_HOURS=336 npm run flake-watcher -w @gazetta/bots
@@ -25,8 +25,17 @@
 import { mkdirSync, readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { findFlakeCandidates, findWorkflowId, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
 import { runClaude } from '../_lib/claude.js'
+import { findFlakeCandidates, findWorkflowId, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
+import {
+  printBanner,
+  printCandidateHeader,
+  printCandidateList,
+  printNotice,
+  printRunSummary,
+  printTranscriptPath,
+  printWarning,
+} from '../_lib/ui.js'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const PROMPT_PATH = resolve(HERE, 'prompt.md')
@@ -40,6 +49,20 @@ const TRANSCRIPTS_DIR = resolve(HERE, '../transcripts')
 const RUN_TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')
 
 async function main(): Promise<void> {
+  printBanner({
+    name: 'flake-watcher',
+    tagline: 'producer bot · self-classifies',
+    purpose: `Find CI flakes (run_attempt >= 2) and file/comment issues.`,
+    inputs: [
+      `${WORKFLOW_NAME} runs in the last ${LOOKBACK_HOURS}h with run_attempt >= 2`,
+      'Open issues matching the failed test path (for dedup)',
+    ],
+    outputs: [
+      'New issue with `bug` + `flake` + `area: X` + `ready-for-agent`',
+      'Or comment on existing matching issue (run-ID-deduped)',
+    ],
+  })
+
   const repo = repoFromEnv()
   const octokit = octokitFromEnv()
   const workflowId = await findWorkflowId(octokit, repo, WORKFLOW_NAME)
@@ -47,50 +70,73 @@ async function main(): Promise<void> {
   const sinceMs = Date.now() - LOOKBACK_HOURS * 60 * 60 * 1000
   const sinceIso = new Date(sinceMs).toISOString().replace(/\.\d{3}Z$/, 'Z')
 
-  console.log(`Flake watcher: scanning ${WORKFLOW_NAME} (workflow id ${workflowId}) runs since ${sinceIso}`)
+  printNotice(`Scanning ${WORKFLOW_NAME} (workflow id ${workflowId}) since ${sinceIso}`)
 
   const flakes = await findFlakeCandidates(octokit, repo, workflowId, sinceIso)
 
   if (flakes.length === 0) {
-    console.log(`No flakes found in last ${LOOKBACK_HOURS}h. CI is healthy.`)
+    printNotice(`No flakes found in last ${LOOKBACK_HOURS}h. CI is healthy. ✨`)
     return
   }
 
-  console.log('Flake candidates:')
-  for (const f of flakes) {
-    console.log(`  run=${f.runId} sha=${f.headSha.slice(0, 8)} conclusion=${f.conclusion} attempt=${f.runAttempt}`)
-  }
+  printCandidateList({
+    noun: 'flake',
+    candidates: flakes.map(f => ({
+      ref: `run ${f.runId}`,
+      label: `sha ${f.headSha.slice(0, 8)}`,
+      meta: `attempt ${f.runAttempt}, ${f.conclusion}`,
+    })),
+  })
 
   if (DRY_RUN) {
-    console.log(`DRY_RUN=1 — exiting before invoking Claude (${flakes.length} would be processed).`)
+    printNotice(`DRY_RUN=1 — exiting before invoking Claude (${flakes.length} flake(s) would be processed).`)
     return
   }
 
   const promptTemplate = readFileSync(PROMPT_PATH, 'utf-8')
   mkdirSync(TRANSCRIPTS_DIR, { recursive: true })
 
+  const runStart = Date.now()
+  let processed = 0
   for (const flake of flakes) {
-    console.log(`\n=== Investigating run ${flake.runId} (sha ${flake.headSha.slice(0, 8)}) ===`)
+    const elapsed = Math.round((Date.now() - runStart) / 1000)
+    printCandidateHeader({
+      index: processed + 1,
+      total: flakes.length,
+      label: `Investigating run ${flake.runId}`,
+      meta: [`sha ${flake.headSha.slice(0, 8)}, attempt ${flake.runAttempt}, ${flake.conclusion}`],
+      elapsedSec: elapsed,
+    })
+
     const prompt = `${promptTemplate}
 
 RUN_ID=${flake.runId}
 LOOKBACK_HOURS=${LOOKBACK_HOURS}`
 
     const transcriptPath = resolve(TRANSCRIPTS_DIR, `${RUN_TIMESTAMP}-run-${flake.runId}.jsonl`)
-    console.log(`(transcript: ${transcriptPath})`)
+    printTranscriptPath(transcriptPath)
 
     try {
       const result = await runClaude({ prompt, transcriptPath })
       if (!result.success) {
         // Don't let one failed investigation kill the whole job.
-        console.log(`Warning: investigation of run ${flake.runId} exited ${result.exitCode}; continuing.`)
+        printWarning(`investigation of run ${flake.runId} exited ${result.exitCode}; continuing.`)
       }
     } catch (err) {
-      console.log(`Warning: investigation of run ${flake.runId} threw: ${err}; continuing.`)
+      printWarning(`investigation of run ${flake.runId} threw: ${err}; continuing.`)
     }
+    processed++
   }
 
-  console.log(`\nFlake watcher complete. Transcripts: ${TRANSCRIPTS_DIR}`)
+  const total = Math.round((Date.now() - runStart) / 1000)
+  printRunSummary({
+    verb: 'Investigated',
+    processed,
+    total: flakes.length,
+    skipped: flakes.length - processed,
+    notes: [`Transcripts: ${TRANSCRIPTS_DIR}`],
+    elapsedSec: total,
+  })
 }
 
 main().catch(err => {

--- a/bots/flake-watcher/prompt.md
+++ b/bots/flake-watcher/prompt.md
@@ -149,19 +149,30 @@ workflow logs.
 
    | Label | When | gh command |
    |---|---|---|
+   | `bug` | Always — flakes ARE bugs (CI test-flake validates the failure exists) | `gh issue edit <N> --add-label bug` |
    | `flake` | Default on every issue (see note below) | `gh issue edit <N> --add-label flake` |
-   | `needs-triage` | Always on NEW issues. Skip if a human has already commented on the issue (signals they've started triaging). | `gh issue edit <N> --add-label "needs-triage"` |
    | `area: <X>` | Always — pick from path → area mapping below | `gh issue edit <N> --add-label "area: cms"` |
+   | `ready-for-agent` | Always on NEW issues — flake-watcher self-validated the failure exists, so the issue is ready for fix-bot to attempt | `gh issue edit <N> --add-label ready-for-agent` |
    | `recurring-flake` | When the issue has 3+ occurrences across distinct days | `gh issue edit <N> --add-label recurring-flake` |
 
+   **Producer-bot pattern.** flake-watcher is a producer bot (along with
+   mutation-watcher). Producer bots fully self-classify their output —
+   triage-bot doesn't process flake-watcher output (its input contract
+   excludes `bug`). The labels above bypass triage and feed straight
+   into fix-bot's queue (`bug` + `ready-for-agent`).
+
+   Do NOT apply `needs-triage` — that label is the skill-canonical
+   "no bot or human has looked yet" state. Once flake-watcher has
+   filed the issue, the bot HAS looked.
+
    **`flake` label semantics.** The `flake` label classifies an issue as "CI
-   test-flake — intermittent failure, not a real bug until proven otherwise
-   via triage." Apply it by default on every issue you file. Skip ONLY if
-   your hypothesis section concludes the failure is structurally a real
-   bug masquerading as a flake (e.g. an equal-millisecond ordering race in
-   a test, a permanently-wrong assertion that happens to pass under timing
-   coincidence). In that case, say so in the body and let humans decide
-   whether to add the label.
+   test-flake — intermittent failure." Apply it by default on every issue
+   you file. Skip ONLY if your hypothesis section concludes the failure
+   is structurally a real bug masquerading as a flake (e.g. an
+   equal-millisecond ordering race in a test, a permanently-wrong
+   assertion that happens to pass under timing coincidence). In that
+   case, say so in the body and let humans decide whether to add the
+   label.
 
    **Path → area mapping:**
 
@@ -182,12 +193,12 @@ workflow logs.
    **Apply all labels in one call** to avoid multiple API roundtrips:
 
    ```
-   gh issue edit <N> --add-label "flake,needs-triage,area: cms"
+   gh issue edit <N> --add-label "bug,flake,area: cms,ready-for-agent"
    ```
 
    For a recurring flake on an existing issue:
    ```
-   gh issue edit <N> --add-label "flake,recurring-flake,area: cms"
+   gh issue edit <N> --add-label "bug,flake,recurring-flake,area: cms,ready-for-agent"
    ```
 
 ## New-issue template

--- a/bots/mutation-watcher/index.ts
+++ b/bots/mutation-watcher/index.ts
@@ -1,0 +1,192 @@
+/**
+ * mutation-watcher — daily review of Stryker mutation-testing results.
+ *
+ * Pairs with the existing `Mutation` workflow (`.github/workflows/mutation.yml`)
+ * which runs Stryker nightly at 03:00 UTC and uploads an HTML report as the
+ * `mutation-report` artifact. This bot runs at 03:30 UTC, fetches that
+ * artifact, and hands the report to `claude -p` to identify surviving
+ * mutants worth filing as bugs.
+ *
+ * Producer-bot pattern (shared with flake-watcher):
+ *   Self-classifies output as `bug` + `area: X` + `ready-for-agent`,
+ *   bypassing triage-bot. The mutation report IS the validation that the
+ *   surviving mutant represents a real test gap — no further triage adds
+ *   value. Goes straight into fix-bot's queue.
+ *
+ * Per-issue grain: ONE mutated source file = ONE issue. A file with five
+ * surviving mutants gets five investigation points in one issue, not five
+ * separate issues. Same root-cause-class scoping rule flake-watcher applies
+ * to test files.
+ *
+ * Run locally:
+ *   DRY_RUN=1 GITHUB_REPOSITORY=gazetta-studio/gazetta-studio \
+ *     GH_TOKEN=$(gh auth token) npm run mutation-watcher -w @gazetta/bots
+ * Run in CI:
+ *   .github/workflows/mutation-watcher.yml (daily 03:30 UTC)
+ */
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { runClaude } from '../_lib/claude.js'
+import { findWorkflowId, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
+import { printBanner, printNotice, printRunSummary, printTranscriptPath, printWarning } from '../_lib/ui.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const PROMPT_PATH = resolve(HERE, 'prompt.md')
+const REPO_ROOT = resolve(HERE, '../..')
+
+const WORKFLOW_NAME = process.env.WORKFLOW_NAME ?? 'Mutation'
+const ARTIFACT_NAME = process.env.ARTIFACT_NAME ?? 'mutation-report'
+const DRY_RUN = process.env.DRY_RUN === '1'
+const TRANSCRIPTS_DIR = resolve(HERE, '../transcripts')
+const REPORT_STAGING_DIR = resolve(HERE, '../mutation-report-staging')
+const RUN_TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')
+
+async function main(): Promise<void> {
+  printBanner({
+    name: 'mutation-watcher',
+    tagline: 'producer bot · self-classifies',
+    purpose: 'Review Stryker mutation report; file issues for surviving mutants.',
+    inputs: [
+      `Latest successful ${WORKFLOW_NAME} workflow run's mutation-report artifact`,
+      'Open issues for the affected source files (for dedup)',
+    ],
+    outputs: [
+      'New issue per source file with surviving mutants — `bug` + `area: X` + `ready-for-agent`',
+      'Or comment on existing matching issue (source-run-deduped)',
+    ],
+  })
+
+  const repo = repoFromEnv()
+  const octokit = octokitFromEnv()
+  const workflowId = await findWorkflowId(octokit, repo, WORKFLOW_NAME)
+
+  printNotice(`Looking up latest successful ${WORKFLOW_NAME} run (workflow id ${workflowId})`)
+
+  // Find the most recent SUCCESSFUL Mutation run. Stryker exits non-zero
+  // when its threshold breaks; we want a run that completed cleanly so the
+  // artifact is well-formed. Failures here mean Stryker itself crashed —
+  // not actionable for mutation analysis.
+  const { data: runs } = await octokit.actions.listWorkflowRuns({
+    ...repo,
+    workflow_id: workflowId,
+    status: 'success',
+    per_page: 1,
+  })
+  const sourceRun = runs.workflow_runs[0]
+  if (!sourceRun) {
+    printNotice(`No successful ${WORKFLOW_NAME} runs found. Nothing to analyze.`)
+    return
+  }
+
+  printNotice(
+    `Source run: id=${sourceRun.id} · sha ${sourceRun.head_sha.slice(0, 8)} · created ${sourceRun.created_at}`,
+  )
+
+  // Stage the report on disk so Claude can grep / parse it via Bash.
+  // Re-fetching every run is fine — artifacts are small (Stryker HTML is
+  // a single ~3 MB file) and the cron is daily.
+  if (existsSync(REPORT_STAGING_DIR)) {
+    rmSync(REPORT_STAGING_DIR, { recursive: true, force: true })
+  }
+  mkdirSync(REPORT_STAGING_DIR, { recursive: true })
+
+  printNotice(`Downloading ${ARTIFACT_NAME} from run ${sourceRun.id}...`)
+  const dl = spawnSync('gh', ['run', 'download', String(sourceRun.id), '-n', ARTIFACT_NAME, '-D', REPORT_STAGING_DIR], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+  })
+  if (dl.status !== 0) {
+    printWarning(`Failed to download ${ARTIFACT_NAME} from run ${sourceRun.id}.`)
+    printWarning('Is the artifact still available (30-day retention)?')
+    process.exit(1)
+  }
+
+  // Locate the HTML report. Stryker writes to packages/gazetta/reports/mutation/
+  // by default; the workflow uploads that whole directory. After download,
+  // the file is at REPORT_STAGING_DIR/mutation.html (or sometimes
+  // REPORT_STAGING_DIR/<sub>/mutation.html depending on artifact shape).
+  const htmlPath = findReportHtml(REPORT_STAGING_DIR)
+  if (!htmlPath) {
+    console.error(`No mutation.html found under ${REPORT_STAGING_DIR}. Listing:`)
+    for (const entry of readdirSync(REPORT_STAGING_DIR, { recursive: true, withFileTypes: true })) {
+      const path = entry.parentPath ? resolve(entry.parentPath, entry.name) : entry.name
+      console.error(`  ${path}`)
+    }
+    process.exit(1)
+  }
+  printNotice(`Mutation report: ${htmlPath}`)
+
+  if (DRY_RUN) {
+    printNotice(`DRY_RUN=1 — exiting before invoking Claude.`)
+    return
+  }
+
+  const promptTemplate = readFileSync(PROMPT_PATH, 'utf-8')
+  mkdirSync(TRANSCRIPTS_DIR, { recursive: true })
+  const transcriptPath = resolve(TRANSCRIPTS_DIR, `${RUN_TIMESTAMP}-mutation-run-${sourceRun.id}.jsonl`)
+  printTranscriptPath(transcriptPath)
+
+  // The prompt receives:
+  //   - SOURCE_RUN_ID: the Mutation workflow run whose artifact we're analyzing
+  //     (used in outcome tags and issue bodies for traceability)
+  //   - SOURCE_RUN_SHA: the commit Stryker ran against
+  //   - REPORT_HTML: absolute path to the HTML file (Claude greps + parses it)
+  //   - RUN_ID: this watcher's own GitHub Actions run ID (for the outcome tag's
+  //     "which watcher run found this" provenance)
+  const prompt = `${promptTemplate}
+
+SOURCE_RUN_ID=${sourceRun.id}
+SOURCE_RUN_SHA=${sourceRun.head_sha}
+SOURCE_RUN_CREATED_AT=${sourceRun.created_at}
+REPORT_HTML=${htmlPath}
+RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
+
+  const runStart = Date.now()
+  try {
+    const result = await runClaude({
+      prompt,
+      transcriptPath,
+      // Bash for gh + grep/jq, Read for inspecting report + source files
+      // Claude wants to cite, Grep/Glob for finding test files that should
+      // have caught a surviving mutant.
+      allowedTools: ['Bash', 'Read', 'Grep', 'Glob'],
+    })
+    if (!result.success) {
+      printWarning(`mutation-watcher exited ${result.exitCode}; transcript at ${transcriptPath}`)
+    }
+  } catch (err) {
+    printWarning(`mutation-watcher threw: ${err}; transcript at ${transcriptPath}`)
+  }
+
+  const totalSec = Math.round((Date.now() - runStart) / 1000)
+  printRunSummary({
+    verb: 'Analyzed',
+    processed: 1,
+    total: 1,
+    skipped: 0,
+    notes: [`Source run: ${sourceRun.id}`, `Transcript: ${transcriptPath}`],
+    elapsedSec: totalSec,
+  })
+}
+
+/**
+ * Walk the staging dir looking for `mutation.html`. Stryker's HTML reporter
+ * always writes that filename; the artifact contents may or may not include
+ * a wrapping subdirectory depending on how the workflow uploaded it.
+ */
+function findReportHtml(root: string): string | null {
+  for (const entry of readdirSync(root, { recursive: true, withFileTypes: true })) {
+    if (entry.isFile() && entry.name === 'mutation.html') {
+      const parent = entry.parentPath ?? root
+      return resolve(parent, entry.name)
+    }
+  }
+  return null
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err)
+  process.exit(1)
+})

--- a/bots/mutation-watcher/prompt.md
+++ b/bots/mutation-watcher/prompt.md
@@ -1,0 +1,286 @@
+# Mutation watcher — investigation prompt
+
+You are reviewing the latest Stryker mutation-testing report for surviving
+mutants — code mutations the test suite failed to catch. Each surviving
+mutant is evidence of a test gap: a behavior that nothing currently
+verifies. Your job is to file actionable issues so fix-bot can write the
+missing tests.
+
+## Inputs (appended below this prompt)
+
+- `SOURCE_RUN_ID` — the Mutation workflow run whose artifact you're analyzing
+- `SOURCE_RUN_SHA` — the commit Stryker ran against
+- `SOURCE_RUN_CREATED_AT` — when that Mutation run completed
+- `REPORT_HTML` — absolute path to `mutation.html` on disk
+- `RUN_ID` — THIS watcher's GitHub Actions run ID (for outcome-tag provenance)
+
+## Decision-log convention
+
+Your transcript (the JSONL stream of every tool call and message) is the
+audit trail a future agent will read to improve this bot. The transcript
+captures WHAT you did automatically; you must also articulate WHY.
+
+Before each non-trivial decision (parsing approach, dedup choice,
+file-vs-comment, area mapping, severity classification), emit a one-line
+text block in the form:
+
+> Decision: <one sentence — what choice and why>
+
+Examples:
+
+> Decision: parsing app.report JSON via grep + node -e because the HTML's <script> block embeds it as a literal — simpler than rendering the page.
+> Decision: filing one issue per source file (history-recorder.ts, history-restorer.ts) rather than per mutant — same root-cause class, easier to fix as a unit.
+> Decision: skipping admin-api/routes/assets.ts mutants because issue #312 already tracks the same surviving mutants — adding a new occurrence comment instead.
+
+Do NOT narrate every tool call (don't say "now running grep"). Only call
+out load-bearing choices.
+
+## Outcome tag convention
+
+Every comment you post AND every new issue body you file MUST end with
+this exact line:
+
+```
+<!-- mutation-watcher: source-run=$SOURCE_RUN_ID watcher-run=$RUN_ID -->
+```
+
+Substitute the actual values. The `source-run` traces back to the Stryker
+artifact that revealed the gap; `watcher-run` traces to this analysis pass.
+A future agent can query `gh issue list --search "mutation-watcher: source-run=12345"`
+to find every issue derived from one Mutation run.
+
+## Why one report, not many
+
+Stryker is deterministic: same SHA + same code + same tests = same
+surviving mutants. Multiple runs against the same SHA add no
+information; multiple runs across different SHAs can't be cleanly
+compared (a mutant on line 42 may not exist in today's code after a
+refactor). So this bot looks at ONE report — the latest successful
+Mutation run — per pass.
+
+The dedup-by-source-run tag means rerunning the watcher against
+today's report tomorrow is a no-op (the source-run is already
+recorded). The next day's watcher consumes a NEW Mutation run with
+its own source-run ID, which dedups independently. Per-file issue
+matching (step 4) handles the "same file, different lines" case
+across SHAs.
+
+## Process
+
+1. **Parse the report.** The Stryker HTML at `$REPORT_HTML` embeds the
+   full report as JSON in a `<script>` block. Find it with:
+
+   ```
+   grep -o "app.report = {.*" "$REPORT_HTML" | head -c 100
+   ```
+
+   To extract just the JSON for processing:
+
+   ```
+   node -e '
+     const html = require("fs").readFileSync(process.env.REPORT_HTML, "utf8");
+     const m = html.match(/app\.report\s*=\s*(\{[\s\S]*?\});\s*<\/script>/);
+     if (!m) { console.error("no app.report found"); process.exit(1); }
+     console.log(m[1]);
+   ' > /tmp/mutation-report.json
+   ```
+
+   The shape is `{ schemaVersion, files: { <path>: { source, mutants: [...] } }, ... }`.
+   Each mutant has: `id`, `mutatorName`, `replacement`, `status`
+   (`Killed` / `Survived` / `NoCoverage` / `Timeout` / `RuntimeError` / etc.),
+   `location: { start: {line, column}, end: {line, column} }`, and
+   `description`.
+
+2. **Filter to actionable mutants.** Two statuses warrant filing:
+
+   | Status | What it means | Action |
+   |---|---|---|
+   | `Survived` | Test ran but didn't catch the change. Real test gap. | File / comment |
+   | `NoCoverage` | No test even executed the code. Worse — tests don't reach this path at all. | File / comment |
+
+   Skip `Killed` (working as intended), `Timeout` (Stryker infra issue),
+   `RuntimeError` (likely a test setup problem, not a coverage gap),
+   `CompileError` (Stryker artifact, not a real gap).
+
+3. **Group by source file.** One mutated source file = one issue. A file
+   with five surviving mutants in the same function gets ONE issue listing
+   all five locations — same root-cause class (this function's behavior
+   isn't tested), easier to fix as a unit. Do NOT file one issue per
+   mutant — that floods the tracker with shrapnel from a single gap.
+
+   Within each file, sub-group by line range when several mutants cluster
+   in one function vs. scattered across the file. The issue body lists
+   each location with its mutator + replacement so fix-bot has concrete
+   targets.
+
+4. **Search existing issues.** For each file with surviving mutants:
+
+   ```
+   gh issue list --state open --search "<filename> mutation in:title,body" --json number,title,body
+   ```
+
+   Use the bare filename (e.g. `history-recorder.ts`, `route-handler.ts`)
+   as the search term. Match grain: per source file, NOT per mutant.
+
+   - **Match (comment)** if the existing issue tracks surviving mutants
+     in the SAME source file
+   - **New issue** if no existing issue covers this file's mutants
+
+   Read the existing issue's body to verify; don't title-match alone.
+
+5. **Dedup against this source run.** If you find a matching open issue,
+   search its comments for the source run ID:
+
+   ```
+   gh issue view <NUMBER> --json comments | jq -r '.comments[].body' | grep -F "source-run=$SOURCE_RUN_ID"
+   ```
+
+   If the source run is already mentioned, skip — already recorded for
+   this Stryker run. (Different source runs naturally produce different
+   tags, so re-running Stryker tomorrow and finding the same mutants
+   adds a new occurrence comment, which is the right behavior.)
+
+6. **Decide and act.**
+
+   - **Match found, source run not yet recorded** → add a short comment to
+     the existing issue. Format:
+
+     ```
+     > *This was generated by AI during triage.*
+
+     New occurrence on Mutation run $SOURCE_RUN_ID (SHA $SHORT_SHA, $DATE):
+
+     - File: `<path>`
+     - Surviving mutants: <count> (<mutator names>)
+     - Locations: <line ranges>
+
+     [no further analysis — the issue body already covers root-cause]
+
+     <!-- mutation-watcher: source-run=$SOURCE_RUN_ID watcher-run=$RUN_ID -->
+     ```
+
+     Use `gh issue comment <NUMBER> --body "..."`.
+
+   - **No match found** → file a new issue using the template below.
+
+7. **Labelling.** Apply the full producer-bot label set on NEW issues; on
+   existing issues, ADD any missing labels (don't remove ones humans
+   applied during triage).
+
+   | Label | When | Notes |
+   |---|---|---|
+   | `bug` | Always — surviving mutants ARE bugs (the test suite has a coverage gap that lets real bugs through) | Producer-bot pattern: self-classify, bypass triage |
+   | `area: <X>` | Always — pick from path → area mapping below | One area only |
+   | `ready-for-agent` | Always on NEW issues — the report IS validation; fix-bot can pick up | Self-validated by Stryker |
+
+   **Producer-bot pattern.** mutation-watcher is a producer bot (along
+   with flake-watcher). Producer bots fully self-classify their output —
+   triage-bot doesn't process mutation-watcher output (its input contract
+   excludes `bug`). The labels above bypass triage and feed straight
+   into fix-bot's queue (`bug` + `ready-for-agent`).
+
+   Do NOT apply `needs-triage` — that label is the skill-canonical
+   "no bot or human has looked yet" state. Mutation-watcher HAS looked.
+
+   Do NOT apply `flake` — surviving mutants are coverage gaps, not
+   intermittent failures.
+
+   **Path → area mapping** (from `stryker.config.json`'s `mutate` patterns):
+
+   | Source path prefix | Area label |
+   |---|---|
+   | `packages/gazetta/src/history-*` | `area: renderer` (history is an internal renderer concern) |
+   | `packages/gazetta/src/publish*` | `area: renderer` (publish pipeline) |
+   | `packages/gazetta/src/admin-api/**` | `area: cms` (admin API surface) |
+   | `packages/gazetta/src/alt/**` | `area: cms` (alt-text suggestion is admin-side) |
+
+   When a mutated path doesn't fit cleanly, pick the closest area and
+   note your reasoning via a `> Decision: ...` line.
+
+   **Apply all labels in one call** to avoid multiple API roundtrips:
+
+   ```
+   gh issue edit <N> --add-label "bug,area: renderer,ready-for-agent"
+   ```
+
+## New-issue template
+
+Title format: `Surviving mutants in <filename>: <count> coverage gap(s)`
+
+- `<filename>` is the bare filename (`history-recorder.ts`)
+- `<count>` is the number of surviving + no-coverage mutants
+
+Body:
+
+```markdown
+> *This was generated by AI during triage.*
+
+## Pattern
+
+Stryker found <N> surviving mutant(s) in `<full path>` on Mutation run
+$SOURCE_RUN_ID (SHA `<short sha>`, $DATE). The test suite executes this
+code but does not assert on the behavior the mutants change.
+
+## Surviving mutants
+
+<one section per cluster of related mutants — same function or same
+behavior class>
+
+### `<function or behavior>` (lines <start>-<end>)
+
+| Line | Mutator | Original → Replacement |
+|---|---|---|
+| 42 | `BlockStatement` | (function body) → `{}` |
+| 45 | `ConditionalExpression` | `x > 0` → `false` |
+
+**Why this gap matters:** <one or two sentences on what behavior is
+unverified — read the source to ground this. Honest about uncertainty:
+"Block-statement mutants surviving usually means the function's side
+effects are unverified" is fine; speculating about specific bugs is not.>
+
+## Test files that should cover this
+
+<list `tests/<file>.test.ts` peer files (use `Glob` to find them). If
+no peer test file exists, say so — that's a different kind of gap.>
+
+## Fix approach
+
+<2-3 sentences on what tests would kill these mutants. For
+block-statement mutants: assert on observable side effects. For
+conditional mutants: add boundary tests on the condition. For string
+literals: assert on the exact value. Mark "(Recommended)" on the
+strongest option.>
+
+## Out of scope
+
+<things adjacent that should not be conflated with the fix>
+
+<!-- mutation-watcher: source-run=$SOURCE_RUN_ID watcher-run=$RUN_ID -->
+```
+
+## Rules
+
+- **Don't speculate beyond evidence.** Surviving mutants tell you "this
+  behavior isn't tested." They don't tell you "this is broken in
+  production." Resist the urge to claim "this is a real bug" unless the
+  source code makes it obvious.
+- **Quote mutators verbatim.** Stryker's mutator names (`BlockStatement`,
+  `ConditionalExpression`, `StringLiteral`, `LogicalOperator`, etc.) are
+  documented; future debuggers grep them.
+- **One issue per file, not per mutant.** Re-read step 3 if tempted.
+- **Read the source before recommending fixes.** A `BlockStatement`
+  mutant surviving in a function with no return value means the function's
+  side effects aren't asserted on. A `ConditionalExpression` mutant in a
+  validator means the validator's branches aren't fully tested. The
+  recommendation depends on what the function does.
+- **Stay terse.** Issue bodies should fit on one screen. Pattern + mutant
+  table + fix approach. No preamble, no summary.
+- **Do not ask the user questions** — you're running headless in CI. If
+  evidence is insufficient (e.g., the report is malformed), file no
+  issues and exit cleanly; the next run picks up the next Mutation
+  artifact.
+- **Skip files with only `Killed` mutants.** If a file has high mutation
+  score (most mutants killed), don't file an issue just because one
+  marginal mutant survived. Use judgment: a file with 1 surviving mutant
+  out of 50 killed is a different signal than 5 surviving out of 10.
+  Document your threshold via `> Decision: ...` if you skip.

--- a/bots/package.json
+++ b/bots/package.json
@@ -7,6 +7,7 @@
   "description": "Repo-scoped bots that run on GitHub Actions cron schedules. Each bot lives in its own subdirectory and shares helpers from _lib/.",
   "scripts": {
     "flake-watcher": "tsx flake-watcher/index.ts",
+    "mutation-watcher": "tsx mutation-watcher/index.ts",
     "triage-bot": "tsx triage-bot/index.ts",
     "discovery-prep-bot": "tsx discovery-prep-bot/index.ts",
     "fix-bot": "tsx fix-bot/index.ts",

--- a/bots/triage-bot/index.ts
+++ b/bots/triage-bot/index.ts
@@ -34,6 +34,15 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { runClaude } from '../_lib/claude.js'
 import { findIssuesByLabels, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
+import {
+  printBanner,
+  printCandidateHeader,
+  printCandidateList,
+  printNotice,
+  printRunSummary,
+  printTranscriptPath,
+  printWarning,
+} from '../_lib/ui.js'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const PROMPT_PATH = resolve(HERE, 'prompt.md')
@@ -52,10 +61,24 @@ const RUN_TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$
 const PER_RUN_BUDGET_MS = Number(process.env.BUDGET_MS ?? 50 * 60 * 1000)
 
 async function main(): Promise<void> {
+  printBanner({
+    name: 'triage-bot',
+    tagline: 'classifier',
+    purpose: 'Classify open issues as bug / enhancement / triage-uncertain.',
+    inputs: [
+      'Open issues with NO classification (no bug / enhancement / triage-uncertain)',
+      'AND no terminal-state label (no ready-for-agent / ready-for-human / wontfix / needs-info)',
+    ],
+    outputs: [
+      'One of bug / enhancement / triage-uncertain + area: X',
+      'Reproducible bug also gets ready-for-agent (auto-advances to fix-bot queue)',
+    ],
+  })
+
   const repo = repoFromEnv()
   const octokit = octokitFromEnv()
 
-  console.log(`Triage bot: scanning ${repo.owner}/${repo.repo} for triage candidates`)
+  printNotice(`Scanning ${repo.owner}/${repo.repo} for triage candidates`)
 
   // Triage-bot's input contract: any open issue with NO classification
   // yet (no `bug` / `enhancement` / `triage-uncertain`) AND no terminal-
@@ -79,7 +102,7 @@ async function main(): Promise<void> {
   })
 
   if (allCandidates.length === 0) {
-    console.log('No triage candidates found. Inbox zero — nothing to do.')
+    printNotice('No triage candidates found. Inbox zero — nothing to do. ✨')
     return
   }
 
@@ -89,14 +112,17 @@ async function main(): Promise<void> {
   // newer issues forever (which a newest-first or arrival-order sort would).
   const candidates = [...allCandidates].sort((a, b) => a.createdAt.localeCompare(b.createdAt))
 
-  console.log(`Triage candidates (${candidates.length}, oldest-first):`)
-  for (const c of candidates) {
-    const labels = c.labels.length ? `[${c.labels.join(', ')}]` : '[unlabeled]'
-    console.log(`  #${c.number} ${labels} "${c.title}"`)
-  }
+  printCandidateList({
+    noun: 'issue',
+    candidates: candidates.map(c => ({
+      ref: `#${c.number}`,
+      label: c.title,
+      meta: c.labels.length ? `[${c.labels.join(', ')}]` : '[unlabeled]',
+    })),
+  })
 
   if (DRY_RUN) {
-    console.log(`DRY_RUN=1 — exiting before invoking Claude (${candidates.length} would be processed).`)
+    printNotice(`DRY_RUN=1 — exiting before invoking Claude (${candidates.length} would be processed).`)
     return
   }
 
@@ -138,20 +164,22 @@ ${roadmap}
     const elapsed = Date.now() - runStart
     if (elapsed > PER_RUN_BUDGET_MS) {
       const remaining = candidates.length - processed
-      console.log(
-        `\nPer-run budget exhausted (${Math.round(elapsed / 1000)}s elapsed > ${Math.round(PER_RUN_BUDGET_MS / 1000)}s budget).`,
+      printWarning(
+        `Per-run budget exhausted (${Math.round(elapsed / 1000)}s > ${Math.round(PER_RUN_BUDGET_MS / 1000)}s). Stopping with ${remaining} un-triaged; tomorrow's run picks them up.`,
       )
-      console.log(`Stopping with ${remaining} candidate(s) un-triaged this run; tomorrow's run picks them up.`)
-      console.log('Skipped (oldest first will be retried tomorrow):')
       for (const skipped of candidates.slice(processed)) {
-        console.log(`  #${skipped.number} "${skipped.title}"`)
+        console.log(`     ⏭  #${skipped.number} "${skipped.title}"`)
       }
       break
     }
 
-    console.log(
-      `\n=== Triaging #${candidate.number}: "${candidate.title}" (${processed + 1}/${candidates.length}, ${Math.round(elapsed / 1000)}s elapsed) ===`,
-    )
+    printCandidateHeader({
+      index: processed + 1,
+      total: candidates.length,
+      label: `#${candidate.number} · ${candidate.title}`,
+      meta: candidate.labels.length ? [`labels: ${candidate.labels.join(', ')}`] : undefined,
+      elapsedSec: Math.round(elapsed / 1000),
+    })
 
     // Every investigation is fresh — the candidate query already excludes
     // classified issues, so any candidate we see is either brand-new or
@@ -164,7 +192,7 @@ ISSUE_TITLE=${candidate.title}
 RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
 
     const transcriptPath = resolve(TRANSCRIPTS_DIR, `${RUN_TIMESTAMP}-issue-${candidate.number}.jsonl`)
-    console.log(`(transcript: ${transcriptPath})`)
+    printTranscriptPath(transcriptPath)
 
     try {
       // Triage needs more tools than flake-watcher: Bash for gh + npm test +
@@ -176,10 +204,10 @@ RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
         allowedTools: ['Bash', 'Read', 'Grep', 'Glob'],
       })
       if (!result.success) {
-        console.log(`Warning: triage of #${candidate.number} exited ${result.exitCode}; continuing.`)
+        printWarning(`triage of #${candidate.number} exited ${result.exitCode}; continuing.`)
       }
     } catch (err) {
-      console.log(`Warning: triage of #${candidate.number} threw: ${err}; continuing.`)
+      printWarning(`triage of #${candidate.number} threw: ${err}; continuing.`)
     }
 
     // No chain-dispatch: discovery-prep-bot now runs on its own cron and
@@ -191,7 +219,15 @@ RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
     processed++
   }
 
-  console.log(`\nTriage bot complete. Processed ${processed}/${candidates.length}. Transcripts: ${TRANSCRIPTS_DIR}`)
+  const totalSec = Math.round((Date.now() - runStart) / 1000)
+  printRunSummary({
+    verb: 'Triaged',
+    processed,
+    total: candidates.length,
+    skipped: candidates.length - processed,
+    notes: [`Transcripts: ${TRANSCRIPTS_DIR}`],
+    elapsedSec: totalSec,
+  })
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary

Two changes, two commits.

**1. Friendlier orchestrator output** for all bots. Workflow logs become structured: each bot opens with a banner naming itself + its label-driven I/O contract, candidates list with metadata, per-candidate header with elapsed time, and a closing summary card. Tool calls now pair with their results on one line (\`🔧 Bash · 1.2s · 4.5KB · gh issue view 245 ...\`); \`Decision: ...\` text Claude emits gets a star prefix. Plain ASCII under \`NO_COLOR\`. Transcripts unchanged (they're the audit trail for replay).

**2. mutation-watcher** — daily review of the latest Stryker mutation report. Files issues for surviving mutants (test-coverage gaps), one issue per source file. Self-classifies output as \`bug\` + \`area: X\` + \`ready-for-agent\` (producer-bot pattern), bypassing triage-bot. Same producer-bot pattern applied to flake-watcher's prompt — \`flake\` + \`bug\` + \`ready-for-agent\` instead of routing through \`needs-triage\`.

## Test plan

- [x] Type-check (\`tsc --noEmit\` in \`bots/\`)
- [x] \`npm run format:check\` clean
- [x] Dry-run all five bots locally (banner + candidate-list output verified)
- [x] mutation-watcher dry-run successfully downloads + locates the latest \`mutation-report\` artifact from a real Mutation workflow run
- [ ] After merge: trigger \`mutation-watcher\` workflow_dispatch once to validate end-to-end against a real artifact + observe Claude's per-file issue filing

## Pipeline shape after merge

\`\`\`
Producer bots — bypass triage, go straight to fix-bot's queue:
─────────────────────────────────────────────────────────────
flake-watcher (12:00 UTC)         mutation-watcher (03:30 UTC)
    ↓ files bug + ready-for-agent     ↓ files bug + ready-for-agent
                          \\           /
                           \\         /
Human-filed → triage-bot → enhancement → discovery-prep-bot → ready-for-human
                        ↘ bug + ready-for-agent ↘
                                                  fix-bot (13:00 UTC) → draft PR
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)