### PR TITLE
chore: configure knip for unused-code detection

### DIFF
--- a/.github/workflows/dead-code-watcher-compact.yml
+++ b/.github/workflows/dead-code-watcher-compact.yml
@@ -1,0 +1,61 @@
+name: Dead code watcher (compact)
+
+# Monthly skip-list compaction. Reads bots/dead-code-watcher/skip-list.json,
+# identifies groups of 3+ entries that share a generalizable pattern,
+# opens a PR replacing them with rules. Keeps the bot's memory compact.
+on:
+  schedule:
+    # First Saturday of the month at 03:00 UTC = 05:00 CEST.
+    # Cron syntax `* * 1-7 * 6` means "Saturdays where day-of-month
+    # is 1-7" — i.e., the first Saturday. Stays 30 min after the
+    # weekly dead-code-watcher fires (02:30 UTC) so they don't
+    # collide on the same morning.
+    - cron: '0 3 1-7 * 6'
+  workflow_dispatch:
+    # Manual trigger for testing or one-off compaction.
+
+jobs:
+  compact:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Configure git author
+        run: |
+          git config user.name 'dead-code-watcher'
+          git config user.email 'noreply@anthropic.com'
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install workspace deps
+        run: npm ci
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run dead-code-watcher:compact
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: npm run dead-code-watcher:compact -w @gazetta/bots
+
+      - name: Upload transcripts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: dead-code-watcher-compact-transcripts
+          path: bots/transcripts/
+          if-no-files-found: ignore
+          retention-days: 90

--- a/.github/workflows/dead-code-watcher.yml
+++ b/.github/workflows/dead-code-watcher.yml
@@ -1,0 +1,74 @@
+name: Dead code watcher
+
+# Weekly scan for dead code (knip findings older than 30 days). Files
+# delete-PRs directly when safe; opens skip-list-entry PRs when
+# uncertain. Composes with the monthly compaction workflow.
+#
+# Different from other producer bots (flake-watcher, mutation-watcher):
+# does NOT delegate to fix-bot. The "TDD-first" contract that fix-bot
+# enforces doesn't compose well with code deletion — the verification
+# is "existing tests pass," not "a new failing test passes."
+on:
+  schedule:
+    # Saturday 02:30 UTC = 04:30 CEST. 1h after Saturday's flake-watcher
+    # to avoid runner contention. Weekly cadence — knip output is stable
+    # across days; daily would mostly re-find the same things.
+    - cron: '30 2 * * 6'
+  workflow_dispatch:
+    # Manual trigger for testing or backfill after prompt iteration.
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 60
+    permissions:
+      # Read CI run history (for past-PR feedback loop), read+write
+      # issues (skip-list comments), read+write PRs (open delete-PRs +
+      # skip-list-entry PRs), read+write contents (push branches).
+      actions: read
+      issues: write
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # need git log for last-modified computation
+
+      - name: Configure git author
+        run: |
+          git config user.name 'dead-code-watcher'
+          git config user.email 'noreply@anthropic.com'
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install workspace deps
+        run: npm ci
+
+      - name: Build gazetta package
+        # Some workspaces need the built package for type-checks during
+        # test runs (the bot validates deletions before pushing).
+        run: npm run build -w packages/gazetta
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run dead-code-watcher
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: npm run dead-code-watcher -w @gazetta/bots
+
+      - name: Upload transcripts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: dead-code-watcher-transcripts
+          path: bots/transcripts/
+          if-no-files-found: ignore
+          retention-days: 90

--- a/bots/README.md
+++ b/bots/README.md
@@ -90,7 +90,7 @@ GITHUB_REPOSITORY=gazetta-studio/gazetta-studio GH_TOKEN=$(gh auth token) \
 |---|---|---|---|---|
 | `flake-watcher` | Daily 02:00 UTC + workflow_dispatch | CI events (run_attempt >= 2) — not labels | New issue with `bug` + `flake` + `area: X` + `ready-for-agent` (+ `recurring-flake` when applicable) | **Producer** — self-classifies, bypasses triage |
 | `mutation-watcher` | `workflow_run` on Mutation completion + workflow_dispatch | Latest Mutation artifact — not labels | New issue with `bug` + `area: X` + `ready-for-agent` per source file with surviving mutants | **Producer** — self-classifies, bypasses triage |
-| `dead-code-watcher` | Weekly Sat 02:30 UTC + workflow_dispatch | knip JSON output (files, exports, types, deps) — not labels; ≥30-day stable filter | Delete-PR per safe finding (full pipeline, NOT delegated to fix-bot) OR skip-list-entry PR | **Producer** — autonomous fixer with durable memory |
+| `dead-code-watcher` | Weekly Sat 02:30 UTC + workflow_dispatch | knip JSON output (files, exports, types, deps) — not labels; ≥30-day stable filter | Delete-PR per safe finding (full pipeline, NOT delegated to fix-bot) OR skip-list-entry PR | **Producer** — autonomous fixer with durable memory + generator-critic reviewer loop |
 | `dead-code-watcher:compact` | Monthly 1st Sat 03:00 UTC + workflow_dispatch | bots/dead-code-watcher/skip-list.json | PR generalizing 3+ entries into 1 rule (memory compaction) | Memory compactor |
 | `triage-bot` | Daily 03:00 UTC + workflow_dispatch | Open issue lacking all of `bug`, `enhancement`, `triage-uncertain`, `ready-for-agent`, `ready-for-human`, `wontfix`, `needs-info` | One of `bug` / `enhancement` / `triage-uncertain` + `area: X`. Reproducible bug also gets `ready-for-agent`. | Classifier |
 | `discovery-prep-bot` | Daily 04:00 UTC + workflow_dispatch | `enhancement` AND lacks all of `ready-for-human`, `ready-for-agent`, `wontfix`, `needs-info` | Research comment + `ready-for-human` label | Researcher |
@@ -111,6 +111,24 @@ producer: it files PRs directly, no fix-bot involvement. The
 difference is whether the bot can complete the loop end-to-end.
 Dead-code-watcher can because deletion's "test" is "existing tests
 pass" — fix-bot's TDD-first contract doesn't compose with deletion.
+
+**Generator-critic loop pattern.** Dead-code-watcher is the first bot
+with two Claude agents in series. Agent A (cleanup) investigates and
+makes changes locally; Agent B (reviewer) inspects the diff fresh —
+no shared transcript — and votes APPROVE / REJECT / NEEDS_HUMAN.
+On REJECT, the orchestrator resets the working tree and re-runs
+Agent A with the reviewer's specific note. Up to `MAX_ATTEMPTS`
+iterations (default 5, configurable) before the bot gives up and
+records `needs-human` in the skip-list.
+
+The reviewer catches failure modes the test-suite gate can't:
+hidden public-API surfaces (JSDoc `@public` markers), accidental
+refactors disguised as deletions, misleading commit messages, and
+architecturally-questionable deletions (extension points,
+documented contracts). Reviewer has `Bash` + `Read` only — no
+ability to push code or modify the diff. Verdict line format
+`VERDICT: APPROVE|REJECT|NEEDS_HUMAN` followed by `Reasoning:` or
+`Note:` is parsed by the orchestrator.
 
 **Durable memory pattern.** Dead-code-watcher is the first bot with
 cross-run memory. Two layers:

--- a/bots/README.md
+++ b/bots/README.md
@@ -90,17 +90,46 @@ GITHUB_REPOSITORY=gazetta-studio/gazetta-studio GH_TOKEN=$(gh auth token) \
 |---|---|---|---|---|
 | `flake-watcher` | Daily 02:00 UTC + workflow_dispatch | CI events (run_attempt >= 2) — not labels | New issue with `bug` + `flake` + `area: X` + `ready-for-agent` (+ `recurring-flake` when applicable) | **Producer** — self-classifies, bypasses triage |
 | `mutation-watcher` | `workflow_run` on Mutation completion + workflow_dispatch | Latest Mutation artifact — not labels | New issue with `bug` + `area: X` + `ready-for-agent` per source file with surviving mutants | **Producer** — self-classifies, bypasses triage |
