### PR TITLE
feat(review-bot): per-type recipes (tdd-first + coverage-shape)

### DIFF
--- a/.claude/rules/design-code-review.md
+++ b/.claude/rules/design-code-review.md
@@ -285,9 +285,13 @@ Phase 2 — Pick top candidate  (TS)
   - Pick top remaining
 
 Phase 3 — Make the change  (Agent A)
-  - Generic agent-a.md prompt + injected candidate + lessons-learned.md
-  - Agent A: TDD-first ordering — failing test first, then implementation
-  - Pushes 2 commits to improve/<candidate-id> branch
+  - Orchestrator composes the shared agent-a.md base + the per-type
+    recipe from prompts/recipes/ (selected by `recipe-select.ts`)
+  - Recipes today: `tdd-first` (correctness/security/architecture/types/
+    comments/style) + `coverage-shape` (tests). New recipes land at
+    prompts/recipes/<shape>.md + one switch arm in `recipe-select.ts`
+  - Agent A follows the recipe's commit shape + anti-tautology
+    discipline; tdd-first emits 2 commits, coverage-shape emits 1
 
 Phase 4 — Review the diff  (Agent B — review-orchestrator skill)
   - Invoke review-orchestrator on git diff main...improve/<candidate-id>

--- a/bots/review-bot/index.ts
+++ b/bots/review-bot/index.ts
@@ -55,6 +55,7 @@ import { type AreaCandidate, scoreAreas } from './area-scorer.js'
 import { type Candidate, extractCandidatesFence, parseCandidatesFence, rankCandidates } from './candidates.js'
 import { collectBotPRsByArea, collectGitTouches, parsePickerOutput } from './phase0-collect.js'
 import { fingerprintToBranch, pastPROutcome } from './past-pr.js'
