### PR TITLE
fix(mutation-watcher): parse Stryker report in TS, not in prompt

### DIFF
--- a/bots/_lib/stryker-parse.ts
+++ b/bots/_lib/stryker-parse.ts
@@ -1,0 +1,298 @@
+/**
+ * Stryker mutation-report HTML parser + summarizer.
+ *
+ * Stryker's HTML reporter embeds the full report as a JS object literal
+ * (NOT pure JSON) at line ~334 of mutation.html, in a `<script>` block:
+ *
+ *   app.report = { "files": { "<path>": { "language": ..., "mutants": [...] } } };
+ *
+ * The non-JSON-ness comes from Stryker's HTML escape pass: it wraps angle-
+ * brackets inside string values with literal `"+"` concatenation tokens
+ * (e.g. `"...Set<"+"foo"`). `JSON.parse` chokes on those; `vm.runInNewContext`
+ * evaluates them as JS string concatenation and produces the right object.
+ *
+ * Why parse-in-TS instead of parse-in-prompt:
+ *   - The full report is ~3 MB. Reading it into Claude's context wastes
+ *     ~50% of the available window before any analysis happens.
+ *   - Per the failed run 25637089951, Claude's autocompact thrashed when
+ *     it tried to enrich the analysis with source-file reads on top of
+ *     the in-context report.
+ *   - The parsing is a deterministic transformation (file shape →
+ *     summary). Doing it in TS produces a fixture-testable, type-checked
+ *     module instead of a prompt instruction Claude has to re-derive
+ *     every run.
+ *
+ * Architecture parallel: triage-bot's orchestrator filters open issues
+ * via the GitHub API into a ranked candidate list, then hands one
+ * candidate at a time to Claude. mutation-watcher does the same with
+ * mutants instead of issues — orchestrator filters down to actionable
+ * surviving mutants per-file, hands a small summary to Claude, Claude
+ * writes the issue bodies.
+ */
+import { readFileSync } from 'node:fs'
+import { runInNewContext } from 'node:vm'
+
+/**
+ * Stryker mutant statuses we care about.
+ *
+ *   Survived       — test ran but didn't catch the change. Real test gap.
+ *   NoCoverage     — no test executed the code at all. Worse — tests don't
+ *                    reach this path.
+ *   Killed         — working as intended. Skip.
+ *   Timeout        — Stryker infra issue. Skip.
+ *   RuntimeError   — likely test setup problem. Skip.
+ *   CompileError   — TS rejected the mutant. Stryker artifact, not a real
+ *                    gap (the mutant wouldn't compile in production
+ *                    either). Skip.
+ *   Pending        — incomplete mutation testing run. Skip.
+ *
+ * Only Survived + NoCoverage feed into actionable issues.
+ */
+type ActionableStatus = 'Survived' | 'NoCoverage'
+const ACTIONABLE_STATUSES: ReadonlySet<ActionableStatus> = new Set(['Survived', 'NoCoverage'])
+
+interface StrykerMutant {
+  id: string
+  mutatorName: string
+  replacement: string
+  status: string
+  location: { start: { line: number; column: number }; end: { line: number; column: number } }
+  statusReason?: string
+  /** Original source between location.start and location.end. May be absent when Stryker emits compile-error mutants. */
+  originalText?: string
+}
+
+interface StrykerFile {
+  language: string
+  mutants: StrykerMutant[]
+}
+
+interface StrykerReport {
+  schemaVersion?: string
+  files: Record<string, StrykerFile>
+  thresholds?: { high: number; low: number }
+  projectRoot?: string
+}
+
+/**
+ * One actionable mutant, projected from Stryker's shape into the slim
+ * shape Claude will see in the prompt.
+ */
+export interface ActionableMutant {
+  mutator: string
+  status: ActionableStatus
+  /** Line range in the source file. */
+  startLine: number
+  endLine: number
+  /** Mutator's replacement text, truncated. */
+  replacement: string
+}
+
+/**
+ * One source file's summary: which mutants survived, plus the per-file
+ * killed/total counts that drive the kill-ratio threshold.
+ */
+export interface FileSummary {
+  /** Source path relative to the package being mutated, e.g. `src/admin-api/routes/publish.ts`. */
+  path: string
+  totalMutants: number
+  killedCount: number
+  survivedCount: number
+  noCoverageCount: number
+  /** killedCount / (killedCount + survivedCount + noCoverageCount). 1.0 = perfect coverage. */
+  killRatio: number
+  /** Up to MAX_MUTANTS_PER_FILE actionable mutants. */
+  mutants: ActionableMutant[]
+}
+
+export interface MutationSummary {
+  /** Total number of files Stryker mutated. */
+  totalFiles: number
+  /** Files with at least one actionable mutant, sorted by descending impact (gap count, then descending kill-ratio inverse). */
+  files: FileSummary[]
+  /** Files filtered out by the high-kill-ratio rule (≥KILL_RATIO_THRESHOLD AND ≤MAX_TRIVIAL_GAPS). */
+  skippedHighScoreFiles: number
+  /** Total surviving mutants across the report (for context). */
+  totalSurvived: number
+  /** Total no-coverage mutants across the report (for context). */
+  totalNoCoverage: number
+}
+
+/** Cap mutants per file so a 50-mutant file doesn't dominate one issue. */
+const MAX_MUTANTS_PER_FILE = 8
+
+/** Cap on replacement text per mutant — Claude doesn't need the full mutated source. */
+const MAX_REPLACEMENT_LEN = 80
+
+/**
+ * Files with kill-ratio above this threshold AND fewer than
+ * MAX_TRIVIAL_GAPS surviving+no-coverage mutants are skipped. The
+ * threshold expresses "this file is mostly tested; the surviving
+ * mutants are likely marginal or boundary-case noise rather than
+ * actionable coverage gaps."
+ */
+const KILL_RATIO_THRESHOLD = 0.85
+const MAX_TRIVIAL_GAPS = 4
+
+/**
+ * Read mutation.html, extract `app.report = { ... }`, evaluate as JS,
+ * and return the parsed report.
+ *
+ * Throws if the HTML doesn't contain the assignment or evaluation fails.
+ */
+export function parseStrykerReport(htmlPath: string): StrykerReport {
+  const html = readFileSync(htmlPath, 'utf-8')
+
+  // Stryker's HTML reporter emits `app.report = {...};` on a single
+  // line. The assignment is followed by the rest of the inline script
+  // (theme handling, etc.), so we anchor on `app.report = ` and walk to
+  // the end of the line; the trailing `;` is then the assignment
+  // terminator. (We don't try to match braces — the value contains
+  // arbitrarily-nested braces inside string values that confound naive
+  // regex matching.)
+  const lineMatch = html.match(/app\.report\s*=\s*(\{.*\});\s*$/m)
+  if (!lineMatch) {
+    throw new Error(`Stryker report at ${htmlPath} does not contain a recognizable app.report assignment.`)
+  }
+
+  // Evaluate as JavaScript — handles the literal `"+"` concatenation
+  // tokens Stryker embeds inside string values (a quirk of its HTML
+  // escape pass on TS compile-error messages).
+  const jsExpression = lineMatch[1]
+  let report: unknown
+  try {
+    report = runInNewContext(`(${jsExpression})`, {}, { timeout: 5000, displayErrors: true })
+  } catch (err) {
+    throw new Error(`Failed to evaluate Stryker app.report expression: ${(err as Error).message}`)
+  }
+
+  if (!isStrykerReport(report)) {
+    throw new Error(`Stryker app.report did not match expected shape (missing 'files' record).`)
+  }
+  return report
+}
+
+function isStrykerReport(value: unknown): value is StrykerReport {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  return typeof v.files === 'object' && v.files !== null
+}
+
+/**
+ * Project a parsed Stryker report into a slim, prioritized summary
+ * suitable for the prompt. Steps:
+ *
+ *   1. For each file, count Killed / Survived / NoCoverage / other.
+ *   2. Skip files with killRatio ≥ KILL_RATIO_THRESHOLD AND
+ *      ≤ MAX_TRIVIAL_GAPS gaps (mostly-tested-with-marginal-residual).
+ *   3. For remaining files, project each Survived/NoCoverage mutant
+ *      into ActionableMutant shape; cap at MAX_MUTANTS_PER_FILE per
+ *      file.
+ *   4. Sort files by gap count desc, then by killRatio asc (worse
+ *      coverage first).
+ */
+export function summarizeReport(report: StrykerReport): MutationSummary {
+  const files: FileSummary[] = []
+  let skippedHighScoreFiles = 0
+  let totalSurvived = 0
+  let totalNoCoverage = 0
+
+  for (const [path, fileData] of Object.entries(report.files)) {
+    let killedCount = 0
+    let survivedCount = 0
+    let noCoverageCount = 0
+    const actionable: ActionableMutant[] = []
+
+    for (const mutant of fileData.mutants) {
+      if (mutant.status === 'Killed') {
+        killedCount++
+      } else if (mutant.status === 'Survived') {
+        survivedCount++
+      } else if (mutant.status === 'NoCoverage') {
+        noCoverageCount++
+      }
+      // Other statuses (Timeout, RuntimeError, CompileError, Pending) are
+      // counted in totalMutants but don't affect killRatio numerator/
+      // denominator — they're Stryker-side issues, not coverage signal.
+
+      if (ACTIONABLE_STATUSES.has(mutant.status as ActionableStatus)) {
+        actionable.push({
+          mutator: mutant.mutatorName,
+          status: mutant.status as ActionableStatus,
+          startLine: mutant.location.start.line,
+          endLine: mutant.location.end.line,
+          replacement: truncate(mutant.replacement, MAX_REPLACEMENT_LEN),
+        })
+      }
+    }
+
+    totalSurvived += survivedCount
+    totalNoCoverage += noCoverageCount
+
+    const gapCount = survivedCount + noCoverageCount
+    if (gapCount === 0) continue // file fully covered, nothing to file
+
+    const totalCounted = killedCount + gapCount
+    const killRatio = totalCounted === 0 ? 0 : killedCount / totalCounted
+
+    // Skip mostly-tested files with marginal residual.
+    if (killRatio >= KILL_RATIO_THRESHOLD && gapCount <= MAX_TRIVIAL_GAPS) {
+      skippedHighScoreFiles++
+      continue
+    }
+
+    // Sort actionable mutants by line number (stable, makes reading the
+    // issue body easier) and cap.
+    actionable.sort((a, b) => a.startLine - b.startLine)
+    const cappedMutants = actionable.slice(0, MAX_MUTANTS_PER_FILE)
+
+    files.push({
+      path,
+      totalMutants: fileData.mutants.length,
+      killedCount,
+      survivedCount,
+      noCoverageCount,
+      killRatio,
+      mutants: cappedMutants,
+    })
+  }
+
+  // Sort files by impact: most gaps first, ties broken by lowest kill-ratio.
+  files.sort((a, b) => {
+    const gapDiff = b.survivedCount + b.noCoverageCount - (a.survivedCount + a.noCoverageCount)
+    if (gapDiff !== 0) return gapDiff
+    return a.killRatio - b.killRatio
+  })
+
+  return {
+    totalFiles: Object.keys(report.files).length,
+    files,
+    skippedHighScoreFiles,
+    totalSurvived,
+    totalNoCoverage,
+  }
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s
+  return `${s.slice(0, max - 1)}…`
+}
+
+/**
+ * Map a source path to an `area: <X>` label per the producer-bot
+ * convention. Mirrors the path → area table in mutation-watcher's
+ * prompt.md.
+ *
+ * Returning the area in TS (rather than asking Claude to derive it
+ * from the path) is one less judgment call per issue Claude has to
+ * make under tight context.
+ */
+export function pathToArea(path: string): string {
+  if (path.startsWith('src/history')) return 'area: renderer'
+  if (path.startsWith('src/publish')) return 'area: renderer'
+  if (path.startsWith('src/admin-api/')) return 'area: cms'
+  if (path.startsWith('src/alt/')) return 'area: cms'
+  // Fallback for any future addition — the prompt instructs Claude to
+  // narrate this case via a Decision: line.
+  return 'area: renderer'
+}