+| `dead-code-watcher` | Weekly Sat 02:30 UTC + workflow_dispatch | knip JSON output (files, exports, types, deps) — not labels; ≥30-day stable filter | Delete-PR per safe finding (full pipeline, NOT delegated to fix-bot) OR skip-list-entry PR | **Producer** — autonomous fixer with durable memory |
+| `dead-code-watcher:compact` | Monthly 1st Sat 03:00 UTC + workflow_dispatch | bots/dead-code-watcher/skip-list.json | PR generalizing 3+ entries into 1 rule (memory compaction) | Memory compactor |
 | `triage-bot` | Daily 03:00 UTC + workflow_dispatch | Open issue lacking all of `bug`, `enhancement`, `triage-uncertain`, `ready-for-agent`, `ready-for-human`, `wontfix`, `needs-info` | One of `bug` / `enhancement` / `triage-uncertain` + `area: X`. Reproducible bug also gets `ready-for-agent`. | Classifier |
 | `discovery-prep-bot` | Daily 04:00 UTC + workflow_dispatch | `enhancement` AND lacks all of `ready-for-human`, `ready-for-agent`, `wontfix`, `needs-info` | Research comment + `ready-for-human` label | Researcher |
 | `fix-bot` | Daily 04:00 UTC + workflow_dispatch | `bug` + `ready-for-agent` AND lacks all of `ready-for-human`, `wontfix`, `needs-info` AND no prior fix-bot comment | EITHER draft PR (two commits: failing test + fix), OR stuck-comment + `ready-for-human` label | Implementer |
 
 **Producer bots vs triage-bot.** Producer bots (`flake-watcher`,
-`mutation-watcher`) consume CI signal and self-classify their output —
-they apply `bug` + `ready-for-agent` directly, bypassing triage-bot.
-Triage-bot's input contract excludes issues already carrying `bug` /
-`enhancement` / `triage-uncertain`, so producer-bot output flows
-straight into fix-bot's queue. The CI signal IS the validation; no
-triage step adds value.
+`mutation-watcher`, `dead-code-watcher`) consume CI signal or
+static-analysis output and self-classify their output, bypassing
+triage-bot. Triage-bot's input contract excludes issues already
+carrying `bug` / `enhancement` / `triage-uncertain`, so producer-bot
+output flows straight into fix-bot's queue. The signal IS the
+validation; no triage step adds value.
+
+**Autonomous fixers vs pipeline producers.** `flake-watcher` and
+`mutation-watcher` are *pipeline* producers: they file issues that
+fix-bot picks up later. `dead-code-watcher` is an *autonomous*
+producer: it files PRs directly, no fix-bot involvement. The
+difference is whether the bot can complete the loop end-to-end.
+Dead-code-watcher can because deletion's "test" is "existing tests
+pass" — fix-bot's TDD-first contract doesn't compose with deletion.
+
+**Durable memory pattern.** Dead-code-watcher is the first bot with
+cross-run memory. Two layers:
+
+  - `bots/dead-code-watcher/skip-list.json` — durable "don't try
+    this again" decisions, edited via PR, version-controlled,
+    diff-readable. Each entry has a fingerprint + reason +
+    timestamp + provenance.
+  - Past-PR query (GitHub API) — the feedback loop: before
+    investigating a finding, the bot checks if there's a recent
+    PR for it. Closed-not-merged → mine the rejection reason →
+    add to skip-list. Open → wait. Merged → finding should be
+    gone (knip won't flag it next run anyway).
+
+The skip-list compacts monthly: ≥3 entries sharing a pattern get
+generalized into one rule with a glob scope. "Compaction" not
+"compression" — the result is smaller AND more powerful (the rule
+catches future findings of the same shape). Same mental model as
+how LLM session memory compacts.
 
 ### Pipeline shape (label-driven)
 

--- a/bots/_lib/git-tree.ts
+++ b/bots/_lib/git-tree.ts
@@ -1,0 +1,101 @@
+/**
+ * Git working-tree helpers for the dead-code-watcher generator-critic
+ * loop.
+ *
+ * Between Agent A attempts, the orchestrator needs to discard Agent A's
+ * work-in-progress (uncommitted changes + the local branch with its
+ * commits) and start over from a clean main. Without this, attempt 2's
+ * Agent A would see attempt 1's changes still in the working tree —
+ * not a fresh re-investigation.
+ */
+import { execFileSync } from 'node:child_process'
+
+export interface GitExecOptions {
+  cwd: string
+  /** When true, log the command before running. Useful for orchestrator UI. */
+  verbose?: boolean
+}
+
+/**
+ * Reset to clean main: drop all uncommitted changes, switch to main,
+ * delete the in-flight branch if it exists.
+ *
+ * Idempotent — calling on an already-clean main is a no-op (the
+ * `branch -D` is best-effort).
+ */
+export function resetToMain(branchName: string, opts: GitExecOptions): void {
+  // Discard unstaged changes + untracked files
+  run(['git', 'reset', '--hard', 'HEAD'], opts)
+  run(['git', 'clean', '-fd'], opts)
+  // Switch to main (no-op if already there, but tolerates being on
+  // any branch including a detached HEAD)
+  run(['git', 'checkout', 'main'], opts)
+  // Delete the in-flight branch if it exists. `-D` is hard-delete
+  // (we explicitly DON'T want git complaining about unmerged commits
+  // here — that's exactly the point of resetting).
+  try {
+    run(['git', 'branch', '-D', branchName], opts)
+  } catch {
+    // Branch didn't exist locally — fine.
+  }
+}
+
+/**
+ * Capture the unified diff between a branch and main.
+ * Used as input to the reviewer agent.
+ *
+ * Returns empty string when there are no changes (Agent A's attempt
+ * produced no diff — usually means it picked a SKIP path).
+ */
+export function captureDiff(branchName: string, opts: GitExecOptions): string {
+  try {
+    return execFileSync('git', ['diff', `main...${branchName}`], {
+      cwd: opts.cwd,
+      encoding: 'utf-8',
+      maxBuffer: 16 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'inherit'],
+    })
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Capture commit messages from a branch (relative to main).
+ * Used to surface Agent A's intent to the reviewer without exposing
+ * Agent A's full transcript.
+ */
+export function captureCommitMessages(branchName: string, opts: GitExecOptions): string {
+  try {
+    return execFileSync('git', ['log', `main..${branchName}`, '--format=%B%n---'], {
+      cwd: opts.cwd,
+      encoding: 'utf-8',
+      maxBuffer: 1 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'inherit'],
+    }).trim()
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * True when the given branch has commits beyond main.
+ * Used to detect "Agent A committed nothing" vs "Agent A made changes."
+ */
+export function branchHasCommits(branchName: string, opts: GitExecOptions): boolean {
+  try {
+    const out = execFileSync('git', ['rev-list', '--count', `main..${branchName}`], {
+      cwd: opts.cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+    return Number.parseInt(out, 10) > 0
+  } catch {
+    return false
+  }
+}
+
+function run(args: string[], opts: GitExecOptions): void {
+  if (opts.verbose) console.log(`$ ${args.join(' ')}`)
+  execFileSync(args[0], args.slice(1), { cwd: opts.cwd, stdio: 'inherit' })
+}

--- a/bots/_lib/knip-parse.ts
+++ b/bots/_lib/knip-parse.ts
@@ -1,0 +1,199 @@
+/**
+ * Knip output parser + filter.
+ *
+ * Converts knip's `--reporter json` output into our internal
+ * `Finding` shape — typed records the orchestrator can rank, dedup,
+ * and serialize.
+ *
+ * Knip's JSON shape (knip 6.x, may shift across majors — we tolerate
+ * unknown extra keys but require the documented core keys):
+ *
+ *   {
+ *     "issues": [
+ *       {
+ *         "file": "<path>",
+ *         "files": [{"name": "<path>"}],         // populated when file itself is unused
+ *         "exports": [{"name": "<symbol>"}],     // unused exports in this file
+ *         "types": [{"name": "<symbol>"}],
+ *         "enumMembers": [{"name": "<symbol>"}],
+ *         "dependencies": [{"name": "<pkg>"}],   // unused deps when file=package.json
+ *         "devDependencies": [{"name": "<pkg>"}],
+ *         // ... other shapes we don't currently consume
+ *       }
+ *     ]
+ *   }
+ */
+import { execSync } from 'node:child_process'
+import type { Fingerprint } from './skip-list.js'
+
+/**
+ * One actionable knip finding, projected into the shape the
+ * orchestrator hands to Claude.
+ *
+ *   - fingerprint: stable identity for dedup + skip-list matching
+ *   - file: path relative to repo root (always set)
+ *   - symbol: export/type/dep name (set when kind != 'file')
+ *   - lastModifiedDays: age in days since the file was last modified
+ *     in git history. NaN when git log returns no commits (file
+ *     untracked or just-added).
+ */
+export interface Finding {
+  fingerprint: Fingerprint
+  file: string
+  symbol?: string
+  lastModifiedDays: number
+}
+
+/** Knip's raw JSON shape — only the keys we consume. */
+export interface KnipReport {
+  issues: KnipIssueRecord[]
+}
+export interface KnipNamed {
+  name: string
+}
+export interface KnipIssueRecord {
+  file: string
+  files?: KnipNamed[]
+  exports?: KnipNamed[]
+  types?: KnipNamed[]
+  enumMembers?: KnipNamed[]
+  dependencies?: KnipNamed[]
+  devDependencies?: KnipNamed[]
+}
+
+/**
+ * Project the knip JSON into a flat list of Findings.
+ *
+ * Each unique (kind, path, symbol?) becomes one Finding. A single
+ * knip issue record can yield multiple findings — e.g., one file with
+ * 5 unused exports yields 5 findings, each with kind='export' and a
+ * different symbol.
+ *
+ * Files with kind='file' (entire file unused) do NOT also produce
+ * per-export findings even when knip lists exports in the same
+ * record — the whole-file remediation supersedes per-export.
+ */
+export function parseKnipReport(report: KnipReport, opts: { repoRoot: string }): Finding[] {
+  const findings: Finding[] = []
+
+  for (const record of report.issues) {
+    const fileFindings = record.files ?? []
+    const fileFlagged = fileFindings.length > 0
+
+    if (fileFlagged) {
+      for (const f of fileFindings) {
+        findings.push({
+          fingerprint: { kind: 'file', path: f.name },
+          file: f.name,
+          lastModifiedDays: gitLastModifiedDays(opts.repoRoot, f.name),
+        })
+      }
+      // When the whole file is unused, skip per-symbol entries on
+      // the same record — the file-level finding covers them.
+      continue
+    }
+
+    for (const e of record.exports ?? []) {
+      findings.push({
+        fingerprint: { kind: 'export', path: record.file, symbol: e.name },
+        file: record.file,
+        symbol: e.name,
+        lastModifiedDays: gitLastModifiedDays(opts.repoRoot, record.file),
+      })
+    }
+    for (const t of record.types ?? []) {
+      findings.push({
+        fingerprint: { kind: 'type', path: record.file, symbol: t.name },
+        file: record.file,
+        symbol: t.name,
+        lastModifiedDays: gitLastModifiedDays(opts.repoRoot, record.file),
+      })
+    }
+    for (const m of record.enumMembers ?? []) {
+      findings.push({
+        fingerprint: { kind: 'enumMember', path: record.file, symbol: m.name },
+        file: record.file,
+        symbol: m.name,
+        lastModifiedDays: gitLastModifiedDays(opts.repoRoot, record.file),
+      })
+    }
+    for (const d of record.dependencies ?? []) {
+      findings.push({
+        fingerprint: { kind: 'dependency', path: record.file, symbol: d.name },
+        file: record.file,
+        symbol: d.name,
+        // Dependency findings use the package.json's last-modified date
+        // as a stand-in. Adding a dep is a package.json edit; deps
+        // older than 30 days are stable candidates.
+        lastModifiedDays: gitLastModifiedDays(opts.repoRoot, record.file),
+      })
+    }
+    for (const d of record.devDependencies ?? []) {
+      findings.push({
+        fingerprint: { kind: 'devDependency', path: record.file, symbol: d.name },
+        file: record.file,
+        symbol: d.name,
+        lastModifiedDays: gitLastModifiedDays(opts.repoRoot, record.file),
+      })
+    }
+  }
+
+  return findings
+}
+
+/**
+ * Git-log age in days for a file. Uses the latest commit that
+ * touched the file. Returns NaN when git knows nothing about it
+ * (uncommitted, or new file).
+ *
+ * Synchronous on purpose — keeps the parser pipeline a pure
+ * read+transform without async surface. Cost is one execSync per
+ * unique file; knip reports typically have <100 unique files.
+ */
+export function gitLastModifiedDays(repoRoot: string, path: string): number {
+  try {
+    const isoTimestamp = execSync(`git log -1 --format=%cI -- "${path}"`, {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+    if (!isoTimestamp) return Number.NaN
+    const lastCommit = new Date(isoTimestamp).getTime()
+    const ageMs = Date.now() - lastCommit
+    return Math.floor(ageMs / (24 * 60 * 60 * 1000))
+  } catch {
+    return Number.NaN
+  }
+}
+
+/** Filter to findings older than the threshold (default 30 days). */
+export function filterStableFindings(findings: Finding[], minDays = 30): Finding[] {
+  return findings.filter(f => Number.isFinite(f.lastModifiedDays) && f.lastModifiedDays >= minDays)
+}
+
+/**
+ * Sort findings by impact, oldest-first within each kind:
+ *
+ *   1. files (highest impact — whole-file delete)
+ *   2. dependencies + devDependencies (supply-chain reduction)
+ *   3. exports + types (export-surface cleanup)
+ *   4. enumMembers (lowest — single-symbol change)
+ *
+ * Within each tier, oldest-modified first (longer-stale = safer
+ * candidate, less likely to be mid-flight WIP).
+ */
+export function rankFindings(findings: Finding[]): Finding[] {
+  const tier = (kind: Fingerprint['kind']): number => {
+    if (kind === 'file') return 0
+    if (kind === 'dependency' || kind === 'devDependency') return 1
+    if (kind === 'export' || kind === 'type') return 2
+    return 3 // enumMember
+  }
+  return [...findings].sort((a, b) => {
+    const ta = tier(a.fingerprint.kind)
+    const tb = tier(b.fingerprint.kind)
+    if (ta !== tb) return ta - tb
+    // Older = bigger lastModifiedDays = ranked higher
+    return b.lastModifiedDays - a.lastModifiedDays
+  })
+}

--- a/bots/_lib/past-pr.ts
+++ b/bots/_lib/past-pr.ts
@@ -1,0 +1,125 @@
+/**
+ * Past-PR helper — implements the feedback loop for dead-code-watcher.
+ *
+ * Before the bot files a fresh delete-PR for a finding, it checks
+ * whether it has previously tried this exact finding. The outcome of
+ * the past PR determines whether to retry, skip, or generate a
+ * skip-list entry from the maintainer's rejection reason.
+ *
+ * Branch-naming convention: each finding gets a deterministic branch
+ * name derived from its fingerprint. PR history is searchable by
+ * branch (`head` field). This is the orchestration-layer dedup
+ * pattern; the bot's outcome-tag in PR body is the orchestration-
+ * layer audit trail.
+ */
+import type { RepoIdentity } from './github.js'
+import type { Octokit } from '@octokit/rest'
+import type { Fingerprint } from './skip-list.js'
+import { formatFingerprint } from './skip-list.js'
+
+/** Outcome of the bot's last attempt on this fingerprint. */
+export type PastOutcome =
+  /** No prior PR exists for this fingerprint — fresh attempt OK. */
+  | { state: 'none' }
+  /** PR was opened and merged — finding should no longer be in knip output, but if it is, retry. */
+  | { state: 'merged'; prNumber: number }
+  /** PR is currently open — wait for human review; don't double-PR. */
+  | { state: 'open'; prNumber: number }
+  /**
+   * PR was closed without merge. The maintainer's rejection reason
+   * (mined from close comment or last review comment) becomes the
+   * skip-list entry's reasonNote.
+   */
+  | { state: 'rejected'; prNumber: number; reasonNote: string }
+
+/**
+ * Branch-name convention: encode the fingerprint into a filesystem-
+ * safe form. We need the branch name to round-trip back to a
+ * recognizable fingerprint when searching past PRs.
+ *
+ * Format: `dead-code/<kind>-<encoded-path>[-at-<encoded-symbol>]`
+ *
+ *   - `kind`: lowercased
+ *   - `path`: slashes → double-dash (so `src/foo.ts` → `src--foo.ts`)
+ *   - `symbol`: appended after `-at-` when present
+ *
+ * Examples:
+ *   - file:src/foo.ts → `dead-code/file-src--foo.ts`
+ *   - export:src/foo.ts#bar → `dead-code/export-src--foo.ts-at-bar`
+ */
+export function fingerprintToBranch(fp: Fingerprint): string {
+  const safePath = fp.path.replace(/\//g, '--')
+  const head = `${fp.kind}-${safePath}`
+  return fp.symbol ? `dead-code/${head}-at-${fp.symbol}` : `dead-code/${head}`
+}
+
+/**
+ * Query GitHub for the most recent PR matching this fingerprint's
+ * branch. Returns the canonical PastOutcome for the bot's decision
+ * tree.
+ *
+ * When the PR is closed-not-merged (state='rejected'), mines a
+ * `reasonNote` from the most recent maintainer comment with content.
+ * If no comment text is found, falls back to a generic "PR was
+ * closed without merge — reason not recorded in comments."
+ */
+export async function pastPROutcome(octokit: Octokit, repo: RepoIdentity, fp: Fingerprint): Promise<PastOutcome> {
+  const branch = fingerprintToBranch(fp)
+  // Octokit's pulls.list takes `head: owner:branch` for filtering.
+  const headRef = `${repo.owner}:${branch}`
+  const { data: prs } = await octokit.pulls.list({
+    ...repo,
+    head: headRef,
+    state: 'all',
+    sort: 'updated',
+    direction: 'desc',
+    per_page: 5,
+  })
+  if (prs.length === 0) return { state: 'none' }
+  // Most-recent PR is canonical (sort by updated_at desc).
+  const pr = prs[0]
+  if (pr.merged_at) return { state: 'merged', prNumber: pr.number }
+  if (pr.state === 'open') return { state: 'open', prNumber: pr.number }
+  // Closed without merge — mine rejection reason.
+  const reasonNote = await mineRejectionReason(octokit, repo, pr.number, formatFingerprint(fp))
+  return { state: 'rejected', prNumber: pr.number, reasonNote }
+}
+
+/**
+ * Read the PR's most recent issue comment + review comment, pick
+ * whichever is more recent + non-bot-authored, return a truncated
+ * version. Falls back to a generic explanation when nothing useful
+ * is found.
+ *
+ * Reads BOTH issue-comments (general PR discussion) and review-
+ * comments (inline code review). Maintainer rejection can land in
+ * either; we want whichever was last.
+ */
+async function mineRejectionReason(
+  octokit: Octokit,
+  repo: RepoIdentity,
+  prNumber: number,
+  fingerprintLabel: string,
+): Promise<string> {
+  // issues.listComments returns BOTH issue comments and PR-discussion
+  // comments (GitHub treats PRs as a kind of issue). It does NOT
+  // return inline review comments — those need pulls.listReviewComments.
+  const [issueRes, reviewRes] = await Promise.all([
+    octokit.issues.listComments({ ...repo, issue_number: prNumber, per_page: 50 }),
+    octokit.pulls.listReviewComments({ ...repo, pull_number: prNumber, per_page: 50 }),
+  ])
+  const all = [
+    ...issueRes.data.map(c => ({ body: c.body ?? '', login: c.user?.login ?? null, when: c.created_at })),
+    ...reviewRes.data.map(c => ({ body: c.body ?? '', login: c.user?.login ?? null, when: c.created_at })),
+  ]
+    // Skip bot-authored content (the bot's own outcome-tag comment).
+    .filter(c => c.login !== 'github-actions[bot]' && c.body.length > 0)
+    // Sort newest-first; pick the first meaningful one.
+    .sort((a, b) => b.when.localeCompare(a.when))
+  if (all.length === 0) {
+    return `PR for ${fingerprintLabel} was closed without merge; no maintainer comment recorded.`
+  }
+  const last = all[0]
+  const truncated = last.body.length > 400 ? `${last.body.slice(0, 400)}…` : last.body
+  return `Maintainer (${last.login ?? 'unknown'}) closed PR for ${fingerprintLabel}: "${truncated}"`
+}

--- a/bots/_lib/reviewer-verdict.ts
+++ b/bots/_lib/reviewer-verdict.ts
@@ -1,0 +1,74 @@
+/**
+ * Reviewer verdict parser.
+ *
+ * Agent B (the reviewer in dead-code-watcher's generator-critic loop)
+ * emits its outcome as a structured line in its final text block:
+ *
+ *   VERDICT: APPROVE
+ *   Reasoning: ...
+ *
+ *   VERDICT: REJECT
+ *   Note: <feedback for Agent A>
+ *
+ *   VERDICT: NEEDS_HUMAN
+ *   Note: <reason this can't be auto-resolved>
+ *
+ * The orchestrator parses the reviewer's last assistant text block for
+ * the VERDICT line. If parsing fails (Claude misformatted the output),
+ * we default to NEEDS_HUMAN with a parser-failure note so the finding
+ * doesn't silently retry on garbage.
+ */
+
+export type ReviewerVerdict =
+  | { kind: 'approve'; reasoning: string }
+  | { kind: 'reject'; note: string }
+  | { kind: 'needs-human'; note: string }
+
+const VERDICT_LINE = /^\s*VERDICT:\s*(APPROVE|REJECT|NEEDS_HUMAN)\s*$/m
+
+/** Pull the body following an optional `Note:` / `Reasoning:` keyword. */
+function extractNote(text: string, after: number): string {
+  // Take everything after the VERDICT line, strip leading "Note: " or
+  // "Reasoning: " if present, trim, truncate.
+  const tail = text.slice(after).trimStart()
+  const stripped = tail.replace(/^(Note|Reasoning):\s*/i, '')
+  return stripped.trim().slice(0, 2000)
+}
+
+/**
+ * Parse a reviewer's final text block into a verdict.
+ *
+ * Defaults to NEEDS_HUMAN when:
+ *   - No VERDICT line is found
+ *   - VERDICT keyword is recognized but malformed
+ *
+ * This is the safe default: ambiguous output should NOT silently
+ * default to APPROVE (which would push code) or REJECT (which would
+ * loop). NEEDS_HUMAN puts the finding on the skip-list and stops.
+ */
+export function parseReviewerVerdict(text: string): ReviewerVerdict {
+  const match = text.match(VERDICT_LINE)
+  if (!match) {
+    return {
+      kind: 'needs-human',
+      note: `Reviewer output did not contain a recognizable "VERDICT: APPROVE|REJECT|NEEDS_HUMAN" line. Raw output: ${text.slice(0, 500)}`,
+    }
+  }
+  const verdict = match[1]
+  const lineEnd = (match.index ?? 0) + match[0].length
+  const tail = extractNote(text, lineEnd)
+  if (verdict === 'APPROVE') {
+    return { kind: 'approve', reasoning: tail || '(no reasoning provided)' }
+  }
+  if (verdict === 'REJECT') {
+    if (!tail) {
+      return {
+        kind: 'needs-human',
+        note: 'Reviewer voted REJECT but provided no Note: explanation. Cannot retry without feedback.',
+      }
+    }
+    return { kind: 'reject', note: tail }
+  }
+  // NEEDS_HUMAN
+  return { kind: 'needs-human', note: tail || '(no reason provided)' }
+}

--- a/bots/_lib/skip-list.ts
+++ b/bots/_lib/skip-list.ts
@@ -1,0 +1,219 @@
+/**
+ * Skip-list — durable memory for dead-code-watcher's "don't try this
+ * again" decisions.
+ *
+ * Two shapes coexist in one JSON file:
+ *
+ *   - **entries**: specific `{ fingerprint, reason, ... }` per-finding
+ *     decisions. Maintainer-friendly granularity; one entry per
+ *     concretely-decided finding.
+ *
+ *   - **rules**: compacted generalisations the monthly compact-bot
+ *     produces. Each rule has a `scope` (glob) + `reason` and matches
+ *     ANY finding whose path satisfies the glob. Rules collapse N
+ *     entries that share a pattern into one durable predicate.
+ *
+ * Both are read every weekly run; a finding is skipped if EITHER
+ * matches. Both are written via PRs (no direct main commits per
+ * team-preferences rule 33). The weekly bot adds entries; the
+ * monthly compact-bot replaces entries with rules.
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+
+/**
+ * Fingerprint shape — uniquely identifies one knip finding.
+ *
+ *   - kind: which knip issue category produced this finding
+ *   - path: source file (relative to repo root)
+ *   - symbol: export/type name (only for kind=export/type/enumMember)
+ */
+export interface Fingerprint {
+  kind: 'file' | 'export' | 'type' | 'dependency' | 'devDependency' | 'enumMember'
+  path: string
+  symbol?: string
+}
+
+/** Reason categories — drives which path Claude takes on subsequent runs. */
+export type SkipReason =
+  /** Public package API consumed by external sites — keep forever. */
+  | 'public-api'
+  /** Used dynamically (worker thread, URL string, dynamic import). */
+  | 'dynamic-load'
+  /** Intentional planned-feature stub. */
+  | 'planned-feature'
+  /** Maintainer rejected the delete-PR with reasoning. */
+  | 'maintainer-rejected'
+  /** Bot tried, tests failed, needs human investigation. */
+  | 'needs-human'
+  /** Other — fall-through; reasonNote must explain. */
+  | 'other'
+
+export interface SkipEntry {
+  fingerprint: Fingerprint
+  reason: SkipReason
+  /** Free-text explanation. Required when reason='other' or 'maintainer-rejected'. */
+  reasonNote?: string
+  /** When the entry was added. ISO-8601. */
+  addedAt: string
+  /** Who decided. Bot = compacted from feedback loop; maintainer = manual edit. */
+  addedBy: 'bot' | 'maintainer'
+  /** PR number that originated the decision (when addedBy=bot). */
+  refPR?: number
+}
+
+export interface SkipRule {
+  /** Stable identifier for diagnostics + compaction replays. */
+  rule: string
+  /**
+   * Glob pattern matched against the finding's `path` (relative to
+   * repo root). Standard glob: `*` matches segment, `**` matches any.
+   * Examples:
+   *   - `packages/gazetta/src/index.ts` (exact)
+   *   - `packages/gazetta/src/**\/index.ts` (all entry points)
+   *   - `examples/**\/*.config.ts` (all starter site configs)
+   */
+  scope: string
+  /**
+   * Optional finding-kind filter. When set, rule only matches findings
+   * of these kinds. When omitted, matches any kind.
+   */
+  kinds?: Array<Fingerprint['kind']>
+  /** Reason category — drives which Claude path runs on match. */
+  reason: SkipReason
+  reasonNote?: string
+  /** When the rule was created. */
+  addedAt: string
+  /** Always 'bot' for rules (only compact-bot creates them). */
+  addedBy: 'bot'
+  /** Number of entries this rule replaced when compacted. */
+  compactedFrom: number
+}
+
+export interface SkipList {
+  version: 1
+  entries: SkipEntry[]
+  rules: SkipRule[]
+}
+
+/** Disk-storage path for the skip-list, relative to repo root. */
+export const SKIP_LIST_PATH = 'bots/dead-code-watcher/skip-list.json'
+
+/** Empty skip-list — shape used when seeding a fresh repo. */
+export function emptySkipList(): SkipList {
+  return { version: 1, entries: [], rules: [] }
+}
+
+/** Read the skip-list from disk. Returns empty skip-list if file doesn't exist. */
+export function readSkipList(absolutePath: string): SkipList {
+  if (!existsSync(absolutePath)) return emptySkipList()
+  const raw = readFileSync(absolutePath, 'utf-8')
+  const parsed = JSON.parse(raw) as SkipList
+  if (parsed.version !== 1) {
+    throw new Error(`Skip-list at ${absolutePath} has unknown version ${parsed.version}`)
+  }
+  return parsed
+}
+
+/** Write the skip-list back to disk, formatted for readable diffs. */
+export function writeSkipList(absolutePath: string, list: SkipList): void {
+  // 2-space indent matches Biome defaults; trailing newline matches POSIX.
+  writeFileSync(absolutePath, `${JSON.stringify(list, null, 2)}\n`)
+}
+
+/**
+ * Stable fingerprint string for equality + display.
+ *
+ *   kind=file → `file:packages/foo/bar.ts`
+ *   kind=export → `export:packages/foo/bar.ts#myExport`
+ */
+export function formatFingerprint(fp: Fingerprint): string {
+  return fp.symbol ? `${fp.kind}:${fp.path}#${fp.symbol}` : `${fp.kind}:${fp.path}`
+}
+
+/** True when two fingerprints describe the same finding. */
+export function fingerprintsEqual(a: Fingerprint, b: Fingerprint): boolean {
+  return a.kind === b.kind && a.path === b.path && a.symbol === b.symbol
+}
+
+/**
+ * Match a finding's fingerprint against the skip-list.
+ *
+ * Checks entries (exact match) first, then rules (glob match). Returns
+ * the first match found; both layers are functionally equivalent
+ * "this is a skip" signal — the bot doesn't need to know which one matched
+ * (the differentiation is for the compact-bot's analysis only).
+ *
+ * Returns null when no match found — the bot should investigate the
+ * finding fresh.
+ */
+export function findSkipMatch(list: SkipList, fp: Fingerprint): SkipEntry | SkipRule | null {
+  for (const entry of list.entries) {
+    if (fingerprintsEqual(entry.fingerprint, fp)) return entry
+  }
+  for (const rule of list.rules) {
+    if (rule.kinds && !rule.kinds.includes(fp.kind)) continue
+    if (globMatches(rule.scope, fp.path)) return rule
+  }
+  return null
+}
+
+/**
+ * Glob matcher — supports `*` (single segment), `**` (any path),
+ * literal `?` (single char), and bracket expressions.
+ *
+ * Intentionally small — knip's fingerprints have simple path shapes
+ * (no need for micromatch's full grammar). Tested against the actual
+ * patterns we generate from compaction.
+ *
+ * Pattern semantics:
+ *   - `foo/bar.ts` matches only that exact path
+ *   - `foo/*.ts` matches any .ts file directly inside `foo/`
+ *   - `foo/**\/bar.ts` matches `foo/bar.ts`, `foo/x/bar.ts`, etc.
+ *   - `foo/**` matches any path under `foo/`
+ */
+export function globMatches(pattern: string, path: string): boolean {
+  // Escape regex metacharacters EXCEPT our glob tokens.
+  // Build a regex by replacing tokens with their regex equivalents.
+  let regex = ''
+  let i = 0
+  while (i < pattern.length) {
+    const c = pattern[i]
+    if (c === '*' && pattern[i + 1] === '*') {
+      // ** — match any path including separators
+      regex += '.*'
+      i += 2
+      // Consume trailing `/` so `foo/**/bar` matches `foo/bar` AND `foo/x/bar`
+      if (pattern[i] === '/') i++
+    } else if (c === '*') {
+      // * — match anything except path separators
+      regex += '[^/]*'
+      i++
+    } else if (c === '?') {
+      regex += '[^/]'
+      i++
+    } else if ('.+^${}()|[]\\'.includes(c)) {
+      // Regex metacharacter — escape
+      regex += `\\${c}`
+      i++
+    } else {
+      regex += c
+      i++
+    }
+  }
+  return new RegExp(`^${regex}$`).test(path)
+}
+
+/**
+ * Append a fresh entry to the skip-list. Idempotent: if an entry with
+ * the same fingerprint already exists, the existing one is kept
+ * unchanged. The caller does NOT need to dedup before calling.
+ *
+ * Returns true when a new entry was added, false when one already
+ * existed.
+ */
+export function appendEntry(list: SkipList, entry: SkipEntry): boolean {
+  const existing = list.entries.find(e => fingerprintsEqual(e.fingerprint, entry.fingerprint))
+  if (existing) return false
+  list.entries.push(entry)
+  return true
+}

--- a/bots/_lib/tests/knip-parse.test.ts
+++ b/bots/_lib/tests/knip-parse.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest'
+import { filterStableFindings, parseKnipReport, rankFindings, type Finding } from '../knip-parse.js'
+
+// We don't shell out to `git log` in tests — the orchestrator hands a
+// pre-parsed report (via JSON files written by knip) and the parser's
+// `gitLastModifiedDays` is the part that touches git. Per `bots/README.md`
+// architecture rules: keep external-shell work in a thin layer that
+// tests stub. The integration path is exercised by manual smoke + the
+// per-finding tests below stub repoRoot to a directory git knows nothing
+// about → lastModifiedDays will be NaN → filtered out by
+// filterStableFindings. The synthesised Finding objects in these tests
+// provide the lastModifiedDays directly.
+
+describe('parseKnipReport — finding kinds', () => {
+  it('emits one finding per file when kind=file', () => {
+    const report = {
+      issues: [
+        {
+          file: 'src/foo.ts',
+          files: [{ name: 'src/foo.ts' }],
+        },
+      ],
+    }
+    const findings = parseKnipReport(report, { repoRoot: '/nonexistent' })
+    expect(findings).toHaveLength(1)
+    expect(findings[0].fingerprint).toEqual({ kind: 'file', path: 'src/foo.ts' })
+    expect(findings[0].file).toBe('src/foo.ts')
+  })
+
+  it('emits one finding per export when kind=export', () => {
+    const report = {
+      issues: [
+        {
+          file: 'src/foo.ts',
+          exports: [{ name: 'bar' }, { name: 'baz' }],
+        },
+      ],
+    }
+    const findings = parseKnipReport(report, { repoRoot: '/nonexistent' })
+    expect(findings).toHaveLength(2)
+    expect(findings[0].fingerprint).toEqual({ kind: 'export', path: 'src/foo.ts', symbol: 'bar' })
+    expect(findings[1].fingerprint).toEqual({ kind: 'export', path: 'src/foo.ts', symbol: 'baz' })
+  })
+
+  it('emits findings for types separately from exports', () => {
+    const report = {
+      issues: [
+        {
+          file: 'src/foo.ts',
+          exports: [{ name: 'bar' }],
+          types: [{ name: 'MyType' }],
+        },
+      ],
+    }
+    const findings = parseKnipReport(report, { repoRoot: '/nonexistent' })
+    expect(findings).toHaveLength(2)
+    expect(findings.map(f => f.fingerprint.kind)).toEqual(['export', 'type'])
+  })
+
+  it('emits findings for dependencies on package.json records', () => {
+    const report = {
+      issues: [
+        {
+          file: 'apps/admin/package.json',
+          dependencies: [{ name: 'primeicons' }, { name: 'zod' }],
+          devDependencies: [{ name: 'vitest' }],
+        },
+      ],
+    }
+    const findings = parseKnipReport(report, { repoRoot: '/nonexistent' })
+    expect(findings).toHaveLength(3)
+    expect(findings.map(f => f.fingerprint.kind)).toEqual(['dependency', 'dependency', 'devDependency'])
+    expect(findings.map(f => f.fingerprint.symbol)).toEqual(['primeicons', 'zod', 'vitest'])
+  })
+
+  it('skips per-export findings when the whole file is unused', () => {
+    const report = {
+      issues: [
+        {
+          file: 'src/foo.ts',
+          files: [{ name: 'src/foo.ts' }],
+          // Knip sometimes lists exports on whole-file-unused records;
+          // the file-level finding supersedes — file deletion drops them all.
+          exports: [{ name: 'bar' }],
+        },
+      ],
+    }
+    const findings = parseKnipReport(report, { repoRoot: '/nonexistent' })
+    expect(findings).toHaveLength(1)
+    expect(findings[0].fingerprint.kind).toBe('file')
+  })
+
+  it('handles missing optional fields gracefully', () => {
+    const report = {
+      issues: [
+        {
+          file: 'src/foo.ts',
+          // No files / exports / types / deps — empty record
+        },
+      ],
+    }
+    const findings = parseKnipReport(report, { repoRoot: '/nonexistent' })
+    expect(findings).toEqual([])
+  })
+
+  it('processes multiple issue records independently', () => {
+    const report = {
+      issues: [
+        { file: 'src/a.ts', exports: [{ name: 'X' }] },
+        { file: 'src/b.ts', files: [{ name: 'src/b.ts' }] },
+      ],
+    }
+    const findings = parseKnipReport(report, { repoRoot: '/nonexistent' })
+    expect(findings).toHaveLength(2)
+    expect(findings.map(f => f.fingerprint.kind)).toEqual(['export', 'file'])
+  })
+})
+
+describe('filterStableFindings', () => {
+  function makeFinding(overrides: Partial<Finding>): Finding {
+    return {
+      fingerprint: { kind: 'file', path: 'src/foo.ts' },
+      file: 'src/foo.ts',
+      lastModifiedDays: 100,
+      ...overrides,
+    }
+  }
+
+  it('keeps findings older than threshold (default 30 days)', () => {
+    const findings = [makeFinding({ lastModifiedDays: 45 }), makeFinding({ lastModifiedDays: 100 })]
+    expect(filterStableFindings(findings)).toHaveLength(2)
+  })
+
+  it('drops findings younger than threshold', () => {
+    const findings = [makeFinding({ lastModifiedDays: 5 }), makeFinding({ lastModifiedDays: 25 })]
+    expect(filterStableFindings(findings)).toHaveLength(0)
+  })
+
+  it('drops findings with NaN age (file not in git)', () => {
+    const findings = [makeFinding({ lastModifiedDays: Number.NaN })]
+    expect(filterStableFindings(findings)).toHaveLength(0)
+  })
+
+  it('threshold boundary is inclusive — exactly minDays passes', () => {
+    const findings = [makeFinding({ lastModifiedDays: 30 })]
+    expect(filterStableFindings(findings, 30)).toHaveLength(1)
+  })
+
+  it('accepts custom minDays threshold', () => {
+    const findings = [makeFinding({ lastModifiedDays: 10 }), makeFinding({ lastModifiedDays: 50 })]
+    expect(filterStableFindings(findings, 5)).toHaveLength(2)
+    expect(filterStableFindings(findings, 20)).toHaveLength(1)
+  })
+})
+
+describe('rankFindings', () => {
+  function f(kind: Finding['fingerprint']['kind'], path: string, ageDays: number, symbol?: string): Finding {
+    return {
+      fingerprint: { kind, path, symbol },
+      file: path,
+      symbol,
+      lastModifiedDays: ageDays,
+    }
+  }
+
+  it('ranks files above deps above exports above enumMembers', () => {
+    const findings = [
+      f('enumMember', 'src/d.ts', 100, 'X'),
+      f('export', 'src/c.ts', 100, 'Y'),
+      f('dependency', 'pkg/package.json', 100, 'lodash'),
+      f('file', 'src/a.ts', 100),
+    ]
+    const ranked = rankFindings(findings)
+    expect(ranked.map(r => r.fingerprint.kind)).toEqual(['file', 'dependency', 'export', 'enumMember'])
+  })
+
+  it('within same tier sorts oldest-first', () => {
+    const findings = [f('file', 'src/recent.ts', 30), f('file', 'src/ancient.ts', 365), f('file', 'src/middle.ts', 90)]
+    const ranked = rankFindings(findings)
+    expect(ranked.map(r => r.file)).toEqual(['src/ancient.ts', 'src/middle.ts', 'src/recent.ts'])
+  })
+
+  it('does not mutate input array', () => {
+    const findings = [f('file', 'src/a.ts', 100)]
+    const ranked = rankFindings(findings)
+    expect(ranked).not.toBe(findings)
+  })
+
+  it('groups types with exports in the same tier', () => {
+    const findings = [f('type', 'src/types.ts', 50, 'T'), f('export', 'src/exports.ts', 100, 'E')]
+    const ranked = rankFindings(findings)
+    // Both kind 2; oldest-first → export (100) before type (50)
+    expect(ranked.map(r => r.fingerprint.kind)).toEqual(['export', 'type'])
+  })
+})

--- a/bots/_lib/tests/past-pr.test.ts
+++ b/bots/_lib/tests/past-pr.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fingerprintToBranch, pastPROutcome } from '../past-pr.js'
+
+describe('fingerprintToBranch', () => {
+  it('encodes file findings with double-dash path separator', () => {
+    expect(fingerprintToBranch({ kind: 'file', path: 'src/foo.ts' })).toBe('dead-code/file-src--foo.ts')
+  })
+
+  it('encodes export findings with -at-symbol suffix', () => {
+    expect(fingerprintToBranch({ kind: 'export', path: 'src/foo.ts', symbol: 'bar' })).toBe(
+      'dead-code/export-src--foo.ts-at-bar',
+    )
+  })
+
+  it('encodes nested paths preserving slashes as double-dash', () => {
+    expect(fingerprintToBranch({ kind: 'export', path: 'packages/gazetta/src/foo.ts', symbol: 'X' })).toBe(
+      'dead-code/export-packages--gazetta--src--foo.ts-at-X',
+    )
+  })
+
+  it('encodes deps without symbol on path', () => {
+    expect(fingerprintToBranch({ kind: 'dependency', path: 'apps/admin/package.json', symbol: 'lodash' })).toBe(
+      'dead-code/dependency-apps--admin--package.json-at-lodash',
+    )
+  })
+})
+
+describe('pastPROutcome', () => {
+  const repo = { owner: 'test-org', repo: 'test-repo' }
+
+  function mockOctokit(
+    prs: Array<Partial<{ number: number; merged_at: string | null; state: string }>>,
+    comments: Array<{ body: string; user: { login: string }; created_at: string }> = [],
+  ): Parameters<typeof pastPROutcome>[0] {
+    return {
+      pulls: {
+        list: vi.fn(async () => ({ data: prs })),
+        listReviewComments: vi.fn(async () => ({ data: [] })),
+      },
+      issues: {
+        listComments: vi.fn(async () => ({ data: comments })),
+      },
+    } as unknown as Parameters<typeof pastPROutcome>[0]
+  }
+
+  it('returns state=none when no PR exists for this fingerprint', async () => {
+    const octokit = mockOctokit([])
+    const outcome = await pastPROutcome(octokit, repo, { kind: 'file', path: 'src/foo.ts' })
+    expect(outcome.state).toBe('none')
+  })
+
+  it('returns state=merged when latest PR was merged', async () => {
+    const octokit = mockOctokit([{ number: 42, merged_at: '2026-05-10T00:00:00Z', state: 'closed' }])
+    const outcome = await pastPROutcome(octokit, repo, { kind: 'file', path: 'src/foo.ts' })
+    expect(outcome).toEqual({ state: 'merged', prNumber: 42 })
+  })
+
+  it('returns state=open when latest PR is open', async () => {
+    const octokit = mockOctokit([{ number: 43, merged_at: null, state: 'open' }])
+    const outcome = await pastPROutcome(octokit, repo, { kind: 'file', path: 'src/foo.ts' })
+    expect(outcome).toEqual({ state: 'open', prNumber: 43 })
+  })
+
+  it('mines rejection reason from non-bot comment when PR closed-not-merged', async () => {
+    const octokit = mockOctokit(
+      [{ number: 44, merged_at: null, state: 'closed' }],
+      [{ body: 'This is public API; keep it.', user: { login: 'maintainer' }, created_at: '2026-05-12T00:00:00Z' }],
+    )
+    const outcome = await pastPROutcome(octokit, repo, { kind: 'file', path: 'src/foo.ts' })
+    expect(outcome.state).toBe('rejected')
+    if (outcome.state === 'rejected') {
+      expect(outcome.prNumber).toBe(44)
+      expect(outcome.reasonNote).toContain('Maintainer (maintainer)')
+      expect(outcome.reasonNote).toContain('public API')
+    }
+  })
+
+  it('falls back to generic note when no maintainer comment exists', async () => {
+    const octokit = mockOctokit(
+      [{ number: 45, merged_at: null, state: 'closed' }],
+      // Only bot comments
+      [{ body: 'bot comment', user: { login: 'github-actions[bot]' }, created_at: '2026-05-12T00:00:00Z' }],
+    )
+    const outcome = await pastPROutcome(octokit, repo, { kind: 'file', path: 'src/foo.ts' })
+    expect(outcome.state).toBe('rejected')
+    if (outcome.state === 'rejected') {
+      expect(outcome.reasonNote).toContain('closed without merge; no maintainer comment')
+    }
+  })
+
+  it('truncates long maintainer comments', async () => {
+    const longBody = 'x'.repeat(600)
+    const octokit = mockOctokit(
+      [{ number: 46, merged_at: null, state: 'closed' }],
+      [{ body: longBody, user: { login: 'maintainer' }, created_at: '2026-05-12T00:00:00Z' }],
+    )
+    const outcome = await pastPROutcome(octokit, repo, { kind: 'file', path: 'src/foo.ts' })
+    if (outcome.state === 'rejected') {
+      // Truncated at 400 chars + ellipsis + the framing text
+      expect(outcome.reasonNote.length).toBeLessThan(longBody.length)
+      expect(outcome.reasonNote).toContain('…')
+    }
+  })
+})

--- a/bots/_lib/tests/reviewer-verdict.test.ts
+++ b/bots/_lib/tests/reviewer-verdict.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { parseReviewerVerdict } from '../reviewer-verdict.js'
+
+describe('parseReviewerVerdict', () => {
+  it('parses APPROVE with following Reasoning', () => {
+    const text = `Looking at the diff...
+
+VERDICT: APPROVE
+Reasoning: The deletion is safe. No dynamic-load patterns reference this file.`
+    const verdict = parseReviewerVerdict(text)
+    expect(verdict.kind).toBe('approve')
+    if (verdict.kind === 'approve') {
+      expect(verdict.reasoning).toContain('deletion is safe')
+    }
+  })
+
+  it('parses APPROVE without Reasoning keyword', () => {
+    const verdict = parseReviewerVerdict('VERDICT: APPROVE\nLooks good.')
+    expect(verdict.kind).toBe('approve')
+    if (verdict.kind === 'approve') {
+      expect(verdict.reasoning).toBe('Looks good.')
+    }
+  })
+
+  it('parses REJECT with Note', () => {
+    const text = `VERDICT: REJECT
+Note: The function on line 42 is dynamically loaded by the template registry.`
+    const verdict = parseReviewerVerdict(text)
+    expect(verdict.kind).toBe('reject')
+    if (verdict.kind === 'reject') {
+      expect(verdict.note).toContain('dynamically loaded')
+    }
+  })
+
+  it('REJECT without Note defaults to needs-human (cannot retry without feedback)', () => {
+    const verdict = parseReviewerVerdict('VERDICT: REJECT')
+    expect(verdict.kind).toBe('needs-human')
+    if (verdict.kind === 'needs-human') {
+      expect(verdict.note).toContain('no Note: explanation')
+    }
+  })
+
+  it('parses NEEDS_HUMAN with Note', () => {
+    const text = `VERDICT: NEEDS_HUMAN
+Note: This is a public API marked @internal but exposed in @types/...`
+    const verdict = parseReviewerVerdict(text)
+    expect(verdict.kind).toBe('needs-human')
+    if (verdict.kind === 'needs-human') {
+      expect(verdict.note).toContain('public API')
+    }
+  })
+
+  it('returns needs-human when VERDICT line is missing', () => {
+    const verdict = parseReviewerVerdict('I think this looks fine.')
+    expect(verdict.kind).toBe('needs-human')
+    if (verdict.kind === 'needs-human') {
+      expect(verdict.note).toContain('did not contain a recognizable')
+    }
+  })
+
+  it('returns needs-human when VERDICT keyword is invalid', () => {
+    const verdict = parseReviewerVerdict('VERDICT: YOLO')
+    expect(verdict.kind).toBe('needs-human')
+  })
+
+  it('accepts leading whitespace before VERDICT', () => {
+    const verdict = parseReviewerVerdict('Some preamble\n   VERDICT: APPROVE\nReasoning: fine')
+    expect(verdict.kind).toBe('approve')
+  })
+
+  it('truncates very long notes to 2000 chars', () => {
+    const longNote = 'x'.repeat(3000)
+    const text = `VERDICT: REJECT\nNote: ${longNote}`
+    const verdict = parseReviewerVerdict(text)
+    if (verdict.kind === 'reject') {
+      expect(verdict.note.length).toBeLessThanOrEqual(2000)
+    }
+  })
+
+  it('tolerates VERDICT with extra trailing whitespace', () => {
+    const verdict = parseReviewerVerdict('VERDICT: APPROVE   \nReasoning: ok')
+    expect(verdict.kind).toBe('approve')
+  })
+})

--- a/bots/_lib/tests/skip-list.test.ts
+++ b/bots/_lib/tests/skip-list.test.ts
@@ -1,0 +1,295 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  appendEntry,
+  emptySkipList,
+  findSkipMatch,
+  fingerprintsEqual,
+  formatFingerprint,
+  globMatches,
+  readSkipList,
+  type SkipList,
+  writeSkipList,
+} from '../skip-list.js'
+
+describe('globMatches', () => {
+  it('matches exact paths', () => {
+    expect(globMatches('packages/foo/bar.ts', 'packages/foo/bar.ts')).toBe(true)
+    expect(globMatches('packages/foo/bar.ts', 'packages/foo/baz.ts')).toBe(false)
+  })
+
+  it('matches single-segment wildcards', () => {
+    expect(globMatches('packages/*/bar.ts', 'packages/foo/bar.ts')).toBe(true)
+    expect(globMatches('packages/*/bar.ts', 'packages/foo/baz/bar.ts')).toBe(false)
+    expect(globMatches('packages/foo/*.ts', 'packages/foo/anything.ts')).toBe(true)
+  })
+
+  it('matches deep wildcards', () => {
+    expect(globMatches('packages/**/bar.ts', 'packages/foo/bar.ts')).toBe(true)
+    expect(globMatches('packages/**/bar.ts', 'packages/foo/sub/bar.ts')).toBe(true)
+    expect(globMatches('packages/**/bar.ts', 'packages/bar.ts')).toBe(true) // `**/` collapses to nothing
+    expect(globMatches('packages/**', 'packages/foo/anything/here.ts')).toBe(true)
+  })
+
+  it('respects literal regex metacharacters in patterns', () => {
+    expect(globMatches('packages/foo+bar.ts', 'packages/foo+bar.ts')).toBe(true)
+    expect(globMatches('packages/foo+bar.ts', 'packages/fooxbar.ts')).toBe(false)
+  })
+
+  it('does not match across segment boundaries with single *', () => {
+    expect(globMatches('packages/*.ts', 'packages/sub/file.ts')).toBe(false)
+  })
+})
+
+describe('fingerprintsEqual', () => {
+  it('matches same kind+path+symbol', () => {
+    expect(
+      fingerprintsEqual(
+        { kind: 'export', path: 'src/foo.ts', symbol: 'bar' },
+        { kind: 'export', path: 'src/foo.ts', symbol: 'bar' },
+      ),
+    ).toBe(true)
+  })
+
+  it('differs on kind', () => {
+    expect(
+      fingerprintsEqual(
+        { kind: 'export', path: 'src/foo.ts', symbol: 'bar' },
+        { kind: 'type', path: 'src/foo.ts', symbol: 'bar' },
+      ),
+    ).toBe(false)
+  })
+
+  it('differs on path', () => {
+    expect(fingerprintsEqual({ kind: 'file', path: 'a.ts' }, { kind: 'file', path: 'b.ts' })).toBe(false)
+  })
+
+  it('differs when one has symbol and other does not', () => {
+    expect(
+      fingerprintsEqual({ kind: 'export', path: 'src/foo.ts', symbol: 'bar' }, { kind: 'export', path: 'src/foo.ts' }),
+    ).toBe(false)
+  })
+})
+
+describe('formatFingerprint', () => {
+  it('formats file findings without symbol', () => {
+    expect(formatFingerprint({ kind: 'file', path: 'src/foo.ts' })).toBe('file:src/foo.ts')
+  })
+
+  it('formats export findings with symbol after #', () => {
+    expect(formatFingerprint({ kind: 'export', path: 'src/foo.ts', symbol: 'bar' })).toBe('export:src/foo.ts#bar')
+  })
+
+  it('formats dependency findings (path is package.json)', () => {
+    expect(formatFingerprint({ kind: 'dependency', path: 'packages/foo/package.json', symbol: 'lodash' })).toBe(
+      'dependency:packages/foo/package.json#lodash',
+    )
+  })
+})
+
+describe('findSkipMatch', () => {
+  it('matches exact entry by fingerprint', () => {
+    const list: SkipList = {
+      version: 1,
+      entries: [
+        {
+          fingerprint: { kind: 'file', path: 'src/foo.ts' },
+          reason: 'public-api',
+          addedAt: '2026-05-14T00:00:00Z',
+          addedBy: 'maintainer',
+        },
+      ],
+      rules: [],
+    }
+    const match = findSkipMatch(list, { kind: 'file', path: 'src/foo.ts' })
+    expect(match).not.toBeNull()
+    expect((match as { reason: string }).reason).toBe('public-api')
+  })
+
+  it('returns null when neither entries nor rules match', () => {
+    const list = emptySkipList()
+    expect(findSkipMatch(list, { kind: 'file', path: 'src/unknown.ts' })).toBeNull()
+  })
+
+  it('matches rule by glob scope', () => {
+    const list: SkipList = {
+      version: 1,
+      entries: [],
+      rules: [
+        {
+          rule: 'gazetta-public-entries',
+          scope: 'packages/gazetta/src/index.ts',
+          reason: 'public-api',
+          addedAt: '2026-05-14T00:00:00Z',
+          addedBy: 'bot',
+          compactedFrom: 3,
+        },
+      ],
+    }
+    const match = findSkipMatch(list, { kind: 'export', path: 'packages/gazetta/src/index.ts', symbol: 'X' })
+    expect(match).not.toBeNull()
+    expect((match as { rule: string }).rule).toBe('gazetta-public-entries')
+  })
+
+  it('honors rule kind filter — skip when kind does not match', () => {
+    const list: SkipList = {
+      version: 1,
+      entries: [],
+      rules: [
+        {
+          rule: 'only-files',
+          scope: 'packages/**/*.ts',
+          kinds: ['file'],
+          reason: 'public-api',
+          addedAt: '2026-05-14T00:00:00Z',
+          addedBy: 'bot',
+          compactedFrom: 2,
+        },
+      ],
+    }
+    // Rule kinds=['file']; finding kind='export' — no match
+    const match = findSkipMatch(list, { kind: 'export', path: 'packages/foo/bar.ts', symbol: 'X' })
+    expect(match).toBeNull()
+  })
+
+  it('honors rule kind filter — match when kind included', () => {
+    const list: SkipList = {
+      version: 1,
+      entries: [],
+      rules: [
+        {
+          rule: 'only-files',
+          scope: 'packages/**/*.ts',
+          kinds: ['file'],
+          reason: 'public-api',
+          addedAt: '2026-05-14T00:00:00Z',
+          addedBy: 'bot',
+          compactedFrom: 2,
+        },
+      ],
+    }
+    const match = findSkipMatch(list, { kind: 'file', path: 'packages/foo/bar.ts' })
+    expect(match).not.toBeNull()
+  })
+
+  it('prefers entry match over rule match (entries checked first)', () => {
+    const list: SkipList = {
+      version: 1,
+      entries: [
+        {
+          fingerprint: { kind: 'file', path: 'src/foo.ts' },
+          reason: 'public-api',
+          addedAt: '2026-05-14T00:00:00Z',
+          addedBy: 'maintainer',
+        },
+      ],
+      rules: [
+        {
+          rule: 'broad',
+          scope: 'src/**',
+          reason: 'planned-feature',
+          addedAt: '2026-05-14T00:00:00Z',
+          addedBy: 'bot',
+          compactedFrom: 1,
+        },
+      ],
+    }
+    const match = findSkipMatch(list, { kind: 'file', path: 'src/foo.ts' })
+    expect(match).not.toBeNull()
+    // Entry's reason wins (was checked first)
+    expect((match as { reason: string }).reason).toBe('public-api')
+  })
+})
+
+describe('appendEntry', () => {
+  it('adds a new entry when fingerprint is unseen', () => {
+    const list = emptySkipList()
+    const added = appendEntry(list, {
+      fingerprint: { kind: 'file', path: 'src/foo.ts' },
+      reason: 'planned-feature',
+      addedAt: '2026-05-14T00:00:00Z',
+      addedBy: 'bot',
+    })
+    expect(added).toBe(true)
+    expect(list.entries).toHaveLength(1)
+  })
+
+  it('skips duplicate fingerprint', () => {
+    const list = emptySkipList()
+    appendEntry(list, {
+      fingerprint: { kind: 'file', path: 'src/foo.ts' },
+      reason: 'planned-feature',
+      addedAt: '2026-05-14T00:00:00Z',
+      addedBy: 'bot',
+    })
+    const added = appendEntry(list, {
+      fingerprint: { kind: 'file', path: 'src/foo.ts' },
+      reason: 'maintainer-rejected',
+      addedAt: '2026-05-15T00:00:00Z',
+      addedBy: 'bot',
+    })
+    expect(added).toBe(false)
+    expect(list.entries).toHaveLength(1)
+    // Original entry retained, NOT overwritten
+    expect(list.entries[0].reason).toBe('planned-feature')
+  })
+})
+
+describe('readSkipList / writeSkipList', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(resolve(tmpdir(), 'skip-list-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('returns empty list when file does not exist', () => {
+    const path = resolve(tempDir, 'missing.json')
+    const list = readSkipList(path)
+    expect(list).toEqual(emptySkipList())
+  })
+
+  it('round-trips through disk', () => {
+    const original: SkipList = {
+      version: 1,
+      entries: [
+        {
+          fingerprint: { kind: 'file', path: 'src/foo.ts' },
+          reason: 'public-api',
+          addedAt: '2026-05-14T00:00:00Z',
+          addedBy: 'maintainer',
+        },
+      ],
+      rules: [
+        {
+          rule: 'r1',
+          scope: 'src/**',
+          reason: 'public-api',
+          addedAt: '2026-05-14T00:00:00Z',
+          addedBy: 'bot',
+          compactedFrom: 5,
+        },
+      ],
+    }
+    const path = resolve(tempDir, 'skip.json')
+    writeSkipList(path, original)
+    const roundtripped = readSkipList(path)
+    expect(roundtripped).toEqual(original)
+  })
+
+  it('throws on unknown version', () => {
+    const path = resolve(tempDir, 'bad.json')
+    mkdirSync(tempDir, { recursive: true })
+    // Write a manually-constructed bad-version file
+    writeSkipList(path, { version: 1, entries: [], rules: [] })
+    // Corrupt the version after write
+    const raw = `{"version":999,"entries":[],"rules":[]}\n`
+    writeSkipList(path, JSON.parse(raw))
+    expect(() => readSkipList(path)).toThrow(/unknown version/)
+  })
+})

--- a/bots/dead-code-watcher/compact.ts
+++ b/bots/dead-code-watcher/compact.ts
@@ -1,0 +1,118 @@
+/**
+ * dead-code-watcher's memory-compaction pass.
+ *
+ * Runs monthly on the 1st Saturday at 03:00 UTC (per
+ * .github/workflows/dead-code-watcher-compact.yml). Reads the
+ * skip-list and asks Claude to identify groups of ≥3 entries that
+ * share a pattern (path-prefix + reason, or glob-collapsible shape),
+ * propose generalized rules, and open a PR with the new skip-list
+ * shape.
+ *
+ * "Compaction" not "compression": the result is the skip-list
+ * literally getting smaller AND more powerful — fewer concrete
+ * entries, more general rules that catch future findings too. Same
+ * shape as how LLM session memory compacts: summarize accumulated
+ * state into a smaller form that preserves load-bearing information.
+ *
+ * Conservatism: rules only get proposed when 3+ entries share a
+ * clear pattern. The compact-bot is allowed to be wrong (the PR is
+ * reviewable), but it's expensive to maintainer-time to review
+ * spurious compactions, so the prompt asks for high-confidence
+ * generalizations only.
+ *
+ * Run locally:
+ *   GITHUB_REPOSITORY=gazetta-studio/gazetta-studio \
+ *     GH_TOKEN=$(gh auth token) npm run dead-code-watcher:compact -w @gazetta/bots
+ * Run in CI:
+ *   .github/workflows/dead-code-watcher-compact.yml (1st Sat 03:00 UTC)
+ */
+import { mkdirSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { runClaude } from '../_lib/claude.js'
+import { readSkipList, SKIP_LIST_PATH } from '../_lib/skip-list.js'
+import { printBanner, printNotice, printRunSummary, printTranscriptPath, printWarning } from '../_lib/ui.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const PROMPT_PATH = resolve(HERE, 'prompts/compact.md')
+const REPO_ROOT = resolve(HERE, '../..')
+const SKIP_LIST_ABS = resolve(REPO_ROOT, SKIP_LIST_PATH)
+const TRANSCRIPTS_DIR = resolve(HERE, '../transcripts')
+const RUN_TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')
+
+const DRY_RUN = process.env.DRY_RUN === '1'
+
+/**
+ * Minimum entries required to consider compaction. Below this we
+ * exit early without invoking Claude — there's nothing to generalize.
+ */
+const MIN_ENTRIES_FOR_COMPACTION = 3
+
+async function main(): Promise<void> {
+  printBanner({
+    name: 'dead-code-watcher:compact',
+    tagline: 'monthly memory compactor',
+    purpose: "Generalize skip-list entries into rules; keep the bot's memory compact and powerful.",
+    inputs: ['bots/dead-code-watcher/skip-list.json'],
+    outputs: ['PR replacing N specific entries with M general rules (compactedFrom: N)'],
+  })
+
+  const skipList = readSkipList(SKIP_LIST_ABS)
+  const entryCount = skipList.entries.length
+  const ruleCount = skipList.rules.length
+
+  printNotice(`Current skip-list: ${entryCount} entries + ${ruleCount} rules`)
+
+  if (entryCount < MIN_ENTRIES_FOR_COMPACTION) {
+    printNotice(`Below MIN_ENTRIES_FOR_COMPACTION=${MIN_ENTRIES_FOR_COMPACTION} — nothing to compact. ✨`)
+    return
+  }
+
+  if (DRY_RUN) {
+    printNotice('DRY_RUN=1 — exiting before invoking Claude.')
+    return
+  }
+
+  // Hand the entire skip-list to Claude. It's small (under 100 entries
+  // typically), no context pressure. Claude reads, proposes rules,
+  // commits + opens PR.
+  mkdirSync(TRANSCRIPTS_DIR, { recursive: true })
+  const promptTemplate = readFileSync(PROMPT_PATH, 'utf-8')
+  const transcriptPath = resolve(TRANSCRIPTS_DIR, `${RUN_TIMESTAMP}-dead-code-compact.jsonl`)
+  printTranscriptPath(transcriptPath)
+
+  const runStart = Date.now()
+  const prompt = `${promptTemplate}
+
+SKIP_LIST_PATH=${SKIP_LIST_PATH}
+SKIP_LIST_JSON=${JSON.stringify(skipList, null, 2)}
+RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
+
+  try {
+    const result = await runClaude({
+      prompt,
+      transcriptPath,
+      allowedTools: ['Bash', 'Read', 'Write', 'Edit'],
+    })
+    if (!result.success) {
+      printWarning(`Claude exited ${result.exitCode}; transcript at ${transcriptPath}`)
+    }
+  } catch (err) {
+    printWarning(`compact threw: ${err}; transcript at ${transcriptPath}`)
+  }
+
+  const totalSec = Math.round((Date.now() - runStart) / 1000)
+  printRunSummary({
+    verb: 'Compacted',
+    processed: 1,
+    total: 1,
+    skipped: 0,
+    notes: [`Transcript: ${transcriptPath}`],
+    elapsedSec: totalSec,
+  })
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err)
+  process.exit(1)
+})

--- a/bots/dead-code-watcher/index.ts
+++ b/bots/dead-code-watcher/index.ts
@@ -38,6 +38,7 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { runClaude } from '../_lib/claude.js'
 import { octokitFromEnv, repoFromEnv } from '../_lib/github.js'
+import { branchHasCommits, captureCommitMessages, captureDiff, resetToMain } from '../_lib/git-tree.js'
 import {
   type Finding,
   filterStableFindings,
@@ -46,6 +47,7 @@ import {
   rankFindings,
 } from '../_lib/knip-parse.js'
 import { fingerprintToBranch, pastPROutcome } from '../_lib/past-pr.js'
+import { parseReviewerVerdict } from '../_lib/reviewer-verdict.js'
 import {
   appendEntry,
   findSkipMatch,
@@ -67,6 +69,7 @@ import {
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const PROMPT_PATH = resolve(HERE, 'prompts/per-finding.md')
+const REVIEWER_PROMPT_PATH = resolve(HERE, 'prompts/reviewer.md')
 const REPO_ROOT = resolve(HERE, '../..')
 const SKIP_LIST_ABS = resolve(REPO_ROOT, SKIP_LIST_PATH)
 
@@ -82,6 +85,14 @@ const PER_RUN_BUDGET_MS = Number(process.env.BUDGET_MS ?? 55 * 60 * 1000)
 
 /** Minimum file-age in days to consider a finding stable (vs mid-flight WIP). */
 const MIN_STABLE_DAYS = Number(process.env.MIN_STABLE_DAYS ?? '30')
+
+/**
+ * Maximum generator-critic loop iterations per finding. Agent A
+ * proposes; Agent B reviews; if REJECT, Agent A retries with the
+ * reviewer's note. After this cap, the orchestrator gives up and
+ * adds a `needs-human` skip-list entry.
+ */
+const MAX_ATTEMPTS = Number(process.env.MAX_ATTEMPTS ?? '5')
 
 async function main(): Promise<void> {
   printBanner({
@@ -253,17 +264,10 @@ async function processFinding(
     return 'past-pr-matched'
   }
 
-  // No past PR — fresh investigation. Hand to Claude.
+  // No past PR — fresh investigation. Run the generator-critic loop.
   const branchName = fingerprintToBranch(finding.fingerprint)
-  const transcriptPath = resolve(
-    TRANSCRIPTS_DIR,
-    `${RUN_TIMESTAMP}-dead-code-${branchName.replace(/[/-]/g, '_')}.jsonl`,
-  )
-  printTranscriptPath(transcriptPath)
-
-  const prompt = `${promptTemplate}
-
-FINDING_JSON=${JSON.stringify(
+  const reviewerPromptTemplate = readFileSync(REVIEWER_PROMPT_PATH, 'utf-8')
+  const findingPayload = JSON.stringify(
     {
       fingerprint: finding.fingerprint,
       fingerprintLabel: formatFingerprint(finding.fingerprint),
@@ -273,20 +277,252 @@ FINDING_JSON=${JSON.stringify(
     },
     null,
     2,
-  )}
+  )
+
+  let priorReviewerNote: string | null = null
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    printNotice(`Attempt ${attempt}/${MAX_ATTEMPTS}: invoking Agent A (cleanup)…`)
+
+    // Reset to clean main between attempts (no-op on attempt 1 unless
+    // a prior partial run left state behind).
+    resetToMain(branchName, { cwd: REPO_ROOT })
+
+    // Run Agent A.
+    const agentATranscript = resolve(
+      TRANSCRIPTS_DIR,
+      `${RUN_TIMESTAMP}-dead-code-${branchName.replace(/[/-]/g, '_')}-attempt${attempt}-A.jsonl`,
+    )
+    printTranscriptPath(agentATranscript)
+    const agentAPrompt = `${promptTemplate}
+
+FINDING_JSON=${findingPayload}
 BRANCH_NAME=${branchName}
 SKIP_LIST_PATH=${SKIP_LIST_PATH}
+ATTEMPT=${attempt}
+MAX_ATTEMPTS=${MAX_ATTEMPTS}
+${priorReviewerNote ? `PRIOR_REVIEWER_NOTE=${priorReviewerNote}\n` : ''}RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
+
+    const aResult = await runClaude({
+      prompt: agentAPrompt,
+      transcriptPath: agentATranscript,
+      allowedTools: ['Bash', 'Read', 'Grep', 'Glob', 'Write', 'Edit'],
+    })
+    if (!aResult.success) {
+      printWarning(`Agent A exited ${aResult.exitCode} on attempt ${attempt}; aborting loop for this finding`)
+      return 'invoked-claude'
+    }
+
+    // What did Agent A produce?
+    //   - A `dead-code-skip/...` branch with a skip-list commit → bot's done,
+    //     skip case. Push that branch (no reviewer needed).
+    //   - The `dead-code/...` branch with delete commit(s) → reviewer time.
+    //   - Nothing (no branch / no commits) → Agent A bailed; record + exit.
+    const skipBranch = `dead-code-skip/${branchName.replace('dead-code/', '')}`
+    const skipBranchHasCommits = branchHasCommits(skipBranch, { cwd: REPO_ROOT })
+    const deleteBranchHasCommits = branchHasCommits(branchName, { cwd: REPO_ROOT })
+
+    if (skipBranchHasCommits) {
+      printNotice('Agent A chose SKIP — pushing skip-list-entry PR (no reviewer needed)')
+      pushBranch(skipBranch)
+      // The branch is already committed by Agent A; nothing more to do.
+      return 'invoked-claude'
+    }
+
+    if (!deleteBranchHasCommits) {
+      printWarning(`Agent A produced no commits on either branch; treating as needs-human and stopping`)
+      recordSkipListEntry(skipList, finding, {
+        reason: 'needs-human',
+        reasonNote: `Agent A attempt ${attempt} produced no commits. See transcript ${agentATranscript}.`,
+      })
+      return 'invoked-claude'
+    }
+
+    // Agent A made a delete-branch — hand to reviewer.
+    printNotice(`Attempt ${attempt}/${MAX_ATTEMPTS}: invoking Agent B (reviewer)…`)
+    const diff = captureDiff(branchName, { cwd: REPO_ROOT })
+    const commitMessages = captureCommitMessages(branchName, { cwd: REPO_ROOT })
+
+    const reviewerTranscript = resolve(
+      TRANSCRIPTS_DIR,
+      `${RUN_TIMESTAMP}-dead-code-${branchName.replace(/[/-]/g, '_')}-attempt${attempt}-B.jsonl`,
+    )
+    printTranscriptPath(reviewerTranscript)
+    const reviewerPrompt = `${reviewerPromptTemplate}
+
+FINDING_JSON=${findingPayload}
+BRANCH_NAME=${branchName}
+ATTEMPT=${attempt}
+${priorReviewerNote ? `PRIOR_REVIEWER_NOTE=${priorReviewerNote}\n` : ''}
+DIFF=
+${diff}
+
+COMMIT_MESSAGES=
+${commitMessages}
+
+TEST_SUMMARY=tests passed (verified by Agent A before commit)
 RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
 
-  const result = await runClaude({
-    prompt,
-    transcriptPath,
-    allowedTools: ['Bash', 'Read', 'Grep', 'Glob', 'Write', 'Edit'],
-  })
-  if (!result.success) {
-    printWarning(`Claude exited ${result.exitCode} on ${formatFingerprint(finding.fingerprint)}`)
+    const bResult = await runClaude({
+      prompt: reviewerPrompt,
+      transcriptPath: reviewerTranscript,
+      // Reviewer has Read for spot-checking, Bash for grep. NO Write/Edit.
+      allowedTools: ['Bash', 'Read'],
+    })
+    if (!bResult.success) {
+      printWarning(`Agent B exited ${bResult.exitCode} on attempt ${attempt}; treating as needs-human`)
+      recordSkipListEntry(skipList, finding, {
+        reason: 'needs-human',
+        reasonNote: `Reviewer (Agent B) crashed on attempt ${attempt}. See transcript ${reviewerTranscript}.`,
+      })
+      return 'invoked-claude'
+    }
+
+    // Parse the reviewer's final text block for the VERDICT line.
+    const reviewerLastText = extractLastAssistantText(reviewerTranscript)
+    const verdict = parseReviewerVerdict(reviewerLastText)
+
+    if (verdict.kind === 'approve') {
+      printNotice(`✅ Reviewer APPROVED on attempt ${attempt}/${MAX_ATTEMPTS}: ${verdict.reasoning.slice(0, 120)}`)
+      pushBranch(branchName)
+      openDeletePR(finding, branchName, verdict.reasoning, extractLastAssistantText(agentATranscript))
+      return 'invoked-claude'
+    }
+
+    if (verdict.kind === 'needs-human') {
+      printWarning(`⚠ Reviewer escalated to NEEDS_HUMAN: ${verdict.note.slice(0, 120)}`)
+      recordSkipListEntry(skipList, finding, {
+        reason: 'needs-human',
+        reasonNote: `Reviewer verdict on attempt ${attempt}: ${verdict.note}`,
+      })
+      return 'invoked-claude'
+    }
+
+    // REJECT — loop with the reviewer's note for Agent A.
+    printNotice(`Reviewer REJECTED on attempt ${attempt}/${MAX_ATTEMPTS}: ${verdict.note.slice(0, 120)}`)
+    priorReviewerNote = verdict.note
+    // continue → next iteration
   }
+
+  // Loop exhausted without convergence.
+  printWarning(`Loop exhausted after ${MAX_ATTEMPTS} attempts — Agent A and reviewer disagreed`)
+  recordSkipListEntry(skipList, finding, {
+    reason: 'needs-human',
+    reasonNote: `Agent A and reviewer didn't converge after ${MAX_ATTEMPTS} attempts. Last reviewer note: ${priorReviewerNote ?? '(none)'}`,
+  })
   return 'invoked-claude'
+}
+
+/**
+ * Push a branch to origin. Failures here are non-fatal — the
+ * commits remain locally; the orchestrator's per-finding budget
+ * absorbs the loss and the next cron retries.
+ */
+function pushBranch(branchName: string): void {
+  try {
+    execFileSync('git', ['push', '-u', 'origin', branchName], {
+      cwd: REPO_ROOT,
+      stdio: 'inherit',
+    })
+  } catch (err) {
+    printWarning(`git push ${branchName} failed: ${err}`)
+  }
+}
+
+/**
+ * Open the delete PR with the reviewer's approve-reasoning + Agent A's
+ * last assistant message as the body. Best-effort; failures non-fatal.
+ */
+function openDeletePR(finding: Finding, branchName: string, reviewerReasoning: string, agentASummary: string): void {
+  const label = formatFingerprint(finding.fingerprint)
+  const body = `## Summary
+
+Knip flagged \`${label}\` as unused. After investigation by Agent A
+and independent review by Agent B (both Claude Code sessions), this
+PR removes it.
+
+## What Agent A checked
+
+${agentASummary || '(no Agent A summary captured)'}
+
+## Reviewer reasoning
+
+${reviewerReasoning || '(no reviewer reasoning captured)'}
+
+## Verification
+
+\`npm test\` passes after removal (verified by Agent A before
+commit; CI re-verifies on this PR).
+
+## What if this is wrong?
+
+Close the PR. The bot's feedback loop will read the close reason
+from your comment and add a skip-list entry so it doesn't re-attempt.
+
+<!-- dead-code-watcher: kind=${finding.fingerprint.kind} path=${finding.fingerprint.path}${finding.fingerprint.symbol ? ` symbol=${finding.fingerprint.symbol}` : ''} run=${process.env.GITHUB_RUN_ID ?? 'local'} -->`
+  try {
+    execFileSync('gh', ['pr', 'create', '--title', `refactor(dead-code): remove unused ${label}`, '--body', body], {
+      cwd: REPO_ROOT,
+      stdio: 'inherit',
+    })
+  } catch (err) {
+    printWarning(`gh pr create failed for ${label}: ${err}`)
+  }
+}
+
+/**
+ * Append a skip-list entry + persist. Used by failure paths where
+ * the bot bails out without going through Agent A's normal SKIP
+ * branch creation.
+ */
+function recordSkipListEntry(
+  skipList: SkipList,
+  finding: Finding,
+  opts: { reason: 'needs-human'; reasonNote: string },
+): void {
+  const added = appendEntry(skipList, {
+    fingerprint: finding.fingerprint,
+    reason: opts.reason,
+    reasonNote: opts.reasonNote,
+    addedAt: new Date().toISOString(),
+    addedBy: 'bot',
+  })
+  if (added) {
+    writeSkipList(SKIP_LIST_ABS, skipList)
+  }
+}
+
+/**
+ * Extract the last assistant text block from a JSONL transcript.
+ * Used to grab Agent A's summary or Agent B's verdict line.
+ *
+ * Returns empty string when no text block exists or the file can't
+ * be read.
+ */
+function extractLastAssistantText(transcriptPath: string): string {
+  try {
+    const lines = readFileSync(transcriptPath, 'utf-8')
+      .split('\n')
+      .filter(l => l.trim().length > 0)
+    let lastText = ''
+    for (const line of lines) {
+      try {
+        const event = JSON.parse(line)
+        if (event.type === 'assistant' && Array.isArray(event.message?.content)) {
+          for (const block of event.message.content) {
+            if (block.type === 'text' && typeof block.text === 'string') {
+              lastText = block.text
+            }
+          }
+        }
+      } catch {
+        // ignore malformed line
+      }
+    }
+    return lastText
+  } catch {
+    return ''
+  }
 }
 
 /**

--- a/bots/dead-code-watcher/index.ts
+++ b/bots/dead-code-watcher/index.ts
@@ -1,0 +1,395 @@
+/**
+ * dead-code-watcher — weekly review of knip findings, files delete-PRs.
+ *
+ * Producer bot (sibling of flake-watcher + mutation-watcher) that owns
+ * the full delete-or-skip pipeline end-to-end. Unlike those bots, this
+ * one DOES NOT delegate to fix-bot — it produces PRs directly. The
+ * rationale: code deletion's "failing test" is just "existing tests
+ * still pass after removal," so fix-bot's TDD-first contract doesn't
+ * compose. See bots/README.md "Architecture: producer vs consumer"
+ * for the broader pattern.
+ *
+ * Memory layers (per the design grilling that locked this shape):
+ *
+ *   1. **skip-list.json** — durable per-fingerprint decisions:
+ *      "intentional", "needs-human", "maintainer-rejected". Survives
+ *      across runs, edited via PR. Compacted monthly into rules.
+ *
+ *   2. **Past-PR query** — the feedback loop. Before investigating
+ *      a fresh finding, search GitHub for the deterministic branch
+ *      name. If a PR was rejected, mine the reason and add an entry
+ *      to the skip-list. If a PR is open, skip (don't double-PR).
+ *      If a PR was merged, knip should no longer flag this finding
+ *      anyway (file deleted from main); if it does, retry.
+ *
+ * Per-run grain: top-5 findings by impact ranking (files > deps >
+ * exports). Backlog drains over multiple weeks. The compact-bot
+ * runs monthly and collapses skip-list patterns into rules.
+ *
+ * Run locally:
+ *   DRY_RUN=1 GITHUB_REPOSITORY=gazetta-studio/gazetta-studio \
+ *     GH_TOKEN=$(gh auth token) npm run dead-code-watcher -w @gazetta/bots
+ * Run in CI:
+ *   .github/workflows/dead-code-watcher.yml (Sat 02:30 UTC)
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { runClaude } from '../_lib/claude.js'
+import { octokitFromEnv, repoFromEnv } from '../_lib/github.js'
+import {
+  type Finding,
+  filterStableFindings,
+  type KnipReport,
+  parseKnipReport,
+  rankFindings,
+} from '../_lib/knip-parse.js'
+import { fingerprintToBranch, pastPROutcome } from '../_lib/past-pr.js'
+import {
+  appendEntry,
+  findSkipMatch,
+  formatFingerprint,
+  readSkipList,
+  type SkipList,
+  SKIP_LIST_PATH,
+  writeSkipList,
+} from '../_lib/skip-list.js'
+import {
+  printBanner,
+  printCandidateHeader,
+  printCandidateList,
+  printNotice,
+  printRunSummary,
+  printTranscriptPath,
+  printWarning,
+} from '../_lib/ui.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const PROMPT_PATH = resolve(HERE, 'prompts/per-finding.md')
+const REPO_ROOT = resolve(HERE, '../..')
+const SKIP_LIST_ABS = resolve(REPO_ROOT, SKIP_LIST_PATH)
+
+const DRY_RUN = process.env.DRY_RUN === '1'
+const TRANSCRIPTS_DIR = resolve(HERE, '../transcripts')
+const RUN_TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')
+
+/** Per-run cap on findings investigated. Backlog drains over weeks. */
+const PER_RUN_FINDING_CAP = Number(process.env.PER_RUN_FINDING_CAP ?? '5')
+
+/** Per-run wall-clock budget. Workflow timeout is 60min; we exit at 55. */
+const PER_RUN_BUDGET_MS = Number(process.env.BUDGET_MS ?? 55 * 60 * 1000)
+
+/** Minimum file-age in days to consider a finding stable (vs mid-flight WIP). */
+const MIN_STABLE_DAYS = Number(process.env.MIN_STABLE_DAYS ?? '30')
+
+async function main(): Promise<void> {
+  printBanner({
+    name: 'dead-code-watcher',
+    tagline: 'producer bot · autonomous fixer',
+    purpose: 'Find dead code via knip; file delete-PRs OR add skip-list entries.',
+    inputs: [
+      'knip JSON output (files, exports, types, deps)',
+      `Findings stable for ≥${MIN_STABLE_DAYS} days (filter out mid-flight WIP)`,
+      'skip-list.json + past-PR history (memory)',
+    ],
+    outputs: [
+      'Delete-PR per safe-to-remove finding (commits + tests pass before push)',
+      'Skip-list-entry PR per "intentional" / "needs-human" / "maintainer-rejected"',
+    ],
+  })
+
+  const repo = repoFromEnv()
+  const octokit = octokitFromEnv()
+
+  // Step 1: run knip, parse output.
+  printNotice('Running knip...')
+  const knipJson = runKnip()
+  const allFindings = parseKnipReport(knipJson, { repoRoot: REPO_ROOT })
+  printNotice(`Knip: ${allFindings.length} total findings (${countByKind(allFindings)})`)
+
+  // Step 2: filter by stability (age >= MIN_STABLE_DAYS).
+  const stable = filterStableFindings(allFindings, MIN_STABLE_DAYS)
+  if (stable.length < allFindings.length) {
+    printNotice(`Filtered ${allFindings.length - stable.length} findings younger than ${MIN_STABLE_DAYS} days`)
+  }
+
+  // Step 3: filter by skip-list (memory).
+  const skipList = readSkipList(SKIP_LIST_ABS)
+  printNotice(`Skip-list: ${skipList.entries.length} entries + ${skipList.rules.length} rules`)
+  const afterSkipList: Finding[] = []
+  let skipMatched = 0
+  for (const finding of stable) {
+    if (findSkipMatch(skipList, finding.fingerprint)) {
+      skipMatched++
+      continue
+    }
+    afterSkipList.push(finding)
+  }
+  if (skipMatched > 0) printNotice(`Skip-list matched ${skipMatched} findings (durable memory)`)
+
+  // Step 4: rank + cap.
+  const ranked = rankFindings(afterSkipList)
+  const candidates = ranked.slice(0, PER_RUN_FINDING_CAP)
+  if (ranked.length === 0) {
+    printNotice('No actionable findings after filters. ✨')
+    return
+  }
+  if (ranked.length > PER_RUN_FINDING_CAP) {
+    printNotice(
+      `Capping to top ${PER_RUN_FINDING_CAP} of ${ranked.length} actionable findings this run; remainder picked up by future cron.`,
+    )
+  }
+
+  printCandidateList({
+    noun: 'finding',
+    candidates: candidates.map(f => ({
+      ref: formatFingerprint(f.fingerprint),
+      label: `${f.lastModifiedDays}d stable`,
+      meta: f.symbol ? `${f.fingerprint.kind} · ${f.file}#${f.symbol}` : `${f.fingerprint.kind} · ${f.file}`,
+    })),
+  })
+
+  if (DRY_RUN) {
+    printNotice(`DRY_RUN=1 — exiting before invoking Claude.`)
+    return
+  }
+
+  // Step 5: per-finding processing.
+  mkdirSync(TRANSCRIPTS_DIR, { recursive: true })
+  const promptTemplate = readFileSync(PROMPT_PATH, 'utf-8')
+
+  const runStart = Date.now()
+  let processed = 0
+  let pastPRMatches = 0
+  for (const finding of candidates) {
+    const elapsed = Date.now() - runStart
+    if (elapsed > PER_RUN_BUDGET_MS) {
+      const remaining = candidates.length - processed
+      printWarning(
+        `Per-run budget exhausted (${Math.round(elapsed / 1000)}s > ${Math.round(PER_RUN_BUDGET_MS / 1000)}s). Stopping with ${remaining} unprocessed; next cron picks them up.`,
+      )
+      break
+    }
+
+    printCandidateHeader({
+      index: processed + 1,
+      total: candidates.length,
+      label: formatFingerprint(finding.fingerprint),
+      meta: [`${finding.lastModifiedDays}d stable`, finding.file],
+      elapsedSec: Math.round(elapsed / 1000),
+    })
+
+    try {
+      const handled = await processFinding(octokit, repo, finding, skipList, promptTemplate)
+      if (handled === 'past-pr-matched') pastPRMatches++
+    } catch (err) {
+      printWarning(`processing ${formatFingerprint(finding.fingerprint)} threw: ${err}; continuing.`)
+    }
+    processed++
+  }
+
+  const totalSec = Math.round((Date.now() - runStart) / 1000)
+  printRunSummary({
+    verb: 'Processed',
+    processed,
+    total: candidates.length,
+    skipped: candidates.length - processed,
+    notes: [
+      `Skip-list matched: ${skipMatched}`,
+      `Past-PR feedback-loop matched: ${pastPRMatches}`,
+      ranked.length > PER_RUN_FINDING_CAP
+        ? `${ranked.length - PER_RUN_FINDING_CAP} more findings queued for next cron`
+        : 'All actionable findings processed',
+    ],
+    elapsedSec: totalSec,
+  })
+}
+
+/**
+ * Per-finding pipeline. Returns 'past-pr-matched' when the feedback
+ * loop short-circuited (skipped due to open PR, merged, or rejected
+ * → skip-list-entry added). Returns 'invoked-claude' when Claude was
+ * called to investigate fresh.
+ */
+async function processFinding(
+  octokit: ReturnType<typeof octokitFromEnv>,
+  repo: ReturnType<typeof repoFromEnv>,
+  finding: Finding,
+  skipList: SkipList,
+  promptTemplate: string,
+): Promise<'past-pr-matched' | 'invoked-claude'> {
+  // Feedback loop: check past PR history first.
+  const past = await pastPROutcome(octokit, repo, finding.fingerprint)
+
+  if (past.state === 'open') {
+    printNotice(`PR #${past.prNumber} is open for this finding — skipping (waiting for review)`)
+    return 'past-pr-matched'
+  }
+
+  if (past.state === 'merged') {
+    // Finding still showing up despite merged delete-PR? Weird — log and skip.
+    // Most likely cause: knip cache stale, or the delete was partial.
+    printWarning(`PR #${past.prNumber} merged but knip still flags this finding — manual investigation needed`)
+    return 'past-pr-matched'
+  }
+
+  if (past.state === 'rejected') {
+    // Mine the rejection reason; persist to skip-list so we don't retry.
+    printNotice(`PR #${past.prNumber} was rejected — adding skip-list entry from rejection reason`)
+    const added = appendEntry(skipList, {
+      fingerprint: finding.fingerprint,
+      reason: 'maintainer-rejected',
+      reasonNote: past.reasonNote,
+      addedAt: new Date().toISOString(),
+      addedBy: 'bot',
+      refPR: past.prNumber,
+    })
+    if (added) {
+      writeSkipList(SKIP_LIST_ABS, skipList)
+      // Open a tiny PR with just the skip-list update.
+      await openSkipListPR(finding, past.prNumber, past.reasonNote)
+    }
+    return 'past-pr-matched'
+  }
+
+  // No past PR — fresh investigation. Hand to Claude.
+  const branchName = fingerprintToBranch(finding.fingerprint)
+  const transcriptPath = resolve(
+    TRANSCRIPTS_DIR,
+    `${RUN_TIMESTAMP}-dead-code-${branchName.replace(/[/-]/g, '_')}.jsonl`,
+  )
+  printTranscriptPath(transcriptPath)
+
+  const prompt = `${promptTemplate}
+
+FINDING_JSON=${JSON.stringify(
+    {
+      fingerprint: finding.fingerprint,
+      fingerprintLabel: formatFingerprint(finding.fingerprint),
+      file: finding.file,
+      symbol: finding.symbol,
+      lastModifiedDays: finding.lastModifiedDays,
+    },
+    null,
+    2,
+  )}
+BRANCH_NAME=${branchName}
+SKIP_LIST_PATH=${SKIP_LIST_PATH}
+RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
+
+  const result = await runClaude({
+    prompt,
+    transcriptPath,
+    allowedTools: ['Bash', 'Read', 'Grep', 'Glob', 'Write', 'Edit'],
+  })
+  if (!result.success) {
+    printWarning(`Claude exited ${result.exitCode} on ${formatFingerprint(finding.fingerprint)}`)
+  }
+  return 'invoked-claude'
+}
+
+/**
+ * Open a tiny PR containing just the skip-list update for a
+ * maintainer-rejected finding. The PR is sent as a draft so the
+ * maintainer doesn't get pinged for re-review; the goal is to commit
+ * the skip-list change so future runs honor it.
+ */
+async function openSkipListPR(finding: Finding, rejectedPR: number, reasonNote: string): Promise<void> {
+  // Branch name: dead-code-skip/<fingerprint-encoding>
+  // Distinct from delete-PR branches so they don't collide.
+  const skipBranch = `dead-code-skip/${fingerprintToBranch(finding.fingerprint).replace('dead-code/', '')}`
+
+  // Use gh to push the skip-list update. Failures here are non-fatal —
+  // the in-memory skip-list is already updated on disk for THIS run;
+  // we just won't have the durable PR-merge artifact. The next run
+  // will retry the PR creation if the entry is still relevant.
+  try {
+    execFileSync('git', ['checkout', '-b', skipBranch], { cwd: REPO_ROOT, stdio: 'inherit' })
+    execFileSync('git', ['add', SKIP_LIST_PATH], { cwd: REPO_ROOT, stdio: 'inherit' })
+    execFileSync(
+      'git',
+      [
+        'commit',
+        '-m',
+        `chore(skip-list): record maintainer rejection of ${formatFingerprint(finding.fingerprint)}\n\nCloses recall via #${rejectedPR}\n\nThe original delete-PR was rejected with: ${reasonNote.slice(0, 200)}`,
+      ],
+      { cwd: REPO_ROOT, stdio: 'inherit' },
+    )
+    execFileSync('git', ['push', '-u', 'origin', skipBranch], { cwd: REPO_ROOT, stdio: 'inherit' })
+    execFileSync(
+      'gh',
+      [
+        'pr',
+        'create',
+        '--draft',
+        '--title',
+        `chore(skip-list): record rejection of ${formatFingerprint(finding.fingerprint)}`,
+        '--body',
+        `Adds a skip-list entry so dead-code-watcher doesn't re-attempt the deletion of \`${formatFingerprint(finding.fingerprint)}\`.\n\n**Source of rejection:** PR #${rejectedPR}\n\n**Reason mined from maintainer comment:**\n\n> ${reasonNote}\n\n<!-- dead-code-watcher: skip-entry source=#${rejectedPR} -->`,
+      ],
+      { cwd: REPO_ROOT, stdio: 'inherit' },
+    )
+  } catch (err) {
+    printWarning(`Couldn't open skip-list PR for ${formatFingerprint(finding.fingerprint)}: ${err}`)
+  } finally {
+    // Return to main so the loop's next iteration starts from a clean state.
+    try {
+      execFileSync('git', ['checkout', 'main'], { cwd: REPO_ROOT, stdio: 'inherit' })
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+/**
+ * Run knip and return its JSON output.
+ *
+ * The npm script uses `--no-exit-code` so knip exits 0 even with
+ * findings (its default behavior is to exit non-zero as a CI gate).
+ * We treat any captured stdout containing valid JSON as success,
+ * regardless of exit code — defense in depth against future knip
+ * versions that change the flag semantics.
+ */
+function runKnip(): KnipReport {
+  let stdout: string
+  try {
+    stdout = execFileSync('npm', ['run', '--silent', 'knip:json'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+      maxBuffer: 64 * 1024 * 1024, // knip JSON can be a few MB
+      stdio: ['ignore', 'pipe', 'inherit'],
+    })
+  } catch (err) {
+    // Non-zero exit. Knip emits JSON on stdout even when exiting
+    // non-zero, so capture that and try to parse it. The exec error
+    // object has the captured streams in `output` / `stdout`.
+    const e = err as { stdout?: string }
+    if (typeof e.stdout !== 'string' || e.stdout.length === 0) {
+      throw new Error('knip exited non-zero with no captured stdout')
+    }
+    stdout = e.stdout
+  }
+  // The actual JSON starts at the first `{` — npm prefixes its own noise
+  // before knip's output.
+  const jsonStart = stdout.indexOf('{')
+  if (jsonStart < 0) throw new Error('knip:json produced no JSON output')
+  return JSON.parse(stdout.slice(jsonStart)) as KnipReport
+}
+
+/** Format a one-line breakdown of findings by kind. */
+function countByKind(findings: Finding[]): string {
+  const counts: Record<string, number> = {}
+  for (const f of findings) {
+    counts[f.fingerprint.kind] = (counts[f.fingerprint.kind] ?? 0) + 1
+  }
+  return Object.entries(counts)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, n]) => `${n} ${k}`)
+    .join(', ')
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err)
+  process.exit(1)
+})

--- a/bots/dead-code-watcher/prompts/compact.md
+++ b/bots/dead-code-watcher/prompts/compact.md
@@ -1,0 +1,216 @@
+# Dead-code-watcher — monthly compaction prompt
+
+You are compacting the bot's skip-list (`bots/dead-code-watcher/skip-list.json`).
+
+**Goal:** identify groups of ≥3 entries that share a generalizable
+pattern, replace them with a single rule. The skip-list ends up
+smaller AND more powerful — fewer concrete entries, more rules that
+catch future findings of the same shape.
+
+## Inputs (appended below)
+
+- `SKIP_LIST_PATH` — relative path to the skip-list file
+- `SKIP_LIST_JSON` — the full current skip-list state
+- `RUN_ID` — this watcher's GH Actions run ID (for outcome tags)
+
+## Decision-log convention
+
+Articulate every proposed compaction with `> Decision: ...`. The
+maintainer needs to see your reasoning — they'll review the PR diff
+plus your commit message.
+
+## What "compaction" actually means
+
+Concretely: replace N skip-list entries (each tied to one specific
+fingerprint) with M rules (each tied to a glob scope + reason).
+
+**Example.** Skip-list before:
+
+```json
+{
+  "entries": [
+    {"fingerprint": {"kind": "export", "path": "packages/gazetta/src/index.ts", "symbol": "X"}, "reason": "public-api"},
+    {"fingerprint": {"kind": "export", "path": "packages/gazetta/src/types.ts", "symbol": "Y"}, "reason": "public-api"},
+    {"fingerprint": {"kind": "type", "path": "packages/gazetta/src/types.ts", "symbol": "Z"}, "reason": "public-api"},
+    {"fingerprint": {"kind": "export", "path": "packages/gazetta/src/schema.ts", "symbol": "W"}, "reason": "public-api"}
+  ]
+}
+```
+
+After:
+
+```json
+{
+  "entries": [],
+  "rules": [
+    {
+      "rule": "gazetta-public-api-entries",
+      "scope": "packages/gazetta/src/{index,types,schema}.ts",
+      "kinds": ["export", "type"],
+      "reason": "public-api",
+      "reasonNote": "These files are public-API entry points per gazetta/package.json exports map. External consumers may use any exported symbol.",
+      "addedAt": "<ISO-8601 now>",
+      "addedBy": "bot",
+      "compactedFrom": 4
+    }
+  ]
+}
+```
+
+4 specific entries → 1 general rule. The rule **also** matches any
+future export added to those files — that's the "more powerful"
+part.
+
+## Process
+
+### 1. Read the current skip-list
+
+Parse `SKIP_LIST_JSON`. Group entries by `reason` + path-prefix.
+
+### 2. Look for compactable groups
+
+A group is compactable when ALL of these hold:
+
+- **3+ entries** share the same `reason` field
+- They share a path-prefix or a glob-collapsible pattern
+- The generalization is sound: the rule, when applied to the
+  shared scope, would correctly capture the original entries AND
+  any future findings of the same shape
+
+**Be conservative.** When you're unsure whether a generalization is
+sound, DON'T compact. False compactions create false skips (real
+dead code that should be removed but the rule blocks the bot from
+filing a PR).
+
+**Examples of safe compactions:**
+
+- 4 entries all under `packages/gazetta/src/*.ts` with reason
+  `public-api` → rule scope `packages/gazetta/src/*.ts`
+- 5 entries all under `examples/starter/templates/*/index.ts` with
+  reason `dynamic-load` → rule scope `examples/starter/templates/*/index.ts`
+- 3 entries all of kind=`devDependency` in same `package.json` with
+  reason `needs-human` → tighten the original entries (don't compact)
+
+**Examples of UNSAFE compactions:**
+
+- 3 entries in `packages/gazetta/src/` but with mixed reasons
+  (`public-api` × 2 + `maintainer-rejected` × 1) → don't compact
+- 3 entries with `reason: maintainer-rejected` but different
+  rejection notes → the maintainer's reasoning differs per entry;
+  don't generalize
+- Anywhere reason is `other` → free-text reason means the entries
+  don't share a structural pattern, just a label
+
+### 3. Compose new rules
+
+For each compactable group, write a rule:
+
+```json
+{
+  "rule": "<descriptive-id>",       // kebab-case, stable
+  "scope": "<glob>",                 // matches all replaced entries
+  "kinds": ["<kind>", ...],          // optional — restrict to specific kinds
+  "reason": "<same as replaced>",
+  "reasonNote": "<one-paragraph why this generalization is sound>",
+  "addedAt": "<ISO-8601 now>",
+  "addedBy": "bot",
+  "compactedFrom": <count>           // how many entries this rule replaced
+}
+```
+
+Pick the `scope` glob carefully:
+
+- `path/to/file.ts` — exact (single entry, no compaction)
+- `path/to/*.ts` — single directory
+- `path/to/**/*.ts` — recursive
+- Brace expansion (`{a,b}.ts`) is NOT supported by the skip-list's
+  glob matcher — use multiple rules if you need it
+
+Use `kinds: [...]` to restrict when the original entries all share
+a kind. Omit when the rule should match any kind under the scope.
+
+### 4. Build the new skip-list
+
+```ts
+const newList = {
+  version: 1,
+  entries: <originalEntries minus compacted ones>,
+  rules: <originalRules + new rules>
+}
+```
+
+### 5. Write to disk + open PR
+
+```bash
+# Write the new skip-list (use Edit/Write tool to format JSON cleanly
+# with 2-space indent + trailing newline; match existing file format)
+
+git checkout -b dead-code-compact/$(date -u +%Y-%m)
+git add $SKIP_LIST_PATH
+
+# Format prevents diff churn
+npm run format
+
+git commit -m "$(cat <<EOF
+chore(skip-list): monthly compaction — $entriesBeforeCount entries → $rulesAfterCount rules
+
+Replaces $compactedCount specific skip-list entries with $rulesAfterCount
+generalized rules. Each rule's reasonNote explains why the
+generalization is sound.
+
+<list of rule names + their compactedFrom counts>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+
+git push -u origin dead-code-compact/$(date -u +%Y-%m)
+
+gh pr create --title "chore(skip-list): monthly compaction" --body "$(cat <<EOF
+## Why
+
+Monthly memory compaction per the dead-code-watcher design.
+
+Before: $entriesBeforeCount entries + $rulesBeforeCount rules
+After:  $entriesAfterCount entries + $rulesAfterCount rules
+
+## Rules proposed
+
+<per-rule section explaining:
+  - what entries it replaces
+  - why the generalization is sound
+  - what future findings it would also catch>
+
+## What if a rule is too broad?
+
+Edit \`$SKIP_LIST_PATH\` in this PR (or a follow-up) to either:
+- Narrow the rule's scope
+- Replace the rule with the original concrete entries
+
+The bot reads the file as-is on next weekly run.
+
+<!-- dead-code-watcher: compact run=$RUN_ID -->
+EOF
+)"
+```
+
+## Rules
+
+- **Conservative beats aggressive.** A skip-list with too many
+  entries is annoying; a skip-list with wrong rules is dangerous
+  (skips real dead code).
+- **Never compact `reason: maintainer-rejected` entries.** Each
+  rejection is a specific maintainer decision; generalizing across
+  them risks creating a rule the maintainer didn't agree to.
+- **Never compact when fewer than 3 entries share the pattern.**
+  Threshold codifies "I've seen this pattern multiple times, not just
+  once."
+- **Always document `reasonNote` on rules.** Future maintainers
+  (and the bot itself) need to understand the generalization.
+- **Don't ask the user questions.** Headless in CI. If you can't
+  find ≥3 compactable entries, exit cleanly with no PR.
+- **One compaction PR per run.** If you find multiple separate
+  compactions, bundle them into ONE PR — the maintainer reviews the
+  full month's compaction in one place.

--- a/bots/dead-code-watcher/prompts/per-finding.md
+++ b/bots/dead-code-watcher/prompts/per-finding.md
@@ -16,6 +16,23 @@ The orchestrator has already filtered out:
 
 So this finding is genuinely fresh — you are the first to investigate it.
 
+## You are Agent A in a generator-critic loop
+
+A separate Claude session (Agent B, the reviewer) will inspect your
+diff after you finish. If they REJECT with a Note, the orchestrator
+discards your branch, hands you the Note, and asks you to retry.
+The maximum is `MAX_ATTEMPTS` retries before the orchestrator gives
+up and adds a `needs-human` skip-list entry.
+
+This changes one thing about your work: **commit locally but DO NOT
+push or open the PR.** The orchestrator pushes + opens the PR after
+the reviewer approves. Stop after committing.
+
+For SKIP decisions: same as before — write a skip-list entry +
+commit it on a `dead-code-skip/...` branch. The orchestrator pushes
+that one without reviewer involvement (skip decisions are safe by
+construction).
+
 ## Inputs (appended below this prompt)
 
 - `FINDING_JSON` — the finding to investigate. Fields:
@@ -29,6 +46,15 @@ So this finding is genuinely fresh — you are the first to investigate it.
   (`dead-code/<encoded-fingerprint>`). Always use this exact name —
   the orchestrator searches for past PRs by this branch ref.
 - `SKIP_LIST_PATH` — relative path to skip-list.json from repo root
+- `ATTEMPT` — 1 for first attempt, 2-5 for retries after a prior
+  reviewer reject. Always provided.
+- `MAX_ATTEMPTS` — the cap. After this attempt, the orchestrator
+  won't retry. If you're on `ATTEMPT == MAX_ATTEMPTS` and uncertain,
+  prefer SKIP `needs-human` over a risky DELETE.
+- `PRIOR_REVIEWER_NOTE` — present only when `ATTEMPT > 1`. The
+  reviewer's specific feedback from your last attempt. Address it
+  in this retry. If you can't address it without changing scope,
+  switch to SKIP `needs-human` and explain.
 - `RUN_ID` — this watcher's GH Actions run ID (for outcome tags)
 
 ## Decision-log convention
@@ -155,7 +181,7 @@ Instead, switch to the SKIP path with reason `needs-human`:
 > failed so a human can investigate.
 ```
 
-### 3c. Push + open PR
+### 3c. Commit (DO NOT push or open PR)
 
 If tests are green:
 
@@ -174,33 +200,16 @@ Stable for $lastModifiedDays days before removal.
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
 )"
-
-git push -u origin $BRANCH_NAME
-
-gh pr create --title "refactor(dead-code): remove unused $fingerprintLabel" --body "$(cat <<EOF
-## Summary
-
-Knip flagged \`$fingerprintLabel\` as unused. After investigation
-(see below), this PR removes it.
-
-## What I checked
-
-<one short paragraph: dynamic-import grep, public-API check, test
-results, anything else relevant>
-
-## Verification
-
-\`npm test\` passes after removal.
-
-## What if this is wrong?
-
-Close the PR. The bot's feedback loop will read the close reason
-from your comment and add a skip-list entry so it doesn't re-attempt.
-
-<!-- dead-code-watcher: kind=$kind path=$path symbol=$symbol run=$RUN_ID -->
-EOF
-)"
 ```
+
+**STOP HERE.** Do NOT `git push`. Do NOT `gh pr create`. The
+reviewer (Agent B) inspects your diff next; the orchestrator pushes
++ opens the PR only after the reviewer approves.
+
+If your last assistant message gives a clear summary (one paragraph:
+what you removed, what you checked, why you're confident), the
+orchestrator includes it in the PR body. So spend your last 5-10
+seconds writing a clear one-paragraph rationale BEFORE you finish.
 
 ### 4. SKIP path — add a skip-list entry
 

--- a/bots/dead-code-watcher/prompts/per-finding.md
+++ b/bots/dead-code-watcher/prompts/per-finding.md
@@ -1,0 +1,263 @@
+# Dead-code-watcher — per-finding investigation prompt
+
+You are investigating ONE knip finding from the codebase and deciding
+whether to:
+
+1. **DELETE** the dead code, file a PR
+2. **SKIP** with reason "intentional" or "needs-human" — add a
+   skip-list entry so future weekly runs don't re-investigate
+
+The orchestrator has already filtered out:
+
+- Findings less than 30 days stable (mid-flight WIP)
+- Findings already covered by a skip-list entry or rule
+- Findings with an open PR (waiting for human review)
+- Findings whose past PR was rejected (auto-added to skip-list)
+
+So this finding is genuinely fresh — you are the first to investigate it.
+
+## Inputs (appended below this prompt)
+
+- `FINDING_JSON` — the finding to investigate. Fields:
+  - `fingerprint.kind`: `file` | `export` | `type` | `dependency` |
+    `devDependency` | `enumMember`
+  - `fingerprint.path`: source file (or `package.json` for deps)
+  - `fingerprint.symbol`: export/type/dep name (absent for `kind=file`)
+  - `fingerprintLabel`: human-readable form (use in commits/PRs)
+  - `lastModifiedDays`: age in days since last modified
+- `BRANCH_NAME` — deterministic branch name for the delete-PR
+  (`dead-code/<encoded-fingerprint>`). Always use this exact name —
+  the orchestrator searches for past PRs by this branch ref.
+- `SKIP_LIST_PATH` — relative path to skip-list.json from repo root
+- `RUN_ID` — this watcher's GH Actions run ID (for outcome tags)
+
+## Decision-log convention
+
+Articulate non-trivial choices inline with `> Decision: ...` text.
+Especially load-bearing here:
+
+- Whether to delete or skip (and why)
+- What reason category to use (`public-api` / `dynamic-load` /
+  `planned-feature` / `needs-human` / `other`)
+- Whether the test suite needs to be run before pushing
+
+Skip the trivial narration (don't say "now running git status").
+
+## Outcome tag convention
+
+Every PR body MUST end with:
+
+```
+<!-- dead-code-watcher: kind=$kind path=$path symbol=$symbol run=$RUN_ID -->
+```
+
+Substitute the actual values. This is how the feedback loop finds
+this PR on future runs.
+
+## Process
+
+### 1. Read the source file and assess "is this really dead?"
+
+Knip's static analysis is good but not omniscient. Before deleting,
+look for:
+
+- **Dynamic consumers**: filename strings, dynamic import expressions,
+  URL-string-loaded code (service workers, web workers, modules
+  loaded by filesystem path). Grep the repo for the file's basename
+  or the symbol's name in non-import contexts.
+- **Public API**: is this file in a package's `exports` map?
+  (`packages/gazetta/package.json`). If yes → reason `public-api`,
+  do NOT delete.
+- **Re-exports**: even when `index.ts` is flagged, downstream code
+  might `import * as X from '../foo'` where `foo` resolves to it.
+- **Test fixtures**: files under `tests/fixtures/` are dynamically
+  loaded by tests via `cp -r` or filesystem path. The orchestrator's
+  knip config should have caught these but be defensive.
+
+Examples of dynamic-load patterns in this repo:
+
+```ts
+// Template loading by filesystem path
+const templatePath = resolve(siteDir, 'templates', name, 'index.ts')
+
+// Service worker registered by URL
+navigator.serviceWorker.register('/sw.js', { type: 'module' })
+
+// Worker thread spawned by filename
+new Worker(resolve(here, './templates-scan-worker.js'))
+```
+
+If you see any of these patterns pointing at the finding's file,
+SKIP with reason `dynamic-load`.
+
+### 2. Decide which path to take
+
+| Signal | Path | Reason category |
+|---|---|---|
+| File is in `package.json` exports map | SKIP | `public-api` |
+| Grep reveals a dynamic-load reference | SKIP | `dynamic-load` |
+| File has a "TODO" or `@deprecated` JSDoc marker pointing at planned work | SKIP | `planned-feature` |
+| You can't tell — the code looks dead but you're not sure | SKIP | `needs-human` |
+| You're confident: nothing references it, tests pass without it | DELETE | (no skip-list entry — PR speaks for itself) |
+
+**Bias toward SKIP when uncertain.** A skip-list entry is reversible
+(maintainer can edit the file). A merged delete-PR is harder to walk
+back — even with git revert, blame and history get noisy.
+
+### 3a. DELETE path
+
+If you're confident the code is dead, proceed:
+
+```bash
+# Always start from a fresh main
+git checkout main && git pull --ff-only
+
+# Create the deterministic branch
+git checkout -b $BRANCH_NAME
+```
+
+Then either:
+
+- **For `kind=file`**: `git rm "$path"` (single file delete)
+- **For `kind=export`/`kind=type`**: open the file, remove the export
+  declaration. Also check if removing the export leaves dead code
+  inside the file — if the symbol was the only export and the rest
+  was helpers feeding it, you may want to delete the file instead.
+- **For `kind=dependency`/`kind=devDependency`**: edit the package.json,
+  remove the entry. Run `npm install` to update the lockfile.
+- **For `kind=enumMember`**: remove the enum member; check that no
+  switch statement was exhaustively casing on it (TypeScript will
+  catch via `--noUnusedLocals` but verify).
+
+### 3b. Verify before push — REQUIRED
+
+```bash
+# Format first (per team-preferences rule 30 — biome auto-rewrites)
+npm run format
+
+# Build (catches type errors from removed exports)
+npm run build -w packages/gazetta || npm run build
+```
+
+Then run the test suite:
+
+```bash
+# All workspace tests
+npm test
+```
+
+If anything red, your removal hypothesis was wrong. **Do NOT push**.
+Instead, switch to the SKIP path with reason `needs-human`:
+
+```
+> Decision: tests failed after removal. Reverting; adding skip-list
+> entry with reason `needs-human` and details about which tests
+> failed so a human can investigate.
+```
+
+### 3c. Push + open PR
+
+If tests are green:
+
+```bash
+git add -A
+git commit -m "$(cat <<EOF
+refactor(dead-code): remove unused $kind $fingerprintLabel
+
+Knip flagged this $kind as unused. Verified manually: <one-paragraph
+explanation of what you checked — dynamic imports, public API, etc.>
+
+Stable for $lastModifiedDays days before removal.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+
+git push -u origin $BRANCH_NAME
+
+gh pr create --title "refactor(dead-code): remove unused $fingerprintLabel" --body "$(cat <<EOF
+## Summary
+
+Knip flagged \`$fingerprintLabel\` as unused. After investigation
+(see below), this PR removes it.
+
+## What I checked
+
+<one short paragraph: dynamic-import grep, public-API check, test
+results, anything else relevant>
+
+## Verification
+
+\`npm test\` passes after removal.
+
+## What if this is wrong?
+
+Close the PR. The bot's feedback loop will read the close reason
+from your comment and add a skip-list entry so it doesn't re-attempt.
+
+<!-- dead-code-watcher: kind=$kind path=$path symbol=$symbol run=$RUN_ID -->
+EOF
+)"
+```
+
+### 4. SKIP path — add a skip-list entry
+
+If you decided to SKIP, edit `$SKIP_LIST_PATH` (it's a JSON file —
+read it first, append to the `entries` array). Entry shape:
+
+```json
+{
+  "fingerprint": {
+    "kind": "$kind",
+    "path": "$path",
+    "symbol": "$symbol or omit if not set"
+  },
+  "reason": "public-api" | "dynamic-load" | "planned-feature" | "needs-human" | "other",
+  "reasonNote": "free-text — required when reason=other or needs-human; helpful otherwise",
+  "addedAt": "<current ISO-8601>",
+  "addedBy": "bot"
+}
+```
+
+Then open a tiny PR with just the skip-list change:
+
+```bash
+git checkout -b dead-code-skip/$BRANCH_NAME-suffix
+git add $SKIP_LIST_PATH
+git commit -m "chore(skip-list): record $reason for $fingerprintLabel
+
+<one-paragraph why>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+
+git push -u origin dead-code-skip/$BRANCH_NAME-suffix
+
+gh pr create --draft --title "chore(skip-list): record $reason for $fingerprintLabel" --body "..."
+```
+
+PR opens as DRAFT — maintainer doesn't need to review urgently;
+the bot just needs the commit to land so future runs honor the decision.
+
+## Rules
+
+- **Test suite MUST pass before pushing a delete-PR.** No exceptions.
+  If tests fail, switch to SKIP with `needs-human`.
+- **Stay narrow.** Don't bundle unrelated cleanups into a delete-PR.
+  If you remove an export and notice adjacent dead code, leave it
+  for the next week's cron — knip will catch it.
+- **Don't refactor.** This bot deletes; it doesn't redesign. If
+  removing the symbol means restructuring the file, SKIP with
+  `needs-human`.
+- **Don't ask the user questions.** You're running headless in CI.
+  When in doubt, choose SKIP with `needs-human` and let a human pick
+  it up.
+- **One PR per finding.** Don't bundle multiple findings into one PR.
+  Each finding has its own deterministic branch name; one finding =
+  one PR.
+- **Don't apply labels.** This bot's PRs go through normal review;
+  no `ready-for-agent` or other bot-pipeline labels. The PR title's
+  `refactor(dead-code):` prefix is enough signal for the maintainer.

--- a/bots/dead-code-watcher/prompts/reviewer.md
+++ b/bots/dead-code-watcher/prompts/reviewer.md
@@ -1,0 +1,176 @@
+# Dead-code-watcher — reviewer (Agent B)
+
+You are reviewing a proposed code deletion from Agent A (a different
+Claude session). Your job is **independent judgment** on whether
+the deletion is safe AND well-executed — beyond the "tests pass"
+signal that already gates Agent A's work.
+
+You do NOT see Agent A's reasoning. You see only:
+
+- The original finding payload (what knip flagged)
+- The unified diff Agent A produced
+- The commit messages Agent A wrote
+- The test-suite result summary
+- The current state of the repo (`Read` tool — but use sparingly)
+
+You issue one of three verdicts at the end of your output:
+
+| Verdict | When |
+|---|---|
+| `APPROVE` | The deletion is safe, the diff is minimal-and-focused, the commit message is accurate |
+| `REJECT` | Something is wrong AND can be fixed by Agent A on retry. Provide actionable feedback in a `Note:` line |
+| `NEEDS_HUMAN` | The deletion is structurally questionable — neither approve nor a retry would resolve it. Maintainer should look |
+
+## Inputs (appended below)
+
+- `FINDING_JSON` — the knip finding Agent A investigated
+- `BRANCH_NAME` — the local branch with Agent A's commits
+- `DIFF` — `git diff main...$BRANCH_NAME`
+- `COMMIT_MESSAGES` — Agent A's commit subjects + bodies
+- `TEST_SUMMARY` — pass/fail counts from Agent A's pre-push test run
+- `ATTEMPT` — 1 for first review, 2+ if Agent A retried after a prior reject
+- `PRIOR_REVIEWER_NOTE` — present only when ATTEMPT > 1; the previous
+  reject reason Agent A was asked to address
+- `RUN_ID` — orchestrator's run ID (for diagnostics)
+
+## Decision-log convention
+
+For each non-trivial part of your review, articulate the reasoning
+inline with `> Decision: ...` text. Examples:
+
+> Decision: checking for dynamic-load patterns referencing the deleted file
+> Decision: the commit message says "remove unused helper" but the diff also
+> modifies the helper's caller — this is a refactor disguised as deletion
+
+Your transcript is the audit trail. Skip the trivial narration.
+
+## What you should specifically check
+
+These are the four failure modes that earn this reviewer step
+(beyond what Agent A's "tests pass" gate already catches):
+
+### 1. Hidden public API
+
+Search the deleted code's call sites for hints it's externally consumed:
+
+- **JSDoc markers**: `@public`, `@api`, `@external`. Knip can't see external consumers; these markers indicate the author knew of them.
+- **Type-only exports re-exported in a workspace's `exports` map** — even if no in-repo code imports them, an external consumer might.
+- **`@deprecated` JSDoc** — deprecated ≠ unused. Removing a deprecated export breaks consumers who hadn't migrated.
+
+**If you find any of these → REJECT with a Note explaining which marker and where.**
+
+### 2. Accidental refactor
+
+The diff should be small and focused. If Agent A "removed an unused
+export" but the diff also:
+
+- Reformats unrelated code
+- Renames variables in remaining code
+- Changes the signature of a still-used function
+- Touches files unrelated to the finding's path
+
+...that's scope creep. **REJECT with a Note asking Agent A to keep the diff narrow.**
+
+### 3. Misleading commit message
+
+The commit subject should accurately describe the change:
+
+- `refactor(dead-code): remove unused function X` → OK if X is removed
+- `refactor(dead-code): remove unused function X` → REJECT if X is renamed-not-removed
+- Subject mentions one file; diff touches three → REJECT
+
+**Don't nitpick wording.** Reject when the message is materially wrong, not when it could be slightly clearer.
+
+### 4. "Feels architecturally wrong"
+
+This is the subjective judgment that's hardest to articulate. Examples:
+
+- The deletion removes a documented "extension point" — a class, base type, or hook designed for downstream extension. Knip says it has no callers because nothing in-repo uses it; that's the *point* of an extension surface.
+- The deletion happens inside a module whose other exports clearly orchestrate a coordinated lifecycle (init/start/stop). Removing one method breaks the contract even if tests pass — the contract is the public API of the orchestration, not the individual methods.
+- The deletion removes the last consumer of a transitive dependency that's still listed in `package.json`. Agent A should have removed the dependency too.
+
+**If something feels wrong but you can't articulate why with confidence → NEEDS_HUMAN** (not REJECT). A retry won't help; a human should look.
+
+## Process
+
+### 1. Read the inputs
+
+Parse `FINDING_JSON`. Look at `DIFF`. Read `COMMIT_MESSAGES`. Check `TEST_SUMMARY`.
+
+If `ATTEMPT > 1`, read `PRIOR_REVIEWER_NOTE` — does Agent A's new
+diff actually address the prior concern? If not, that's grounds to
+escalate to NEEDS_HUMAN (Agent A and reviewer disagreed; retry
+isn't converging).
+
+### 2. Run targeted checks
+
+For findings where dynamic-load is plausible (anything in
+`src/templates*`, `src/admin-api/**/*.ts`, sites, workers), spot-check:
+
+```bash
+# Find dynamic-load patterns referencing the deleted file/symbol
+grep -rn "from.*'\(.*/\)\?$(basename $FILE .ts)'" packages apps sites
+grep -rn "$(basename $FILE)" --include="*.ts" --include="*.tsx" packages apps sites tools | grep -v "$FILE"
+```
+
+Read at most ONE source file per review if you need to verify a specific concern — context budget matters even for reviewers.
+
+### 3. Form your verdict
+
+Output your verdict as the FINAL line(s) of your response. The
+orchestrator parses these via regex; format matters.
+
+**Approve:**
+```
+VERDICT: APPROVE
+Reasoning: <one paragraph why this deletion is sound>
+```
+
+**Reject (Agent A can retry):**
+```
+VERDICT: REJECT
+Note: <specific, actionable feedback Agent A can use to fix this>
+```
+
+The Note MUST be specific and actionable. Bad: "this seems wrong."
+Good: "the function `processItem` on line 42 is called by
+`templates/loader.ts:18` via dynamic import; please verify by
+running `grep -rn processItem packages/gazetta/src/templates`."
+
+**Escalate to human (no retry can fix this):**
+```
+VERDICT: NEEDS_HUMAN
+Note: <why a human needs to look — what's structurally questionable>
+```
+
+### 4. DO NOT
+
+- DO NOT modify the diff. You have `Bash` + `Read`, NOT `Write`/`Edit`.
+- DO NOT push, comment on existing PRs, or open new PRs. Your output is the verdict; the orchestrator acts on it.
+- DO NOT search the bot's PR history. Past PRs aren't relevant to this review.
+- DO NOT speculate about what Agent A "probably meant." Review the diff as-is.
+- DO NOT approve to be "nice" — your job is independent judgment. If you're uncertain, REJECT or NEEDS_HUMAN.
+
+## When to choose REJECT vs NEEDS_HUMAN
+
+The difference matters because REJECT retries and NEEDS_HUMAN stops.
+
+**REJECT when:**
+- The problem has a concrete fix Agent A can apply
+- The fix lies within the same finding's scope (deleting the right thing, narrowing the diff, fixing the commit message)
+- Example: "you also need to remove the now-unused import on line 5"
+
+**NEEDS_HUMAN when:**
+- The problem is structural and the right answer is "don't delete this at all"
+- The problem requires maintainer judgment (which extension points are real, what's "architecturally right")
+- ATTEMPT > 1 and Agent A still hasn't addressed your prior concern
+- Example: "this is a documented extension point; the question of whether to remove unused extension surfaces is policy-level"
+
+## Stay terse
+
+Your output goes to a maintainer reading the PR. Keep it focused:
+
+- 1-3 paragraphs of reasoning at most
+- The verdict line + Note/Reasoning is the only "API" — everything else is just context
+
+You're the second pair of eyes, not a code-review novel.

--- a/bots/dead-code-watcher/skip-list.json
+++ b/bots/dead-code-watcher/skip-list.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "entries": [],
+  "rules": []
+}

--- a/bots/package.json
+++ b/bots/package.json
@@ -11,6 +11,8 @@
     "triage-bot": "tsx triage-bot/index.ts",
     "discovery-prep-bot": "tsx discovery-prep-bot/index.ts",
     "fix-bot": "tsx fix-bot/index.ts",
+    "dead-code-watcher": "tsx dead-code-watcher/index.ts",
+    "dead-code-watcher:compact": "tsx dead-code-watcher/compact.ts",
     "replay": "tsx _lib/replay.ts",
     "test": "vitest run"
   },

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,0 +1,131 @@
+// Knip configuration — https://knip.dev
+//
+// Goal: report should be mostly true positives, so the planned
+// dead-code-watcher bot doesn't flood the issue queue with noise.
+//
+// Knip's static analysis can't see two classes of consumer in this repo:
+//
+//   1. Dynamic file loading. The gazetta runtime loads templates,
+//      site.config.ts, custom editors, asset analyzers etc. at runtime
+//      via filesystem paths — no static `import`. Each dynamic-load
+//      pattern needs an explicit `entry` so knip doesn't flag the
+//      target as unused.
+//
+//   2. External consumers of public package APIs. The gazetta package's
+//      `exports` map lists 12 public entry points consumed by sites
+//      and apps outside this repo. The packages/gazetta/`entry` list
+//      mirrors that exports map.
+//
+// If you add a workspace, a public entry point, or a new dynamic-load
+// pattern, update this file in the same commit.
+{
+  "$schema": "https://unpkg.com/knip@6/schema-jsonc.json",
+
+  "workspaces": {
+    // Core package. The entry list mirrors packages/gazetta/package.json
+    // exports map; each name is a public API consumed by external sites
+    // or apps. Tests + benches are also entry points (they invoke the
+    // package directly, not as a consumer of the exports map).
+    "packages/gazetta": {
+      "entry": [
+        "src/index.ts",
+        "src/types.ts",
+        "src/format.ts",
+        "src/save-etag.ts",
+        "src/editor/mount.ts",
+        "src/admin-api/index.ts",
+        "src/admin-api/schemas/index.ts",
+        "src/schema.ts",
+        "src/testing/index.ts",
+        "src/providers/azure-blob.ts",
+        "src/providers/s3.ts",
+        "src/workers/cloudflare-r2.ts",
+        "src/cli/index.ts",
+        // Worker-thread entry: spawned by templates-scan.ts via `new
+        // Worker(resolve(here, './templates-scan-worker.js'))` rather
+        // than `import`. Without this, knip flags it as unused.
+        "src/templates-scan-worker.ts",
+        "tests/**/*.test.ts",
+        "tests/_helpers/**/*.ts",
+        "tests/**/*.bench.ts"
+      ],
+      "project": ["src/**/*.ts"]
+    },
+
+    // Vue admin SPA. Vite + index.html consume the client entry; the
+    // server entry is invoked by `gazetta dev` / `gazetta serve`. The
+    // service-worker source (sw.ts) is registered via a URL-string,
+    // never imported — listing it as an entry stops the false flag.
+    "apps/admin": {
+      "entry": [
+        "src/server/index.ts",
+        "src/client/main.ts",
+        "src/client/admin-loader.ts",
+        "src/client/sw.ts",
+        "tests/**/*.test.ts"
+      ],
+      "project": ["src/**/*.{ts,tsx,vue}"]
+    },
+
+    // Each bot's index.ts is invoked directly via npm scripts from the
+    // bot's workflow YAML. Replay harness is a separate manual entry.
+    "bots": {
+      "entry": [
+        "flake-watcher/index.ts",
+        "triage-bot/index.ts",
+        "discovery-prep-bot/index.ts",
+        "fix-bot/index.ts",
+        "mutation-watcher/index.ts",
+        "_lib/replay.ts",
+        "_lib/tests/**/*.test.ts",
+        "fix-bot/tests/**/*.test.ts"
+      ],
+      "project": ["**/*.ts"]
+    },
+
+    // MCP dev server — entry is the bin script per package.json.
+    "tools/mcp-dev": {
+      "entry": ["src/index.ts"],
+      "project": ["src/**/*.ts"]
+    },
+
+    // Starter site: every .ts/.tsx file is dynamically loaded by the
+    // gazetta runtime. Templates, custom editors, fields, hooks, and
+    // site.config are all loaded by filesystem path, never imported
+    // statically from in-repo code.
+    "examples/starter": {
+      "entry": [
+        "sites/**/*.config.ts",
+        "templates/**/index.{ts,tsx}",
+        "admin/editors/**/*.{ts,tsx}",
+        "admin/fields/**/*.{ts,tsx}",
+        "admin/hooks/**/*.ts"
+      ],
+      "project": ["**/*.{ts,tsx}"]
+    },
+
+    // Production gazetta.studio site (dogfooded). Same dynamic-loading
+    // pattern as the starter plus a Cloudflare Worker entry.
+    "sites/gazetta.studio": {
+      "entry": ["site.config.ts", "templates/**/index.{ts,tsx}", "worker/src/index.ts"],
+      "project": ["**/*.{ts,tsx}"]
+    },
+
+    // Test fixture site exercised by the target-matrix e2e suite. Every
+    // template + site config is a dynamic entry; the suite loads them
+    // via the gazetta CLI, not via JS imports.
+    "tests/fixtures/sites/target-matrix": {
+      "entry": ["sites/**/site.config.ts", "templates/**/index.{ts,tsx}"],
+      "project": ["**/*.{ts,tsx}"]
+    }
+  },
+
+  // One-off scripts (benchmarks, etc.) live outside any workspace and
+  // aren't worth knip-tracking. Generated dist/ trees are derived state.
+  "ignore": ["scripts/**", "packages/gazetta/dist/**", "apps/admin/dist/**", "**/node_modules/**"],
+
+  // Stryker's typescript-checker is invoked by Stryker config (not via
+  // `import`). TypeScript itself is used by every workspace via `tsc`
+  // — knip can't see that pattern.
+  "ignoreDependencies": ["@stryker-mutator/typescript-checker", "typescript"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@storybook/addon-a11y": "^10.3.6",
         "@storybook/addon-themes": "^10.3.6",
         "@storybook/vue3-vite": "^10.3.6",
+        "knip": "6.13.1",
         "playwright": "^1.59.1",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
@@ -3345,30 +3346,6 @@
         "node": ">=20.19.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -5225,6 +5202,348 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.130.0.tgz",
+      "integrity": "sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.130.0.tgz",
+      "integrity": "sha512-oFWFJrsGv9siFM4HjMqKNB7IuIZD/SMmZdCXl8xyx7lDplGvPKyewpOo272rSWgMXe2Wx7bWI0Yj+gkHv4qbeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.130.0.tgz",
+      "integrity": "sha512-sGUzupdTplK9jQg7eJZ878HfEgQjJNBc6dAYVWJ9W5aU+J8rLfRJhTVsKThiu1pNwm6Y1qKCcbC6WhNWSXR3Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.130.0.tgz",
+      "integrity": "sha512-PsB4cdCISbC00Uy8eiD8bc2AkGWjZqrSrJnkBFuG2ptrrf6mZ2F5gLFSjOAVMMgZPg8B1D7OydJwLWSfyI2Plg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.130.0.tgz",
+      "integrity": "sha512-DgABp3l38hS77JbXCV4qk1+n6DPym5u8zzwuweokezm2tX194nDSJDENbDRECxVsiNbprKATLbk+Z5wlHT0OHw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.130.0.tgz",
+      "integrity": "sha512-4Kn3CTEmwFrzhTSC/JuUW16qovmaMdX7jeSKbL8w0pLtLww7To1a2XJi9Z5uD8QWUkfUHhqfV+VD6dVzBnWzoA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.130.0.tgz",
+      "integrity": "sha512-D35KZM3F4rRu1uAFKyBlg3Gaf/ybCjyaPR1hfgvk5ex8NtcTmRgc0JgSighEyNg96TPrFhemFba68SZuxaha8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.130.0.tgz",
+      "integrity": "sha512-Q9o7oVlo955KHwS8l1u0bCzIx+JsZUA3XToLXC+MsMhye/9LeBQbt84nh120cl2XLy+TEzvugYDiHShg5yaX6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.130.0.tgz",
+      "integrity": "sha512-EiJ/gC0ljbcwVpycC8YWw6ggMbtsPX8XMOt0mPx0aqWeMsNR+L9m05Flbvd5T+GlivG+GkSWQL7tM9SRFpM/dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.130.0.tgz",
+      "integrity": "sha512-b+h/lsLLurp756dMGizNs5uPaJfyEdWrTcV5t8M609jWm1DEHB1StpRXCkyvwtkJx3m+qL5BNQ0dEKan/4yGFA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.130.0.tgz",
+      "integrity": "sha512-O19Cil83XAyjEFfo8WhkMwY58ALqZ7ckjGL+25mjMIuF84urWBeANH0FC8B8BsSSygWU3/1aY3ADdDbp+wlBnw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.130.0.tgz",
+      "integrity": "sha512-BgXRVC0+83n3YzCscLQjj6nbyeBIVeZYPTI4fFMAE4WNm2+4RXhWp03IVizL7esIz36kgmT48aebk1iM+cs8sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.130.0.tgz",
+      "integrity": "sha512-6tJz0xvnGhsokE7N1WlUSBXibpYmT9xSJFS1Ce41Km/+8gQvdlW8MLhRv8PD0L7ix8vRG0FDDepp3jdOFzdVdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.130.0.tgz",
+      "integrity": "sha512-9aCWj83dp3heTQGmGnZGdIWgxjZrr/7VQ0TGFHH5PKByxJKF2Hcr4qvaSUHhhGEa3MSsDjTL1YDP8RAgdL5/Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.130.0.tgz",
+      "integrity": "sha512-afXt87aZBqrUVli8TB/I8H1G50RDWcwirjWtXGXYqJ2ZqWEiErH7V72j3LUSDZaivmtu2OLX0KQ/mbhP81mr7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.130.0.tgz",
+      "integrity": "sha512-I0NCrZV/YZuCGWgqwNN/GO/iXlLF2z+Wgc7u+Aa9N4P51oYeIa0XT+zVBUne4csO9GqxskXgI4g8JzzWGRpfOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.130.0.tgz",
+      "integrity": "sha512-sJgQkGaBX0WJvPUDfwciex6IcTk5O5NLQ1bhEb6f3nBruh1GshKMRSMt2bxZlYrgBzjyBbJzsnO+InPG0bg+fA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.130.0.tgz",
+      "integrity": "sha512-bjcma99sQrNh6RY4mPO9yTkfxql6TDFoN3HWdK31RCKXwNhcDgJXW/l8PUtzKNiQ+9vpKJfJtQq+LklBuxSOBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.130.0.tgz",
+      "integrity": "sha512-hRYbv6HhpSTzT4xTiIkadLI7upLQxuOdLPR/9nL1fTjwhgutBTPXrwaAPb/jTFVx6/8C7Jb5HcUKhmNwloTbFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.130.0.tgz",
+      "integrity": "sha512-RBpA9TsRucJq6HNVNCFF1iKg+QeTkLdZf7hi4xaOGCPvMZWvDHjQgSOEZMUpuW4JNciHbxNhLEYmz5CVygjVGQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.129.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
@@ -5234,6 +5553,289 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.19.1.tgz",
+      "integrity": "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.19.1.tgz",
+      "integrity": "sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.19.1.tgz",
+      "integrity": "sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.19.1.tgz",
+      "integrity": "sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.19.1.tgz",
+      "integrity": "sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.19.1.tgz",
+      "integrity": "sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.19.1.tgz",
+      "integrity": "sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.19.1.tgz",
+      "integrity": "sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.19.1.tgz",
+      "integrity": "sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.19.1.tgz",
+      "integrity": "sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.19.1.tgz",
+      "integrity": "sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.19.1.tgz",
+      "integrity": "sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.19.1.tgz",
+      "integrity": "sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.19.1.tgz",
+      "integrity": "sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.19.1.tgz",
+      "integrity": "sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.19.1.tgz",
+      "integrity": "sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.19.1.tgz",
+      "integrity": "sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.19.1.tgz",
+      "integrity": "sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-ia32-msvc": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-11.19.1.tgz",
+      "integrity": "sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.19.1.tgz",
+      "integrity": "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@playwright/test": {
       "version": "1.60.0",
@@ -11243,6 +11845,16 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fd-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "walk-up-path": "^4.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -11352,6 +11964,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/formatly": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
+      "integrity": "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fd-package-json": "^2.0.0"
+      },
+      "bin": {
+        "formatly": "bin/index.mjs"
+      },
+      "engines": {
+        "node": ">=18.3.0"
       }
     },
     "node_modules/forwarded": {
@@ -12894,6 +13522,46 @@
         "node": ">=6"
       }
     },
+    "node_modules/knip": {
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.13.1.tgz",
+      "integrity": "sha512-hvSnb+YDpDWW1LXub4U0JFfkQhscwgInWuQOv99WTutPZavf1cEP3GwxzEzO2JJpGI9yATk6l0jPLY1V3fp1sQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/webpro"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/knip"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "formatly": "^0.3.0",
+        "get-tsconfig": "4.14.0",
+        "jiti": "^2.7.0",
+        "minimist": "^1.2.8",
+        "oxc-parser": "^0.130.0",
+        "oxc-resolver": "^11.19.1",
+        "picomatch": "^4.0.4",
+        "smol-toml": "^1.6.1",
+        "strip-json-comments": "5.0.3",
+        "tinyglobby": "^0.2.16",
+        "unbash": "^3.0.0",
+        "yaml": "^2.9.0",
+        "zod": "^4.1.11"
+      },
+      "bin": {
+        "knip": "bin/knip.js",
+        "knip-bun": "bin/knip-bun.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/lazystream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
@@ -14117,6 +14785,86 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.130.0.tgz",
+      "integrity": "sha512-X0PJ+NmOok8qP3vK9uaW431ngkdM9UPEK7KG466urtIL2+EYTEgbZK2yqe2MWKJKBjRlFweP/pJPx0x9muMEVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.130.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.130.0",
+        "@oxc-parser/binding-android-arm64": "0.130.0",
+        "@oxc-parser/binding-darwin-arm64": "0.130.0",
+        "@oxc-parser/binding-darwin-x64": "0.130.0",
+        "@oxc-parser/binding-freebsd-x64": "0.130.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.130.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.130.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.130.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.130.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.130.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.130.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.130.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.130.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.130.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.130.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.130.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.130.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.130.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.130.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.130.0"
+      }
+    },
+    "node_modules/oxc-parser/node_modules/@oxc-project/types": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.19.1.tgz",
+      "integrity": "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.19.1",
+        "@oxc-resolver/binding-android-arm64": "11.19.1",
+        "@oxc-resolver/binding-darwin-arm64": "11.19.1",
+        "@oxc-resolver/binding-darwin-x64": "11.19.1",
+        "@oxc-resolver/binding-freebsd-x64": "11.19.1",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.19.1",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-x64-musl": "11.19.1",
+        "@oxc-resolver/binding-openharmony-arm64": "11.19.1",
+        "@oxc-resolver/binding-wasm32-wasi": "11.19.1",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1",
+        "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.19.1"
       }
     },
     "node_modules/parse-ms": {
@@ -15959,6 +16707,19 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -16379,6 +17140,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strnum": {
@@ -17017,6 +17791,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unbash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unbash/-/unbash-3.0.0.tgz",
+      "integrity": "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/unbox-primitive": {
@@ -17894,6 +18678,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/weapon-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,8 +69,6 @@
     },
     "apps/admin/node_modules/typescript": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -97,8 +95,6 @@
     },
     "bots/node_modules/typescript": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -256,20 +252,6 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
@@ -284,20 +266,6 @@
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-crypto/sha256-js": {
@@ -337,24 +305,10 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1045.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1045.0.tgz",
-      "integrity": "sha512-fsuO3Y6t+3Ro9Bsg41DKj4Sfy53CGSrhnMldNplWmG8Tx0UbYk+YDa4RD1hVlJpERw4JBmPkl0+J9qlxMh1pcA==",
+      "version": "3.1046.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1046.0.tgz",
+      "integrity": "sha512-Cwl2SPm0CLczqNLEW2AZR9G/W+Jap85K7uUVOTRHzG3pErVeYRKOnbzsbAqGHnSYBdaxZ9a58YVaWj67P8tF4w==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -362,57 +316,28 @@
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-node": "^3.972.39",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
-        "@aws-sdk/middleware-expect-continue": "^3.972.10",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.16",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/core": "^3.974.9",
+        "@aws-sdk/credential-provider-node": "^3.972.40",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.11",
+        "@aws-sdk/middleware-expect-continue": "^3.972.11",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.17",
+        "@aws-sdk/middleware-host-header": "^3.972.11",
         "@aws-sdk/middleware-location-constraint": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.12",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.38",
         "@aws-sdk/middleware-ssec": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/middleware-user-agent": "^3.972.39",
+        "@aws-sdk/region-config-resolver": "^3.972.14",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.26",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/eventstream-serde-browser": "^4.2.14",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
-        "@smithy/eventstream-serde-node": "^4.2.14",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-blob-browser": "^4.2.15",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/hash-stream-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/md5-js": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@aws-sdk/util-endpoints": "^3.996.9",
+        "@aws-sdk/util-user-agent-browser": "^3.972.11",
+        "@aws-sdk/util-user-agent-node": "^3.973.25",
+        "@smithy/core": "^3.24.1",
+        "@smithy/fetch-http-handler": "^5.4.1",
+        "@smithy/node-http-handler": "^4.7.1",
         "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -420,25 +345,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
-      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+      "version": "3.974.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.9.tgz",
+      "integrity": "sha512-bXxosFunr+v/kqNb99r1NRkrVBha7CG036fRSpWGbC1A/e363XFQN6wcZMx7MYTdRr1tYwNnkrWX2xc1rT3BCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.22",
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@aws-sdk/xml-builder": "^3.972.23",
+        "@smithy/core": "^3.24.1",
+        "@smithy/signature-v4": "^5.4.1",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -446,9 +363,9 @@
       }
     },
     "node_modules/@aws-sdk/crc64-nvme": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.7.tgz",
-      "integrity": "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.8.tgz",
+      "integrity": "sha512-fVfUCL/Xh2zINYMPZvj+iBn6XWouQf0DAnjaWCI9MkmqXzL2Iy5FoQB8O7syFe6gN6AH1ecDDU58T51Ou0kFkA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -460,15 +377,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
-      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.35.tgz",
+      "integrity": "sha512-WkFQ8BedszVomhh/Zzs8WwnE/XBmTqZjoQVB8u/4zH6kZCjouXZpPpb93gD8m0EZmzAl7dxHE/y+yDpuKzNCMw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/core": "^3.974.9",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -477,21 +394,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
-      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.37.tgz",
+      "integrity": "sha512-ylx0ZJTU+2eNcvXQ69VNR3TVSYa/ibpvdK717/NxqR9aXRMn2QRWZaiI8aa5yY/fOWZ5mknSmxGaVxxtdwv3EA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/core": "^3.974.9",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/core": "^3.24.1",
+        "@smithy/fetch-http-handler": "^5.4.1",
+        "@smithy/node-http-handler": "^4.7.1",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -499,24 +413,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
-      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.39.tgz",
+      "integrity": "sha512-QhRSrdkk+Gq0AFIylpiI0N6lcJqFYV9Jtr4Luz5FpYOYbjJSfyTG6iLhnK/UPIgN1Jnon8WAmSC//16XYGvwkA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-env": "^3.972.34",
-        "@aws-sdk/credential-provider-http": "^3.972.36",
-        "@aws-sdk/credential-provider-login": "^3.972.38",
-        "@aws-sdk/credential-provider-process": "^3.972.34",
-        "@aws-sdk/credential-provider-sso": "^3.972.38",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
-        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/core": "^3.974.9",
+        "@aws-sdk/credential-provider-env": "^3.972.35",
+        "@aws-sdk/credential-provider-http": "^3.972.37",
+        "@aws-sdk/credential-provider-login": "^3.972.39",
+        "@aws-sdk/credential-provider-process": "^3.972.35",
+        "@aws-sdk/credential-provider-sso": "^3.972.39",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.39",
+        "@aws-sdk/nested-clients": "^3.997.7",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.1",
+        "@smithy/credential-provider-imds": "^4.3.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -525,18 +438,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
-      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.39.tgz",
+      "integrity": "sha512-1hU0NtC04QbFIuoBuF4aQ2A97GsSE5/A0ZJpDijwexsBREIQ4KPRYl3v/FfKCPBYsaTeGjkOFx5nLhWHY24LOw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/core": "^3.974.9",
+        "@aws-sdk/nested-clients": "^3.997.7",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -545,22 +456,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
-      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.40.tgz",
+      "integrity": "sha512-ZgrQaGkpyTlVSCCsffzijVg+KgftTAWYvI5Otc36J/4jNiHb+7MmBiJIR0a5AHLvifC92PiYHt5pijP0dswd1w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.34",
-        "@aws-sdk/credential-provider-http": "^3.972.36",
-        "@aws-sdk/credential-provider-ini": "^3.972.38",
-        "@aws-sdk/credential-provider-process": "^3.972.34",
-        "@aws-sdk/credential-provider-sso": "^3.972.38",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/credential-provider-env": "^3.972.35",
+        "@aws-sdk/credential-provider-http": "^3.972.37",
+        "@aws-sdk/credential-provider-ini": "^3.972.39",
+        "@aws-sdk/credential-provider-process": "^3.972.35",
+        "@aws-sdk/credential-provider-sso": "^3.972.39",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.39",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.1",
+        "@smithy/credential-provider-imds": "^4.3.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -569,16 +479,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
-      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.35.tgz",
+      "integrity": "sha512-hNj1rAwZWT1vfz54BwH8FUWxZuqStrM25Q5LEIwn2erHPMRVAjLlpZqEbCEEqS99eEEOhdeetnS0WeNa3iYeEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/core": "^3.974.9",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -587,18 +496,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
-      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.39.tgz",
+      "integrity": "sha512-mwIPNPldyCZkvHozb6E0X/vuQLN1UCjcA6MwUf1gaO7EwghCmuNZXatq0L3zptKFvPC4Nds7+WFUkifI1XmbSw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
-        "@aws-sdk/token-providers": "3.1041.0",
+        "@aws-sdk/core": "^3.974.9",
+        "@aws-sdk/nested-clients": "^3.997.7",
+        "@aws-sdk/token-providers": "3.1046.0",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -607,17 +515,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
-      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.39.tgz",
+      "integrity": "sha512-b9HT8CnpyPVn1hU14Q7ihjwSPlRzToYmRYJxRd5jNHEZ43lrIhoLaTT8JmfQQt5j5M8rTX1iN1X8mvu0SM1dXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/core": "^3.974.9",
+        "@aws-sdk/nested-clients": "^3.997.7",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -626,15 +533,13 @@
       }
     },
     "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.1045.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1045.0.tgz",
