### PR TITLE
fix(skill): document cancelled-run CI artifact in /review-prs

### DIFF
--- a/.claude/skills/review-prs/SKILL.md
+++ b/.claude/skills/review-prs/SKILL.md
@@ -70,6 +70,23 @@ If `gh pr checks <N>` returns "no checks reported," diagnose:
 | Draft flipped to ready, no checks | Workflow's `pull_request:` trigger doesn't list `ready_for_review` (default types are only `[opened, synchronize, reopened]`) | Fix the workflow: `types: [opened, synchronize, reopened, ready_for_review]`. Short-term unblock: close+reopen, or push an empty commit. |
 | All PRs cold | Workflow disabled / file syntax error | `gh api repos/:owner/:repo/actions/workflows/ci.yml --jq .state` should return `active` |
 
+### Reading mixed-run CI status
+
+After a force-push, `gh pr checks <N>` lists ALL recent workflow runs' jobs together — including jobs from the previous run that the concurrency rule cancelled mid-flight. A `smoke fail` row from an older `runs/XXXXX` URL is usually a cancelled job whose `needs:` dependency was cancelled, not a real test failure.
+
+To filter to the current run only:
+
+```bash
+gh pr view <N> --json statusCheckRollup --jq '.statusCheckRollup
+  | group_by(.detailsUrl | capture("runs/(?<id>[0-9]+)").id)
+  | map({runId: (.[0].detailsUrl | capture("runs/(?<id>[0-9]+)").id),
+         checks: [.[] | {name, status, conclusion}]})'
+```
+
+The newest run's `runId` will be the highest number. If all of its jobs show `SUCCESS`, the PR is genuinely green even if older-run rows show `CANCELLED` / `fail`.
+
+**Monitor scripts that aggregate "all pass" can produce false-failure signals from cancelled-run artifacts.** When this happens, manually verify with the `runId` grouping above before assuming the PR is broken.
+
 ## Recommend merge / close / changes
 
 Before recommending, consider:


### PR DESCRIPTION
## Summary

Adds a section to the `/review-prs` skill explaining what to do when `gh pr checks` mixes results from multiple workflow runs.

## Why

During the session where the skill was used (today), I force-pushed a rebased PR and the older run was cancelled by the concurrency rule. `gh pr checks` then showed both:
- All current-run jobs: `pass`
- One older-run job (`smoke`) marked `fail` — because its `needs: pack` dependency was cancelled mid-flight

A monitor script aggregating "all pass" emitted "RESULT: has failures" even though every current-run check was green. Misleading signal.

## The fix

- Documents the `runId`-grouping jq snippet to filter to the current run's status
- Warns that monitor scripts may emit false-failure signals from cancelled-run artifacts; manually verify with the grouping above before concluding the PR is broken

## Test plan

- [ ] Next `/review-prs` session that encounters a force-pushed PR validates the runId-grouping approach surfaces the right signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)