### PR TITLE
docs(testing-plan): sync mutation scope description to current config

### DIFF
--- a/.claude/rules/testing-plan.md
+++ b/.claude/rules/testing-plan.md
@@ -71,11 +71,16 @@ class of failure that AI-assisted development is structurally prone to.
 | **Mutation testing** (StrykerJS, nightly) | Tests that pass without asserting anything meaningful | [`packages/gazetta/stryker.config.json`](../../packages/gazetta/stryker.config.json) + [`.github/workflows/mutation.yml`](../../.github/workflows/mutation.yml) |
 | **Property-based testing** (fast-check) | Boundary / Unicode / encoding edge cases AI's "safe middle" inputs miss | `packages/gazetta/tests/hash-sidecar-names.test.ts` is the reference example |
 
-**Mutation scope expansion (next):** StrykerJS today only mutates `hash.ts`
-(70% baseline, found one real survived mutant). Expand to AI-heavy modules
-where tautological tests are most likely. **Smallest-first** so the workflow
-calibrates (mutants-per-module, triage time, artifact retention) on a
-focused surface before tackling the largest:
+**Mutation scope expansion (next):** StrykerJS currently mutates the
+admin-API surface (`admin-api/**/*.ts`), `publish.ts`, `publish-rendered.ts`,
+the three history modules (`history-provider.ts`, `history-recorder.ts`,
+`history-restorer.ts`), and `alt/route-handler.ts` — see
+[`packages/gazetta/stryker.config.json`](../../packages/gazetta/stryker.config.json)
+for the current `mutate` glob. Nightly runtime ~1h 45m. Expand to
+AI-heavy modules where tautological tests are most likely.
+**Smallest-first** so the workflow calibrates (mutants-per-module, triage
+time, artifact retention) on a focused surface before tackling the
+largest:
 
 1. `packages/gazetta/src/hooks/registry.ts` — priority dispatch, error taxonomy. Smallest module; pure logic.
 2. `packages/gazetta/src/archive/` — helpers, aliases. Recent feature, all cuts AI-paired; focused surface.


### PR DESCRIPTION
## Summary

`testing-plan.md` claimed "StrykerJS today only mutates `hash.ts`" but the actual `stryker.config.json` mutates ~50 files and does NOT include `hash.ts`. The doc lied in both directions:

- It mutates MORE than `hash.ts` (admin-API + publish + history + alt/route-handler)
- It mutates `hash.ts` LESS than claimed — actually zero

The drift accumulated as scope expanded over time. The admin-API track section (lines 91-104) already acknowledges admin-API + alt/route-handler are in scope; the internal-module preamble (line 74) was never updated to match. Caught while answering "do the mutation tests cover all areas?" — the doc gave the wrong answer.

## What changed

- Replace the stale "only mutates hash.ts" sentence with a one-paragraph summary of current scope
- Point at `stryker.config.json` as the source of truth
- Note measured nightly runtime (~1h 45m, from 5 recent runs averaged)

## Out of scope (deliberate)

Decide whether `hash.ts` should be re-added to the mutate glob. The doc said it was the baseline; the config doesn't include it. Either the config dropped it deliberately or the doc was always aspirational. Resolving that question is separate from the documentation correction in this PR.

## Test plan

- [ ] CI passes (docs-only; no behavioral risk)
- [ ] Future reader of testing-plan.md sees actual current scope, not the stale claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)