-      "integrity": "sha512-F7dp2ST/83Iz6JTMMmUYEXxg7R1JDewfvzJeWWiDTwe0vLsg67JTN7OsBe6G8DWYbLQ+EyPWkyc3oFnxOjCVfg==",
+      "version": "3.1046.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1046.0.tgz",
+      "integrity": "sha512-rHMBcqYj0WZZR6wyANGCU60Mh6fEbgOG0iDncCXOmthUO2dNgBffozwRA+G9Jx1VHVWZKlSF4aNXpFV2MyDVsw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
         "buffer": "5.6.0",
         "events": "3.3.0",
@@ -645,22 +550,20 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-s3": "^3.1045.0"
+        "@aws-sdk/client-s3": "^3.1046.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.10.tgz",
-      "integrity": "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.11.tgz",
+      "integrity": "sha512-AhVDn+qObNacklqmBABnFa3YfVk08CzksuuecL/x+lo95dZxXuAkqJZLUsAEKQ3EiDd5E9wTUBjh0cSogmKMYA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/core": "^3.974.9",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -668,14 +571,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.10.tgz",
-      "integrity": "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.11.tgz",
+      "integrity": "sha512-xpobcctR1AHSrvkiArgTyLffn78Lt9unPMpa/yic9RKn+bOf/5M55UIM6RaPL5xKzI06/GSsTDywTWvzEAbyyw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -684,25 +587,20 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.16.tgz",
-      "integrity": "sha512-6ru8doI0/XzszqLIPXf0E/V7HhAw1Pu94010XCKYtBUfD0LxF0BuOzrUf8OQGR6j2o6wgKTHUniOmndQycHwCA==",
+      "version": "3.974.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.17.tgz",
+      "integrity": "sha512-Js24a6sdH9SU5DI5++nlQJayCuOweiiTjnCcAsY75/JtaXF+xysDQ6nRBYx6pUPNY22viRYmdDTFZDaA9AF46g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/crc64-nvme": "^3.972.7",
+        "@aws-sdk/core": "^3.974.9",
+        "@aws-sdk/crc64-nvme": "^3.972.8",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -710,14 +608,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.11.tgz",
+      "integrity": "sha512-CBC6+tVYaOJo7QXgN1zJ4Ba2f3/Cpy4eRViYFimXW/O5Mn8hBmgXXzHu4vy4ubT80YWnp8aCFygr7dTOa14yQg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -756,15 +654,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.12.tgz",
+      "integrity": "sha512-5eltYxKB4MfdQv7/VhWxRbAVQKow5dz9votRFigTYrWJHMQXwLMltlbk7KFWSZh5NDBySfmjT7Jv/DWfYCmDng==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -773,25 +671,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
-      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.38.tgz",
+      "integrity": "sha512-Yuv3urkJtd1/b3kIURzHwihc1SV6n1t+uiXffOD2OpylZ7+4/QnO2W73yhLZzK1Z762BaqwQ3IVRqAHWzNbQ4A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/core": "^3.974.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.26",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/core": "^3.24.1",
+        "@smithy/signature-v4": "^5.4.1",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -814,19 +705,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
-      "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.39.tgz",
+      "integrity": "sha512-MlNSvNsSVlMKKWaCzA0GP1nS4Cuq3WCXUN1vmMvd+Ctztib5kmRcpmTtKx9kikN8szAc+gcdp7uqJJervV2nQg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/core": "^3.974.9",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@smithy/core": "^3.23.17",
-        "@smithy/protocol-http": "^5.3.14",
+        "@aws-sdk/util-endpoints": "^3.996.9",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-retry": "^4.3.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -834,50 +723,29 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
-      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
+      "version": "3.997.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.7.tgz",
+      "integrity": "sha512-jT2AXOODobQfTYGC2SChMSnZ/voIcRV/LHlY1suyhY1bdgP/voKkhEg8Ci1jiGQ4lBiaso5BEAV3ZWWpPTfmYA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/core": "^3.974.9",
+        "@aws-sdk/middleware-host-header": "^3.972.11",
         "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.12",
