### PR TITLE
docs: defer Lighthouse validator indefinitely

### DIFF
--- a/.claude/rules/design-cache.md
+++ b/.claude/rules/design-cache.md
@@ -417,7 +417,7 @@ How cache composes with each of the other 12 foundational dimensions plus the mu
 - Worker cache (L3) is governed by `design-rendering.md` Q1; not part of this design pass.
 
 ### Validation (#9)
-- Validator results cached when expensive (axe-core, html-validate, Lighthouse); content-hash key.
+- Validator results cached when expensive (axe-core, html-validate); content-hash key.
 - Cache invalidation on save flows through normal Q2 lock.
 
 ### Plugin (#10)

--- a/.claude/rules/design-validation-implementation.md
+++ b/.claude/rules/design-validation-implementation.md
@@ -15,11 +15,11 @@ Per [team-preferences.md rule 17](team-preferences.md): "Build and validate, don
 | **1** | Validator infrastructure + save-delta | 4 days | None | ✓ |
 | **2** | Background scanner + admin UI surfaces | 4 days | Cut 1 | ✓ — `scanner.ts` + `SiteHealthDrawer.vue` + `validationScanner` / `validationIssues` stores; 3 background-only validators shipped (`schema-conformance`, `orphaned-locale-file`, `unused-fragment`) |
 | **3** | Render-for-analysis + quality validators (a11y, html-validate) + altRequired | 5 days | Cut 1, Cut 2 | ✓ — `validators/accessibility.ts`, `html-validity.ts`, `alt-required.ts`, `alt-required-walker.ts` shipped |
-| **4** | Publish gate + heavy validators (Lighthouse, linkinator) | 5 days | Cut 3 | ◐ — pre-publish audit step in `PublishPanel.vue` + `publish-audit.ts` + `validators/broken-links.ts` (linkinator) shipped; **Lighthouse validator deferred** |
+| **4** | Publish gate + linkinator | 5 days | Cut 3 | ✓ — pre-publish audit step in `PublishPanel.vue` + `publish-audit.ts` + `validators/broken-links.ts` (linkinator) shipped. **Lighthouse validator deferred indefinitely** — see "What's deferred from this plan" |
 | **5** | `gazetta validate` CLI rewrite | 2 days | Cut 1 (more useful after Cut 3) | ✓ — `runValidate` rebuilt around scanner orchestrator; `parseValidateFlags` supports `--severity`, `--include-quality`, `--no-warn-as-error`, `--verbose`; 15 tests across `cli-validate-flags.test.ts` + `cli-validate.test.ts` |
 | **6** | Template-developer surfaces | 3 days | Cut 2 | ✓ — `template-impact.ts` shipped |
 
-**Total: ~23 days** for the full plan. **Status as of 2026-05-12:** Cuts 1–3, 5, 6 fully shipped; Cut 4 partial (Lighthouse remains). Plus 5 additional soft-delete validators (`aliasof-points-to-archived`, `archive-not-supported-on-target`, `circular-alias`, `dangling-alias`, `referenced-archived-without-alias`) shipped beyond the original cut scope.
+**Total: ~23 days** for the full plan. **Status as of 2026-05-12:** All 6 cuts shipped. Lighthouse (originally Cut 4) deferred indefinitely — pre-publish audit framework supports adding it later when concrete operator demand surfaces. Plus 5 additional soft-delete validators (`aliasof-points-to-archived`, `archive-not-supported-on-target`, `circular-alias`, `dangling-alias`, `referenced-archived-without-alias`) shipped beyond the original cut scope.
 
 **Minimum useful ship: Cut 1 (4 days)** — catches the most common author-introduced breaks; establishes the abstraction.
 
@@ -145,7 +145,7 @@ Per [team-preferences.md rule 17](team-preferences.md): "Build and validate, don
 - Cache aggressively; invalidation only on dependency changes
 - Validators run in parallel against the same rendered output
 
-### Cut 4 — Publish gate + heavy validators (5 days)
+### Cut 4 — Publish gate + linkinator (5 days)
 
 **What ships:**
 - Pre-publish audit step in publish dialog:
@@ -153,20 +153,20 @@ Per [team-preferences.md rule 17](team-preferences.md): "Build and validate, don
   - Per issue: "Fix" / "Ignore once" / "Promote to error"
   - Block publish on remaining errors
 - Per-target audit config: `targets.production.publishAudit: { strict: boolean }`
