### PR TITLE
fix(ci): trigger CI on ready_for_review draft-flip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,13 @@ on:
   # No base-branch filter — CI runs on every PR, including stacked ones
   # whose base is another feature branch. Without this, stacked PRs show
   # zero checks until they're retargeted to main.
+  #
+  # `ready_for_review` is added explicitly: GitHub's default pull_request
+  # types are [opened, synchronize, reopened] — flipping a draft to
+  # ready does NOT trigger CI without this. fix-bot opens PRs as drafts;
+  # this ensures CI fires when they're flipped.
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Adds `types: [opened, synchronize, reopened, ready_for_review]` to the `pull_request:` trigger
- Documents why the explicit `types:` line is required so it doesn't get pruned back

## Why

Default `pull_request` types are `[opened, synchronize, reopened]` only — flipping a draft to ready does NOT trigger CI without `ready_for_review` listed explicitly. fix-bot opens its PRs as drafts; until this fix, draft → ready transitions left CI silent until a subsequent push fired `synchronize`.

Caught when flipping #324 and #325 to ready and seeing empty `statusCheckRollup`.

## Test plan

- [ ] CI runs on this PR (which is itself a `pull_request` open event → already covered by defaults; this proves nothing about `ready_for_review` directly)
- [ ] After merge, flipping #326 from draft to ready should fire CI without needing a push

🤖 Generated with [Claude Code](https://claude.com/claude-code)