+        "@aws-sdk/middleware-user-agent": "^3.972.39",
+        "@aws-sdk/region-config-resolver": "^3.972.14",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.26",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@aws-sdk/util-endpoints": "^3.996.9",
+        "@aws-sdk/util-user-agent-browser": "^3.972.11",
+        "@aws-sdk/util-user-agent-node": "^3.973.25",
+        "@smithy/core": "^3.24.1",
+        "@smithy/fetch-http-handler": "^5.4.1",
+        "@smithy/node-http-handler": "^4.7.1",
         "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -885,15 +753,14 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.14.tgz",
+      "integrity": "sha512-VuLXVmm7+lKVxqFcOItPkXhjbJ02iUfxkxheRu41SfWf6/xrZup2A2SwHZos/LeQGu3SBHeqTQht80Uo3ienPA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -902,16 +769,15 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
-      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+      "version": "3.996.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.26.tgz",
+      "integrity": "sha512-2N62veqdMZBCwQUHsbhtnaovOFjOa5Dn3dAD1nRqFTUXR4QmirT3HZnfus/L1DS08Vm5CkoKmL0iMVt6YbqEag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/core": "^3.24.1",
+        "@smithy/signature-v4": "^5.4.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -920,17 +786,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1041.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
-      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+      "version": "3.1046.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1046.0.tgz",
+      "integrity": "sha512-9je8nZt+ntB8IjhpGNayU/AkBgvq/f4aFO2bH1LSNC5JX6K8zY4LUnr/ymqunePrwq+B5OVBpL7ILjYzMFSZAw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/core": "^3.974.9",
+        "@aws-sdk/nested-clients": "^3.997.7",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -952,30 +817,16 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
-      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "version": "3.996.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.9.tgz",
+      "integrity": "sha512-ibx8Vd73rCTHekNGeXX8cpGWoBKbNAlwKHL3yjSxxttu5QnNDaSAM7/0MFYDjU31/F4lyrPoQcGirT0ew61xcg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -996,9 +847,9 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.11.tgz",
+      "integrity": "sha512-kq3RS6XQtHMrLFShbkem6h+8fxazB3jEIsbMC6aaSInOciRGE+eGAqTgJ+obO7Euo/pjM8thVqLiLISEH9X9DA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1009,17 +860,16 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
-      "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
+      "version": "3.973.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.25.tgz",
+      "integrity": "sha512-066hKH/0nvV7x4ofV/iK9kz8r/qNfcR6rzuEOFqI2vQL/fcTTsDAbTw0jmXkyMzANK8ltQdALj19ns3zuOJiUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/middleware-user-agent": "^3.972.39",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/core": "^3.24.1",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1035,9 +885,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
-      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+      "version": "3.972.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.23.tgz",
+      "integrity": "sha512-A0YmgYFv+hTI9c17Ntvd2hSehm9bmJfkb+ggADBwVKA8H/3+Jx94SzR2qOB9bAA9WFeDqnfz9PKKQ+D+YAKomA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1361,6 +1211,7 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -3230,9 +3081,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
-      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
       "funding": [
         {
           "type": "github",
@@ -3253,9 +3104,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
-      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
       "funding": [
         {
           "type": "github",
@@ -3269,7 +3120,7 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.2.0"
+        "@csstools/css-calc": "^3.2.1"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -3303,9 +3154,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
-      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
       "funding": [
         {
           "type": "github",
@@ -3344,6 +3195,30 @@
       "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3996,13 +3871,46 @@
         "hono": "^4"
       }
     },
+    "node_modules/@hono/vite-dev-server/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@hono/vite-dev-server/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@hono/vite-dev-server/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@html-validate/stylish": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@html-validate/stylish/-/stylish-5.2.0.tgz",
-      "integrity": "sha512-7lF57/RTs2tZi0FtgY7Y5CP73Y2GEPPMaJ9PeZKRRUOs7Bt7/Qlqt8kdsAbVMO7GrpuWtUfGvR11riSOryioow==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@html-validate/stylish/-/stylish-6.0.0.tgz",
+      "integrity": "sha512-d1/lI3qIXhGVJF3+MmKEBn1dRX6U4Z+BDaOdDI3E6SXcO+OQ7hC/3mSo6BIjwQlcuV6NdDOKm6QCrzIQL1EezQ==",
       "license": "MIT",
       "engines": {
-        "node": "^20.18 || ^22.16 || >= 24.0"
+        "node": "^22.16.0 || >= 24.0.0"
       }
     },
     "node_modules/@img/colour": {
@@ -4943,6 +4851,23 @@
         "hono": "^4"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mswjs/interceptors": {
       "version": "0.41.9",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
@@ -5545,9 +5470,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
-      "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
       "devOptional": true,
       "license": "MIT",
       "funding": {
@@ -6036,6 +5961,12 @@
         "react": ">=18"
       }
     },
+    "node_modules/@rjsf/utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
     "node_modules/@rjsf/validator-ajv8": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv8/-/validator-ajv8-6.5.2.tgz",
@@ -6054,27 +5985,10 @@
         "@rjsf/utils": "^6.5.x"
       }
     },
-    "node_modules/@rjsf/validator-ajv8/node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
-      "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
       "cpu": [
         "arm64"
       ],
@@ -6089,9 +6003,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
-      "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
       "cpu": [
         "arm64"
       ],
@@ -6106,9 +6020,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
-      "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
       "cpu": [
         "x64"
       ],
@@ -6123,9 +6037,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
-      "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
       "cpu": [
         "x64"
       ],
@@ -6140,9 +6054,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
-      "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
       "cpu": [
         "arm"
       ],
@@ -6157,9 +6071,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
-      "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
       "cpu": [
         "arm64"
       ],
@@ -6174,9 +6088,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
-      "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
       "cpu": [
         "arm64"
       ],
@@ -6191,9 +6105,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
-      "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
       "cpu": [
         "ppc64"
       ],
@@ -6208,9 +6122,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
-      "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
       "cpu": [
         "s390x"
       ],
@@ -6225,9 +6139,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
-      "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
       "cpu": [
         "x64"
       ],
@@ -6242,9 +6156,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
-      "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
       "cpu": [
         "x64"
       ],
@@ -6259,9 +6173,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
-      "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
       "cpu": [
         "arm64"
       ],
@@ -6276,9 +6190,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
-      "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
       "cpu": [
         "wasm32"
       ],
@@ -6295,9 +6209,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
-      "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
       "cpu": [
         "arm64"
       ],
@@ -6312,9 +6226,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
-      "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
       "cpu": [
         "x64"
       ],
@@ -6454,6 +6368,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.3",
@@ -6913,18 +6834,18 @@
       "license": "MIT"
     },
     "node_modules/@sidvind/better-ajv-errors": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-5.0.0.tgz",
