### PR TITLE
fix(dead-code-watcher): orchestrator opens skip-list PR (was: Agent A)

### DIFF
--- a/bots/dead-code-watcher/index.ts
+++ b/bots/dead-code-watcher/index.ts
@@ -344,7 +344,13 @@ RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
     if (skipBranchHasCommits) {
       printNotice('Agent A chose SKIP — pushing skip-list-entry PR (no reviewer needed)')
       pushBranch(skipBranch)
-      // The branch is already committed by Agent A; nothing more to do.
+      // Agent A committed the skip-list entry locally on `skipBranch`
+      // and stopped. The orchestrator opens the draft PR — Agent A's
+      // prompt instructs it to STOP after the commit (symmetric with
+      // the DELETE path) so the bot doesn't run terminal `gh pr create`
+      // mid-loop and create surprise output. We open the PR here.
+      const commitMessages = captureCommitMessages(skipBranch, { cwd: REPO_ROOT })
+      openAgentASkipPR(finding, skipBranch, commitMessages)
       return 'invoked-claude'
     }
 
@@ -506,6 +512,79 @@ from your comment and add a skip-list entry so it doesn't re-attempt.
     })
   } catch (err) {
     printWarning(`gh pr create failed for ${label}: ${err}`)
+  }
+}
+
+/**
+ * Open a draft PR for Agent A's SKIP-path branch. Agent A has already
+ * committed the skip-list entry locally; the orchestrator pushes the
+ * branch (above) and opens the PR here.
+ *
+ * Distinct from `openSkipListPR` further down — that one builds an
+ * entry from a maintainer rejection. THIS one wraps Agent A's
+ * already-authored commit, mining the commit message for the SKIP
+ * reason + rationale.
+ *
+ * Sent as draft so the maintainer doesn't get pinged for urgent
+ * review; the goal is just to land the skip-list entry on main so
+ * future runs honor it. Best-effort; failures are non-fatal (the
+ * branch stays around for manual recovery).
+ *
+ * History: shipped 2026-05-14 after observing run 25864744962 push
+ * a `dead-code-skip/...` branch but never open the PR — the prompt
+ * had asked Agent A to do `gh pr create` itself, but the DELETE-path
+ * "STOP HERE" instruction confused Agent A into stopping early.
+ * Moving PR creation to the orchestrator makes the SKIP path
+ * symmetric with the DELETE path.
+ */
+function openAgentASkipPR(finding: Finding, skipBranch: string, agentACommitMessages: string): void {
+  const label = formatFingerprint(finding.fingerprint)
+  // First non-blank line is the conventional-commits header, e.g.
+  // "chore(skip-list): record planned-feature for ...". Mine the
+  // reason category from it for the PR title.
+  const firstLine = agentACommitMessages.split('\n').find(l => l.trim().length > 0) ?? ''
+  const reasonMatch = firstLine.match(/record (\w[\w-]*) for/)
+  const reason = reasonMatch?.[1] ?? 'bot-decided'
+  const body = `## Summary
+
+Knip flagged \`${label}\` as unused. After investigation, Agent A
+decided NOT to delete — it chose the SKIP path with reason
+\`${reason}\` and committed a skip-list entry instead.
+
+## Agent A's rationale
+
+${agentACommitMessages || '(no commit message captured)'}
+
+## What this PR does
+
+Adds an entry to \`bots/dead-code-watcher/skip-list.json\` so future
+bot runs will skip this finding by matching the fingerprint, rather
+than re-investigating it.
+
+## What if this is wrong?
+
+Close the PR + remove the skip-list entry. The next weekly run
+will surface the finding again.
+
+<!-- dead-code-watcher: kind=${finding.fingerprint.kind} path=${finding.fingerprint.path}${finding.fingerprint.symbol ? ` symbol=${finding.fingerprint.symbol}` : ''} reason=${reason} run=${process.env.GITHUB_RUN_ID ?? 'local'} -->`
+  try {
+    execFileSync(
+      'gh',
+      [
+        'pr',
+        'create',
+        '--draft',
+        '--title',
+        `chore(skip-list): record ${reason} for ${label}`,
+        '--body',
+        body,
+        '--head',
+        skipBranch,
+      ],
+      { cwd: REPO_ROOT, stdio: 'inherit' },
+    )
+  } catch (err) {
+    printWarning(`gh pr create failed for skip-list ${label}: ${err}`)
   }
 }
 