-- Two new heavy validators (opt-in via flag):
-  - `lighthouse` — Playwright + Lighthouse against rendered output
+- One new validator (opt-in via flag):
   - `broken-links` — linkinator against rendered output
-- Admin UI: pre-publish modal in `PublishDialog.vue`
+- Admin UI: pre-publish modal in `PublishPanel.vue`
 
 **Tests:**
 - Operator config promotes warns to errors when `strict: true`
 - "Ignore once" suppresses for current publish; doesn't persist
 - Publish blocks on remaining errors
-- Lighthouse validator runs in spawned process; doesn't block admin event loop
 
-**Risk:** medium. Lighthouse + Playwright are heavy deps; opt-in keeps the cost behind a flag.
+**Risk:** low. linkinator is a lightweight dep; the heavy work (pre-publish framework) is the same machinery Cut 3 already exercises.
 
 **Why this is last:** these validators are valuable but not critical for daily editor UX. They earn their place at the operator's commitment moment.
+
+**Lighthouse not in scope.** Originally listed alongside linkinator as a Cut 4 validator; deferred indefinitely (see "What's deferred from this plan" below). Reason: accessibility is covered better by direct axe-core; SEO is covered by `seo-plan.md`'s primitives; the remaining performance + best-practices value doesn't justify the ~200MB Chromium + Lighthouse deps, the 5-15s per-page runtime, or the maintenance burden of tracking Lighthouse's evolving scoring methodology. Operators wanting performance budgets at publish use CI-side Lighthouse (`treosh/lighthouse-ci-action`) or PageSpeed Insights. The pre-publish audit framework supports adding a `lighthouse` validator later if concrete operator demand surfaces — it's one more validator slotting into the existing framework.
 
 ### Cut 5 — `gazetta validate` CLI rewrite (2 days)
 
@@ -269,7 +269,8 @@ the existing site-health drawer (no Cut 6 dependency).
 | Per-validator severity override (vs. coarse strict flag) | Operators ask for per-rule control |
 | Custom validators (site authors plug in their own) | Concrete operator use case for site-specific rules |
 | `css-validity` (stylelint) | Lower priority than a11y/HTML; ship in a follow-up |
-| Performance budget gates (LCP, CLS) | Lighthouse covers this once configured |
+| `lighthouse` validator (performance + best-practices + Lighthouse-flavored a11y/SEO) | Concrete operator demand for "gate publish on perf budget" OR a measured regression on real Gazetta sites that other validators didn't catch. Until then: operators run Lighthouse in CI (`treosh/lighthouse-ci-action`) or via PageSpeed Insights. Cost of shipping speculatively: ~200MB of Chromium + Lighthouse deps, 5-15s per page at publish, maintenance burden tracking scoring methodology changes (e.g., FID→INP in 2024). Accessibility already covered by direct axe-core; SEO by `seo-plan.md` primitives. |
+| Performance budget gates (LCP, CLS) | Bundled with the `lighthouse` validator decision above. |
 | Cross-content validation (e.g., "every page has a meta description") | Authors ask |
 | `template-deps` reverse-dep sidecar relation (peer to `fragment-deps` / `asset-refs`) | Concrete demand for incremental invalidation on template edits — from validation scanner OR publish flow's "items affected by template change". v1 falls back to full-site rescan; template edits are rare relative to content edits. Mechanical to add when needed (one new `DepRelation` binding + save/publish writers + reindex CLI handler). |
 | **Target-side validation** (validate published HTML on a target, not just source) | Concrete operator demand from drift scenarios — direct-to-prod edits via `editable: true`, multi-region targets diverging, "is what's actually live OK?" dashboards. v1 validates source: render-for-analysis re-renders source content + scans the result. Target-side validation is a different surface (forensic, operator-facing, not author-facing). Trigger: 3+ operator reports of drift surprise OR a compliance ask for "validate live content." Likely shape: peer scanner reading published HTML directly from target storage, surfaced in a separate "Target health" drawer alongside source's "Site health". Cut 4's publish gate already provides pre-publish coverage at the most common moment authors want it. |
@@ -297,7 +298,7 @@ Wall-clock for solo dev. Real pace depends on what you hit.
 | Cut 1 — Save-delta + 5 validators | 4 days |
 | Cut 2 — Background scanner + UI | 4 days |
 | Cut 3 — Render-for-analysis + a11y + html + altRequired | 5 days |