--- a/bots/_lib/tests/fixtures/stryker-fixture.html
+++ b/bots/_lib/tests/fixtures/stryker-fixture.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head><title>Stryker fixture</title></head>
+<body>
+<mutation-test-report-app></mutation-test-report-app>
+<script>
+const app = document.querySelector('mutation-test-report-app');
+      app.report = {"files":{"src/admin-api/routes/publish.ts":{"language":"typescript","mutants":[{"id":"1","mutatorName":"BlockStatement","replacement":"{}","status":"Survived","location":{"start":{"line":42,"column":3},"end":{"line":50,"column":4}}},{"id":"2","mutatorName":"ConditionalExpression","replacement":"false","status":"NoCoverage","location":{"start":{"line":61,"column":7},"end":{"line":61,"column":18}}},{"id":"3","mutatorName":"StringLiteral","replacement":"\"\"","status":"Killed","location":{"start":{"line":80,"column":12},"end":{"line":80,"column":18}}},{"id":"4","mutatorName":"StringLiteral","replacement":"\"\"","status":"CompileError","statusReason":"Type 'Set<"+"\"\" | \"replace\">' is not assignable","location":{"start":{"line":99,"column":3},"end":{"line":99,"column":11}}}]},"src/history-recorder.ts":{"language":"typescript","mutants":[{"id":"5","mutatorName":"BlockStatement","replacement":"{}","status":"Killed","location":{"start":{"line":10,"column":1},"end":{"line":15,"column":2}}},{"id":"6","mutatorName":"BlockStatement","replacement":"{}","status":"Killed","location":{"start":{"line":20,"column":1},"end":{"line":25,"column":2}}},{"id":"7","mutatorName":"ConditionalExpression","replacement":"true","status":"Killed","location":{"start":{"line":30,"column":1},"end":{"line":30,"column":10}}},{"id":"8","mutatorName":"ConditionalExpression","replacement":"true","status":"Killed","location":{"start":{"line":40,"column":1},"end":{"line":40,"column":10}}},{"id":"9","mutatorName":"ConditionalExpression","replacement":"true","status":"Killed","location":{"start":{"line":50,"column":1},"end":{"line":50,"column":10}}},{"id":"10","mutatorName":"ConditionalExpression","replacement":"true","status":"Killed","location":{"start":{"line":60,"column":1},"end":{"line":60,"column":10}}},{"id":"11","mutatorName":"BlockStatement","replacement":"{}","status":"Survived","location":{"start":{"line":70,"column":1},"end":{"line":75,"column":2}}}]},"src/admin-api/routes/clean.ts":{"language":"typescript","mutants":[{"id":"12","mutatorName":"BlockStatement","replacement":"{}","status":"Killed","location":{"start":{"line":1,"column":1},"end":{"line":5,"column":2}}}]}}};
+function updateTheme() {}
+</script>
+</body>
+</html>