-      "integrity": "sha512-FeI/V2KGtOaDX+r0akidCGYy79lVR4YnAqk1GFgZFuHADErCAEmtZL4+IdCAcDXHqfZsII3fs9DrfC1pIR+19w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-6.0.0.tgz",
+      "integrity": "sha512-FwR0Pm0tAZhoy/6HjgwWo1mV8MvGckxUDM7aaOI0/U1Dt4c4ekKRcGudrKJRLDK2Tijg9dqb8U9yZRiIYQ2GvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "kleur": "^4.1.0"
       },
       "engines": {
-        "node": "^20.19 || ^22.12 || >= 24.0"
+        "node": "^22.12 || >= 24.0"
       },
       "peerDependencies": {
-        "ajv": "^7.0.0 || ^8.0.0"
+        "ajv": "^8.0.0"
       }
     },
     "node_modules/@sindresorhus/merge-streams": {
@@ -6940,24 +6861,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@smithy/config-resolver": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.5.1.tgz",
-      "integrity": "sha512-abXk3LhODsvRHsk0ZS9ztrg/fZatTa9Z/z4pgx65YSLR+rY6kvUG/1IgcDKEUciR8MfdnkT5oPeHJTy/HhzDIQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/core": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.1.tgz",
-      "integrity": "sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g==",
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.2.tgz",
+      "integrity": "sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6970,56 +6877,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.1.tgz",
-      "integrity": "sha512-0S/acwHnqX4WrjXzhdiDRxsG2s9SC0cpPIK9nZ1R6UOHd+j7uL28+4bHu22urbLk2TVw3fkp6na/+fkUt/pLNQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.2.tgz",
+      "integrity": "sha512-iYr9ekBjmZ+FwkiHEopqGscBbl78X62cq3p5Dd0eC+gNd7fybNZFQQdDuOQjTVmFymleuA8YRWZnuXWZ8B3kKA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.3.1.tgz",
-      "integrity": "sha512-X7MyI1fu8M84IPKk49kO4kb27Mqp6un9/0o/MsA1ngZ5OxxWKGUxPS3S/AJ9q1cPVTSGmRcbaGNfGUSsflTJkg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.4.1.tgz",
-      "integrity": "sha512-JZGbSXaBk7JY8VPzsh66ksJ0nTWXbApduFDkA/pEl3aTm2EoAiUZE1Iltp6c+X1bB8kxPQW0mHDfVdYCpWTOzg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.3.1.tgz",
-      "integrity": "sha512-6Cn4xTNVxn9PWTHSbvf8zmcDhQW8lrLE1Xq5CJgmX6wEvdjS2S0KuE79Aiznv/jx51jpFJ98OuWyE+Bt+oG1MQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7027,70 +6892,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.1.tgz",
-      "integrity": "sha512-r7bN6spQ+caZC8AnyvSxkRUb57zt2jhhRw3Z+2Ez8hjq6coIikDBFUUI/+CQ1xx9K6eX1Gx6wUKo4ylU66TIqw==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.2.tgz",
+      "integrity": "sha512-3wF40g8OOCA5BnwQUvwtzZqYBbWWftDjpAlWIUo6Yld3ZzJaMAKqg7MWQBPjE8oLaqvZQUE7tVGlZPsae6A4bQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-blob-browser": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.3.1.tgz",
-      "integrity": "sha512-2fbltQVQYmGd0OzPv2oDMRF0pxkzeIx8cbpx2x6W3UJWGaEyUzVPxF4d0sDXZ/r2obg+RbTyhTidXWlPDsKRKw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.3.1.tgz",
-      "integrity": "sha512-u0/zo11mg7yNneoYgTkH4sXwSmcBpbl49o4UNCtQ7hYsXxynsN25KYHmXzqi7TPk5HQL5klGnpU5koOY0O+9hw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-stream-node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.3.1.tgz",
-      "integrity": "sha512-4NOnngIoXngbJw9By3u8KXRgqt4vYATpAobNBnNWxOREP7JY3kB0bUmbBNhZ7dtZV/b4auO1eFMD4cLj9OauVg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/invalid-dependency": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.3.1.tgz",
-      "integrity": "sha512-cLmwtDoulyZvRepAfyV+3rx5oMvuh51dbE+6En3vGC09j3uVSRt1U4oguNu32ub3soGX0oYtBs8E7S2Q4SxTqg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7098,168 +6907,27 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.3.1.tgz",
-      "integrity": "sha512-9aVG6VjOFVFHC6Z4hGAzIIrsVWpp1QOO4ERQ2k1S19VrgCamUGIBE2ilAnMWCfr+mlowHlLRXBStsTk/2c5HfA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/md5-js": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.3.1.tgz",
-      "integrity": "sha512-98NalujRdzv6ggVQNYPWpL2K57UKeUB8roIr61u6+JiHd7KUlMQ+sn/vk6IG4XxEjw2vlC7eu/xjYXshUE4XXg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-content-length": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.3.1.tgz",
-      "integrity": "sha512-l4BUIP+wljW/Ar+0/QcGdmElI9lalrywfzNijXMBG34Z510FRzPyrDLx/blNTZOAm0C4Mvx5t/bf760CZo1ajg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.5.1.tgz",
-      "integrity": "sha512-qtqu5TS+8Y18ZDkJoiXN5AMW1G4JAg1+xytzpsUvIR5a4EUsgd5HQg12lekEHWpm2TDUmOgg+hBaHK7dvyWdkA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.6.1.tgz",
-      "integrity": "sha512-eTaQhxs0rfUuAkL2MSKrH8DTO7YCeAgrdN0B2/RAeuHmXQ+x52dk5qUBsi/jtcqe5LxItgq5AG5tI6Cp8c0sow==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-serde": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.3.1.tgz",
-      "integrity": "sha512-t7YtUe076zWVypVmy1rX91oKi2TFJCkpfFpfMhJFpEIRPP0iL9JxjeSyFQ+1bF45JUfDzOzslUJa150WcSrBug==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-stack": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.3.1.tgz",
-      "integrity": "sha512-1jKwiKZxCMQNqmp4uVPYA6r+MLGjEtH07gnOUdPgbnjuOIrl/0JY/ICdpQtFgeBsQ/Up01gnSv8GYEL0fb8yvg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/node-config-provider": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.4.1.tgz",
-      "integrity": "sha512-q7tDJEJXcaSG/8TVpu2f2l9bzxTzDM9geWmltbzsY6Hfh3yiuXXTpLIO8+zwYASPPVFaTJpdKwjSSjdoDoccgw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.1.tgz",
-      "integrity": "sha512-BdEYko85f/ldp68uH8XEyIvo810xFk6eyPH81SRggTOApYHWA+Xu7B2EzLuHbe37WVLaUA7F1fWR3/zBeme2WA==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.2.tgz",
+      "integrity": "sha512-EdksTZ8UXYxGUgQ4mpIKrHoaj9WVGsp66TpZuixLAz1Jex8YDLnS4RH9ktGED5aOpN0OJlEtrsC9IGt76go1eA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/property-provider": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.3.1.tgz",
-      "integrity": "sha512-3NHoqVBhzpY2b4YBx9AqyKC4C8nnEjl5FyKuxrCjvnjinG0ODj+yg1xX360nNahT6wghYjSw1SooCt3kIdnqIA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/protocol-http": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.4.1.tgz",
-      "integrity": "sha512-8irPNCQgYxcSFp1aGcnDNFkTwSA+xPUaFq9V/v1+JXWu8sKr5b3cFmg2kBTkjkvypDmGeNffuNu0x5iqw1NoAw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.5.1.tgz",
-      "integrity": "sha512-FKoKxVzdFPhyynFI+SPTWrgOP60fZ4l1UwukWYj4eyhpSmEI7MJ6p58hawIIt9bwp+aek9NEm8Zika7E+GEoeg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7267,28 +6935,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.1.tgz",
-      "integrity": "sha512-728lZZEWYWubBESrfntNslZQYDKRlJDY4dcDnYbL50+gu35pGPLblu4S0/RH/RDLF6me1M87ECHsHELGL7dA/Q==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.2.tgz",
+      "integrity": "sha512-1km1OjdLRFuITWpCPofjFqzZ+tbeWuB72ZhcYjbjkCxZ21tTPfIs4GUxRrelMyKMLxLghGD58RENnXorU/O8cw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/smithy-client": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.13.1.tgz",
-      "integrity": "sha512-IcznNM8Qd9u1X3oflp12tkzyOB4HbT+sfYWlWiyEysgNzSHoWcHUUsTT4y1jjDjtVuuVVQbYks+g1kVd7u1eGQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -7309,62 +6962,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/url-parser": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.3.1.tgz",
-      "integrity": "sha512-tuelFlF2PZR/wogFC58NIrPOv+Zna4N1+3kA161/33D1Gbwvl6Nh4WsAsW05ZyPp0O6CMGsdbb0S2b/qVjRMCw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-base64": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.4.1.tgz",
-      "integrity": "sha512-fTHiwW2xbiRiWzfSk4IGAr3gNZCH4fuRYqt8+IuarsP/YON35576iVdePraZ6yJlFxlCL0eMec3/F7xYqoKzlg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.3.1.tgz",
-      "integrity": "sha512-1scg5t4nV3hV7CZs996/XHb80aDZ5YotH4NcvkW/w/rHj+cSz0aCIzwz8aUNKB4nCDPSHRCbrKoj+TvycYefmw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.3.1.tgz",
-      "integrity": "sha512-VRC8MKVPKrgUYThTA7ughcKMfjW6/X92H0wXGJoda0Apw4O5xbXL0GMLz40DTWlsb5hh2iItk6+XL72uJdxYcw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/util-buffer-from": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
@@ -7379,143 +6976,18 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-config-provider": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.3.1.tgz",
-      "integrity": "sha512-lw6L5GF5+W19vO6o3fZwRT2cXEG+8b2LH0b9ppjDT6nIxjUgmljEQGninx5XorylwKZZ4XLVABeroJ8oaF9RmQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.4.1.tgz",
-      "integrity": "sha512-1rA7w+LjK1WJClsffC81Z/ZtjFt22QsKhBjUYEnZsGVS2nOTfOENKBzdg4SxhdwFvBCjcbpjscUfXOPwE3UHWQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.3.1.tgz",
-      "integrity": "sha512-1fk1wfQHBenQD5NitVKOFgW0wsISYAFPIXGyStJWAeCtMyRhgHYvtJxBk2rwGWA0L5QX6oM6yeHSLKPFMk59ww==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-endpoints": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.5.1.tgz",
-      "integrity": "sha512-yORYzJD5zoGbSDkAACr0dIjDiSEA3X8h8lggDENl1dkKpCG0TQIoItPBqtvuJHzFFjRXumcoH+/09xIuixGyCw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-middleware": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.3.1.tgz",
-      "integrity": "sha512-SRRMDcIgVXVhVbxviBaSZbuWuVW3jD08wv4ESV0V2oiw0Mki8TPVQ5IxwD3MvSTPg52QYsRP+JoMw5WdUdeWAg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-retry": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.4.1.tgz",
-      "integrity": "sha512-qkgWgwn1xw0GoY9Ea/B6FrYSPfHA0zyOtJkokwxZuvucRf2+2lfTut6adi4e4Y7LEAaxsFG7r6i05mtDCxbHKA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.6.1.tgz",
-      "integrity": "sha512-GjZfEft0M0V3n2YM/LGkr5LeLd8gxHUIzW0rUz6VtTtlAq245GxHlJghvoPEjJHKTj255iHFAiA4IsIdK40Ueg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-utf8": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.3.1.tgz",
-      "integrity": "sha512-FtRrSnriXtOs4+J8/y9SbQ1xmN71hrOsN/YJr5PQQj5nR1l7YNkGS/TEk4gr0WN7gyrUqw8/RFaYVjI18732ZA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-waiter": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.4.1.tgz",
-      "integrity": "sha512-G/gWDykZNL0NVcd1qXkoKm45jxJECp6q53DSomM5QKMsyAMEsGksVq+HwgonqYxfFJEzzHi6ljtWKXVS1pl0/Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@stablelib/base64": {
@@ -7532,9 +7004,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-a11y": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.3.6.tgz",
-      "integrity": "sha512-cbwXIT5CeHZ9AFbTKQ6YB7Ct6TAl/kKOgALbvzzVtFfRvm51JYygGaiJaB7PbPWn9wgJP2olJcFt+erlEc6cRw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.4.0.tgz",
+      "integrity": "sha512-N1QRmh+PMe5O81KDf8oPDv/csdLAmDCRCYLByukqdUXpTNlcULHDFUJNXl00/rFpbt7PbOZqzRzs72JJt6nWPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7546,13 +7018,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.6"
+        "storybook": "^10.4.0"
       }
     },
     "node_modules/@storybook/addon-themes": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.3.6.tgz",
