### PR TITLE
fix(skill): correct close+reopen recovery in /review-prs

### DIFF
--- a/.claude/skills/review-prs/SKILL.md
+++ b/.claude/skills/review-prs/SKILL.md
@@ -66,8 +66,8 @@ If `gh pr checks <N>` returns "no checks reported," diagnose:
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| PR opened by `GITHUB_TOKEN` (Actions bot author) | GitHub's anti-recursion: PRs opened by Actions don't trigger `pull_request` events | `gh pr close <N> && gh pr reopen <N>` — `reopened` event fires normally |
-| Draft flipped to ready, no checks | Workflow's `pull_request:` trigger doesn't list `ready_for_review` (it's not in the default `[opened, synchronize, reopened]`) | Either close+reopen, push empty commit, or fix workflow to add `types: [..., ready_for_review]` |
+| PR opened by `GITHUB_TOKEN` (Actions bot author) | GitHub anti-recursion: events triggered by `GITHUB_TOKEN` do NOT create new workflow runs ([docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow)) | **User account** close+reopen via `gh pr close <N> && gh pr reopen <N>` — actor identity becomes the user, not the bot, so `reopened` fires. (Close+reopen done by the bot itself stays suppressed.) Permanent fix: switch the bot to a GitHub App installation token or PAT. |
+| Draft flipped to ready, no checks | Workflow's `pull_request:` trigger doesn't list `ready_for_review` (default types are only `[opened, synchronize, reopened]`) | Fix the workflow: `types: [opened, synchronize, reopened, ready_for_review]`. Short-term unblock: close+reopen, or push an empty commit. |
 | All PRs cold | Workflow disabled / file syntax error | `gh api repos/:owner/:repo/actions/workflows/ci.yml --jq .state` should return `active` |
 
 ## Recommend merge / close / changes


### PR DESCRIPTION
## Summary

Follow-up correction to #333. The CI-not-firing recovery table claimed `gh pr close <N> && gh pr reopen <N>` always works — that's wrong when the bot itself runs it.

## What changed

GitHub's anti-recursion (per [docs.github.com/en/actions/using-workflows/triggering-a-workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow)) applies to ANY event triggered by `GITHUB_TOKEN`, including `reopened`. So:

- ✅ **User account** close+reopen fires `reopened` event → CI runs
- ❌ **Bot's own** close+reopen stays suppressed → CI still doesn't run
- 🔑 **Permanent fix**: switch the bot to a GitHub App installation token or PAT

Also clarified the `ready_for_review` row: workflow fix is the permanent solution; close+reopen / empty commit are short-term unblocks.

## How this was caught

Fact-check pass against the skill's own claims after merge of #333. Used a subagent to verify against official GitHub docs; the response confirmed the close+reopen-by-bot suppression that wasn't in my original write-up.

## Test plan

- [x] Frontmatter still parses
- [x] Rule references still valid
- [ ] First real-world use of `/review-prs` validates the corrected table

🤖 Generated with [Claude Code](https://claude.com/claude-code)