-| Cut 4 — Publish gate + Lighthouse | 5 days |
+| Cut 4 — Publish gate + linkinator | 5 days |
 | Cut 5 — CLI rewrite | 2 days |
 | Cut 6 — Template-developer surfaces | 3 days |
 
@@ -339,7 +340,7 @@ Cut 6 changes how schema changes are surfaced. New panel; existing flow unchange
 
 **Phased so each cut is independently valuable.** Cut 1 alone (4 days) catches the most painful "I broke something" cases. Stopping there is acceptable.
 
-**Real tools, not reimplementation.** axe-core, html-validate, Lighthouse, linkinator. Each plugs into the validator interface. CMS owns scheduling, surfacing, and incremental scope; tools own the analysis.
+**Real tools, not reimplementation.** axe-core, html-validate, linkinator. Each plugs into the validator interface. CMS owns scheduling, surfacing, and incremental scope; tools own the analysis.
 
 **Save stays fast.** Cut 1's save-delta only checks introduced refs; everything else is the background scanner. Authors aren't punished for accumulated debt.
 

--- a/.claude/rules/design-validation.md
+++ b/.claude/rules/design-validation.md
@@ -21,7 +21,7 @@ How the CMS surfaces correctness, integrity, and quality issues to authors and o
 
 **Out of scope:**
 - Real-time keystroke validation (already covered by @rjsf's Zod-driven form layer)
-- Reimplementing accessibility / HTML / CSS analysis (use real tools — axe-core, html-validate, stylelint, Lighthouse, linkinator — under the abstraction)
+- Reimplementing accessibility / HTML / CSS analysis (use real tools — axe-core, html-validate, stylelint, linkinator — under the abstraction)
 - A "site SEO score" or content scoring (per [seo-plan.md](seo-plan.md): weakly correlated with rankings, encourages over-optimization)
 - Blocking save on accumulated pre-existing issues (hostile UX; the background scanner surfaces them visibly without blocking)
 - Server-side keystroke validation (the form layer is sufficient)
@@ -136,7 +136,7 @@ export interface Issue {
 
 - **background**: Admin server runs a long-lived scanner. Initial scan on admin boot. Incremental rescan when file watcher detects manifest/template/asset changes. Per-page validation run cached by content hash; only re-runs when something material changed. Issues stored in a Pinia store, surfaced in the UI.
 
-- **pre-publish**: Publish dialog gains a "Run audit" affordance (or always-runs for opted-in targets). Heavy validators (Lighthouse) only run here. Operator sees consolidated `Issue[]` with severity per their target's config. Fix / ignore / promote-to-error per issue. Block publish on remaining errors.
+- **pre-publish**: Publish dialog gains a "Run audit" affordance (or always-runs for opted-in targets). Operator sees consolidated `Issue[]` with severity per their target's config. Fix / ignore / promote-to-error per issue. Block publish on remaining errors. (The heavy-validator slot — originally Lighthouse — is intentionally empty; see implementation-doc deferred-items table.)
 
 - **cli**: `gazetta validate` runs all validators in non-interactive mode. Exit non-zero on any error. Useful for CI gating before deploy.
 
@@ -155,7 +155,6 @@ export interface Issue {
 | `html-validity` (html-validate) | — | ✓ warn | ✓ warn | ✓ warn |
 | `css-validity` (stylelint) | — | ✓ info | ✓ warn | ✓ warn |
 | `broken-links` (linkinator) | — | — | ✓ warn (opt-in) | ✓ warn (opt-in) |
-| `lighthouse` | — | — | ✓ info (opt-in, heavy) | ✓ info (opt-in) |
 | `orphaned-locale-file` | — | ✓ warn | — | ✓ warn |
 | `unused-fragment` | — | ✓ info | — | ✓ info |
 
@@ -264,7 +263,8 @@ The architectural call: use real tools for the actual analysis. Each tool plugs 
 | HTML validity | `html-validate` | Fast, configurable, widely used in CI. |
 | CSS lint | `stylelint` | Industry standard. |
 | Broken links | `linkinator` | Crawl rendered output for outbound link rot. |
-| Performance / SEO score | Lighthouse via Playwright | Heavy (5-15s per page). Pre-publish only, opt-in. |
+
+Lighthouse was originally specced for the "Performance / SEO score" slot but is deferred indefinitely (see `design-validation-implementation.md` deferred-items table). Reasoning: accessibility is covered better by direct axe-core; SEO by `seo-plan.md`'s primitives; the remaining performance + best-practices value doesn't justify the ~200MB Chromium + Lighthouse deps, the 5-15s per-page runtime, and the maintenance burden of tracking scoring methodology changes. Operators wanting publish-time perf budgets use CI-side Lighthouse. The pre-publish audit framework supports adding the validator later if concrete demand surfaces.
 
 Why this is the right move:
 - These tools encode decades of domain expertise; any in-house validator would be strictly worse
@@ -275,7 +275,7 @@ Why this is the right move:
 What we DON'T do:
 - Reimplement a11y rules
 - Build a Yoast-style content score (rejected per [seo-plan.md](seo-plan.md))
-- Run heavy tools (Lighthouse) in the background scanner
+- Ship Lighthouse as a built-in validator (deferred indefinitely; see implementation-doc deferred-items table for reasoning + revisit trigger)
 
 ## Render-for-analysis
 
@@ -325,7 +325,7 @@ Validation is itself foundational dimension #9 of 13. This section answers how e
 
 - **Multi-instance check** (discipline) — save-delta runs on the instance receiving the save request; no cross-instance coordination. Background scanner (Cut 2) per-page cache is per-admin-instance (each instance scans + caches independently); the multi-instance pattern is "every instance reads source-of-truth from storage on demand, caches results in-process, no cross-instance cache sharing." Per-page content-hash cache key ensures different instances arrive at the same cached result without coordination. Suppression state (when shipped) lives in storage, not in-memory.
 
-- **Scale check** — save-delta is O(diff) per save; only checks refs introduced by THIS save, not the full site. Background scanner (Cut 2) caches per-page validation results by content hash; only re-validates when something material changed. Heavy validators (Cut 4 Lighthouse, linkinator) are pre-publish only, opt-in. The framework scales because phase-separation matches detection cost to author commitment level. Gates: Cut 2 must reuse the existing sidecar dependency tracking (`findDependentsFromSidecars`) so a fragment edit only invalidates pages that use that fragment.
+- **Scale check** — save-delta is O(diff) per save; only checks refs introduced by THIS save, not the full site. Background scanner (Cut 2) caches per-page validation results by content hash; only re-validates when something material changed. Pre-publish-only validators (Cut 4 linkinator) are opt-in. The framework scales because phase-separation matches detection cost to author commitment level. Gates: Cut 2 must reuse the existing sidecar dependency tracking (`findDependentsFromSidecars`) so a fragment edit only invalidates pages that use that fragment.
 
 - **Theme check** — validation runs against rendered output for quality validators (Cut 3 axe-core, html-validate). Render-for-analysis composes with the active theme: when themes ship per [`design-themes.md`](design-themes.md), render-for-analysis renders per-(content, locale, theme) tuple, and validators see theme-specific output. Cache key includes theme. v1 (single-theme world): no impact.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Strategic forward-looking priorities for Gazetta. Captures what's prioritized, what's deferred, and what's a non-goal.
 
-**Updated**: 2026-05-12 (papercut cluster + validation cuts status)
+**Updated**: 2026-05-12 (papercut cluster + validation cuts status; Lighthouse deferred)
 
 ## How to read this
 
@@ -27,7 +27,7 @@ The framing decisions that shape multi-quarter priorities. Resolved (no longer "
 - ✓ Land dependabot PR #219 — shipped
 - ✓ Land `@hono/node-server` v2 bump (PR #224) — shipped
 - ✓ Fix bug #106 (component reordering immediate-save, PR #225) — shipped
-- ✓ Validation Cuts 1, 2, 3, 5, 6 — shipped. Cut 1: save-time integrity (`Validator` interface, save-delta orchestrator, 5 ref-existence validators, 409 wiring, `ValidationBanner.vue`). Cut 2: background scanner + `SiteHealthDrawer.vue` + 3 background-only validators (`schema-conformance`, `orphaned-locale-file`, `unused-fragment`). Cut 3: render-for-analysis + a11y (axe-core) + html-validity + `altRequired`. Cut 5: `gazetta validate` CLI rewrite (15 tests). Cut 6: template-developer surfaces (`template-impact.ts`). Plus 5 soft-delete-related validators beyond the original scope. Closes #40. **Cut 4 partial** — pre-publish audit step + linkinator shipped; Lighthouse validator remains (see Phase 3).
+- ✓ Validation Cuts 1–6 — all shipped. Cut 1: save-time integrity (`Validator` interface, save-delta orchestrator, 5 ref-existence validators, 409 wiring, `ValidationBanner.vue`). Cut 2: background scanner + `SiteHealthDrawer.vue` + 3 background-only validators (`schema-conformance`, `orphaned-locale-file`, `unused-fragment`). Cut 3: render-for-analysis + a11y (axe-core) + html-validity + `altRequired`. Cut 4: pre-publish audit step in `PublishPanel.vue` + `publish-audit.ts` + linkinator (`validators/broken-links.ts`). Cut 5: `gazetta validate` CLI rewrite (15 tests). Cut 6: template-developer surfaces (`template-impact.ts`). Plus 5 soft-delete-related validators beyond the original scope. Closes #40. **Lighthouse validator** (originally Cut 4) **deferred indefinitely** — see `design-validation-implementation.md` deferred-items table.
 
 ### Editor papercut cluster (largely shipped; one open)
 Aggregate small-but-high-impact UX wins. 3 of 4 closed; only the design pass for creation UX remains.
@@ -187,7 +187,6 @@ These can run in parallel with Phase 1-2 since they don't depend on the foundati
 
 After foundations + features land:
 
-- **Validation Cut 4 (Lighthouse only)** — pre-publish audit step + linkinator already shipped; Lighthouse validator remains
 - **Static publish fan-out** (#202, 1-2w)
 - **Small content cluster** (1-2w): #61 redirects, #58 RSS/Atom, #57 pagination, #91 connectivity validate
 - **Operability cluster** (2w): #19, #38, #39, #75, #76, #195, #198

--- a/docs/audits/cms-feature-audit.md
+++ b/docs/audits/cms-feature-audit.md
@@ -141,7 +141,7 @@ Legend: ✅ shipped · ⚠ partial · ❌ missing · ⛔ explicit non-goal
 | HTML validity | ❌ | Cut 3 |
 | CSS lint | ❌ | Cut 3 |
 | Broken link checking | ❌ | Cut 4 |
-| Lighthouse / perf scoring | ❌ | Cut 4 |
+| Lighthouse / perf scoring | ❌ | Deferred indefinitely — operators use CI-side Lighthouse or PageSpeed Insights. See `design-validation-implementation.md` deferred-items table. |
 | `gazetta validate` CLI | ⚠ | Exists; rewrite designed (Cut 5) |
 | Pre-publish gate | ❌ | Cut 4 |
 


### PR DESCRIPTION
## Summary
Lighthouse was the last unshipped piece of Validation Cut 4. Rather than ship it, defer indefinitely with a documented revisit trigger.

**Why defer:**
- Accessibility already covered better by direct axe-core
- SEO covered by \`seo-plan.md\`'s primitives
- Remaining performance + best-practices value doesn't justify the ~200MB Chromium + Lighthouse deps, 5-15s per-page runtime, and maintenance burden of tracking evolving scoring methodology (FID→INP in 2024, LCP threshold shifts)
- Operators wanting publish-time perf budgets use CI-side Lighthouse (\`treosh/lighthouse-ci-action\`) or PageSpeed Insights
- Pre-publish audit framework supports adding it later as one more validator

**Revisit trigger:** concrete operator demand for "gate publish on perf budget" OR a measured regression on real Gazetta sites that other validators didn't catch.

## Files changed
- \`design-validation.md\` — drop lighthouse from validator matrix + real-tools table; explain the empty heavy-validator slot
- \`design-validation-implementation.md\` — rename Cut 4 to "Publish gate + linkinator"; add "Lighthouse not in scope" subsection; add deferred-items entry with revisit trigger
- \`design-cache.md\` — drop lighthouse from expensive-validators cache comment
- \`ROADMAP.md\` — mark Cut 4 ✓ shipped (linkinator only); drop the "Cut 4 (Lighthouse only)" Phase 3 line
- \`cms-feature-audit.md\` — update Lighthouse cell to point at the deferral

## Test plan
- [x] All Lighthouse references now contextualized as deferred or describe the deferral itself
- [x] No code changes; doc-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)