### PR TITLE
fix(mutation-watcher): workflow_run trigger + dedup closed issues

### DIFF
--- a/.github/workflows/mutation-watcher.yml
+++ b/.github/workflows/mutation-watcher.yml
@@ -1,9 +1,13 @@
 name: Mutation watcher
 
-# Daily review of Stryker mutation results. Pairs with the Mutation
-# workflow (mutation.yml) which runs at 03:00 UTC and uploads an HTML
-# report. This watcher runs at 03:30 UTC, fetches that artifact, and
-# files issues for surviving mutants worth investigating.
+# Review of Stryker mutation results. Pairs with the Mutation workflow
+# (mutation.yml) — fires when Mutation completes successfully (any
+# event, including manual workflow_dispatch). The previous cron-based
+# trigger (`30 3 * * *`) raced with Stryker's variable runtime (~1-3h)
+# AND GitHub Actions cron skew (scheduled runs can start hours late on
+# free runners); the watcher consistently consumed yesterday's artifact
+# instead of today's. workflow_run is event-driven, so the dependency
+# is correct regardless of when Stryker actually finishes.
 #
 # Producer-bot pattern: self-classifies output as `bug` + `area: X` +
 # `ready-for-agent`, bypassing triage-bot. Surviving mutants are
@@ -12,14 +16,16 @@ name: Mutation watcher
 # This workflow's failure doesn't block anything (continue-on-error) —
 # monitoring infrastructure, not a gate.
 on:
-  schedule:
-    # 03:30 UTC daily — 30 min after the Mutation workflow's nightly
-    # run. Mutation runs ~1-3h on the current target set; the artifact
-    # is ready well before our 30-min lag, but the lag absorbs delays.
-    - cron: '30 3 * * *'
+  workflow_run:
+    workflows: [Mutation]
+    # Both success and failure: Stryker exits non-zero when the
+    # mutation score breaks the threshold, but the HTML artifact is
+    # still uploaded and worth analyzing. The bot's prompt handles
+    # "no actionable mutants" gracefully when there's nothing to file.
+    types: [completed]
   workflow_dispatch:
     # Manual trigger — useful for testing prompt changes against the
-    # latest Mutation artifact without waiting for the next cron.
+    # latest Mutation artifact without waiting for the next nightly run.
 
 jobs:
   watch:

--- a/bots/mutation-watcher/prompt.md
+++ b/bots/mutation-watcher/prompt.md
@@ -54,16 +54,32 @@ Stryker artifact; `watcher-run` traces to this analysis pass.
 ### 1. Search for an existing issue tracking this file
 
 ```
-gh issue list --state open --search "<file.filename> mutation in:title,body" --json number,title,body
+gh issue list --state all --search "<file.filename> mutation in:title,body" --json number,title,state,body
 ```
+
+Use `--state all` (not `--state open`) — closed issues matter for
+dedup. A file with surviving mutants might have a closed prior issue
+because someone shipped tests against it. If we search only open
+issues, mutation-watcher re-files duplicates for already-fixed files
+on every cron (this happened: #319 duplicated #308 after PR #315
+shipped tests). The closed-issue match path skips filing; surviving
+mutants in an already-handled file are "tests don't yet cover these
+specific cases, but we've already started" — not actionable as a
+fresh issue.
 
 Use the bare `file.filename` (e.g. `publish.ts`) as the search term.
 Match grain: per source file, NOT per mutant.
 
-- **Match** when an existing issue's title or body names the same
-  source file (path-suffix match) AND describes Stryker mutation
-  gaps. Read the body to verify; don't title-match alone.
-- **No match** → file a new issue.
+- **Match found, issue is OPEN** → proceed to step 2 (dedup against
+  source run); may comment per step 3a.
+- **Match found, issue is CLOSED** → skip entirely. Don't file, don't
+  comment. Stryker still flags the file but a prior fix attempt
+  exists; trust the human to re-open or file a fresh issue if the
+  remaining mutants warrant follow-up.
+- **No match** → file a new issue per step 3b.
+
+Document the skip decision with a `> Decision: ...` line so the
+transcript records why nothing was filed for this file.
 
 ### 2. Dedup against this source run
 


### PR DESCRIPTION
## Why

[Today's mutation-watcher cron filed #319](https://github.com/gazetta-studio/gazetta-studio/issues/319) — byte-for-byte duplicate of [#308](https://github.com/gazetta-studio/gazetta-studio/issues/308), which was fixed yesterday by PR #315. Two root causes compounded:

1. **Cron timing race.** mutation-watcher fires at \`30 3 * * *\` (03:30 UTC). Stryker's nightly is \`0 3 * * *\` (03:00 UTC) but takes 2-3h, and GitHub Actions cron skew on free runners can delay scheduled jobs by hours. Today's Stryker actually ran **06:44–08:27 UTC**; mutation-watcher fired at 06:52 UTC and consumed *yesterday's* artifact (source-run \`25621614362\`).
2. **Dedup blindness to closed issues.** \`gh issue list --state open\` misses closed-and-fixed issues. #308 closed yesterday at 21:30 UTC when PR #315 merged; #319's dedup search didn't see it.

Validation: #319 and #308 reference identical \`source-run\` IDs and have byte-identical mutant tables (all 8 rows match).

## What

Two coupled changes addressing both root causes:

### 1. workflow_run trigger replaces cron

\`\`\`yaml
on:
  workflow_run:
    workflows: [Mutation]
    types: [completed]
  workflow_dispatch:
\`\`\`

mutation-watcher now fires precisely when Mutation completes. No cron-skew possible — event-driven dependency. Falls back to \`workflow_dispatch\` for manual reruns.

### 2. Dedup against \`--state all\` with closed-skip branch

The prompt now searches all states and branches three ways:
- **Open match** → may comment per source-run dedup (existing behavior)
- **Closed match** → skip entirely (new) — trust the prior fix attempt
- **No match** → file new (existing)

## Validation

Tomorrow's mutation-watcher fire (driven by Mutation's completion) should:
- Consume *today's* Stryker artifact (not yesterday's)
- Search closed + open issues for each affected file
- Find closed #308 covering \`publish-rendered.ts\` → skip
- File only for files with no prior issue (open OR closed)

Local checks:
- [x] \`tsc --noEmit\` clean
- [x] 25 tests pass
- [x] \`format:check\` clean
- [x] Workflow YAML is structurally valid (manually verified \`on.workflow_run\` shape)

## Cleanup

#319 closed as duplicate of #308 with comment + link to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)