### PR TITLE
chore(dead-code-watcher): expose tuning knobs via workflow_dispatch

### DIFF
--- a/.github/workflows/dead-code-watcher.yml
+++ b/.github/workflows/dead-code-watcher.yml
@@ -16,6 +16,19 @@ on:
     - cron: '30 2 * * 6'
   workflow_dispatch:
     # Manual trigger for testing or backfill after prompt iteration.
+    inputs:
+      min_stable_days:
+        description: 'Override MIN_STABLE_DAYS (default 30). Lower values let the bot act on more recent findings.'
+        required: false
+        default: '30'
+      max_attempts:
+        description: 'Override MAX_ATTEMPTS for the reviewer loop (default 5).'
+        required: false
+        default: '5'
+      per_run_finding_cap:
+        description: 'Override PER_RUN_FINDING_CAP (default 5).'
+        required: false
+        default: '5'
 
 jobs:
   watch:
@@ -62,6 +75,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
+          # Optional overrides via workflow_dispatch inputs. Cron runs
+          # use the orchestrator's defaults; manual dispatch can lower
+          # MIN_STABLE_DAYS for testing against younger findings, etc.
+          MIN_STABLE_DAYS: ${{ inputs.min_stable_days || '30' }}
+          MAX_ATTEMPTS: ${{ inputs.max_attempts || '5' }}
+          PER_RUN_FINDING_CAP: ${{ inputs.per_run_finding_cap || '5' }}
         run: npm run dead-code-watcher -w @gazetta/bots
 
       - name: Upload transcripts


### PR DESCRIPTION
Adds three optional workflow_dispatch inputs to dead-code-watcher.yml: \`min_stable_days\`, \`max_attempts\`, \`per_run_finding_cap\`. Defaults preserve current cron behavior; manual dispatch can override.

## Why

The bot's first dispatch (run 25860467829) exited in 43s with "No actionable findings after filters" — correct production behavior (no findings yet ≥30 days stable; max is 27 days for usePreview.ts) but blocks testing the new reviewer-loop architecture end-to-end. Manual dispatch with \`min_stable_days=10\` lets us validate the loop now instead of waiting 3+ days for the natural threshold to cross.

## Test plan

After merge: \`gh workflow run dead-code-watcher.yml -f min_stable_days=10\` exercises Agent A → Agent B → reviewer-verdict → branch+PR or skip-list-entry per the locked v2 architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)