--- a/bots/dead-code-watcher/prompts/per-finding.md
+++ b/bots/dead-code-watcher/prompts/per-finding.md
@@ -28,10 +28,12 @@ This changes one thing about your work: **commit locally but DO NOT
 push or open the PR.** The orchestrator pushes + opens the PR after
 the reviewer approves. Stop after committing.
 
-For SKIP decisions: same as before — write a skip-list entry +
-commit it on a `dead-code-skip/...` branch. The orchestrator pushes
-that one without reviewer involvement (skip decisions are safe by
-construction).
+For SKIP decisions: write a skip-list entry + commit it on a
+`dead-code-skip/...` branch and **STOP**. The orchestrator pushes
+the branch + opens the draft PR after you finish (skip decisions
+are safe by construction, so the reviewer is bypassed — but the
+push + PR creation happens orchestrator-side for symmetry with
+the DELETE path).
 
 ## Inputs (appended below this prompt)
 
@@ -233,26 +235,33 @@ read it first, append to the `entries` array). Entry shape:
 }
 ```
 
-Then open a tiny PR with just the skip-list change:
+Then commit it on a `dead-code-skip/...` branch and **STOP** — do
+NOT push, do NOT open a PR. The orchestrator detects the
+skip-branch's commits, pushes the branch, and opens the draft PR
+on your behalf (symmetric with how the DELETE path works after
+reviewer approval).
 
 ```bash
 git checkout -b dead-code-skip/$BRANCH_NAME-suffix
 git add $SKIP_LIST_PATH
 git commit -m "chore(skip-list): record $reason for $fingerprintLabel
 
-<one-paragraph why>
+<one-paragraph why — this commit message becomes the PR body's
+'Agent A's rationale' section, so be specific>
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
-
-git push -u origin dead-code-skip/$BRANCH_NAME-suffix
-
-gh pr create --draft --title "chore(skip-list): record $reason for $fingerprintLabel" --body "..."
 ```
 
-PR opens as DRAFT — maintainer doesn't need to review urgently;
-the bot just needs the commit to land so future runs honor the decision.
+**STOP HERE.** Do NOT `git push`. Do NOT `gh pr create`. The
+orchestrator handles both — it pushes the skip branch and opens a
+draft PR titled `chore(skip-list): record $reason for $fingerprintLabel`,
+mining the reason + rationale from your commit message.
+
+Draft because the maintainer doesn't need to review urgently;
+the bot just needs the entry to land on main so future runs
+honor the decision.
 
 ## Rules
 


### PR DESCRIPTION
## The bug

Run 25864744962 (dead-code-watcher dispatched after merging #375/#376) produced a skip-list-entry commit on `dead-code-skip/export-packages--gazetta--src--concurrency.ts-at-DEFAULT_CONCURRENCY` — but **no PR**. The branch sat orphaned on the remote.

Recovered manually via PR #383.

### Root cause

The SKIP-path prompt asked Agent A to run `git push` + `gh pr create --draft` itself. But the **global "STOP HERE — Do NOT git push. Do NOT gh pr create"** at line 199 of the DELETE-path's bash block confused Agent A into stopping early. The run log shows Agent A reliably did the push (line 14:12:14) but skipped the `gh pr create`.

The prompt had a contradiction:
- Line 27-34 (intro): "the orchestrator pushes that one without reviewer involvement"
- Line 199 (DELETE-path): "Do NOT git push. Do NOT gh pr create."
- Lines 248-251 (SKIP-path): "git push -u origin..." + "gh pr create --draft..."

## The fix

Move PR creation orchestrator-side, symmetric with the DELETE path:

- **New `openAgentASkipPR(finding, skipBranch, commitMessages)` helper** in `bots/dead-code-watcher/index.ts`. Called right after `pushBranch(skipBranch)` in `processFinding`. Mines the SKIP reason from Agent A's commit-message first line for the PR title; uses the full commit message as the rationale section of the PR body.
- **Prompt's SKIP-path bash block** no longer includes `git push` or `gh pr create`. Adds an explicit "STOP HERE" symmetric with the DELETE path so the contradiction is gone.
- **Intro paragraph** clarifies that the orchestrator handles push + PR creation on both paths now.

## Test plan

- [x] `npm test -w @gazetta/bots` — 139/139 pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run format` clean
- [ ] After merge: next dead-code-watcher run that produces a SKIP decision should open a draft PR titled `chore(skip-list): record <reason> for <fingerprint>`

## Notes

No tests added — the new helper is a pure shell-out wrapper around `gh pr create`, exercised only in CI against a live GitHub instance. The existing `branchHasCommits` + `pushBranch` + the SKIP-vs-DELETE path detection is unchanged and already tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)