+import { selectRecipe } from './recipe-select.js'
 import { appendReviewerLog } from './reviewer-log.js'
 import {
   type Fingerprint,
@@ -73,6 +74,7 @@ const LESSONS_PATH = resolve(HERE, 'lessons-learned.md')
 const REVIEWER_LOG_PATH = resolve(HERE, 'reviewer-log.jsonl')
 const PICKER_PROMPT_PATH = resolve(HERE, 'prompts', 'area-picker.md')
 const AGENT_A_PROMPT_PATH = resolve(HERE, 'prompts', 'agent-a.md')
+const RECIPES_DIR = resolve(HERE, 'prompts', 'recipes')
 const TRANSCRIPT_DIR = resolve(HERE, '..', 'transcripts', 'review-bot')
 
 const MAX_ATTEMPTS = Number(process.env.MAX_ATTEMPTS ?? '5')
@@ -157,6 +159,26 @@ async function main(): Promise<void> {
     const agentAResult = await phase3AgentA(candidate, branchName, attempt, priorReviewerNote, lessons, runId)
     if (!agentAResult.pushed) {
       printWarning(`Agent A did not push commits (RESULT: ${agentAResult.kind}). Recording skip + exiting.`)
+
+      // Append to reviewer-log even though Agent B never ran. The
+      // compactor reads this to surface cross-candidate patterns
+      // (e.g. "tests-class candidates with no failing-test driver
+      // route consistently STUCK before fix-bot rewrites the
+      // recipe table"). Without this append, the stuck-path is
+      // invisible to the monthly compactor — patterns can't form.
+      // verdict = 'needs-human' for stuck/crashed/no-commits per
+      // the reviewer-log schema (we have no Agent B verdict yet).
+      appendReviewerLog(REVIEWER_LOG_PATH, {
+        ts: new Date().toISOString(),
+        runId,
+        fingerprint,
+        fingerprintLabel: `${candidate.type}/${candidate.area}`,
+        attempt,
+        verdict: 'needs-human',
+        reasoning: `Agent A ${agentAResult.kind}: ${agentAResult.note}`,
+        agentASummary: `(no commits — ${agentAResult.kind})`,
+      })
+
       const updated = recordSkipListEntry(skipList, fingerprint, {
         reason: agentAResult.kind === 'stuck' ? 'stuck' : 'needs-human',
         reasonNote: agentAResult.note,
@@ -321,9 +343,14 @@ async function phase3AgentA(
   runId: string,
 ): Promise<AgentAResult> {
   const template = readFileSync(AGENT_A_PROMPT_PATH, 'utf-8')
+  const recipeName = selectRecipe(candidate.type)
+  const recipeTemplate = readFileSync(resolve(RECIPES_DIR, `${recipeName}.md`), 'utf-8')
   const candidateBlock = JSON.stringify(candidate, null, 2)
 
-  const prompt = `${template}\n\n# Inputs\n\nCANDIDATE_JSON:\n${candidateBlock}\n\nBRANCH_NAME=${branchName}\nATTEMPT=${attempt}\nMAX_ATTEMPTS=${MAX_ATTEMPTS}\n${priorReviewerNote ? `PRIOR_REVIEWER_NOTE=${priorReviewerNote}\n` : ''}LESSONS_LEARNED=\n${lessons}\n\nRUN_ID=${runId}\n`
+  // Compose: shared base + recipe contract for this candidate's type + injected inputs.
+  // The recipe is the load-bearing per-type discipline; the base is the
+  // shared scaffolding (inputs format, RESULT shape, stop conditions).
+  const prompt = `${template}\n\n## Recipe (composed by orchestrator for type=${candidate.type})\n\n${recipeTemplate}\n\n# Inputs\n\nCANDIDATE_JSON:\n${candidateBlock}\n\nRECIPE=${recipeName}\nBRANCH_NAME=${branchName}\nATTEMPT=${attempt}\nMAX_ATTEMPTS=${MAX_ATTEMPTS}\n${priorReviewerNote ? `PRIOR_REVIEWER_NOTE=${priorReviewerNote}\n` : ''}LESSONS_LEARNED=\n${lessons}\n\nRUN_ID=${runId}\n`
 
   const transcriptPath = resolve(TRANSCRIPT_DIR, `agent-a-${runId}-attempt${attempt}.jsonl`)
   const result = await runClaude({
@@ -357,10 +384,16 @@ async function phase3AgentA(
 }
 
 function extractResultSummary(text: string): string {
+  // RESULT: PUSHED can carry one of two shapes depending on recipe:
+  //   - tdd-first: Branch + Test commit + Fix commit
+  //   - coverage-shape (and other single-commit recipes): Branch + Commit + (optional) Counterfactuals
+  // Extract all known fields; concatenate the ones present.
   const branch = text.match(/^Branch:\s*(.+)$/m)?.[1]
   const test = text.match(/^Test commit:\s*(.+)$/m)?.[1]
   const fix = text.match(/^Fix commit:\s*(.+)$/m)?.[1]
-  return [branch, test, fix].filter(Boolean).join(' | ') || '(no summary)'
+  const single = text.match(/^Commit:\s*(.+)$/m)?.[1]
+  const counterfactuals = text.match(/^Counterfactuals:\s*(.+)$/m)?.[1]
+  return [branch, test, fix, single, counterfactuals].filter(Boolean).join(' | ') || '(no summary)'
 }
 
 // --- Phase 4: Agent B (review-orchestrator) --------------------------

--- a/bots/review-bot/prompts/agent-a.md
+++ b/bots/review-bot/prompts/agent-a.md
@@ -1,8 +1,9 @@
 # review-bot Agent A — improve the codebase
 
 You are improving the gazetta codebase. You've been given ONE candidate
-improvement from an `audit-area` discovery pass. Your job: implement it
-on a fresh branch with TDD-first ordering.
+improvement from an `audit-area` discovery pass. Your job: implement
+it on a fresh branch following the **recipe** the orchestrator has
+included below for this candidate's type.
 
 ## Inputs (orchestrator injects below)
 
@@ -17,127 +18,71 @@ on a fresh branch with TDD-first ordering.
   at run time. Cross-candidate patterns the monthly compactor distilled.
 - `RUN_ID` — diagnostic only.
 
-## TDD-first contract
+## Recipe-driven contract
 
-Per [team-preferences.md rule 31](../../../.claude/rules/team-preferences.md):
+The orchestrator selects a **recipe** based on the candidate's `type`
+field (per `bots/review-bot/recipe-select.ts`). The recipe's contract
+is appended below this prompt — it tells you the commit shape, the
+anti-tautology discipline, and what counts as STUCK for this
+candidate type.
 
-1. **First commit MUST be a failing test.** Subject: `test: ...` or
-   `failing test: ...`. The test must exercise the candidate's specified
-   improvement; running it before the fix MUST fail.
-2. **Second commit IS the implementation.** Subject prefix per the
-   candidate's type (`fix(<area>): ...`, `refactor(<area>): ...`,
-   `feat(<area>): ...`, etc.).
+Recipe contracts available today:
 
-If you cannot capture the candidate as a failing test (the candidate
-is structural — e.g., "split a file into smaller files" — and the
-test would be tautological), post a stuck-comment-style note to the
-issue queue + apply `ready-for-human`. Do NOT push an implementation-
-only commit; the reviewer (Agent B) will REJECT it.
+| Recipe | Used for | Commit shape |
+|---|---|---|
+| `tdd-first` | `correctness`, `security`, `architecture`, `types`, `comments`, `style` | Failing test commit → fix commit |
+| `coverage-shape` | `tests` | Single commit adding tests against working code, with anti-tautology counterfactual |
 
-## Process
+Read the appended recipe carefully — it's the load-bearing contract
+for THIS candidate. Don't apply TDD-first to a coverage-shape
+candidate or vice versa.
 
-### 1. Read CANDIDATE_JSON; read the cited design doc
+## Stop conditions (every recipe)
 
-The candidate's `rule` field cites a design doc (or `file:line`). Read
-that doc; it's the contract you're improving against. Don't re-litigate
-the candidate — the audit-area skill already ranked it as worth doing.
+- **Stuck on the candidate**: the recipe's specific stuck conditions
+  don't apply (it's not a fit for your tier; the candidate's premise
+  is wrong; the cited rule has been superseded). Post `RESULT: STUCK`
+  with a constructive maintainer-action recommendation.
+- **Out-of-scope encounter**: implementing the candidate requires
+  modifications outside the named area (a foundational refactor; a
+  cross-cutting concern that's bigger than a single PR). `RESULT:
+  STUCK`; recommend the area for a separate design pass.
+- **Premise failure**: investigating the candidate reveals the
+  underlying assumption is wrong (the "bug" doesn't exist; the area
+  is already correct). `RESULT: STUCK` with the evidence.
 
-### 2. Read LESSONS_LEARNED
+## RESULT format (parsed by orchestrator)
 
-Cross-candidate patterns from prior review-bot runs. Examples to expect
-once data accumulates:
-- Common candidate-types that maintainers reject (skip those).
-- Areas where prior Agent A produced stuck-comments (scope your change
-  tighter to avoid the same trap).
-- Hints from prior runs (e.g., "always add the validator at the
-  background phase if save-delta would be too eager").
-
-### 3. Write the failing test
-
-The test must:
-- Live in the right tier per [`testing-plan.md`](../../../.claude/rules/testing-plan.md)
-  (pyramid for core; honeycomb for providers; trophy for admin SPA; crab
-  for CLI).
-- Exercise the SPECIFIC improvement the candidate names. Don't write a
-  generic "this area should work" test; assert the behavior the
-  candidate would unlock.
-- Have a clear failure message that aligns with the candidate's
-  `summary`.
-
-Commit: `git add <test-files>; git commit -m "test: <what the test asserts>"`.
-
-### 4. Verify the test FAILS before the fix
-
-Run the test (most-specific invocation; per `team-preferences.md#32`):
-```bash
-npx vitest run <path-to-new-test-file>
-```
-
-Expected: FAIL with a message that matches the candidate's summary.
-If the test PASSES already, the candidate may already be implemented
-or the test is tautological. Stuck-comment + bail.
-
-### 5. Implement the fix
-
-Apply the improvement per the candidate's `suggested_action`. Stay
-narrow — do NOT add unrelated cleanup, refactor surrounding code, or
-expand scope beyond what the candidate names. The reviewer (Agent B)
-will REJECT scope creep.
-
-Commit: `git add <impl-files>; git commit -m "<verb>(<area>): <change>"`.
-
-### 6. Re-run the test; verify it PASSES
-
-```bash
-npx vitest run <path-to-new-test-file>
-```
-
-Expected: PASS. The fix made the test green without changing the test.
-
-If the test still fails, the implementation didn't cover the test's
-assertion. Iterate ONCE on the implementation (no new commit; amend
-the fix commit before the orchestrator pushes). If still failing after
-amendment, stuck-comment + bail.
-
-### 7. Push the branch
-
-```bash
-git push origin $BRANCH_NAME
-```
-
-The orchestrator's next step (Agent B / reviewer) takes over from here.
-Don't open a PR yourself — Agent B's verdict gates that.
-
-## Stop conditions
-
-- **Stuck on the candidate**: cannot capture as a failing test, OR test
-  passes before the fix, OR test still fails after the fix. Post a
-  stuck-comment-style note + exit without committing.
-- **Out-of-scope encounter**: the candidate's area requires
-  modifications outside the area the candidate names. Stuck-comment
-  + bail; the orchestrator's skip-list will record the candidate.
-
-## Output format
-
-End your output with one of:
+End your output with ONE of:
 
 ```
 RESULT: PUSHED
 Branch: improve/<candidate-id>
-Test commit: <subject>
-Fix commit: <subject>
+Test commit: <subject>          (when recipe requires it)
+Fix commit: <subject>           (when recipe requires it)
+Commit: <subject>               (single-commit recipes)
 ```
 
 OR
 
 ```
 RESULT: STUCK
-Reason: <one-paragraph why the candidate didn't fit the TDD-first
-shape; what the maintainer would need to do to implement>
+Reason: <one-paragraph why the candidate didn't fit this recipe; what
+the maintainer would need to do to implement OR why the candidate's
+premise is wrong>
 ```
 
 The orchestrator parses for `RESULT: PUSHED` to proceed to Agent B;
-otherwise records the stuck reason in the skip-list.
+otherwise records the stuck reason via the reviewer-log + skip-list.
+
+## Decision-log convention
+
+Per `bots/README.md` decision-log convention, emit `> Decision: ...`
+notes inline for load-bearing choices. Especially:
+- Why you picked the specific test shape for this candidate
+- Anti-tautology check (counterfactual: "would my test fail under
+  reasonable mutation X of the SUT?")
+- Why you stopped (when STUCK) — cite the recipe's stop conditions
 
 ## Don't
 
@@ -147,3 +92,6 @@ otherwise records the stuck reason in the skip-list.
   in the orchestrator.
 - Don't span multiple candidates in one run. One candidate per run;
   the orchestrator picks the next one in the next cron.
+- Don't apply a recipe's contract to a candidate type it wasn't
+  written for. If the recipe truly doesn't fit, that's STUCK with
+  the reason — not "let me try the other recipe."

--- a/bots/review-bot/prompts/recipes/README.md
+++ b/bots/review-bot/prompts/recipes/README.md
@@ -1,0 +1,81 @@
+# Recipes
+
+Per-candidate-type contract fragments that Agent A follows. The shared
+base prompt lives in `bots/review-bot/prompts/agent-a.md`; each recipe
+here is a self-contained discipline composed onto the base at
+invocation time by the orchestrator.
+
+## What a recipe is
+
+A recipe is a **commit-shape + anti-tautology discipline** tailored to
+one class of candidate. Different candidate types need different
+contracts:
+
+- A bug fix wants TDD-first ordering (failing test → fix)
+- A coverage gap can't drive working code with TDD-first; it needs a
+  single-commit shape with anti-tautology counterfactuals
+- A refactor (future) wants behavior-preserving multi-commit ordering
+
+The recipe names a commit shape, when to consider yourself stuck, and
+the specific RESULT format Agent A emits on success.
+
+## Available recipes
+
+| File | Used for | Commit shape |
+|---|---|---|
+| `tdd-first.md` | `correctness`, `security`, `architecture`, `types`, `comments`, `style` | Failing test commit → fix commit |
+| `coverage-shape.md` | `tests` (coverage gap) | Single test commit against working code, with anti-tautology counterfactuals |
+
+The candidate-type → recipe mapping lives in `../../recipe-select.ts`
+(typed exhaustive switch — adding a new `CandidateType` forces a
+compile error if no recipe is assigned, so this layer can't silently
+drop a type).
+
+## Adding a new recipe
+
+1. **Write the recipe file** at `bots/review-bot/prompts/recipes/<name>.md`.
+   Follow the existing recipes' structure:
+   - Use when / not for (preamble)
+   - The contract (the load-bearing rules)
+   - Process (step-by-step)
+   - Recipe-specific stuck conditions
+   - RESULT format (parsed by `bots/review-bot/index.ts`)
+   - Reviewer expectations (Agent B's view) — optional but
+     recommended; helps the reviewer apply matching action policy
+
+2. **Add to `recipe-select.ts`**: extend the `RecipeName` union with
+   the new recipe's filename (minus `.md`) and add an entry to
+   `RECIPE_BY_TYPE` for the candidate types that select it.
+
+3. **Add a vitest case** in `bots/review-bot/tests/recipe-select.test.ts`
+   pinning the dispatch (e.g.,
+   `expect(selectRecipe('refactor')).toBe('refactor-shape')`).
+
+4. **Update this README's "Available recipes" table.**
+
+## Naming convention
+
+Filenames describe the **recipe shape**, not the candidate type they
+serve. Reasoning:
+- One recipe can serve multiple types (`tdd-first` serves 5 of the
+  7 candidate types)
+- One type can in principle select different recipes per context
+  (a future security candidate with new-capability shape might use
+  a different recipe than one with missing-gate shape)
+- Recipe names compose naturally across bots — `tdd-first` reads
+  identically whether fix-bot or review-bot uses it
+
+## Cross-bot promotion
+
+Per `bots/README.md`: "If three+ bots end up needing the same helper,
+extract to `_lib/`." If a third bot starts using one of these recipes,
+promote the file to `bots/_lib/recipes/<name>.md` and update both
+consumers' `recipe-select.ts` to import the path.
+
+Today (v1):
+- review-bot uses recipes for Agent A
+- fix-bot has its own per-issue prompt that COULD adopt this pattern
+  (its TDD-first contract is structurally identical to ours); not
+  refactored yet — would land as a separate fix-bot consolidation cut
+- dead-code-watcher's deletion shape doesn't fit either recipe;
+  unlikely to use this directory

--- a/bots/review-bot/prompts/recipes/coverage-shape.md
+++ b/bots/review-bot/prompts/recipes/coverage-shape.md
@@ -1,0 +1,212 @@
+# Recipe: coverage-shape
+
+**Use when** the candidate type is `tests` AND the candidate's
+`summary` describes a coverage gap (e.g., "no test file exists for
+X", "no test covers boundary condition Y", "no test exercises error
+path Z").
+
+**Not for** test-quality candidates that already have tests but the
+tests are tautological / wrong-tier / isolation-broken — those fit
+`tdd-first` because the fix is "rewrite the bad test" and a failing
+test against the new shape can drive it.
+
+## Why coverage-shape is NOT TDD-first
+
+TDD-first ordering says: `failing test → fix`. For a coverage gap
+against working code, this is impossible — there is no defect to
+test-drive, no failing state to make green. Forcing TDD-first onto
+this shape produces one of two failure modes:
+
+- **Synthetic-failure trap**: write a test, observe it fails, write
+  "the fix" that's actually just confirming what the code already
+  did. The test is tautological by construction.
+- **Stuck**: Agent A correctly refuses to write tautological tests
+  and emits STUCK — leaving the genuinely valuable coverage gap
+  unfilled.
+
+The coverage-shape contract gives Agent A a path to add tests
+against working code WITHOUT producing tautological tests, by
+enforcing an explicit anti-tautology discipline.
+
+## Coverage-shape contract
+
+1. **Single commit.** No "failing test → fix" pair; the test should
+   pass against the existing code on first run. Subject:
+   `test(<area>): cover <what's covered>` or similar.
+
+2. **Test against the interface, not the implementation.** Read the
+   SUT's public surface (exported functions, route handlers, public
+   class methods). Assert input/output behavior. Do NOT read the
+   SUT's implementation while authoring assertions — that's how
+   tautological tests are born (assertions match observed output).
+
+3. **Anti-tautology counterfactual.** For EACH test you write, name
+   the counterfactual: "what mutation of the SUT would make this
+   test fail?" If you can't name a non-trivial mutation, the test
+   is tautological — drop it or rewrite to a behavioral assertion
+   that has a real counterfactual.
+
+   Emit the counterfactual inline as a `> Decision: ...` note for
+   each non-trivial test, so the reviewer can validate it.
+
+4. **Cover real behavior, not coverage metrics.** Don't write tests
+   to hit lines you haven't covered. Write tests for the contract
+   the SUT exposes: input boundary conditions, error paths, side
+   effects (when intentional), invariants (when documented). The
+   review-tests skill's static-tautology check (Agent B) will
+   catch tests that just exercise lines without asserting behavior.
+
+5. **Right tier per testing-plan.md.** Pyramid for core; honeycomb
+   for providers; trophy for admin SPA; crab for CLI. A test in the
+   wrong tier is a finding (review-tests will flag it).
+
+## Process
+
+### 1. Read CANDIDATE_JSON; read the cited rule + testing-plan.md
+
+The candidate's `rule` may cite `testing-plan.md` (e.g., a
+"single-route coverage gaps" entry). Read it; the rule names the
+tier shape + the kind of test expected.
+
+### 2. Read the SUT's interface ONLY
+
+Open the file the candidate names. **Read the exports + public
+function signatures + any documented invariants in comments. Do
+NOT read the function bodies before you've drafted assertions.**
+
+(Why: reading the body before drafting assertions = the assertions
+become a description of "what does this code do?" That's the
+tautology pattern. Reading the interface first lets you assert
+"what should this code do?" from outside.)
+
+### 3. Read LESSONS_LEARNED
+
+Cross-candidate patterns. Especially: areas where prior coverage
+attempts produced tautological tests → avoid that pattern.
+
+### 4. Draft assertions for behavior the interface promises
+
+For each public surface, list:
+- The input shape (parameters, request body, etc.)
+- The expected output shape per input class
+- Documented errors / boundary conditions
+- Side effects (if any) — observable through the interface
+
+Each assertion targets a behavior; each behavior must have a
+**non-trivial counterfactual**.
+
+### 5. Now read the implementation to verify your assertions are correct
+
+Only AFTER drafting assertions, open the impl to confirm your
+expected outputs are right. If they're wrong, update the assertion
++ document a `> Decision:` explaining the surprise (often: the
+candidate's premise was that the code SHOULD do X but it actually
+does Y — that's worth surfacing).
+
+If the impl differs from what the interface promises (genuine bug
+discovered during coverage work), STOP coverage and emit `RESULT:
+STUCK` with the bug description — the maintainer should triage as
+a `correctness` candidate via a fresh audit-area run, not roll a
+bug fix into coverage work.
+
+### 6. Write the tests
+
+Per `testing-plan.md`'s tier shape:
+- Pyramid sub-systems: unit-style with `vitest`
+- Honeycomb sub-systems: integration with `testcontainers` if storage
+- Trophy sub-systems: API-first via `app.request()` against
+  `createAdminApp()` (the reference pattern is
+  `admin-api-suggest-alt.test.ts`)
+- Crab sub-systems: CLI scenario tests
+
+Use `memoryStorage()` by default for admin-API tests (per
+`testing-plan.md` "Storage tier"); fs-tier only when justified.
+
+### 7. Run the tests; verify they PASS
+
+```bash
+npx vitest run <path-to-new-test-file>
+```
+
+Expected: PASS on first run. The tests describe what the working code
+already does correctly. If a test FAILS, you either:
+- Discovered a genuine bug → STOP coverage; STUCK with the bug
+- Got the interface contract wrong → fix the assertion (not the impl)
+
+### 8. Verify counterfactuals (anti-tautology gate)
+
+For each non-trivial test, mentally run the counterfactual you
+emitted as `> Decision: ...`. Concretely:
+- If you said "the test would fail if the route returned 200 instead
+  of 404 for missing items," would the test actually fail under that
+  mutation? Trace your assertion.
+
+If any counterfactual doesn't survive, that test is tautological.
+Either rewrite it to a real counterfactual OR drop it.
+
+### 9. Commit + push
+
+```bash
+git add <test-files>
+git commit -m "test(<area>): cover <what's covered>"
+git push origin $BRANCH_NAME
+```
+
+Single commit. The orchestrator's next step (Agent B / reviewer)
+takes over.
+
+## Coverage-shape-specific stuck conditions
+
+In addition to the shared stop conditions in `agent-a.md`:
+
+- **Genuine bug found during coverage**: the impl doesn't honor the
+  interface's documented promise. STUCK; describe the bug. Maintainer
+  triages as `correctness` via a fresh audit-area run.
+- **Interface is undocumented + uninspectable**: no doc, no comments,
+  no clear contract — you can't write tests against an interface that
+  doesn't tell you what it promises. STUCK; recommend the maintainer
+  document the contract first.
+- **All possible tests would be tautological**: the SUT is a
+  pass-through / identity / one-liner. STUCK; the coverage gap isn't
+  worth filling.
+
+## RESULT format
+
+On success:
+
+```
+RESULT: PUSHED
+Branch: improve/<candidate-id>
+Commit: <subject>
+Counterfactuals: <N counterfactuals emitted in commit / decision log>
+```
+
+On stuck:
+
+```
+RESULT: STUCK
+Reason: <one paragraph: what made coverage-shape not fit; what the
+maintainer should do instead (file as correctness candidate / document
+the interface / accept the coverage gap)>
+```
+
+## Reviewer expectations (Agent B's view)
+
+The `review-tests` skill checks coverage-shape work with these
+specific lenses (in addition to standard test-quality checks):
+
+- **Counterfactual presence**: did Agent A emit a counterfactual
+  per non-trivial test? Missing counterfactuals → IMPORTANT finding.
+- **Counterfactual quality**: does each counterfactual name a
+  non-trivial mutation? "The test would fail if I deleted it" is
+  not a counterfactual. → IMPORTANT finding.
+- **Tier-shape match**: is the test in the right tier per
+  `testing-plan.md`? Wrong tier → IMPORTANT finding.
+- **Behavioral vs implementation-coupled**: do assertions reference
+  what the code's interface promises (good) or what its
+  implementation does (bad)? → CRITICAL when assertions read
+  obviously implementation-derived.
+
+If Agent B's review-tests skill finds tautology smells, the verdict
+is REJECT with the specific test names — Agent A iterates by
+rewriting them, not adding new ones.

--- a/bots/review-bot/prompts/recipes/tdd-first.md
+++ b/bots/review-bot/prompts/recipes/tdd-first.md
@@ -1,0 +1,133 @@
+# Recipe: tdd-first
+
+**Use when** the candidate type is `correctness`, `security`,
+`architecture`, `types`, `comments`, or `style` (bug-class candidates
+where the fix changes behavior, the cited rule names a defect, or
+the change shape is "wrong → right").
+
+**Not for** `tests`-class candidates (use `coverage-shape` instead).
+A `tests`-class candidate is one where the SUT is already working
+and the gap is "no test exists" — TDD-first can't drive working code.
+
+## TDD-first contract
+
+Per [team-preferences.md rule 31](../../../../.claude/rules/team-preferences.md):
+
+1. **First commit MUST be a failing test.** Subject: `test: ...` or
+   `failing test: ...`. The test must exercise the candidate's
+   specified improvement; running it BEFORE the fix MUST fail.
+2. **Second commit IS the implementation.** Subject prefix per the
+   candidate's type (`fix(<area>): ...`, `refactor(<area>): ...`,
+   `feat(<area>): ...`, etc.).
+
+If you cannot capture the candidate as a failing test (the candidate
+is structural — e.g., "split a file into smaller files" — or the
+test would be tautological), emit `RESULT: STUCK` with a constructive
+maintainer-action recommendation. Do NOT push an implementation-only
+commit; the reviewer (Agent B) will REJECT it.
+
+## Process
+
+### 1. Read CANDIDATE_JSON; read the cited design doc
+
+The candidate's `rule` field cites a design doc (or `file:line`). Read
+that doc; it's the contract you're improving against. Don't re-litigate
+the candidate — the audit-area skill already ranked it as worth doing.
+
+### 2. Read LESSONS_LEARNED
+
+Cross-candidate patterns from prior review-bot runs. Examples to expect
+once data accumulates:
+- Common candidate-types that maintainers reject (skip those)
+- Areas where prior Agent A produced stuck-comments (scope your change
+  tighter to avoid the same trap)
+- Hints from prior runs (e.g., "always add the validator at the
+  background phase if save-delta would be too eager")
+
+### 3. Write the failing test
+
+The test must:
+- Live in the right tier per [`testing-plan.md`](../../../../.claude/rules/testing-plan.md)
+  (pyramid for core; honeycomb for providers; trophy for admin SPA; crab
+  for CLI)
+- Exercise the SPECIFIC improvement the candidate names. Don't write a
+  generic "this area should work" test; assert the behavior the
+  candidate would unlock
+- Have a clear failure message that aligns with the candidate's
+  `summary`
+
+Commit: `git add <test-files>; git commit -m "test: <what the test asserts>"`.
+
+### 4. Verify the test FAILS before the fix
+
+Run the test (most-specific invocation; per `team-preferences.md#32`):
+
+```bash
+npx vitest run <path-to-new-test-file>
+```
+
+Expected: FAIL with a message that matches the candidate's summary.
+If the test PASSES already, the candidate may already be implemented
+or the test is tautological. `RESULT: STUCK` + bail.
+
+### 5. Implement the fix
+
+Apply the improvement per the candidate's `suggested_action`. Stay
+narrow — do NOT add unrelated cleanup, refactor surrounding code, or
+expand scope beyond what the candidate names. The reviewer (Agent B)
+will REJECT scope creep.
+
+Commit: `git add <impl-files>; git commit -m "<verb>(<area>): <change>"`.
+
+### 6. Re-run the test; verify it PASSES
+
+```bash
+npx vitest run <path-to-new-test-file>
+```
+
+Expected: PASS. The fix made the test green without changing the test.
+
+If the test still fails, the implementation didn't cover the test's
+assertion. Iterate ONCE on the implementation (no new commit; amend
+the fix commit before the orchestrator pushes). If still failing
+after amendment, `RESULT: STUCK` + bail.
+
+### 7. Push the branch
+
+```bash
+git push origin $BRANCH_NAME
+```
+
+The orchestrator's next step (Agent B / reviewer) takes over from here.
+Don't open a PR yourself — Agent B's verdict gates that.
+
+## TDD-first-specific stuck conditions
+
+In addition to the shared stop conditions in `agent-a.md`:
+
+- **Cannot write a failing test**: candidate is structural (e.g.,
+  "split this file") and TDD-first doesn't apply. STUCK; recommend
+  the candidate move to a different recipe or to a maintainer.
+- **Test passes without the fix**: the candidate's premise is wrong
+  OR the test is tautological. STUCK; report your investigation.
+- **Test still fails after one amendment to the impl**: the fix
+  approach is wrong or out of scope. STUCK; report what you tried.
+
+## RESULT format
+
+On success:
+
+```
+RESULT: PUSHED
+Branch: improve/<candidate-id>
+Test commit: <subject of commit 1>
+Fix commit: <subject of commit 2>
+```
+
+On stuck:
+
+```
+RESULT: STUCK
+Reason: <one paragraph: what made TDD-first not fit this candidate;
+constructive maintainer action recommended>
+```

--- a/bots/review-bot/recipe-select.ts
+++ b/bots/review-bot/recipe-select.ts
@@ -1,0 +1,38 @@
+/**
+ * Recipe selector — maps a candidate type to the Agent A recipe file
+ * the orchestrator composes onto the shared agent-a.md base.
+ *
+ * The Record<CandidateType, RecipeName> exhaustive shape forces a TS
+ * error if a new CandidateType lands without a recipe assignment —
+ * the type system catches the dispatch gap that the runtime would
+ * otherwise hit at first invocation.
+ *
+ * See bots/review-bot/prompts/recipes/README.md for naming and
+ * extension rules.
+ */
+import type { CandidateType } from './candidates.js'
+
+export type RecipeName = 'tdd-first' | 'coverage-shape'
+
+const RECIPE_BY_TYPE: Record<CandidateType, RecipeName> = {
+  // Bug-class candidates: failing-test → fix is the right shape.
+  correctness: 'tdd-first',
+  security: 'tdd-first',
+  architecture: 'tdd-first',
+  types: 'tdd-first',
+
+  // Documentation + style candidates: TDD-first today (the test
+  // captures the documentation invariant or style violation). May
+  // earn their own recipe later if comment-rot fixes / style-only
+  // fixes consistently struggle with TDD-first.
+  comments: 'tdd-first',
+  style: 'tdd-first',
+
+  // Coverage-gap candidates: TDD-first can't drive working code;
+  // coverage-shape is the discipline.
+  tests: 'coverage-shape',
+}
+
+export function selectRecipe(type: CandidateType): RecipeName {
+  return RECIPE_BY_TYPE[type]
+}

--- a/bots/review-bot/tests/recipe-select.test.ts
+++ b/bots/review-bot/tests/recipe-select.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import type { CandidateType } from '../candidates.js'
+import { selectRecipe } from '../recipe-select.js'
+
+// Tests derived from the candidate-type → recipe mapping locked in
+// prompts/recipes/README.md "Available recipes" table. NOT derived
+// from observing the implementation (per team-preferences rule 31).
+
+describe('selectRecipe — locked mapping from prompts/recipes/README.md', () => {
+  it('bug-class candidates select tdd-first', () => {
+    expect(selectRecipe('correctness')).toBe('tdd-first')
+    expect(selectRecipe('security')).toBe('tdd-first')
+    expect(selectRecipe('architecture')).toBe('tdd-first')
+    expect(selectRecipe('types')).toBe('tdd-first')
+  })
+
+  it('documentation + style candidates select tdd-first', () => {
+    expect(selectRecipe('comments')).toBe('tdd-first')
+    expect(selectRecipe('style')).toBe('tdd-first')
+  })
+
+  it('tests-class candidates select coverage-shape', () => {
+    expect(selectRecipe('tests')).toBe('coverage-shape')
+  })
+
+  it('every CandidateType has a recipe assignment (exhaustive)', () => {
+    // The dispatcher's Record<CandidateType, RecipeName> shape makes
+    // this a compile-time check; this test pins it at runtime too as
+    // a regression guard against a future refactor that introduces
+    // partial typing.
+    const allTypes: CandidateType[] = ['correctness', 'security', 'architecture', 'tests', 'types', 'comments', 'style']
+    for (const t of allTypes) {
+      const recipe = selectRecipe(t)
+      expect(['tdd-first', 'coverage-shape']).toContain(recipe)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

First-run discovery (PR #390 merged; review-bot ran #25990296462): Agent A correctly emitted `RESULT: STUCK` on a `tests`-class candidate. The TDD-first contract can't drive working code; coverage gaps were unfillable as designed.

Fix: extract Agent A's prompt into a **shared base + per-type recipes**, with a new `coverage-shape` recipe that gives Agent A a path to add tests against working code under an explicit anti-tautology discipline.

## What this changes

**New layout** under `bots/review-bot/prompts/`:
- `agent-a.md` (shared base, ~80 lines) — inputs, branch creation, RESULT format, stop conditions
- `recipes/tdd-first.md` — the old TDD-first contract (extracted; behavior unchanged)
- `recipes/coverage-shape.md` — NEW recipe: single commit, anti-tautology counterfactual per test, interface-first assertion drafting, tier shape per testing-plan.md
- `recipes/README.md` — naming convention + "how to add a new recipe" guide

**Dispatcher** (`bots/review-bot/recipe-select.ts`):
- `Record<CandidateType, RecipeName>` exhaustive switch — compile-time gate against missing recipe assignments when a new CandidateType lands
- 4 vitest tests pinning the locked mapping

**Orthogonal fix**: stuck-path now appends to reviewer-log (`verdict: 'needs-human'`) so the monthly compactor can surface this failure-mode pattern.

**Design doc** updated to describe the recipe layer (Phase 3 section + recipe table).

## Recipe selection (locked)

| Candidate type | Recipe |
|---|---|
| `correctness`, `security`, `architecture`, `types`, `comments`, `style` | `tdd-first` |
| `tests` | `coverage-shape` |

## Coverage-shape contract (the new piece)

1. **Single commit** against working code (no failing-test → fix pair)
2. **Anti-tautology counterfactual** per non-trivial test — Agent A names "what mutation would make this test fail?"; if no answer, the test is tautological
3. **Interface-first assertion drafting** — read exports + signatures BEFORE the impl, so assertions describe "what should this code do?" not "what does it do?"
4. **Tier shape** per `testing-plan.md` (pyramid/honeycomb/trophy/crab)
5. **Right tier discipline** — review-tests skill flags wrong-tier as IMPORTANT

Agent A emits the counterfactual inline as `> Decision: ...` notes; Agent B's `review-tests` skill validates them statically as part of its existing tautology check.

## Test plan

- [x] CI green (vitest + typecheck + format across workspaces)
- [x] Local: `DRY_RUN=1` smoke run shows Phase 0 unchanged
- [ ] Post-merge: trigger another review-bot run; verify if Phase 1 surfaces a `tests`-type candidate, Agent A follows coverage-shape (not TDD-first)
- [ ] Watch for first `coverage-shape` PR's structure — single commit + counterfactuals listed

## Risks

- **Coverage-shape recipe is unproven against real candidates** — first run only validated the `tests`-class candidate's STUCK behavior. The actual recipe's effectiveness is a Cut 21 (observation) item. Mitigation: review-tests skill's static-tautology check catches bad coverage tests at Agent B's review step.
- **Recipe composition adds ~10 LOC of read+concat to phase3AgentA** — minor surface area increase; well-tested via the dispatcher's vitest cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)