-      "integrity": "sha512-/6lPU36+nDQzoDJqwy5BrAO0zFHOHDXn6hy/aq2aKF/RTS54+KrA0fdv0sxTssaBo5tjqZ4jKs60hB0iRWKkFA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.4.0.tgz",
+      "integrity": "sha512-ctHlkFBaKOOj4fBkc/cFWLn5CVXDIquAh3qSuebxweQU+wbcTESoZ/jkOEbntSvSHqoCqZDdfTXYOG/EWHQzGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7563,17 +7035,17 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.6"
+        "storybook": "^10.4.0"
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.3.6.tgz",
-      "integrity": "sha512-gpvR/sE4BcrFtmQZ+Ker7zD23oQzoVeqD9nF6cK6yzY+Q0svJXyX2EPmFG4y+EwygD5/vNzDpP84gGMut8VRwg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.4.0.tgz",
+      "integrity": "sha512-RCq8uzvTc0vhK2aN0y2Z48DJ9Q7oKXh8A5pdU3YAmkgMcX/+Vi3Ju1nmueLrGIO+tKwYGpYS/ccUtscNt92rCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "10.3.6",
+        "@storybook/csf-plugin": "10.4.0",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -7581,14 +7053,14 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.6",
+        "storybook": "^10.4.0",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.3.6.tgz",
-      "integrity": "sha512-9kBf7VRdRqTSIYo+rPtVn5yjYYyK8kP2QhEYx3oiXvfwy4RexmbJnhk/tXa/lNiTqukA1TqaWQ2+5MqF4fu6YQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.4.0.tgz",
+      "integrity": "sha512-iSmrhMyEi2ohCWKu49ZUUf8l+k0OIStbWI1BTWt2FvKySlnqY/aHenus7839SgNL3aUNG5P0y9zlyN6/HlwlEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7601,7 +7073,7 @@
       "peerDependencies": {
         "esbuild": "*",
         "rollup": "*",
-        "storybook": "^10.3.6",
+        "storybook": "^10.4.0",
         "vite": "*",
         "webpack": "*"
       },
