### PR TITLE
fix(config): admin.hooks schema accepts array per ADR-0009

### DIFF
--- a/packages/gazetta/src/config/schemas.ts
+++ b/packages/gazetta/src/config/schemas.ts
@@ -84,15 +84,24 @@ export const SiteConfigSchema = z
      */
     cache: z.unknown().optional(),
     /**
-     * Reserved for future foundations (auth, plugins, hooks, audit,
-     * notifications). Each block is validated by its own factory at
-     * load time per the Universal Provider Requirements.
+     * Reserved for future foundations (auth, hooks, audit, notifications).
+     * Each block is validated by its own factory at load time per the
+     * Universal Provider Requirements.
+     *
+     * Extension surfaces per ADR-0009:
+     *   - `hooks` is `HookContribution[]` — array of factory-call results
+     *     (e.g., `[autoSlugify(), cdnPurge({...})]`). Runtime treats
+     *     `Array.isArray(hooks)`; schema accepts opaque array.
+     *   - Future `validators` + `routes` follow the same contribution-array
+     *     shape when they ship.
+     *
+     * The `plugins` field was retired per ADR-0009 — no `Plugin` runtime
+     * contract; operators import per-surface factories.
      */
     admin: z
       .object({
         auth: z.record(z.string(), z.unknown()).optional(),
-        plugins: z.array(z.unknown()).optional(),
-        hooks: z.record(z.string(), z.unknown()).optional(),
+        hooks: z.array(z.unknown()).optional(),
         audit: z.record(z.string(), z.unknown()).optional(),
         notifications: z.record(z.string(), z.unknown()).optional(),
         offline: z.record(z.string(), z.unknown()).optional(),

--- a/packages/gazetta/tests/config-types.test.ts
+++ b/packages/gazetta/tests/config-types.test.ts
@@ -116,8 +116,26 @@ describe('SiteConfigSchema validation', () => {
       cache: { get: () => null, set: () => {}, invalidate: () => {} },
       admin: {
         auth: { trust: 'cloudflare-access' },
-        plugins: [],
         audit: { providers: ['history'] },
+      },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts admin.hooks as an array of contributions per ADR-0009', () => {
+    // Documented operator pattern per design-hooks.md "Registration":
+    // `admin.hooks: HookContribution[]` — array of factory-call results.
+    // Schema must accept the array shape; runtime treats it via
+    // `Array.isArray()` at packages/gazetta/src/cli/index.ts:67.
+    const result = SiteConfigSchema.safeParse({
+      name: 'main',
+      admin: {
+        hooks: [
+          {
+            source: 'site-local:auto-slugify',
+            hooks: [{ phase: 'beforeSave', handler: () => undefined }],
+          },
+        ],
       },
     })
     expect(result.success).toBe(true)


### PR DESCRIPTION
## Summary

Schema/runtime contract was broken — Zod schema at \`packages/gazetta/src/config/schemas.ts:95\` declared \`hooks: z.record(z.string(), z.unknown())\` (rejects arrays); runtime at \`cli/index.ts:67\` treats \`Array.isArray(hooks)\`.

The documented operator pattern in \`design-hooks.md\` \"Registration\":
\`\`\`ts
admin: {
  hooks: [autoSlugify(), cdnPurge({...})],
}
\`\`\`

Any operator following the docs hit \`ConfigValidationError\` at boot.

**Latent because:**
- Hook integration tests bypass \`SiteConfigSchema\` — they call \`buildHooksRegistry({ contributions })\` directly
- The starter site's \`admin.hooks\` example is commented out
- No real operator config exercises this path end-to-end

## Changes
- \`schemas.ts\`: \`hooks\` is now \`z.array(z.unknown())\` (matches runtime)
- \`schemas.ts\`: \`plugins\` field removed per ADR-0009 (zero consumers in source)
- Updated JSDoc comment to reflect ADR-0009's extension-surface model

## TDD ordering
Per [rule 31](.claude/rules/team-preferences.md), failing test landed in commit \`a9d654a\` first; this commit's schema fix turns it green:
- \`accepts admin.hooks as an array of contributions per ADR-0009\` — failing before fix, green after
- Existing forward-compat test \`accepts config with admin block\` updated to drop \`plugins: []\` reference

## Test plan
- [x] \`npx vitest run tests/config-types.test.ts\` → 28/28 pass
- [x] \`npx vitest run tests/config-loader.test.ts tests/hooks-plugin-contribution-audit.test.ts\` → 23/23 pass
- [x] Reverting just \`schemas.ts\` fails the new regression test (TDD-verified per [rule 31](.claude/rules/team-preferences.md))

🤖 Generated with [Claude Code](https://claude.com/claude-code)