--- a/bots/_lib/tests/stryker-parse.test.ts
+++ b/bots/_lib/tests/stryker-parse.test.ts
@@ -1,0 +1,107 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { parseStrykerReport, pathToArea, summarizeReport } from '../stryker-parse.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const FIXTURE_PATH = resolve(HERE, 'fixtures/stryker-fixture.html')
+
+describe('parseStrykerReport', () => {
+  it('extracts and evaluates the app.report assignment', () => {
+    const report = parseStrykerReport(FIXTURE_PATH)
+    expect(report.files).toBeTypeOf('object')
+    expect(Object.keys(report.files)).toEqual([
+      'src/admin-api/routes/publish.ts',
+      'src/history-recorder.ts',
+      'src/admin-api/routes/clean.ts',
+    ])
+  })
+
+  it('handles the Stryker `"+"` concatenation quirk in TS compile-error statusReason', () => {
+    // The fixture's mutant id=4 has statusReason with `Set<"+"\"\" | \"replace\">"`
+    // — Stryker's HTML escape pass inserts literal `"+"` tokens that JSON.parse
+    // chokes on. vm.runInNewContext evaluates them as JS string concatenation.
+    const report = parseStrykerReport(FIXTURE_PATH)
+    const mutants = report.files['src/admin-api/routes/publish.ts'].mutants
+    const compileErr = mutants.find(m => m.id === '4')
+    expect(compileErr).toBeDefined()
+    // The string concat result: `Set<"" | "replace">` (the `"+"` tokens
+    // disappear after evaluation).
+    expect(compileErr?.statusReason).toContain(`Set<"" | "replace">`)
+    expect(compileErr?.statusReason).not.toContain('"+"')
+  })
+
+  it('throws when mutation.html lacks an app.report assignment', () => {
+    // Use this very test file as a non-Stryker HTML — guaranteed not to match.
+    expect(() => parseStrykerReport(resolve(HERE, 'stryker-parse.test.ts'))).toThrow(
+      /does not contain a recognizable app.report/,
+    )
+  })
+})
+
+describe('summarizeReport', () => {
+  it('counts mutants by status per file', () => {
+    const report = parseStrykerReport(FIXTURE_PATH)
+    const summary = summarizeReport(report)
+    const publish = summary.files.find(f => f.path === 'src/admin-api/routes/publish.ts')
+    expect(publish).toBeDefined()
+    expect(publish?.killedCount).toBe(1) // id 3
+    expect(publish?.survivedCount).toBe(1) // id 1
+    expect(publish?.noCoverageCount).toBe(1) // id 2
+    expect(publish?.totalMutants).toBe(4) // ids 1-4 incl. CompileError
+  })
+
+  it('skips fully-tested files (no actionable mutants)', () => {
+    const report = parseStrykerReport(FIXTURE_PATH)
+    const summary = summarizeReport(report)
+    // src/admin-api/routes/clean.ts has only one Killed mutant.
+    expect(summary.files.find(f => f.path === 'src/admin-api/routes/clean.ts')).toBeUndefined()
+  })
+
+  it('skips files with kill-ratio ≥ 0.85 AND ≤4 gaps as marginal residual', () => {
+    const report = parseStrykerReport(FIXTURE_PATH)
+    const summary = summarizeReport(report)
+    // history-recorder has 6 killed + 1 survived → killRatio ≈ 0.857, 1 gap.
+    // Above threshold AND under MAX_TRIVIAL_GAPS, so should be filtered.
+    const historyRecorder = summary.files.find(f => f.path === 'src/history-recorder.ts')
+    expect(historyRecorder).toBeUndefined()
+    expect(summary.skippedHighScoreFiles).toBe(1)
+  })
+
+  it('only projects Survived + NoCoverage mutants into actionable list', () => {
+    const report = parseStrykerReport(FIXTURE_PATH)
+    const summary = summarizeReport(report)
+    const publish = summary.files.find(f => f.path === 'src/admin-api/routes/publish.ts')
+    // 1 Survived (id 1) + 1 NoCoverage (id 2) = 2 actionable.
+    expect(publish?.mutants).toHaveLength(2)
+    const statuses = publish?.mutants.map(m => m.status)
+    expect(statuses).toEqual(expect.arrayContaining(['Survived', 'NoCoverage']))
+    // Killed (id 3) and CompileError (id 4) excluded.
+    expect(publish?.mutants.map(m => m.mutator)).not.toContain('StringLiteral')
+  })
+
+  it('sorts files by impact: most gaps first, then lowest kill-ratio', () => {
+    const report = parseStrykerReport(FIXTURE_PATH)
+    const summary = summarizeReport(report)
+    // Only one actionable file in this fixture (publish.ts), so sort
+    // verification needs a synthesized report. Just confirm shape.
+    expect(summary.files.length).toBeGreaterThan(0)
+    expect(summary.totalSurvived).toBe(2) // id 1 + id 11
+    expect(summary.totalNoCoverage).toBe(1) // id 2
+  })
+})
+
+describe('pathToArea', () => {
+  it.each([
+    ['src/history-recorder.ts', 'area: renderer'],
+    ['src/history-provider.ts', 'area: renderer'],
+    ['src/publish.ts', 'area: renderer'],
+    ['src/publish-rendered.ts', 'area: renderer'],
+    ['src/admin-api/routes/pages.ts', 'area: cms'],
+    ['src/admin-api/index.ts', 'area: cms'],
+    ['src/alt/route-handler.ts', 'area: cms'],
+    ['src/something-uncategorized.ts', 'area: renderer'], // fallback
+  ])('maps %s to %s', (path, expected) => {
+    expect(pathToArea(path)).toBe(expected)
+  })
+})

--- a/bots/mutation-watcher/index.ts
+++ b/bots/mutation-watcher/index.ts
@@ -4,19 +4,34 @@
  * Pairs with the existing `Mutation` workflow (`.github/workflows/mutation.yml`)
  * which runs Stryker nightly at 03:00 UTC and uploads an HTML report as the
  * `mutation-report` artifact. This bot runs at 03:30 UTC, fetches that
- * artifact, and hands the report to `claude -p` to identify surviving
- * mutants worth filing as bugs.
+ * artifact, parses it server-side, and hands ONE per-file summary at a
+ * time to `claude -p` to file/comment issues.
  *
- * Producer-bot pattern (shared with flake-watcher):
+ * Why parse-in-orchestrator (not parse-in-prompt):
+ *
+ *   The first iteration asked Claude to read the 3 MB mutation.html and
+ *   parse it. That blew the context window — Claude correctly diagnosed
+ *   the Stryker `"+"` quirk (string concat in JSON-shaped JS) and
+ *   pivoted to vm.runInNewContext, but by the time it had a parsed
+ *   summary + read source files for issue bodies, autocompact thrashed
+ *   and the run failed with zero issues filed (run 25637089951).
+ *
+ *   This iteration moves the deterministic transformation (HTML → small
+ *   per-file summary) into TS code. Claude receives a tiny JSON for ONE
+ *   file at a time, writes a focused issue body, applies labels, and
+ *   moves on. Same architecture as triage-bot's per-issue Claude call.
+ *
+ * Producer-bot pattern:
  *   Self-classifies output as `bug` + `area: X` + `ready-for-agent`,
- *   bypassing triage-bot. The mutation report IS the validation that the
- *   surviving mutant represents a real test gap — no further triage adds
- *   value. Goes straight into fix-bot's queue.
+ *   bypassing triage-bot. The mutation report IS the validation that
+ *   the surviving mutant represents a real test gap. Goes straight
+ *   into fix-bot's queue.
  *