@@ -7639,9 +7111,9 @@
       }
     },
     "node_modules/@storybook/vue3": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/vue3/-/vue3-10.3.6.tgz",
-      "integrity": "sha512-QXBq+l8h9DkrDxMKLkHp/1rGrFi3jGzng5YOsWmUfiJFNe0Nbj8ezGODr4Lgcc4SK8G3eBk/QRfBflmIcf+2gw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@storybook/vue3/-/vue3-10.4.0.tgz",
+      "integrity": "sha512-o7AYssA/XasjSYQHLF69XN3Z3N8HckbY1ARK8Bg6ANgw1tCdqzm0Sz8WxSje6o8wQVTtWbXdJd38LBv93kuGnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7654,19 +7126,19 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.6",
+        "storybook": "^10.4.0",
         "vue": "^3.0.0"
       }
     },
     "node_modules/@storybook/vue3-vite": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/@storybook/vue3-vite/-/vue3-vite-10.3.6.tgz",
-      "integrity": "sha512-49rwk3jRU3j0rjtuSVIIMUhv+6iPvW8v9LKVI3XVVU4//RkZjGa6FA/hMVTmtMzU1yOtlDGYB6Ku9PvOTG56nA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@storybook/vue3-vite/-/vue3-vite-10.4.0.tgz",
+      "integrity": "sha512-znrWMWIKTXxeqIJb1qBlFDTrRMsro+i+fA50P24/qNgD5OZFRGGZ5up8bvhnuY7OYZeGblwovBjHiUAcRNJ5ZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/builder-vite": "10.3.6",
-        "@storybook/vue3": "10.3.6",
+        "@storybook/builder-vite": "10.4.0",
+        "@storybook/vue3": "10.4.0",
         "magic-string": "^0.30.0",
         "typescript": "^5.9.3",
         "vue-component-meta": "^2.0.0",
