### PR TITLE
ci: run bots tests on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,22 @@ jobs:
       - run: npm run build -w packages/gazetta
       - run: npm test -w packages/gazetta
 
+  bots:
+    # Pure-logic tests for the bots workspace (Stryker report parser,
+    # fix-bot's failure-diagnostic + issue-shape helpers). Fast (~150ms)
+    # and infrastructure-free — no testcontainers, no Playwright, no
+    # workspace build needed. Gates only the bots/ tree, but runs on
+    # every PR because changes to `bots/_lib/*` affect every bot.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test -w @gazetta/bots
+
   e2e:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## What

Adds a \`bots\` job to ci.yml that runs \`npm test -w @gazetta/bots\` (vitest, 33 tests today).

## Why a separate job

Fast (~150ms tests + ~3-5s npm ci on cache hit) and infrastructure-free — no testcontainers, no Playwright browsers, no workspace build step. Burying it in the existing \`test\` job would slow that job's success signal; keeping it separate means per-job PR checks point at the failure surface directly.

## Why no path filter

Bot test failures can be triggered by changes to \`bots/_lib/*\`, \`bots/<name>/*\`, or root \`package-lock.json\`. A path filter listing those is brittle; running on every PR is cheap (~5s total) and produces the right gate.

## Validation

\`\`\`
$ npm test -w @gazetta/bots
 Test Files  3 passed (3)
      Tests  33 passed (33)
   Duration  111ms
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)