### PR TITLE
fix(bots): default to Opus 4.7 [1m] for all bots

### DIFF
--- a/bots/_lib/claude.ts
+++ b/bots/_lib/claude.ts
@@ -55,7 +55,39 @@ export interface ClaudeOptions {
    * want this wrapper.
    */
   transcriptPath: string
+  /**
+   * Model to use. Defaults to `DEFAULT_MODEL` below — Opus 4.7 with 1M
+   * context. Override per-call to use a smaller / cheaper model when the
+   * task is small.
+   *
+   * Pass either an alias (`'opus'`, `'sonnet'`, `'haiku'`) which resolves
+   * to the latest model in that line, or a full model ID like
+   * `'claude-opus-4-7[1m]'`. The `[1m]` bracket suffix selects the 1M
+   * context window for models that support it; without the suffix you
+   * get the default 200K window.
+   */
+  model?: string
 }
+
+/**
+ * Default model for all bot Claude invocations: Opus 4.7 with the 1M
+ * context window.
+ *
+ * Why Opus 4.7 [1m]: bots routinely read multiple source files + tests +
+ * issue bodies (fix-bot reads 30-50KB; mutation-watcher consumes a
+ * pre-parsed summary but Claude still reads source files to ground fix
+ * recommendations). Sonnet 4.6 (200K — the CLI default) blew the
+ * context window on fix-bot's first dispatch against
+ * `publish-rendered.ts` (22.7KB × 6 re-reads → autocompact thrash, run
+ * 25639089938 exit 1 with no work product).
+ *
+ * Cost note: Opus is more expensive per-token, but bots run 1-2 times
+ * per cron and read ~30-50KB. The dollar cost is cents per call. The
+ * alternative (Sonnet 4.6) is the bot failing entirely, wasting the
+ * full attempt — net more expensive. See team-preferences.md rule 21
+ * on capturing this kind of operational lesson.
+ */
+const DEFAULT_MODEL = 'claude-opus-4-7[1m]'
 
 export interface ClaudeResult {
   /** Exit code from the claude binary. 0 = success. */
@@ -132,6 +164,8 @@ interface ResultEvent extends StreamEventBase {
  *                                   for the transcript + summary split
  *   --verbose                     : required alongside stream-json (CLI
  *                                   refuses without it)
+ *   --model <id>                  : Opus 4.7 with 1M context by default —
+ *                                   see DEFAULT_MODEL below for rationale
  *   --allowedTools <list>         : restrict to tools the prompt needs
  *   --dangerously-skip-permissions: no human in CI to approve tool calls;
  *                                   --allowedTools is the safety boundary
@@ -140,6 +174,7 @@ interface ResultEvent extends StreamEventBase {
  */
 export async function runClaude(opts: ClaudeOptions): Promise<ClaudeResult> {
   const tools = opts.allowedTools ?? ['Bash']
+  const model = opts.model ?? DEFAULT_MODEL
   await mkdir(dirname(opts.transcriptPath), { recursive: true })
   const transcript = createWriteStream(opts.transcriptPath, { flags: 'w' })
 
@@ -157,6 +192,8 @@ export async function runClaude(opts: ClaudeOptions): Promise<ClaudeResult> {
         '--output-format',
         'stream-json',
         '--verbose',
+        '--model',
+        model,
         '--allowedTools',
         tools.join(','),
         '--dangerously-skip-permissions',


### PR DESCRIPTION
## Why

Bots called \`claude -p\` without \`--model\`, getting the CLI default — Sonnet 4.6 with 200K context. Too small for fix-bot.

[fix-bot run 25639089938](https://github.com/gazetta-studio/gazetta-studio/actions/runs/25639089938) against #308 hit autocompact thrashing at 1225s after re-reading \`publish-rendered.ts\` (22.7KB) 6+ times. Exit 1, no work product — no branch, no comment, no label change. Indistinguishable from "never tried."

Same root cause as mutation-watcher's first failure (#25637089951), which we fixed structurally in PR #306 (parse-in-TS). Fix-bot can't pre-summarize the way mutation-watcher could; it genuinely needs to read source + tests + write the fix. The right fix is the bigger model.

## What

Add \`model\` to \`ClaudeOptions\` in \`bots/_lib/claude.ts\`; default to \`claude-opus-4-7[1m]\`. All 5 bots inherit automatically.

The explicit \`[1m]\` bracket suffix is **required** — the bare \`opus\` alias resolves to 4.6 (200K) today. Verified via local CLI smoke:

\`\`\`
$ claude --print --model 'claude-opus-4-7[1m]' --output-format stream-json --verbose 'hi' \
    | jq -r 'select(.type == "system" and .subtype == "init") | .model'
claude-opus-4-7[1m]
\`\`\`

## Trade-off

Opus is more expensive per-token. But:
- Bots run 1-2 times per cron, read ~30-50KB of code
- Dollar cost is cents per call
- Sonnet 4.6 was failing entirely on large-file issues — net more expensive once you count maintainer recovery time
- Per-call override remains available for future cost tuning

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`npm run format:check\` clean
- [x] 16/16 stryker-parse tests still pass
- [x] CLI smoke: \`--model 'claude-opus-4-7[1m]'\` resolves correctly
- [ ] After merge: re-dispatch fix-bot against #308 — same input that just failed; should now complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)