@@ -7677,7 +7149,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.6",
+        "storybook": "^10.4.0",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
@@ -7756,43 +7228,14 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@stryker-mutator/core/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+    "node_modules/@stryker-mutator/core/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "dev": true,
-      "license": "MIT",
+      "license": "BSD-3-Clause",
       "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">= 12"
       }
     },
     "node_modules/@stryker-mutator/instrumenter": {
@@ -8058,9 +7501,9 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.23.2.tgz",
-      "integrity": "sha512-yjv2N7gaQMbIVfsSZHBMscLoybgetcTraXsSMrELAerl/jfRipg5S1dBXMFvgRy8Kh48+TGoH+5nqshxdOEGoQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.23.4.tgz",
+      "integrity": "sha512-ni2LWE52bVeSt3L2HVBSmbBw+elc32ATej9C68EyKzN/8vR5ILxFn6RCdDTKm4asmwZyq2jys12dKmBdWMr9QA==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -8068,39 +7511,39 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "3.23.2"
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.23.2.tgz",
-      "integrity": "sha512-BBN22/nUErRzUr1HI/Q4iPFBNavWoNC5Fx0KXp9oDOCCrCvj55rtGwLn2dB3r4vLfhjYvhEZ38wN+r7Y9RhORA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.23.4.tgz",
+      "integrity": "sha512-7YjSibNlPcy9eGK+tHt5G/Njr7nPxl+rZ3rCC6TwtLIRLSHPnoGDsfFOgTPkXxaQcE1a/VQwemnYfWc3kdIjDQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-bold": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.23.2.tgz",
-      "integrity": "sha512-onPFP260enNkjMGhR7sDSqaF80A4sgvMZ/VZLxp7zGa6DAfcuN4PyUQhZN61KmYgbUdr+qrAAMx+tPuid22F4g==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.23.4.tgz",
+      "integrity": "sha512-3L9tnZ12i+98u5df2nV2zGu/sc3rhI87E3ocn1YYAO8PJUAgZnMwdet8JawCrS1uut5sRKlxo3SXEmdNfRVm/w==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.23.2.tgz",
-      "integrity": "sha512-S0LZg6EMdkr5CiYAGmOwzuNPd2T18ZR5pWrgHHHZjt0IFqU01tBJa3zLzC1Vd7noPCec64ygW9S8+p8CHBgOIA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.23.4.tgz",
+      "integrity": "sha512-EPTpL/IFp/aTGZErBq/Mc3dKznj6G/qNEkVYWjueOn1oKApyT0P6WVHGvu/vpMdErhzmoGDuFPPGVS6T8Upx2Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8111,80 +7554,80 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2",
-        "@tiptap/pm": "3.23.2"
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-bullet-list": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.23.2.tgz",
-      "integrity": "sha512-jhvu1qa8F53r//6DrLdA2OkTbRgY73NkQL51Ruozzi+JrfVIo3IfaTNRq01BXO5qcvNH7P/aDBF5cByvuiUMzQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.23.4.tgz",
+      "integrity": "sha512-mXB2KZOz1R+E6VNTZ3vzdAk7ZDGKjPmsJEZIQg1B5qRycTKg49/rCCkLA2QnqAwX6BzS3mLLH1RWE2W0oXD7vg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.23.2"
+        "@tiptap/extension-list": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-code": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.23.2.tgz",
-      "integrity": "sha512-5yHYavvBEkxgWL6DCPYNHujxBXF7c812MFNoU62ljNJjIYDc2Mu8ftOie/ajNJbMLqwSVzCuGfG9swEuEKxY5g==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.23.4.tgz",
+      "integrity": "sha512-C0TeRipMycUEBnV+Mzx6eLp/yZb6Vi/waP3Tkb0lO5/ikg7LWLB7AlmMunjIXEUcR/pJHID/aEh5PfJFpysUDg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-code-block": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.23.2.tgz",
-      "integrity": "sha512-oWwjsLi+m7zHTqM0kYnnogjS3vFENCaLk3ue/1XE9ccpZlmmPzmK70hodB/UPylFJmgr3g726rhxViYv9LRS7A==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.23.4.tgz",
+      "integrity": "sha512-UEU1w/85CSNKktbhESnIRmtjKcH7DeschReZA8err1wAnYLTKzid5ucnJSJ25iRg2V5Fnuws5gnPT5CVgdfXCQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2",
-        "@tiptap/pm": "3.23.2"
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-document": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.23.2.tgz",
-      "integrity": "sha512-Ff/MAaWPzFtb7nhPG6ETdu7/OqkD6cAmJfViBAiRqh9PPULH98fGDaMBm3TGa1s3XB7hGO7c/xVKxEdjYij5rg==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.23.4.tgz",
+      "integrity": "sha512-YC4G6VkxT629rlqUTwD6XvOpxjvghn7fxrK4RbyKVJY2C6E1vgmX0won1Ast6v+qTE6iONOMS6f6VyPxSGjg4w==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-dropcursor": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.23.2.tgz",
-      "integrity": "sha512-T7pVfIF5uDj043CDJlurNoMAmXPy36EjBz/YQVYrVMSSUbvUlOaL3xxoDODRmir29jVrmCROjaKwVExqooQTqQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.23.4.tgz",
+      "integrity": "sha512-ujJQUIENk0RwVFCh5g/TOSEv1a7Pnam/cjHmSUqHWUNZkYS9aOqjm+JfURJPCinRS2oHvo3AARul5mkKgDJYcA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "3.23.2"
+        "@tiptap/extensions": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-floating-menu": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.23.2.tgz",
-      "integrity": "sha512-1rfxx5X52h44jSS9R1fUx8sOaRpNq8CM0IR3EdjpthVvaRZ9XD1tKX4h5EcwGFqNiwtWXxNne2mV7ZJuH2UYsQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.23.4.tgz",
+      "integrity": "sha512-eAc72bKM26yIPx0jsU8qdjE71vFNVu5R9jGbdItBMFc0SPLS4qY8g+8RJ+iWoLwbcSEpgooLS9D9sLfdAU+Tvw==",
       "license": "MIT",
       "optional": true,
       "funding": {
@@ -8193,97 +7636,97 @@
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "3.23.2",
-        "@tiptap/pm": "3.23.2"
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-gapcursor": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.23.2.tgz",
-      "integrity": "sha512-I3LKYVwyxRaiVaJxss98QWOXzZZrHmsJD3RgAZ0Uoguu3pL29Krn2tXfwp4FAd9NG79wdQHj20c+XuqJLNkAbw==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.23.4.tgz",
+      "integrity": "sha512-RuyvOlIGP6UpVOc0Lw0L63jKLtYM49CNhPV2OMSfwwwbBZ3pJGos2/SqpYg71d3sn+qpsAopS4Pfr8iPZog73A==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "3.23.2"
+        "@tiptap/extensions": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-hard-break": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.23.2.tgz",
-      "integrity": "sha512-3p00oC2caRAVtkOweJ9IjTgjhzm34R9tNyMCykzMRygC8CdO08Jv2JKvUaOeMVVmWZI+O9wkGUpaA2Drg6pY4g==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.23.4.tgz",
+      "integrity": "sha512-ODlpZCi7n136BH9luM09EFL8Pg+bbRCd0tzCQM5BKMXRkLitYZA8Gl/f5DLmGJ50wzFsDPXK2Br2g9UvZK7COg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-heading": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.23.2.tgz",
-      "integrity": "sha512-ldQh38ZWTIedSY6XsOkn1ULtk+mD/mezLogrvcVv8neez0qM/S25vyMZKqP7i2/x4i4ds1JYIJLw9y3HX/B69Q==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.23.4.tgz",
+      "integrity": "sha512-8W9Hqi0J69Xbqg08nPf4xRMJXMccaKFAgUE1tvy5PAWJSQxOMwkKQXgZXxwe+80sOMUnV8qveBqUy/ODMPgAxQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-horizontal-rule": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.23.2.tgz",
-      "integrity": "sha512-LbLACqe/OiTdYIq3zbsY7Ue7WOP+mYTGufNDfs8rSGcUbWI2GwUwoGRrTPBbLIesnuCdH6FyMB60Tg/HzjKaYw==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.23.4.tgz",
+      "integrity": "sha512-EA4kK8ywZ4dQNOdxeZbplmDDs5T5LjMgHpqxRwukj9wwKiILOK5E3fcKm1fCKh9Q02w96jax6YVccHwmgJP3sQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2",
-        "@tiptap/pm": "3.23.2"
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-italic": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.23.2.tgz",
-      "integrity": "sha512-pauWOkom8riyZoIGn8I8uFE//uRgE6kL46Pd6PdSd5Wt6w/ao/le9Ju2Ln947NGjz/6whaDiFnBrkSbZEAhpmw==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.23.4.tgz",
+      "integrity": "sha512-jUAHi+HZlg47BzgVIy6y/UH5vev7vPQ95jddhB5K3hC122kvWFMXlken7UOnqzbxNcHs2+4Oi/ZJirYMpT4P5w==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-link": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.23.2.tgz",
-      "integrity": "sha512-h0D3Lwom0hGDsbpZ6tW0+DRKgBP0qSl4rO/iBfGk3Krb2CoyEn1yII3pSTd1PwAld7bHt/buURi6DWudQsIhgg==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.23.4.tgz",
+      "integrity": "sha512-XjxltY7MomwfTs6jmN6Bw5bb/upb34lpyqv2RiXppFTK25Br7ipksRjUpWpB4/csZeg30qwrLGVKxCol38ffrw==",
       "license": "MIT",
       "dependencies": {
-        "linkifyjs": "^4.3.2"
+        "linkifyjs": "^4.3.3"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2",
-        "@tiptap/pm": "3.23.2"
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-list": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.23.2.tgz",
-      "integrity": "sha512-tRbbjpOPrY4ApIHtn3ctnKIhkkioewMsZa5gJzqVB47LJFNyzLXLo/aID4sJRKTIMi1wd1fA9TiBKPe6KqczPA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.23.4.tgz",
+      "integrity": "sha512-yuauDm6qW/7q+ZO0YJBKQEGdnUm6DDTJM8AMp9bMZrT4jRf/zyUtNcZ91QEfFvBcyVuI+10PIOXtNPevhQ741Q==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -8291,118 +7734,118 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2",
-        "@tiptap/pm": "3.23.2"
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-list-item": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.23.2.tgz",
-      "integrity": "sha512-I9Yed0mmBE6AAhc4Cc5UhZLZUMCft9XdPkdBM/wjcjpLwdMhdzelVQXEhNDyPfRkA1TTGs5VHlc6twjCPCTgLg==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.23.4.tgz",
+      "integrity": "sha512-Q/JXosShD5oyDwukE6igdrZD2lb0ZgyoQTHYchk0pzU4frClFbn3RI1wKP+XeqKLhdO6KH2WZ9rERGH7PtDi7Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.23.2"
+        "@tiptap/extension-list": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-list-keymap": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.23.2.tgz",
-      "integrity": "sha512-aE4PzCy+OWXXFc8UsrrYjcfEbyXCh8f7LuGgFPl8jf0JjgIK0FHmzWDg3912zWb5Ww66AF2j0KJzTB9NFOMWlw==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.23.4.tgz",
+      "integrity": "sha512-9FezifCfuoc0o+5K6l4QNOOfelqxnDGg/f9oL1D/LFZPC54bPxpWWft9QCWOqyqZgyLCLjbCjciAlbgkrFUmmw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.23.2"
+        "@tiptap/extension-list": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-ordered-list": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.23.2.tgz",
-      "integrity": "sha512-ZhMejT4jXfOEECqI60AVBzULl8AVN8BXk/9vjVnJHxBtcQxW+tIu5GHVZ4DPaCfTX7mH+hsceFMhQ2BvV7qvbg==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.23.4.tgz",
+      "integrity": "sha512-+3ofyssYnOTa1+nFWEmCAY1ngn8nAV1xo25JnNNC87NMU9WkSgr93jB7/uUJP0uui1C2dBLlaup3XXm108yarw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.23.2"
+        "@tiptap/extension-list": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-paragraph": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.23.2.tgz",
-      "integrity": "sha512-UzHx5zOi9fjhC9TAqHeD7BV5eJIA3t65pa2Mq8b54V9nrIg1yAlgiafU0WDWoom11TF+IWxz5JBsjlW0/P/VeQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.23.4.tgz",
+      "integrity": "sha512-KbhXjCFzWphvFn5VU7E4dtmYDm+bssI1i0+CnXPWCXkjdaaX88ck68Xp1fKz8/bbI/CqlgiNDO/3TvqgtZ6woQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-placeholder": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.23.2.tgz",
-      "integrity": "sha512-HTLOE+xrj9B4wTx1ssMfLiTC8sxy1GdzCK1hqm7EACmnFbY9yH27QzXDfOKbo/J4+Ffg64eSqjs/NRnQwMWAww==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.23.4.tgz",
+      "integrity": "sha512-yHtAZkFR9M2AQmCi555w4ns1BBCqwRyYDYMtd10DBvqPX7T3TmGerPdUfI6sLr74GxnZ5zHOnOYdwAbeG5JzNw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "3.23.2"
+        "@tiptap/extensions": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-strike": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.23.2.tgz",
-      "integrity": "sha512-m1BN3EXwYagzVdReGoI7McvuZFyolFwuXLgzU6c+RN7E+u+K68EY+2U3pJI5ee8UgPYGW4eBs/3BT/5k+0so3Q==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.23.4.tgz",
+      "integrity": "sha512-Vnq5vW801zPbu1LtKeA5k4R241jY+hRjXeijYwIPxy15KzIiipY12518HiCf6/8kkRbMxgOfdYg9X4BRV3HV3g==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-text": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.23.2.tgz",
-      "integrity": "sha512-Ny4FC+BivfwACTuJO3QPe+BXtVFfzWQVBcfhlFlA7xTaeBktFeBavH2cEyXR8Qbez3Wio/Hn+bibT4d44EBLyg==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.23.4.tgz",
+      "integrity": "sha512-q9kxver/MR18p66aWZHSPycnr9hcBFyVGeGj8gf+BQCzn5hpvtSYTfLvk1nq8GFhygdQ9/e3f7B5ovrm/jnpvw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-underline": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.23.2.tgz",
-      "integrity": "sha512-HdPX1nZarOF8UkDccu6gBy6brZd4vDFCa5Mz1liw3B3D6UBiC+8vzE1YGHtggO+KEBBQYf4GgjT3qqIgOcsTEQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.23.4.tgz",
+      "integrity": "sha512-F1ocPT10LV+seky25R1TMCRdc/Iof99jLcDSYDGr6mNEDY4ct2RvOeSM8aDdYq6CkH+vXt3i3JDeRwV23KzswQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extensions": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.23.2.tgz",
-      "integrity": "sha512-kRHQ3nSbAfkFdxj9FtDdr4hpREndGgWFA6ZEAwlLeGUxf8QYTpuF9zb2yxdBPBlTc5+JsbPcskNt+u1PazGKYw==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.23.4.tgz",
+      "integrity": "sha512-SlGPXauW8iKWG7wwuwC/0y/smLImp0h6GBIGgNnTBgIP/ThXQnjLMSZH0mW/REO87dQxkku01V3ARRywi+juhg==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -8410,14 +7853,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2",
-        "@tiptap/pm": "3.23.2"
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.23.2.tgz",
-      "integrity": "sha512-1kvsBqGNu2ZJ0P/lkxN0pAMqSyUcpkMIzE4xwGUIyAiD0pZV6dr+OCMwGWOTLllSyrn91xI5K7OLk3pYeCPKqA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.23.4.tgz",
+      "integrity": "sha512-+C5ngcoza47n3MjtjVBqBEBICPC0McdbwzJ+X6SSCviCLoqnSYanv5mIX9HWG0Q4fJ4BkdNM3VibZUxQaTbKyQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -8440,9 +7883,9 @@
       }
     },
     "node_modules/@tiptap/react": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.23.2.tgz",
-      "integrity": "sha512-qfl70xRDQbwov8y5QvK+EiYk6JyoyzUimNtOmLSfeun2NjQwv67hW1iQ+c3geDbcwfUY5+h3XYMy1Lm+Bt46NQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.23.4.tgz",
+      "integrity": "sha512-mb5aIY9PuLreOVLExqs+8BAI20I/8+jCUBfEIqheuFY2GRRuBiwczejSlYuADfVDBbPVN5uPw4UMADCaH5wueQ==",
       "license": "MIT",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
@@ -8454,12 +7897,12 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "optionalDependencies": {
-        "@tiptap/extension-bubble-menu": "^3.23.2",
-        "@tiptap/extension-floating-menu": "^3.23.2"
+        "@tiptap/extension-bubble-menu": "^3.23.4",
+        "@tiptap/extension-floating-menu": "^3.23.4"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.23.2",
-        "@tiptap/pm": "3.23.2",
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -8476,35 +7919,35 @@
       }
     },
     "node_modules/@tiptap/starter-kit": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.23.2.tgz",
-      "integrity": "sha512-t0o//bLmlUW/3j9ke1wIrrKkvfVYcBiC/cowCUNwN/YQx9Bc3S++yInkR6hat4qI4+O49+NRknVeaF/Sp247QA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.23.4.tgz",
+      "integrity": "sha512-3VhU+NO6/ec9DMj/5Ej0nzARSq42cXnqW+QHCmTL3FNXkXQz+tw1KlfruT5GGJ3M0RssjWjRC0a39N/4S3qxeA==",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^3.23.2",
-        "@tiptap/extension-blockquote": "^3.23.2",
-        "@tiptap/extension-bold": "^3.23.2",
-        "@tiptap/extension-bullet-list": "^3.23.2",
-        "@tiptap/extension-code": "^3.23.2",
-        "@tiptap/extension-code-block": "^3.23.2",
-        "@tiptap/extension-document": "^3.23.2",
-        "@tiptap/extension-dropcursor": "^3.23.2",
-        "@tiptap/extension-gapcursor": "^3.23.2",
-        "@tiptap/extension-hard-break": "^3.23.2",
-        "@tiptap/extension-heading": "^3.23.2",
-        "@tiptap/extension-horizontal-rule": "^3.23.2",
-        "@tiptap/extension-italic": "^3.23.2",
-        "@tiptap/extension-link": "^3.23.2",
-        "@tiptap/extension-list": "^3.23.2",
-        "@tiptap/extension-list-item": "^3.23.2",
-        "@tiptap/extension-list-keymap": "^3.23.2",
-        "@tiptap/extension-ordered-list": "^3.23.2",
-        "@tiptap/extension-paragraph": "^3.23.2",
-        "@tiptap/extension-strike": "^3.23.2",
-        "@tiptap/extension-text": "^3.23.2",
-        "@tiptap/extension-underline": "^3.23.2",
-        "@tiptap/extensions": "^3.23.2",
-        "@tiptap/pm": "^3.23.2"
+        "@tiptap/core": "^3.23.4",
+        "@tiptap/extension-blockquote": "^3.23.4",
+        "@tiptap/extension-bold": "^3.23.4",
+        "@tiptap/extension-bullet-list": "^3.23.4",
+        "@tiptap/extension-code": "^3.23.4",
+        "@tiptap/extension-code-block": "^3.23.4",
+        "@tiptap/extension-document": "^3.23.4",
+        "@tiptap/extension-dropcursor": "^3.23.4",
+        "@tiptap/extension-gapcursor": "^3.23.4",
+        "@tiptap/extension-hard-break": "^3.23.4",
+        "@tiptap/extension-heading": "^3.23.4",
+        "@tiptap/extension-horizontal-rule": "^3.23.4",
+        "@tiptap/extension-italic": "^3.23.4",
+        "@tiptap/extension-link": "^3.23.4",
+        "@tiptap/extension-list": "^3.23.4",
+        "@tiptap/extension-list-item": "^3.23.4",
+        "@tiptap/extension-list-keymap": "^3.23.4",
+        "@tiptap/extension-ordered-list": "^3.23.4",
+        "@tiptap/extension-paragraph": "^3.23.4",
+        "@tiptap/extension-strike": "^3.23.4",
+        "@tiptap/extension-text": "^3.23.4",
+        "@tiptap/extension-underline": "^3.23.4",
+        "@tiptap/extensions": "^3.23.4",
+        "@tiptap/pm": "^3.23.4"
       },
       "funding": {
         "type": "github",
@@ -8637,6 +8080,12 @@
         "parse5": "^8.0.0",
         "undici-types": "^7.21.0"
       }
+    },
+    "node_modules/@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -8885,16 +8334,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/mocker/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/@vitest/pretty-format": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
@@ -9111,6 +8550,24 @@
         "source-map-js": "^1.2.1"
       }
     },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
     "node_modules/@vue/compiler-dom": {
       "version": "3.5.34",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
@@ -9138,6 +8595,12 @@
         "postcss": "^8.5.14",
         "source-map-js": "^1.2.1"
       }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
       "version": "3.5.34",
@@ -9213,6 +8676,39 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/language-core/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@vue/reactivity": {
@@ -9417,9 +8913,9 @@
       }
     },
     "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -9876,16 +9372,19 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -10091,13 +9590,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -10591,12 +10093,17 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cookie-signature": {
@@ -11151,9 +10658,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
+      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -11192,6 +10699,23 @@
         "node": ">=14"
       }
     },
+    "node_modules/editorconfig/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/editorconfig/node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -11200,6 +10724,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ee-first": {
@@ -11225,9 +10765,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.353",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
-      "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
+      "version": "1.5.355",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.355.tgz",
+      "integrity": "sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -11258,12 +10798,12 @@
       }
     },
     "node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -11489,10 +11029,14 @@
       }
     },
     "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "license": "MIT"
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -11619,7 +11163,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -11659,9 +11202,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
-      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.2.0"
@@ -11674,6 +11217,15 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/exsolve": {
@@ -11914,6 +11466,23 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -12220,47 +11789,12 @@
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
         "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -12490,9 +12024,9 @@
       }
     },
     "node_modules/html-validate": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/html-validate/-/html-validate-11.0.0.tgz",
-      "integrity": "sha512-7VYVH0dTv9cbXQdl3XuChkBdRmmuueVPE9kOW2m8QG6ndkLXT5hN6Qcmmng/PsuwcmWVybq7tAp55JlgCYd0Ew==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/html-validate/-/html-validate-11.1.0.tgz",
+      "integrity": "sha512-Crv2oW+xHO7g9b5q+uP9+xJQplOy1IzF+W8rK4tpRNXbfJ3aUt2gp9faFXQpozFFKd4kUqnMNuWxZuUGrUKgZg==",
       "funding": [
         {
           "type": "github",
@@ -12501,12 +12035,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@html-validate/stylish": "^5.2.0",
-        "@sidvind/better-ajv-errors": "5.0.0",
+        "@html-validate/stylish": "^6.0.0",
+        "@sidvind/better-ajv-errors": "6.0.0",
         "ajv": "^8.0.0",
-        "glob": "^13.0.0",
         "kleur": "^4.1.0",
-        "minimist": "^1.2.0",
         "prompts": "^2.0.0",
         "semver": "^7.0.0"
       },
@@ -12514,7 +12046,7 @@
         "html-validate": "bin/html-validate.mjs"
       },
       "engines": {
-        "node": "^22.16.0 || >= 24.0.0"
+        "node": "^22.17.0 || >= 24.0.0"
       },
       "peerDependencies": {
         "@jest/globals": "^29.0.3 || ^30.0.0",
@@ -13034,9 +12566,10 @@
       "license": "MIT"
     },
     "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -13262,12 +12795,12 @@
       "license": "ISC"
     },
     "node_modules/isomorphic-dompurify": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.12.0.tgz",
-      "integrity": "sha512-8n+j+6ypTHvriJwFOQ2qusQ6bzGjZVcR3jbe1pBpLcGI1dn4WIl0ctLBngqE5QttquQBAlKXwJeTMw+X7x7qKw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.13.0.tgz",
+      "integrity": "sha512-QzgzjAGJN0QoOpLWx7mkMhhTQvQXsBpS6oEi2Wy58mEWwrvaRJrx5hrVEdsM70nNKOwHCHj3bwYkwI+HFd3Khg==",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "^3.4.2",
+        "dompurify": "^3.4.3",
         "jsdom": "^29.1.1"
       },
       "engines": {
@@ -13505,13 +13038,6 @@
         "is-promise": "^2.0.0",
         "promise": "^7.0.1"
       }
-    },
-    "node_modules/jstransformer/node_modules/is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -13887,9 +13413,9 @@
       }
     },
     "node_modules/linkifyjs": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
-      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
       "license": "MIT"
     },
     "node_modules/local-pkg": {
@@ -14237,16 +13763,16 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -14256,6 +13782,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -14265,6 +13792,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -14383,20 +13911,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/msw/node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/msw/node_modules/type-fest": {
@@ -14526,9 +14040,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
-      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -14537,10 +14051,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.js"
+        "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
-        "node": "^18 || >=20"
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/negotiator": {
@@ -14825,16 +14339,6 @@
         "@oxc-parser/binding-win32-x64-msvc": "0.130.0"
       }
     },
-    "node_modules/oxc-parser/node_modules/@oxc-project/types": {
-      "version": "0.130.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
     "node_modules/oxc-resolver": {
       "version": "11.19.1",
       "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.19.1.tgz",
@@ -14892,18 +14396,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parse5/node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -14956,6 +14448,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -14972,6 +14465,7 @@
       "version": "11.3.6",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
       "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -15153,24 +14647,6 @@
         "postcss": "^8.0.0"
       }
     },
-    "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/pretty-bytes": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
@@ -15198,13 +14674,6 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
-    },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -15799,9 +15268,10 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -15852,6 +15322,23 @@
         "minimatch": "^5.1.0"
       }
     },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/readdir-glob/node_modules/minimatch": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
@@ -15893,16 +15380,6 @@
       },
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/recast/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/redent": {
@@ -16133,14 +15610,14 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
-      "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.129.0",
-        "@rolldown/pluginutils": "1.0.0"
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -16149,27 +15626,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0",
-        "@rolldown/binding-darwin-arm64": "1.0.0",
-        "@rolldown/binding-darwin-x64": "1.0.0",
-        "@rolldown/binding-freebsd-x64": "1.0.0",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0",
-        "@rolldown/binding-linux-x64-musl": "1.0.0",
-        "@rolldown/binding-openharmony-arm64": "1.0.0",
-        "@rolldown/binding-wasm32-wasi": "1.0.0",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0"
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
-      "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -16247,6 +15724,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/router/node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/router/node_modules/path-to-regexp": {
       "version": "8.4.2",
@@ -16721,13 +16204,13 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">= 12"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -16748,16 +16231,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/space-separated-tokens": {
@@ -16874,15 +16347,15 @@
       }
     },
     "node_modules/storybook": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.3.6.tgz",
-      "integrity": "sha512-vbSz7g/1rGMC1uAULqMZjALkIuLu2QABqfhRYhyr/11kzyesi+vAmwyJLukZP1FfecxGOgMwOh6GS0YsGpHAvQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.0.tgz",
+      "integrity": "sha512-zrtctbVa6xEXCXuE3vsiR0At31zLOtzj8QudN/GaBJLZl0Z2DfF1rDPtTxdAbAp11M2J/7JVHaTIQKXauQPbmg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/icons": "^2.0.1",
+        "@storybook/icons": "^2.0.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/user-event": "^14.6.1",
         "@vitest/expect": "3.2.4",
@@ -16890,6 +16363,8 @@
         "@webcontainer/env": "^1.1.1",
         "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0",
         "open": "^10.2.0",
+        "oxc-parser": "^0.127.0",
+        "oxc-resolver": "^11.19.1",
         "recast": "^0.23.5",
         "semver": "^7.7.3",
         "use-sync-external-store": "^1.5.0",
@@ -16903,16 +16378,433 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "prettier": "^2 || ^3",
         "vite-plus": "^0.1.15"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
         "prettier": {
           "optional": true
         },
         "vite-plus": {
           "optional": true
         }
+      }
+    },
+    "node_modules/storybook/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.127.0.tgz",
+      "integrity": "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.127.0.tgz",
+      "integrity": "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.127.0.tgz",
+      "integrity": "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.127.0.tgz",
+      "integrity": "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.127.0.tgz",
+      "integrity": "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.127.0.tgz",
+      "integrity": "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.127.0.tgz",
+      "integrity": "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.127.0.tgz",
+      "integrity": "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.127.0.tgz",
+      "integrity": "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.127.0.tgz",
+      "integrity": "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.127.0.tgz",
+      "integrity": "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.127.0.tgz",
+      "integrity": "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.127.0.tgz",
+      "integrity": "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.127.0.tgz",
+      "integrity": "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.127.0.tgz",
+      "integrity": "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.127.0.tgz",
+      "integrity": "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.127.0.tgz",
+      "integrity": "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.127.0.tgz",
+      "integrity": "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.127.0.tgz",
+      "integrity": "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.127.0.tgz",
+      "integrity": "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/storybook/node_modules/oxc-parser": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.127.0.tgz",
+      "integrity": "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.127.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.127.0",
+        "@oxc-parser/binding-android-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-x64": "0.127.0",
+        "@oxc-parser/binding-freebsd-x64": "0.127.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.127.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.127.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.127.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.127.0"
       }
     },
     "node_modules/stream-browserify": {
@@ -17577,14 +17469,13 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.1.tgz",
+      "integrity": "sha512-5QE2Q04cN1u0993w0LT5rPw3faZqZU1fFn1mGE0pV53N1Dn7c+QFFxQu1mBeSgeOXwFyTicZw02wVgp3Tb5cAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.27.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -17642,17 +17533,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -18161,9 +18069,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
-      "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
@@ -18171,7 +18079,7 @@
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.14",
-        "rolldown": "1.0.0",
+        "rolldown": "1.0.1",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -18520,9 +18428,9 @@
       "license": "MIT"
     },
     "node_modules/vue-component-type-helpers": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.8.tgz",
-      "integrity": "sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.9.tgz",
+      "integrity": "sha512-S3BiWYaLSzHxTpln665ELSrMR9UYmrIDUmhik7nVZxmJjTKL2/a+ew1hvGxksKelivm0ujjWfG1fYOiU/2e8rA==",
       "dev": true,
       "license": "MIT"
     },
@@ -18571,14 +18479,14 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.6.tgz",
-      "integrity": "sha512-9+kmUTGbKMyW9Asoy98IXXYIzrTMT7JDAdpDDeEkorHvybpUvBI2wsrSM5jFOXrFydpzRFJ9vAh+80DN2PGu9w==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.7.tgz",
+      "integrity": "sha512-dqfk8kvRbCutmCOCj/XLDqDEYxc1wBdAOGLuVy5M93ifYMsBd5fIjfaPN4tQAbxr5IprdBDIox1gr4wYyOx/SA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/generator": "^7.28.6",
+        "@babel/generator": "^8.0.0-rc.4",
         "@vue-macros/common": "^3.1.1",
-        "@vue/devtools-api": "^8.0.6",
+        "@vue/devtools-api": "^8.1.1",
         "ast-walker-scope": "^0.8.3",
         "chokidar": "^5.0.0",
         "json5": "^2.2.3",
@@ -18599,9 +18507,9 @@
       },
       "peerDependencies": {
         "@pinia/colada": ">=0.21.2",
-        "@vue/compiler-sfc": "^3.5.17",
+        "@vue/compiler-sfc": "^3.5.34",
         "pinia": "^3.0.4",
-        "vue": "^3.5.0"
+        "vue": "^3.5.34"
       },
       "peerDependenciesMeta": {
         "@pinia/colada": {
@@ -18613,6 +18521,69 @@
         "pinia": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-router/node_modules/@babel/generator": {
+      "version": "8.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.5.tgz",
+      "integrity": "sha512-nFZPWz3FHIS7y6rMIVoa/WBwjdutfIaRJIBQjzn+t3RnecZoRNlGmGcyR2wb0T/IgSd50Kz/6dG8/LvMCRunjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0-rc.5",
+        "@babel/types": "^8.0.0-rc.5",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/vue-router/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.5.tgz",
+      "integrity": "sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/vue-router/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.5.tgz",
+      "integrity": "sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/vue-router/node_modules/@babel/parser": {
+      "version": "8.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.5.tgz",
+      "integrity": "sha512-/Mfg83rK3+jsRbl4Vbd0jqxc6M1A1/WNFtgrowRM1unEsD3XcNnrBdMM0JWakd0/RN9lseQKwPduW1TiEwKOlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0-rc.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/vue-router/node_modules/@babel/types": {
+      "version": "8.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.5.tgz",
+      "integrity": "sha512-JeSVu/m8x/zpp4CLjYHVNXuhEyOkhPXuxM8YOXjh6L4LlvQNKuUNOTo5KdBuKAcTDHw8DquToTaEkhsBqPXOaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0-rc.5",
+        "@babel/helper-validator-identifier": "^8.0.0-rc.5"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/vue-router/node_modules/@vue/devtools-api": {
@@ -19515,10 +19486,26 @@
         }
       }
     },
+    "packages/gazetta/node_modules/nanoid": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
     "packages/gazetta/node_modules/typescript": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -19569,8 +19556,6 @@
     },
     "tools/mcp-dev/node_modules/typescript": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "smoke": "bash scripts/smoke-publish.sh",
     "format": "biome format --write .",
     "format:check": "biome format .",
+    "knip": "knip --reporter compact",
+    "knip:json": "knip --reporter json",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
@@ -34,6 +36,7 @@
     "@storybook/addon-a11y": "^10.3.6",
     "@storybook/addon-themes": "^10.3.6",
     "@storybook/vue3-vite": "^10.3.6",
+    "knip": "6.13.1",
     "playwright": "^1.59.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "knip": "knip --reporter compact",
-    "knip:json": "knip --reporter json",
+    "knip:json": "knip --reporter json --no-exit-code",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },


### PR DESCRIPTION
## Why

Prerequisite work for the planned dead-code-watcher bot (per [bots/README.md "Architecture: producer vs consumer"](../bots/README.md)). Without a tuned config, knip's raw output has too many false positives for a bot to consume — it would flood the issue queue.

## What

Adds \`knip@6.13.1\` as a root devDependency + \`knip.jsonc\` config so:
- Templates, custom editors, fields, hooks loaded dynamically by the gazetta runtime aren't flagged as unused
- Public package APIs (gazetta's exports map) aren't flagged as unused
- Worker-thread entries (\`templates-scan-worker.ts\`) and URL-string-registered service workers (\`sw.ts\`) aren't flagged

## Validation

- \`npm run knip\` → compact human report
- \`npm run knip:json\` → JSON for programmatic consumption (bot's input)
- 224 raw findings → **67 tuned findings** (~70% noise drop)
- All 5 unused-file findings verified manually as genuine:
  - \`usePreview.ts\` — replaced by \`usePreviewStore\`
  - \`app.ts\` — \`createApp\` not consumed anywhere
  - \`ai/index.ts\`, \`alt/index.ts\`, \`cache/errors.ts\` — re-exports with zero in-repo consumers

## What's NOT in this PR

- The dead-code-watcher bot itself — separate PR after this lands and knip output is proven stable
- 10 "Unlisted dependencies" findings (\`workbox-precaching\`, \`testcontainers\`, etc.) — real \`package.json\` bugs but different shape; separate per-workspace fixes
- Locale-suffixed sidecar gitignore bug surfaced during testing — separate

🤖 Generated with [Claude Code](https://claude.com/claude-code)