- * Per-issue grain: ONE mutated source file = ONE issue. A file with five
- * surviving mutants gets five investigation points in one issue, not five
- * separate issues. Same root-cause-class scoping rule flake-watcher applies
- * to test files.
+ * Per-run budget: process at most N files per cron (default 5).
+ * Backlog converges over multiple daily runs the same way triage-bot's
+ * does. Files are sorted oldest-first by impact (most gaps first), so
+ * the worst-coverage files always get attention first regardless of
+ * when the bot was last run.
  *
  * Run locally:
  *   DRY_RUN=1 GITHUB_REPOSITORY=gazetta-studio/gazetta-studio \
@@ -25,12 +40,21 @@
  *   .github/workflows/mutation-watcher.yml (daily 03:30 UTC)
  */
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { runClaude } from '../_lib/claude.js'
 import { findWorkflowId, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
-import { printBanner, printNotice, printRunSummary, printTranscriptPath, printWarning } from '../_lib/ui.js'
+import { type FileSummary, parseStrykerReport, pathToArea, summarizeReport } from '../_lib/stryker-parse.js'
+import {
+  printBanner,
+  printCandidateHeader,
+  printCandidateList,
+  printNotice,
+  printRunSummary,
+  printTranscriptPath,
+  printWarning,
+} from '../_lib/ui.js'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const PROMPT_PATH = resolve(HERE, 'prompt.md')
@@ -42,6 +66,22 @@ const DRY_RUN = process.env.DRY_RUN === '1'
 const TRANSCRIPTS_DIR = resolve(HERE, '../transcripts')
 const REPORT_STAGING_DIR = resolve(HERE, '../mutation-report-staging')
 const RUN_TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')
+
+/**
+ * Per-run cap on how many actionable files Claude is asked to process.
+ * Each file = one Claude call (writes one issue or one comment), so
+ * higher = longer runs. Mutation reports today have ~36 actionable
+ * files; processing 5/run drains the backlog in ~7 days while the
+ * Mutation workflow itself runs daily, so the queue stays steady-state.
+ */
+const PER_RUN_FILE_CAP = Number(process.env.PER_RUN_FILE_CAP ?? '5')
+
+/**
+ * Per-run wall-clock budget. Workflow timeout is 30 min; we exit
+ * gracefully at 25 min to leave 5 min margin for the upload-artifacts
+ * step.
+ */
+const PER_RUN_BUDGET_MS = Number(process.env.BUDGET_MS ?? 25 * 60 * 1000)
 
 async function main(): Promise<void> {
   printBanner({
@@ -64,10 +104,6 @@ async function main(): Promise<void> {
 
   printNotice(`Looking up latest successful ${WORKFLOW_NAME} run (workflow id ${workflowId})`)
 
-  // Find the most recent SUCCESSFUL Mutation run. Stryker exits non-zero
-  // when its threshold breaks; we want a run that completed cleanly so the
-  // artifact is well-formed. Failures here mean Stryker itself crashed —
-  // not actionable for mutation analysis.
   const { data: runs } = await octokit.actions.listWorkflowRuns({
     ...repo,
     workflow_id: workflowId,
@@ -80,19 +116,15 @@ async function main(): Promise<void> {
     return
   }
 
-  printNotice(
-    `Source run: id=${sourceRun.id} · sha ${sourceRun.head_sha.slice(0, 8)} · created ${sourceRun.created_at}`,
-  )
+  printNotice(`Source run: ${sourceRun.id} · sha ${sourceRun.head_sha.slice(0, 8)} · ${sourceRun.created_at}`)
 
-  // Stage the report on disk so Claude can grep / parse it via Bash.
-  // Re-fetching every run is fine — artifacts are small (Stryker HTML is
-  // a single ~3 MB file) and the cron is daily.
+  // Stage the report on disk + parse it.
   if (existsSync(REPORT_STAGING_DIR)) {
     rmSync(REPORT_STAGING_DIR, { recursive: true, force: true })
   }
   mkdirSync(REPORT_STAGING_DIR, { recursive: true })
 
-  printNotice(`Downloading ${ARTIFACT_NAME} from run ${sourceRun.id}...`)
+  printNotice(`Downloading ${ARTIFACT_NAME} from run ${sourceRun.id}…`)
   const dl = spawnSync('gh', ['run', 'download', String(sourceRun.id), '-n', ARTIFACT_NAME, '-D', REPORT_STAGING_DIR], {
     cwd: REPO_ROOT,
     stdio: 'inherit',
@@ -103,72 +135,162 @@ async function main(): Promise<void> {
     process.exit(1)
   }
 
-  // Locate the HTML report. Stryker writes to packages/gazetta/reports/mutation/
-  // by default; the workflow uploads that whole directory. After download,
-  // the file is at REPORT_STAGING_DIR/mutation.html (or sometimes
-  // REPORT_STAGING_DIR/<sub>/mutation.html depending on artifact shape).
   const htmlPath = findReportHtml(REPORT_STAGING_DIR)
   if (!htmlPath) {
-    console.error(`No mutation.html found under ${REPORT_STAGING_DIR}. Listing:`)
+    printWarning(`No mutation.html found under ${REPORT_STAGING_DIR}. Listing:`)
     for (const entry of readdirSync(REPORT_STAGING_DIR, { recursive: true, withFileTypes: true })) {
       const path = entry.parentPath ? resolve(entry.parentPath, entry.name) : entry.name
       console.error(`  ${path}`)
     }
     process.exit(1)
   }
-  printNotice(`Mutation report: ${htmlPath}`)
 
-  if (DRY_RUN) {
-    printNotice(`DRY_RUN=1 — exiting before invoking Claude.`)
+  // Parse + summarize. Claude never sees the raw 3 MB report.
+  printNotice(`Parsing ${htmlPath}…`)
+  const report = parseStrykerReport(htmlPath)
+  const summary = summarizeReport(report)
+
+  printNotice(
+    `Stryker analysis: ${summary.totalFiles} files mutated · ${summary.totalSurvived} survived · ${summary.totalNoCoverage} no-coverage · ${summary.skippedHighScoreFiles} files filtered (mostly-tested)`,
+  )
+
+  if (summary.files.length === 0) {
+    printNotice('No actionable files. Coverage is healthy. ✨')
     return
   }
 
-  const promptTemplate = readFileSync(PROMPT_PATH, 'utf-8')
+  const candidates = summary.files.slice(0, PER_RUN_FILE_CAP)
+  if (summary.files.length > PER_RUN_FILE_CAP) {
+    printNotice(
+      `Capping to top ${PER_RUN_FILE_CAP} of ${summary.files.length} actionable files this run; remainder picked up by future cron.`,
+    )
+  }
+
+  printCandidateList({
+    noun: 'file',
+    candidates: candidates.map(f => ({
+      ref: f.path,
+      label: `${f.survivedCount + f.noCoverageCount} gaps`,
+      meta: `kill-ratio ${(f.killRatio * 100).toFixed(0)}% · ${pathToArea(f.path)}`,
+    })),
+  })
+
+  if (DRY_RUN) {
+    printNotice(`DRY_RUN=1 — exiting before invoking Claude (${candidates.length} files would be processed).`)
+    return
+  }
+
   mkdirSync(TRANSCRIPTS_DIR, { recursive: true })
-  const transcriptPath = resolve(TRANSCRIPTS_DIR, `${RUN_TIMESTAMP}-mutation-run-${sourceRun.id}.jsonl`)
-  printTranscriptPath(transcriptPath)
-
-  // The prompt receives:
-  //   - SOURCE_RUN_ID: the Mutation workflow run whose artifact we're analyzing
-  //     (used in outcome tags and issue bodies for traceability)
-  //   - SOURCE_RUN_SHA: the commit Stryker ran against
-  //   - REPORT_HTML: absolute path to the HTML file (Claude greps + parses it)
-  //   - RUN_ID: this watcher's own GitHub Actions run ID (for the outcome tag's
-  //     "which watcher run found this" provenance)
-  const prompt = `${promptTemplate}
-
-SOURCE_RUN_ID=${sourceRun.id}
-SOURCE_RUN_SHA=${sourceRun.head_sha}
-SOURCE_RUN_CREATED_AT=${sourceRun.created_at}
-REPORT_HTML=${htmlPath}
-RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
+  const promptTemplate = await import('node:fs').then(fs => fs.readFileSync(PROMPT_PATH, 'utf-8'))
 
   const runStart = Date.now()
-  try {
-    const result = await runClaude({
-      prompt,
-      transcriptPath,
-      // Bash for gh + grep/jq, Read for inspecting report + source files
-      // Claude wants to cite, Grep/Glob for finding test files that should
-      // have caught a surviving mutant.
-      allowedTools: ['Bash', 'Read', 'Grep', 'Glob'],
-    })
-    if (!result.success) {
-      printWarning(`mutation-watcher exited ${result.exitCode}; transcript at ${transcriptPath}`)
+  let processed = 0
+  for (const file of candidates) {
+    const elapsed = Date.now() - runStart
+    if (elapsed > PER_RUN_BUDGET_MS) {
+      const remaining = candidates.length - processed
+      printWarning(
+        `Per-run budget exhausted (${Math.round(elapsed / 1000)}s > ${Math.round(PER_RUN_BUDGET_MS / 1000)}s). Stopping with ${remaining} unprocessed; tomorrow's run picks them up.`,
+      )
+      for (const skipped of candidates.slice(processed)) {
+        console.log(`     ⏭  ${skipped.path}`)
+      }
+      break
     }
-  } catch (err) {
-    printWarning(`mutation-watcher threw: ${err}; transcript at ${transcriptPath}`)
+
+    printCandidateHeader({
+      index: processed + 1,
+      total: candidates.length,
+      label: file.path,
+      meta: [
+        `${file.survivedCount + file.noCoverageCount} gaps · kill-ratio ${(file.killRatio * 100).toFixed(0)}% · ${pathToArea(file.path)}`,
+      ],
+      elapsedSec: Math.round(elapsed / 1000),
+    })
+
+    try {
+      await fileOneIssue(file, sourceRun, promptTemplate)
+    } catch (err) {
+      printWarning(`processing ${file.path} threw: ${err}; continuing.`)
+    }
+    processed++
   }
 
   const totalSec = Math.round((Date.now() - runStart) / 1000)
   printRunSummary({
-    verb: 'Analyzed',
-    processed: 1,
-    total: 1,
-    skipped: 0,
-    notes: [`Source run: ${sourceRun.id}`, `Transcript: ${transcriptPath}`],
+    verb: 'Processed',
+    processed,
+    total: candidates.length,
+    skipped: candidates.length - processed,
+    notes: [
+      `Source run: ${sourceRun.id}`,
+      summary.files.length > PER_RUN_FILE_CAP
+        ? `${summary.files.length - PER_RUN_FILE_CAP} more file(s) queued for tomorrow's cron`
+        : 'All actionable files processed this run',
+    ],
     elapsedSec: totalSec,
   })
+}
+
+/**
+ * Hand one file's per-file summary to Claude. The prompt instructs
+ * Claude to: search for an existing issue tracking this file, decide
+ * file-vs-comment, write the body using the supplied mutant table,
+ * apply labels.
+ */
+async function fileOneIssue(
+  file: FileSummary,
+  sourceRun: { id: number; head_sha: string; created_at: string | null | undefined },
+  promptTemplate: string,
+): Promise<void> {
+  // Build the per-file payload Claude will consume. JSON is small
+  // (single file, capped mutants), so total prompt stays well under
+  // any context concern.
+  const payload = {
+    sourceRunId: sourceRun.id,
+    sourceRunSha: sourceRun.head_sha,
+    sourceRunSha8: sourceRun.head_sha.slice(0, 8),
+    sourceRunCreatedAt: sourceRun.created_at,
+    file: {
+      path: file.path,
+      filename: file.path.split('/').pop() ?? file.path,
+      areaLabel: pathToArea(file.path),
+      totalMutants: file.totalMutants,
+      killedCount: file.killedCount,
+      survivedCount: file.survivedCount,
+      noCoverageCount: file.noCoverageCount,
+      killRatioPct: Math.round(file.killRatio * 100),
+      mutants: file.mutants,
+      mutantsTruncatedFromCount: file.survivedCount + file.noCoverageCount - file.mutants.length,
+    },
+  }
+
+  const transcriptPath = resolve(TRANSCRIPTS_DIR, `${RUN_TIMESTAMP}-mutation-${file.path.replace(/[/.]/g, '-')}.jsonl`)
+  printTranscriptPath(transcriptPath)
+
+  const prompt = `${promptTemplate}
+
+PAYLOAD_JSON=${JSON.stringify(payload, null, 2)}
+WATCHER_RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
+
+  // Stage the payload to a file too — Claude can re-read it via Read
+  // if the prompt's inline JSON gets truncated by some upstream layer.
+  // (Defense in depth; the inline JSON is small enough that this
+  // shouldn't trigger.)
+  writeFileSync(resolve(TRANSCRIPTS_DIR, `${RUN_TIMESTAMP}-payload-${file.path.replace(/[/.]/g, '-')}.json`), prompt)
+
+  const result = await runClaude({
+    prompt,
+    transcriptPath,
+    // Bash for `gh` (issue search/file/comment/label), Read for
+    // optionally checking ONE source file when writing fix
+    // recommendations. No Grep/Glob — the orchestrator already
+    // identified the affected file path.
+    allowedTools: ['Bash', 'Read'],
+  })
+  if (!result.success) {
+    printWarning(`Claude exited ${result.exitCode} on ${file.path}; transcript at ${transcriptPath}`)
+  }
 }
 
 /**

--- a/bots/mutation-watcher/prompt.md
+++ b/bots/mutation-watcher/prompt.md
@@ -1,286 +1,211 @@
 # Mutation watcher — investigation prompt
 
-You are reviewing the latest Stryker mutation-testing report for surviving
-mutants — code mutations the test suite failed to catch. Each surviving
-mutant is evidence of a test gap: a behavior that nothing currently
-verifies. Your job is to file actionable issues so fix-bot can write the
-missing tests.
+You are reviewing ONE source file from the latest Stryker mutation
+report. The orchestrator has already parsed the report, filtered to
+actionable mutants, and selected this file for you. Your job is
+narrow: search for an existing issue tracking this file, decide
+file-vs-comment, write a focused issue body, apply labels.
 
-## Inputs (appended below this prompt)
+The file payload is supplied as `PAYLOAD_JSON` below this prompt
+(JSON object). It contains:
 
-- `SOURCE_RUN_ID` — the Mutation workflow run whose artifact you're analyzing
-- `SOURCE_RUN_SHA` — the commit Stryker ran against
-- `SOURCE_RUN_CREATED_AT` — when that Mutation run completed
-- `REPORT_HTML` — absolute path to `mutation.html` on disk
-- `RUN_ID` — THIS watcher's GitHub Actions run ID (for outcome-tag provenance)
+- `sourceRunId` — the Mutation workflow run whose artifact was analyzed
+- `sourceRunSha` / `sourceRunSha8` — the commit Stryker ran against
+- `sourceRunCreatedAt` — when that Mutation run completed
+- `file.path` — relative source path (e.g. `src/admin-api/routes/publish.ts`)
+- `file.filename` — bare filename for issue title + search
+- `file.areaLabel` — `area: cms` / `area: renderer` / etc. (already mapped)
+- `file.totalMutants` — total mutants Stryker generated for this file
+- `file.killedCount` / `file.survivedCount` / `file.noCoverageCount` — per-status counts
+- `file.killRatioPct` — kill-ratio as a percentage (0-100)
+- `file.mutants` — array of actionable mutants (Survived + NoCoverage),
+  capped at 8 per file. Each has `mutator`, `status`, `startLine`,
+  `endLine`, `replacement`.
+- `file.mutantsTruncatedFromCount` — how many additional actionable
+  mutants exist but didn't fit the cap (mention in body if > 0)
+
+`WATCHER_RUN_ID` is THIS watcher's GitHub Actions run ID (for the
+outcome tag's "which watcher run found this" provenance).
 
 ## Decision-log convention
 
-Your transcript (the JSONL stream of every tool call and message) is the
-audit trail a future agent will read to improve this bot. The transcript
-captures WHAT you did automatically; you must also articulate WHY.
-
-Before each non-trivial decision (parsing approach, dedup choice,
-file-vs-comment, area mapping, severity classification), emit a one-line
-text block in the form:
+Your transcript captures every tool call automatically; you must also
+articulate WHY for non-trivial choices. Before each load-bearing
+decision (file-vs-comment match, source-file read, area override),
+emit:
 
 > Decision: <one sentence — what choice and why>
 
-Examples:
-
-> Decision: parsing app.report JSON via grep + node -e because the HTML's <script> block embeds it as a literal — simpler than rendering the page.
-> Decision: filing one issue per source file (history-recorder.ts, history-restorer.ts) rather than per mutant — same root-cause class, easier to fix as a unit.
-> Decision: skipping admin-api/routes/assets.ts mutants because issue #312 already tracks the same surviving mutants — adding a new occurrence comment instead.
-
-Do NOT narrate every tool call (don't say "now running grep"). Only call
-out load-bearing choices.
+Skip narration of trivial calls (don't say "now searching issues").
 
 ## Outcome tag convention
 
-Every comment you post AND every new issue body you file MUST end with
-this exact line:
+Every comment AND every new issue body MUST end with:
 
 ```
-<!-- mutation-watcher: source-run=$SOURCE_RUN_ID watcher-run=$RUN_ID -->
+<!-- mutation-watcher: source-run=$sourceRunId watcher-run=$WATCHER_RUN_ID -->
 ```
 
-Substitute the actual values. The `source-run` traces back to the Stryker
-artifact that revealed the gap; `watcher-run` traces to this analysis pass.
-A future agent can query `gh issue list --search "mutation-watcher: source-run=12345"`
-to find every issue derived from one Mutation run.
-
-## Why one report, not many
-
-Stryker is deterministic: same SHA + same code + same tests = same
-surviving mutants. Multiple runs against the same SHA add no
-information; multiple runs across different SHAs can't be cleanly
-compared (a mutant on line 42 may not exist in today's code after a
-refactor). So this bot looks at ONE report — the latest successful
-Mutation run — per pass.
-
-The dedup-by-source-run tag means rerunning the watcher against
-today's report tomorrow is a no-op (the source-run is already
-recorded). The next day's watcher consumes a NEW Mutation run with
-its own source-run ID, which dedups independently. Per-file issue
-matching (step 4) handles the "same file, different lines" case
-across SHAs.
+Substitute the actual values. The `source-run` traces back to the
+Stryker artifact; `watcher-run` traces to this analysis pass.
 
 ## Process
 
-1. **Parse the report.** The Stryker HTML at `$REPORT_HTML` embeds the
-   full report as JSON in a `<script>` block. Find it with:
+### 1. Search for an existing issue tracking this file
 
-   ```
-   grep -o "app.report = {.*" "$REPORT_HTML" | head -c 100
-   ```
+```
+gh issue list --state open --search "<file.filename> mutation in:title,body" --json number,title,body
+```
 
-   To extract just the JSON for processing:
+Use the bare `file.filename` (e.g. `publish.ts`) as the search term.
+Match grain: per source file, NOT per mutant.
 
-   ```
-   node -e '
-     const html = require("fs").readFileSync(process.env.REPORT_HTML, "utf8");
-     const m = html.match(/app\.report\s*=\s*(\{[\s\S]*?\});\s*<\/script>/);
-     if (!m) { console.error("no app.report found"); process.exit(1); }
-     console.log(m[1]);
-   ' > /tmp/mutation-report.json
-   ```
+- **Match** when an existing issue's title or body names the same
+  source file (path-suffix match) AND describes Stryker mutation
+  gaps. Read the body to verify; don't title-match alone.
+- **No match** → file a new issue.
 
-   The shape is `{ schemaVersion, files: { <path>: { source, mutants: [...] } }, ... }`.
-   Each mutant has: `id`, `mutatorName`, `replacement`, `status`
-   (`Killed` / `Survived` / `NoCoverage` / `Timeout` / `RuntimeError` / etc.),
-   `location: { start: {line, column}, end: {line, column} }`, and
-   `description`.
+### 2. Dedup against this source run
 
-2. **Filter to actionable mutants.** Two statuses warrant filing:
+If you find a match, check whether this `sourceRunId` is already
+recorded:
 
-   | Status | What it means | Action |
-   |---|---|---|
-   | `Survived` | Test ran but didn't catch the change. Real test gap. | File / comment |
-   | `NoCoverage` | No test even executed the code. Worse — tests don't reach this path at all. | File / comment |
+```
+gh issue view <NUMBER> --json comments | jq -r '.comments[].body' | grep -F "source-run=$sourceRunId"
+```
 
-   Skip `Killed` (working as intended), `Timeout` (Stryker infra issue),
-   `RuntimeError` (likely a test setup problem, not a coverage gap),
-   `CompileError` (Stryker artifact, not a real gap).
+If yes → skip. Already recorded.
+If no → comment (step 3a).
 
-3. **Group by source file.** One mutated source file = one issue. A file
-   with five surviving mutants in the same function gets ONE issue listing
-   all five locations — same root-cause class (this function's behavior
-   isn't tested), easier to fix as a unit. Do NOT file one issue per
-   mutant — that floods the tracker with shrapnel from a single gap.
+### 3a. Match found, source run not recorded → comment
 
-   Within each file, sub-group by line range when several mutants cluster
-   in one function vs. scattered across the file. The issue body lists
-   each location with its mutator + replacement so fix-bot has concrete
-   targets.
+```
+gh issue comment <NUMBER> --body "$(cat <<'EOF'
+> *This was generated by AI during triage.*
 
-4. **Search existing issues.** For each file with surviving mutants:
+New occurrence on Mutation run $sourceRunId (SHA $sourceRunSha8, $sourceRunCreatedAt):
 
-   ```
-   gh issue list --state open --search "<filename> mutation in:title,body" --json number,title,body
-   ```
+- Surviving / no-coverage mutants: $survivedCount survived + $noCoverageCount no-coverage
+- Kill-ratio: $killRatioPct%
+- Top mutants: <list 2-3 from the payload's mutant table>
 
-   Use the bare filename (e.g. `history-recorder.ts`, `route-handler.ts`)
-   as the search term. Match grain: per source file, NOT per mutant.
+<!-- mutation-watcher: source-run=$sourceRunId watcher-run=$WATCHER_RUN_ID -->
+EOF
+)"
+```
 
-   - **Match (comment)** if the existing issue tracks surviving mutants
-     in the SAME source file
-   - **New issue** if no existing issue covers this file's mutants
+### 3b. No match → file a new issue
 
-   Read the existing issue's body to verify; don't title-match alone.
+Title: `Surviving mutants in <filename>: <gapCount> coverage gap(s)`
+where `<gapCount> = survivedCount + noCoverageCount`.
 
-5. **Dedup against this source run.** If you find a matching open issue,
-   search its comments for the source run ID:
-
-   ```
-   gh issue view <NUMBER> --json comments | jq -r '.comments[].body' | grep -F "source-run=$SOURCE_RUN_ID"
-   ```
-
-   If the source run is already mentioned, skip — already recorded for
-   this Stryker run. (Different source runs naturally produce different
-   tags, so re-running Stryker tomorrow and finding the same mutants
-   adds a new occurrence comment, which is the right behavior.)
-
-6. **Decide and act.**
-
-   - **Match found, source run not yet recorded** → add a short comment to
-     the existing issue. Format:
-
-     ```
-     > *This was generated by AI during triage.*
-
-     New occurrence on Mutation run $SOURCE_RUN_ID (SHA $SHORT_SHA, $DATE):
-
-     - File: `<path>`
-     - Surviving mutants: <count> (<mutator names>)
-     - Locations: <line ranges>
-
-     [no further analysis — the issue body already covers root-cause]
-
-     <!-- mutation-watcher: source-run=$SOURCE_RUN_ID watcher-run=$RUN_ID -->
-     ```
-
-     Use `gh issue comment <NUMBER> --body "..."`.
-
-   - **No match found** → file a new issue using the template below.
-
-7. **Labelling.** Apply the full producer-bot label set on NEW issues; on
-   existing issues, ADD any missing labels (don't remove ones humans
-   applied during triage).
-
-   | Label | When | Notes |
-   |---|---|---|
-   | `bug` | Always — surviving mutants ARE bugs (the test suite has a coverage gap that lets real bugs through) | Producer-bot pattern: self-classify, bypass triage |
-   | `area: <X>` | Always — pick from path → area mapping below | One area only |
-   | `ready-for-agent` | Always on NEW issues — the report IS validation; fix-bot can pick up | Self-validated by Stryker |
-
-   **Producer-bot pattern.** mutation-watcher is a producer bot (along
-   with flake-watcher). Producer bots fully self-classify their output —
-   triage-bot doesn't process mutation-watcher output (its input contract
-   excludes `bug`). The labels above bypass triage and feed straight
-   into fix-bot's queue (`bug` + `ready-for-agent`).
-
-   Do NOT apply `needs-triage` — that label is the skill-canonical
-   "no bot or human has looked yet" state. Mutation-watcher HAS looked.
-
-   Do NOT apply `flake` — surviving mutants are coverage gaps, not
-   intermittent failures.
-
-   **Path → area mapping** (from `stryker.config.json`'s `mutate` patterns):
-
-   | Source path prefix | Area label |
-   |---|---|
-   | `packages/gazetta/src/history-*` | `area: renderer` (history is an internal renderer concern) |
-   | `packages/gazetta/src/publish*` | `area: renderer` (publish pipeline) |
-   | `packages/gazetta/src/admin-api/**` | `area: cms` (admin API surface) |
-   | `packages/gazetta/src/alt/**` | `area: cms` (alt-text suggestion is admin-side) |
-
-   When a mutated path doesn't fit cleanly, pick the closest area and
-   note your reasoning via a `> Decision: ...` line.
-
-   **Apply all labels in one call** to avoid multiple API roundtrips:
-
-   ```
-   gh issue edit <N> --add-label "bug,area: renderer,ready-for-agent"
-   ```
-
-## New-issue template
-
-Title format: `Surviving mutants in <filename>: <count> coverage gap(s)`
-
-- `<filename>` is the bare filename (`history-recorder.ts`)
-- `<count>` is the number of surviving + no-coverage mutants
-
-Body:
+Body template (substitute from PAYLOAD_JSON):
 
 ```markdown
 > *This was generated by AI during triage.*
 
 ## Pattern
 
-Stryker found <N> surviving mutant(s) in `<full path>` on Mutation run
-$SOURCE_RUN_ID (SHA `<short sha>`, $DATE). The test suite executes this
-code but does not assert on the behavior the mutants change.
+Stryker found <gapCount> actionable mutant(s) in `<file.path>` on
+Mutation run $sourceRunId (SHA `$sourceRunSha8`, $sourceRunCreatedAt).
+The test suite executes this code with kill-ratio $killRatioPct%
+($killedCount/$totalMutants killed) but does not assert on the
+behaviors the surviving mutants change.
 
 ## Surviving mutants
 
-<one section per cluster of related mutants — same function or same
-behavior class>
+| Line | Mutator | Status | Replacement |
+|---|---|---|---|
+<one row per mutant from file.mutants>
 
-### `<function or behavior>` (lines <start>-<end>)
+<if file.mutantsTruncatedFromCount > 0:
+"…plus <count> additional mutants not shown (capped at 8 per issue
+to keep this focused; see Stryker run $sourceRunId for the full
+list)."
+>
 
-| Line | Mutator | Original → Replacement |
-|---|---|---|
-| 42 | `BlockStatement` | (function body) → `{}` |
-| 45 | `ConditionalExpression` | `x > 0` → `false` |
+## Why this gap matters
 
-**Why this gap matters:** <one or two sentences on what behavior is
-unverified — read the source to ground this. Honest about uncertainty:
-"Block-statement mutants surviving usually means the function's side
-effects are unverified" is fine; speculating about specific bugs is not.>
+<2-4 sentences interpreting the mutant pattern. Examples:
+- "Block-statement mutants surviving means functions' side effects
+  are unverified — tests run the function but don't assert on what
+  it did."
+- "Conditional-expression mutants surviving means the branches
+  aren't covered with both true and false cases."
+- "NoCoverage means no test reaches this code path at all — that's
+  worse than surviving (a test ran but missed) — likely the test
+  file lacks a scenario for this branch."
 
-## Test files that should cover this
-
-<list `tests/<file>.test.ts` peer files (use `Glob` to find them). If
-no peer test file exists, say so — that's a different kind of gap.>
+Be honest about uncertainty. If the mutator pattern doesn't suggest
+a clear root cause, say so: "Mixed mutator pattern — would need to
+read the source to identify a coherent root cause." You may Read the
+source file ONCE to ground the recommendation if needed (DO NOT read
+multiple times — your context is limited).>
 
 ## Fix approach
 
-<2-3 sentences on what tests would kill these mutants. For
-block-statement mutants: assert on observable side effects. For
-conditional mutants: add boundary tests on the condition. For string
-literals: assert on the exact value. Mark "(Recommended)" on the
-strongest option.>
+<2-3 options ordered by leverage. Mark "(Recommended)" on the
+strongest. For each, say what it costs and what it catches.
+Examples:
+- "Add boundary tests for the conditional on line N" — cheap, high
+  leverage; covers the immediate gap
+- "Add an integration test exercising this whole route" — broader
+  coverage; catches the reported gap plus class of related ones
+- "Refactor to extract pure functions, then unit-test those" —
+  highest leverage, also slowest"
+>
 
 ## Out of scope
 
 <things adjacent that should not be conflated with the fix>
 
-<!-- mutation-watcher: source-run=$SOURCE_RUN_ID watcher-run=$RUN_ID -->
+<!-- mutation-watcher: source-run=$sourceRunId watcher-run=$WATCHER_RUN_ID -->
 ```
+
+### 4. Apply labels (NEW issues only)
+
+```
+gh issue edit <N> --add-label "bug,$file.areaLabel,ready-for-agent"
+```
+
+The orchestrator already mapped the path to an area; use
+`$file.areaLabel` as-is.
+
+For comments on existing issues: ADD any missing labels (don't
+remove ones humans applied during triage). The most common case is
+the existing issue already has the labels from a prior run — `gh
+issue edit ... --add-label` is idempotent on the GitHub side.
+
+## Producer-bot pattern
+
+mutation-watcher is a producer bot (along with flake-watcher).
+Producer bots fully self-classify their output — triage-bot doesn't
+process producer-bot output (its input contract excludes `bug`).
+The labels above bypass triage and feed straight into fix-bot's
+queue (`bug` + `ready-for-agent`).
+
+Do NOT apply `needs-triage` — that label is the skill-canonical
+"no bot or human has looked yet" state. Mutation-watcher HAS looked.
+
+Do NOT apply `flake` — surviving mutants are coverage gaps, not
+intermittent failures.
 
 ## Rules
 
-- **Don't speculate beyond evidence.** Surviving mutants tell you "this
-  behavior isn't tested." They don't tell you "this is broken in
-  production." Resist the urge to claim "this is a real bug" unless the
+- **Don't speculate beyond evidence.** Surviving mutants tell you
+  "this behavior isn't tested." They don't tell you "this is broken
+  in production." Resist claiming "this is a real bug" unless the
   source code makes it obvious.
-- **Quote mutators verbatim.** Stryker's mutator names (`BlockStatement`,
-  `ConditionalExpression`, `StringLiteral`, `LogicalOperator`, etc.) are
-  documented; future debuggers grep them.
-- **One issue per file, not per mutant.** Re-read step 3 if tempted.
-- **Read the source before recommending fixes.** A `BlockStatement`
-  mutant surviving in a function with no return value means the function's
-  side effects aren't asserted on. A `ConditionalExpression` mutant in a
-  validator means the validator's branches aren't fully tested. The
-  recommendation depends on what the function does.
-- **Stay terse.** Issue bodies should fit on one screen. Pattern + mutant
-  table + fix approach. No preamble, no summary.
-- **Do not ask the user questions** — you're running headless in CI. If
-  evidence is insufficient (e.g., the report is malformed), file no
-  issues and exit cleanly; the next run picks up the next Mutation
-  artifact.
-- **Skip files with only `Killed` mutants.** If a file has high mutation
-  score (most mutants killed), don't file an issue just because one
-  marginal mutant survived. Use judgment: a file with 1 surviving mutant
-  out of 50 killed is a different signal than 5 surviving out of 10.
-  Document your threshold via `> Decision: ...` if you skip.
+- **Quote mutators verbatim.** Stryker's mutator names
+  (`BlockStatement`, `ConditionalExpression`, `StringLiteral`,
+  `LogicalOperator`, etc.) are documented; future debuggers grep
+  them.
+- **Read the source file at most ONCE per issue if you need it for
+  fix recommendations.** Your context is small; don't re-read or
+  read multiple files.
+- **Stay terse.** Issue body should fit on one screen. Pattern +
+  mutant table + interpretation + fix options. No preamble, no
+  summary.
+- **Do not ask the user questions** — you're running headless in
+  CI. If something blocks (e.g., gh API error), file no issue, log
+  the error via a `> Decision:` line, and exit cleanly.

--- a/bots/package.json
+++ b/bots/package.json
@@ -11,7 +11,8 @@
     "triage-bot": "tsx triage-bot/index.ts",
     "discovery-prep-bot": "tsx discovery-prep-bot/index.ts",
     "fix-bot": "tsx fix-bot/index.ts",
-    "replay": "tsx _lib/replay.ts"
+    "replay": "tsx _lib/replay.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@octokit/rest": "^22.0.0"
@@ -19,6 +20,7 @@
   "devDependencies": {
     "@types/node": "^25.6.0",
     "tsx": "^4.21.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,8 @@
       "devDependencies": {
         "@types/node": "^25.6.0",
         "tsx": "^4.21.0",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
       }
     },
     "examples/starter": {


### PR DESCRIPTION
## Why

[mutation-watcher run 25637089951](https://github.com/gazetta-studio/gazetta-studio/actions/runs/25637089951) failed with \`Autocompact is thrashing\` after 641s — Claude exhausted context before filing any issues.

**Root cause:** the prompt asked Claude to parse a 3 MB \`mutation.html\` (Stryker's HTML reporter embeds the full report as JS at line ~334). Two compounding problems:

1. The embedded \`app.report = {...}\` is a JS object literal with literal \`"+"\` concatenation tokens inside string values (a Stryker quirk on TS compile-error \`statusReason\` fields). \`JSON.parse\` chokes; \`vm.runInNewContext\` works. Claude correctly diagnosed this and pivoted, but the recovery cost ~3 min.
2. Reading source files to write good issue bodies (4 reads of \`publish.ts\`, ~26KB cumulative) on top of the in-context 2.8MB JSON tipped Claude over the context limit.

The first run actually completed analysis (41 files, 720 survived, 788 no-coverage) and was about to file issues — it just couldn't fit the issue-writing step.

## What

Move the parse + filter + summarize into TS where it belongs.

- **\`bots/_lib/stryker-parse.ts\`** — \`parseStrykerReport\` extracts \`app.report = {...}\` and evaluates it via \`vm.runInNewContext\` (handles the \`"+"\` quirk natively). \`summarizeReport\` projects per file: counts mutants by status, skips fully-tested files, filters mostly-tested files with marginal residual (kill-ratio ≥ 0.85 AND ≤4 gaps), caps actionable mutants at 8/file, sorts by impact. \`pathToArea\` maps to area labels server-side.
- **\`bots/_lib/tests/stryker-parse.test.ts\`** — 16 tests, including a regression test for the \`"+"\` quirk. Adds vitest to \`bots/\` workspace.
- **\`bots/mutation-watcher/index.ts\`** — orchestrator parses the report and loops one Claude call per file (capped at 5/run; backlog converges over ~1 week of crons). Each call gets a small \`PAYLOAD_JSON\` for ONE file — Claude never sees the raw HTML.
- **\`bots/mutation-watcher/prompt.md\`** — rewritten to consume \`PAYLOAD_JSON\`. Allowed tools narrowed to \`Bash\` + \`Read\` (no Grep/Glob; orchestrator already identified the path). Source-file Read capped at one per issue.

## Validated locally

Dry-run against the real artifact from Mutation run 25621614362:

\`\`\`
ℹ Stryker analysis: 49 files mutated · 720 survived · 788 no-coverage · 5 files filtered (mostly-tested)
ℹ Capping to top 5 of 36 actionable files this run; remainder picked up by future cron.

📋 5 files (oldest first):
   src/admin-api/routes/publish.ts        385 gaps · kill-ratio 15% · area: cms
   src/publish-rendered.ts                136 gaps · kill-ratio 37% · area: renderer
   src/admin-api/routes/archive.ts        123 gaps · kill-ratio 46% · area: cms
   src/admin-api/routes/assets.ts         106 gaps · kill-ratio 55% · area: cms
   src/admin-api/index.ts                 102 gaps · kill-ratio 20% · area: cms
\`\`\`

## Test plan

- [x] \`vitest run\` in \`bots/\` — 16/16 pass
- [x] \`tsc --noEmit\` clean
- [x] \`npm run format:check\` clean
- [x] Dry-run end-to-end against the real Stryker artifact
- [ ] After merge: \`gh workflow run mutation-watcher.yml\` to validate the per-file Claude calls succeed and file real issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)