### PR TITLE
fix(review-bot): preserve audit-area's Decision-log prose in Phase 1

### DIFF
--- a/bots/review-bot/index.ts
+++ b/bots/review-bot/index.ts
@@ -304,13 +304,17 @@ async function phase1Discovery(area: string, runId: string): Promise<Candidate[]
   const transcriptPath = resolve(TRANSCRIPT_DIR, `discovery-${runId}.jsonl`)
   const prompt = `Invoke the \`audit-area\` skill via the Skill tool with the path argument \`${area}\`.
 
-After audit-area returns, emit ONLY its candidates fence to stdout. Do not add
-prose around it. The orchestrator parses the fence directly.
+Pass through audit-area's complete output verbatim — including the prose-with-
+\`> Decision: ...\` notes ABOVE the candidates fence that the skill's prompt
+requires. The orchestrator's TS parser extracts only the fence body (via
+\`extractCandidatesFence\`); the surrounding prose is preserved in the transcript
+for replay-loop diffability + maintainer review of what the skill considered
+before settling on the emitted candidates.
 
-If audit-area returns no candidates, emit an empty fence:
-
-\`\`\`candidates
-\`\`\`
+If audit-area returns no candidates, the skill emits an empty \`\`\`candidates\`\`\`
+fence with prose explaining what was checked. Pass that through too — the
+"no-candidates + reason" outcome is informative and the empty fence still
+parses correctly.
 `
   const result = await runClaude({
     prompt,


### PR DESCRIPTION
## Summary

Behavioral analysis of review-bot run [#25991026418](https://github.com/gazetta-studio/gazetta-studio/actions/runs/25991026418) found audit-area's Phase 1 transcript contained only the candidates fence — no prose-with-`> Decision:` notes above it, even though `.claude/skills/audit-area/SKILL.md` explicitly requires them.

## Root cause

`phase1Discovery()` in `bots/review-bot/index.ts` instructed the outer Claude session: *"emit ONLY its candidates fence to stdout. Do not add prose around it."*

That suppressed audit-area's required decision-log output. Bug was in the orchestrator wrapper, not in audit-area's SKILL.md.

## Fix

Relax the Phase 1 wrapper to pass through audit-area's complete output verbatim. The TS parser (`extractCandidatesFence`) only extracts the fence body via regex — prose around the fence is invisible to dispatch but preserved in the transcript artifact (90-day retention) for:
- Replay-loop diffability (the `npm run replay` tool diffs transcripts; missing decision-log notes makes runs harder to compare)
- Maintainer review of what the skill considered before settling on the emitted candidates

## What's NOT in this PR

- No changes to audit-area/SKILL.md — that file's prompt is correct
- No changes to Phase 4 (Agent B) wrapper — already correctly says "the markdown summary + the aggregated findings JSONL fence." Run #25991026418's Agent B emitted decision-log notes correctly, confirming the pattern works when the wrapper doesn't restrict
- No new tests — `candidates.test.ts:18` already pins the prose-around-fence parsing contract

## Test plan

- [x] CI green
- [x] 290/290 vitest tests pass
- [x] Typecheck + format clean
- [ ] Post-merge: trigger another review-bot run; verify discovery transcript contains prose-with-Decision-notes above the candidates fence

🤖 Generated with [Claude Code](https://claude.com/claude-code)