### PR TITLE
chore(skip-list): record planned-feature for DEFAULT_CONCURRENCY

### DIFF
--- a/bots/dead-code-watcher/skip-list.json
+++ b/bots/dead-code-watcher/skip-list.json
@@ -1,5 +1,17 @@
 {
   "version": 1,
-  "entries": [],
+  "entries": [
+    {
+      "fingerprint": {
+        "kind": "export",
+        "path": "packages/gazetta/src/concurrency.ts",
+        "symbol": "DEFAULT_CONCURRENCY"
+      },
+      "reason": "planned-feature",
+      "reasonNote": "Named in design-scale.md and design-scale-implementation.md as part of the in-flight provider-aware-concurrency migration. Cut 2 (pending) adds `recommendedConcurrency: 20` on the filesystem provider that 'matches existing DEFAULT_CONCURRENCY'; Cut 2's risk note shows `mapLimit(items, fn, DEFAULT_CONCURRENCY)` as the explicit-pass shape callers use until Cut 3 migrates them. Removing the export now would force re-adding it when scale Cut 2-3 lands.",
+      "addedAt": "2026-05-14T14:11:53Z",
+      "addedBy": "bot"
+    }
+  ],
   "rules": []
 }


### PR DESCRIPTION
## Why

Recovered skip-list entry from dead-code-watcher run 25864744962 (2026-05-14 14:12 UTC). The bot identified \`export DEFAULT_CONCURRENCY\` as a SKIP-with-\`planned-feature\` decision (referenced by name in scale design docs as part of the in-flight Cut 2-3 migration), but the orchestrator failed to open the PR for the commit it pushed — a bug in the SKIP path that's being fixed in a follow-up PR.

This PR lands the skip-list entry the bot meant to land. Cherry-picked verbatim from the original commit \`e3a3e8b\` on the now-stale orphan branch \`dead-code-skip/export-packages--gazetta--src--concurrency.ts-at-DEFAULT_CONCURRENCY\` (which will be deleted after this PR merges).

## Effect

Future dead-code-watcher runs will skip the \`DEFAULT_CONCURRENCY\` finding via the skip-list match instead of re-investigating it.

<!-- dead-code-watcher: kind=export path=packages/gazetta/src/concurrency.ts symbol=DEFAULT_CONCURRENCY run=manual-recovery -->