### PR TITLE
design: mutation-area-picker — autonomous mutation-scope bot

### DIFF
--- a/.claude/rules/design-mutation-area-picker.md
+++ b/.claude/rules/design-mutation-area-picker.md
@@ -139,10 +139,33 @@ Per the project's "bots should have separate memory" rule (ADR-0011 + the v2 bot
 - **`bots/mutation-area-picker/skip-list.json`** — modules to never propose. Two entry types:
   - **never-mutate** — generated code, third-party shims, files where mutation testing is meaningless
   - **maintainer-rejected** — bot proposed it; maintainer closed the PR with a reason
-- **`bots/mutation-area-picker/reviewer-log.jsonl`** — every decision logged (ADD/SWAP/REMOVE/NOOP + reasoning). Read by monthly compactor.
-- **`bots/mutation-area-picker/lessons-learned.md`** — distilled patterns from compactor (e.g., "AI-pairing density correlates poorly with surviving-mutant count on this codebase; lowered to 0.15")
+- **`bots/mutation-area-picker/reviewer-log.jsonl`** — every decision logged (ADD/SWAP/REMOVE/NOOP + reasoning). Future compactor input.
+- **`bots/mutation-area-picker/lessons-learned.md`** — distilled patterns from a future compactor (e.g., "AI-pairing density correlates poorly with surviving-mutant count on this codebase; lowered to 0.15"). Empty placeholder in v1.
 
 Persisted via `actions/cache@v4` keyed `mutation-area-picker-reviewer-log-v1` (ADR-0011 pattern). Skip-list and lessons-learned are committed to repo via PR.
+
+**No compactor in v1 — deliberately deferred.** Unlike dead-code-watcher
+and fix-bot (which produce 100+ decisions per cron and accumulate
+skip-list entries quickly), mutation-area-picker produces ~1 decision per
+week. Skip-list growth is rate-limited to ~1-3 maintainer rejections per
+year at steady state; reviewer-log fills the 200-entry cache ceiling
+after ~4 years. Compactor value depends on signal volume; at this
+cadence, the volume isn't there.
+
+The portfolio itself self-compacts via SWAP/REMOVE actions (each cron's
+empirical eviction is continuous compaction of the working set, not a
+memory artifact). What a compactor WOULD do — distilling cross-decision
+patterns into prose — has too thin a signal to justify the ~150 LOC + a
+monthly `bots-compact.yml` job slot until the bot has been running for
+6+ months.
+
+**Triggers to revisit compactor design** — any one:
+- Skip-list grows past 10 entries with visible glob-compactable patterns
+- Reviewer-log entries accumulate past 200 (cache ceiling) and we want
+  bounded cache via the `pruneReviewerLog` helper
+- Calibration drift becomes obvious — bot consistently picks weak
+  candidates because heuristic weights are wrong; lessons-learned would
+  surface the recurring pattern
 
 ## PR shape
 
@@ -165,7 +188,7 @@ Persisted via `actions/cache@v4` keyed `mutation-area-picker-reviewer-log-v1` (A
 | Failure | Detection | Recovery |
 |---|---|---|
 | Wrong-pick module (low actual value) | Maintainer closes PR with reason | Bot reads close reason via past-PR feedback loop; adds to skip-list. Same pattern as dead-code-watcher. |
-| Weights miscalibrated (consistently bad picks) | Pattern across reviewer-log entries | Monthly compactor surfaces "we keep rejecting picks where signal X dominated" into lessons-learned. Operator adjusts env var weights based on the lesson. |
+| Weights miscalibrated (consistently bad picks) | Pattern across reviewer-log entries | Manual recalibration by reading the cached reviewer-log; operator adjusts env var weights. (Future compactor surfaces patterns automatically when it ships — triggers above.) |
 | Bot proposes ADD beyond budget | Wouldn't — bot estimates before proposing | N/A by construction |
 | Glob already at budget, no eviction-ripe module | NOOP fires; bot exits silently | Normal operation — wait for kill ratios to mature |
 | Bootstrap period bug | First 4 runs ADD only; eviction history accumulates | Document explicitly; bot's banner shows "bootstrap: week N/4" |

--- a/.claude/rules/design-mutation-area-picker.md
+++ b/.claude/rules/design-mutation-area-picker.md
@@ -1,0 +1,213 @@
+# Mutation-area-picker
+
+Autonomous bot that decides which source modules belong in `stryker.config.json`'s `mutate` glob. Runs weekly; opens a PR only when its judgment says the scope should change.
+
+The portfolio of mutated modules is bounded by nightly Stryker runtime (currently ~1h 45m, hard ceiling 3h). The bot CAN'T mutate everything — it has to choose, and the choice has been a human decision until now.
+
+**Status**: design pass complete (2026-05-17). Implementation deferred until the existing v2 reviewer-loop work (PR #395 + earlier bot infrastructure) has stabilised in production for one full week.
+
+**Companion docs**:
+- [`.claude/rules/testing-plan.md`](testing-plan.md) — where the human-curated next-list lived (replaced by this bot)
+- [`docs/adr/0014-mutation-eviction-by-empirical-evidence.md`](../../docs/adr/0014-mutation-eviction-by-empirical-evidence.md) — the load-bearing decision to evict modules empirically (kill-ratio + fix-rate), not by time
+- [`docs/adr/0011-bot-memory-cache-persistence.md`](../../docs/adr/0011-bot-memory-cache-persistence.md) — cache-based persistence pattern this bot inherits
+- [`bots/README.md`](../../bots/README.md) — bot ecosystem context (memory, generator-critic, concurrency)
+- [`packages/gazetta/stryker.config.json`](../../packages/gazetta/stryker.config.json) — the `mutate` glob the bot owns
+
+## Why this is a bot, not a script
+
+Three things make autonomous selection meaningfully harder than the current human discipline:
+
+- **Five cross-references no human computes by hand** — AI-pairing density, test/source ratio, churn, flake correlation, bug-fix correlation. Together they predict where surviving mutants will accumulate; separately each is one signal among many.
+- **Portfolio management under a runtime budget** — adding a module without freeing one costs nightly minutes. As coverage matures, the question shifts from "add" to "swap" to "remove." Humans don't track per-module saturation.
+- **Weekly cadence** — every cron sees fresh Stryker data; humans don't react that frequently.
+
+The bot replaces `testing-plan.md`'s human-curated next-list. After ship, that list is dead weight.
+
+## Scope
+
+**In v1:**
+- Weekly cron trigger after the weekly Stryker run
+- Five-signal weighted inclusion score for un-mutated modules
+- Composite eviction score (kill-ratio sustained + fix-rate of past issues) for scoped modules
+- Decision tree: ADD / SWAP / REMOVE / NOOP per run
+- One draft PR per acting week (or zero)
+- Per-bot durable memory (skip-list + reviewer-log) per the project's bot memory pattern
+- Module-level granularity (one row per src file, NOT per-glob)
+- Bootstrap discipline: first 4 runs do not evict (need 4-week kill-ratio history)
+- Runtime budget env-overridable (`MUTATION_BUDGET_MINUTES`, default 105)
+
+**Out of v1 (explicit):**
+- A reviewer agent (Agent B). Mutation testing IS the empirical reviewer — Stryker's next run tells us whether the pick was right. Adding a reviewer here would be cargo-cult pattern-matching of dead-code-watcher's loop.
+- Cross-bot signal sharing (e.g., reading mutation-watcher's skip-list). Different domains; keep memory separate.
+- Tactical per-run file prioritisation. Locked as a future second bot (`mutation-target-prioritiser`); designed separately.
+- Time-bound eviction (graduating modules just because they've been in glob long). Time without kill-ratio evidence would graduate weak coverage; rejected.
+
+**Non-goals:**
+- Beating human judgment on the first week. Initial heuristic weights are guesses; calibration happens over 4-6 PRs as data accumulates.
+- Mutating everything. Permanent constraint: portfolio size is bounded by runtime budget; the bot manages the portfolio, doesn't eliminate the boundary.
+
+## Decision model
+
+### The portfolio
+
+The bot maintains a set of modules in `stryker.config.json`'s `mutate` glob, bounded by runtime budget. Every cron, the bot evaluates:
+
+```
+ADD     when: budget headroom exists for the top un-mutated candidate
+SWAP    when: at budget AND top un-mutated outranks lowest scoped (by eviction score)
+REMOVE  when: at budget AND a scoped module is eviction-ripe AND no un-mutated candidate clears the SWAP bar
+NOOP    otherwise — exit silently, no PR
+```
+
+The bot never proposes ADD beyond budget. SWAP and REMOVE keep the portfolio sustainable.
+
+### Inclusion score (for un-mutated modules)
+
+Composite weighted sum across five signals:
+
+| Signal | Weight | Source |
+|---|---|---|
+| AI-pairing density | 0.30 | `git log --grep "Co-Authored-By: Claude" --since=90d --name-only \| sort \| uniq -c` per module path |
+| Test/source LOC ratio, inverse | 0.25 | `find packages/gazetta/tests -name "*<basename>*" \| xargs wc -l` vs `wc -l src/<mod>` |
+| Recent churn | 0.20 | `git log --since=90d --name-only \| sort \| uniq -c` per module path |
+| Flake correlation | 0.15 | `gh issue list --label flake --state all` — does module path appear in title or body? |
+| Bug-fix correlation | 0.10 | `gh pr list --search "fix:" --search "created:>2026-04-17"` — does module path appear in PR diff? |
+
+Each signal normalised to [0, 1] across the candidate set, then weighted. Final score in [0, 1].
+
+**Why these weights:** initial guesses informed by `team-preferences.md` rule 31 (AI-paired code most likely to have tautological tests) and the asymmetry between empirical signals (flake, bug-fix) and structural signals (LOC ratio, churn). Concrete weights are env-overridable so we can adjust without a code change. After 4-6 PRs we'll have data on which signals correlate with surviving-mutant counts and recalibrate.
+
+### Eviction score (for scoped modules)
+
+Composite triggering condition:
+
+```
+evict = (killRatio > 0.85 sustained across last 4 weekly Stryker runs)
+     AND (>70% of mutation-watcher issues for this module are closed-merged in last 90 days)
+```
+
+Both thresholds env-overridable (`EVICTION_KILL_RATIO`, `EVICTION_FIX_RATE`).
+
+**Why two conditions, not one:**
+
+- Kill ratio alone could be high because nobody added new code to mutate (stale module). Doesn't catch "tests are weak but mutants happen to be in covered branches."
+- Fix-rate alone tracks human responsiveness, not test quality. Could be high while underlying tests stay weak.
+- Together they triangulate: high kill ratio with humans actively fixing → mutation testing achieved its purpose.
+
+**Why not time-bound:** time without kill-ratio evidence graduates weak coverage. A module mutated for 6 months with kill ratio 0.5 should STAY until tests improve, not rotate out.
+
+### Bootstrap
+
+First 4 weekly runs after deployment: bot does NOT evict. Reason: the eviction rule requires "kill-ratio sustained across last 4 weekly Stryker runs" — that history doesn't exist for week 1, 2, 3. Bot can only ADD or NOOP during bootstrap.
+
+After week 4, full decision tree fires.
+
+Today's mutate glob (`src/history-*.ts`, `src/publish*.ts`, `src/admin-api/**/*.ts`, `src/alt/route-handler.ts`, `src/hooks/registry.ts`) is treated as "earned-in" — these modules are scoped because humans deliberated; the bot inherits them without re-justifying.
+
+### Runtime budget
+
+Default `MUTATION_BUDGET_MINUTES=105` (= 1h 45m current). Hard ceiling 180 min (workflow timeout).
+
+Bot estimates per-module cost from Stryker's per-file timing reports (already in Stryker's JSON output). For un-mutated modules, the bot uses a conservative estimate: `(lines mutated) × 0.1 seconds per mutant × estimated mutant density`. Stryker reports mutant counts per file once mutation runs.
+
+When budget is exceeded by sum-of-scoped: the bot SHOULD eventually propose REMOVE. In practice this only happens if humans manually expand the glob beyond the budget; bot's own ADDs respect the cap.
+
+## Decision criteria detail
+
+**ADD fires when:**
+- Top un-mutated candidate's inclusion score ≥ `INCLUSION_THRESHOLD` (default 0.4)
+- Estimated cost of adding it + sum-of-scoped ≤ budget
+
+**SWAP fires when:**
+- At budget (no ADD possible)
+- Top un-mutated inclusion score > best eviction score on scoped set
+- The scoped module being evicted has eviction score ≥ `EVICTION_THRESHOLD` (default 0.7)
+
+**REMOVE fires when:**
+- At budget (no ADD possible)
+- A scoped module has eviction score ≥ `EVICTION_THRESHOLD`
+- No un-mutated candidate clears the SWAP bar (i.e., nothing better to replace it with)
+
+**NOOP fires when:**
+- Below ADD threshold AND below SWAP/REMOVE thresholds
+- Exit silently, no PR opened. Run summary banner shows "No scope change justified this week."
+
+## Memory
+
+Per the project's "bots should have separate memory" rule (ADR-0011 + the v2 bot infrastructure):
+
+- **`bots/mutation-area-picker/skip-list.json`** — modules to never propose. Two entry types:
+  - **never-mutate** — generated code, third-party shims, files where mutation testing is meaningless
+  - **maintainer-rejected** — bot proposed it; maintainer closed the PR with a reason
+- **`bots/mutation-area-picker/reviewer-log.jsonl`** — every decision logged (ADD/SWAP/REMOVE/NOOP + reasoning). Read by monthly compactor.
+- **`bots/mutation-area-picker/lessons-learned.md`** — distilled patterns from compactor (e.g., "AI-pairing density correlates poorly with surviving-mutant count on this codebase; lowered to 0.15")
+
+Persisted via `actions/cache@v4` keyed `mutation-area-picker-reviewer-log-v1` (ADR-0011 pattern). Skip-list and lessons-learned are committed to repo via PR.
+
+## PR shape
+
+**Draft PR.** Title:
+- `chore(mutation): add <X> to stryker mutate glob`
+- `chore(mutation): swap <Y> for <X> (mature: <Y> kill ratio Z%)`
+- `chore(mutation): remove <Y> from stryker mutate glob (mature: kill ratio Z%)`
+
+**Body sections:**
+1. **Decision** — which action (ADD / SWAP / REMOVE) and what fired the rule
+2. **Top 3 inclusion candidates** — module + scores per signal + composite. Maintainer sanity-checks weighting in every PR.
+3. **Eviction scores for all scoped modules** — composite + breakdown. Surfaces "X is graduating soon" before the actual eviction PR.
+4. **Estimated runtime impact** — current portfolio cost + delta from this PR
+5. **Files changed** — `stryker.config.json` + `testing-plan.md` mutation-scope section
+
+**Outcome tag** at body end for the feedback loop: `<!-- mutation-area-picker: action=ADD module=hooks/registry.ts run=$RUN_ID -->`
+
+## Failure modes + recovery
+
+| Failure | Detection | Recovery |
+|---|---|---|
+| Wrong-pick module (low actual value) | Maintainer closes PR with reason | Bot reads close reason via past-PR feedback loop; adds to skip-list. Same pattern as dead-code-watcher. |
+| Weights miscalibrated (consistently bad picks) | Pattern across reviewer-log entries | Monthly compactor surfaces "we keep rejecting picks where signal X dominated" into lessons-learned. Operator adjusts env var weights based on the lesson. |
+| Bot proposes ADD beyond budget | Wouldn't — bot estimates before proposing | N/A by construction |
+| Glob already at budget, no eviction-ripe module | NOOP fires; bot exits silently | Normal operation — wait for kill ratios to mature |
+| Bootstrap period bug | First 4 runs ADD only; eviction history accumulates | Document explicitly; bot's banner shows "bootstrap: week N/4" |
+
+## Foundational checks
+
+How this bot composes with each of the 13 foundational dimensions + multi-instance discipline:
+
+- **Multi-instance check.** Bot runs as singleton workflow per `concurrency: group: mutation-area-picker` (ADR-0011 pattern). No cross-workflow racing on the cached reviewer-log.
+- **Scale check.** Per-cron cost: 5 signal queries × ~50 candidate modules = 250 light operations + 1 Claude invocation. Well under the per-cron 50-min budget. The cron runtime is dominated by the gh API calls, not the Claude call.
+- **Locale / Theme / RTL checks.** Bot doesn't render UI; N/A.
+- **Auth + RBAC.** Bot uses `GH_TOKEN` (GitHub Actions default) for repo writes. Same trust model as other producer bots.
+- **Audit.** Every decision logged to `reviewer-log.jsonl`. PR creation creates GitHub audit trail. No `action: 'mutation-scope-change'` audit-log event needed — bot output IS the audit trail.
+- **Review workflow.** N/A (bot's PRs go through standard human review).
+- **Hook check.** Bot doesn't fire hooks. Its output is a config-file PR.
+- **Render / Validation / Plugin / Cache / Offline / Collaboration.** N/A (infrastructure bot, not user-facing surface).
+
+## UX check
+
+Per `team-preferences.md` rule 23 — "Don't Make Me Think":
+
+- **Absence-as-state.** Bot exits silently (no PR) on NOOP weeks. Maintainer's inbox stays clean unless action is justified.
+- **Universal language in PR body.** "ADD / SWAP / REMOVE / NOOP" — verbs the maintainer can scan in one glance.
+- **No help tooltips.** PR body's "Top 3 candidates" section IS the explanation. If a maintainer can't tell why the bot picked X over Y from the body, the body is wrong; fix it rather than adding a comment thread.
+- **Same affordance regardless of state.** PR body has the same shape whether bot ADDs, SWAPs, or REMOVEs. Maintainer's review pattern is uniform.
+
+## Migration
+
+`testing-plan.md`'s "Mutation scope expansion (next)" section's ordered next-list gets replaced with a one-liner pointing at this design doc. The list represents thinking we've already absorbed into the inclusion-score heuristic (smallest-first → factored into test/source LOC ratio; AI-heavy → factored into AI-pairing density).
+
+No code migration. The bot ships fresh; first run after deployment treats existing glob as earned-in.
+
+## Open implementation questions
+
+1. **Module granularity definition.** `src/admin-api/**/*.ts` in current glob covers ~30 files. The bot needs to score per-file, not per-glob. Migration: the bootstrap step normalises today's glob into per-file entries; bot operates per-file going forward.
+2. **Stryker per-file timing report parsing.** Stryker emits per-file timing in HTML; bot reads via mutation-watcher's existing `mutation-report-staging/` artifact. Confirm the JSON output format includes timings (it should — Stryker's `--reporters json` shape).
+3. **Initial weights as env vars vs constants.** Env vars give operator override without code change; constants live with the code. Recommend env vars for thresholds (`INCLUSION_THRESHOLD`, `EVICTION_KILL_RATIO`, etc.) but constants for the five signal weights (those need code change + PR review since they're heuristic-load-bearing).
+4. **Bootstrap cliff.** Week 4 → week 5 transition: bot suddenly enables eviction. Soft-launch by lowering eviction threshold for first month? Or hard cutover? Defaulting to hard cutover (simpler) unless the first month's data shows incorrect graduations.
+
+## Future directions
+
+- **Mutation-target-prioritiser** — tactical sibling bot. Re-ranks the "top-N actionable files" mutation-watcher investigates each cron. Ships when actionable-file set grows large enough that count-only ranking misses high-value targets.
+- **Weight auto-tuning** — currently weights are operator-set via env. Could be auto-tuned from "did the picks have high surviving-mutant counts after testing?" feedback. Earned when 12+ months of data accumulates.
+- **Cross-bot signal** — read mutation-watcher's skip-list to suppress modules with recent attempts. Currently rejected (bots should have separate memory); could revisit if signal proves valuable.
+- **Eviction budget reuse** — when a module evicts, its freed runtime budget should pool for the next ADD. Bot tracks this implicitly via the budget recompute on every cron.

--- a/.claude/rules/dev-glossary.md
+++ b/.claude/rules/dev-glossary.md
@@ -139,14 +139,20 @@ artifact-handling on focused surfaces before tackling large ones. See
 [testing-plan.md](testing-plan.md).
 
 **Mutation-area-picker (strategic)**:
-Monthly bot that owns the `mutate` glob in `stryker.config.json`. Picks ONE
-module per month to add to the scope and opens a PR. Phase 1 follows
-`testing-plan.md`'s procedural next-list verbatim (autonomous but
-human-authored order); Phase 2 (after the list is exhausted) uses
-risk-weighted heuristic signals — AI-pairing density, test/source LOC
-ratio, churn, flake correlation, bug-fix correlation — to pick. Distinct
-from mutation-watcher (which consumes Stryker output) and from the
-mutation-target-prioritiser (tactical, per-cron).
+Weekly autonomous bot that owns the `mutate` glob in
+`stryker.config.json`. Manages a PORTFOLIO of mutated modules under a
+runtime budget (currently ~1h 45m, hard ceiling 3h). Picks one of
+ADD / SWAP / REMOVE / NOOP per cron based on risk-weighted heuristic
+signals (AI-pairing density, test/source LOC ratio, churn, flake
+correlation, bug-fix correlation) and empirical eviction per
+[ADR-0014](../../docs/adr/0014-mutation-eviction-by-empirical-evidence.md)
+(kill ratio sustained + fix rate met). Bootstrap weeks 1-4 do ADD-only.
+Opens a draft PR on acting weeks; exits silently on NOOP weeks. NO
+compactor in v1 — at ~52 decisions/year, signal volume is too thin to
+justify one; deferred until skip-list crosses 10 entries OR reviewer-log
+hits its 200-entry cache ceiling. Distinct from mutation-watcher
+(consumes Stryker output) and from the mutation-target-prioritiser
+(tactical, per-cron).
 
 **Mutation-target-prioritiser (tactical)**:
 Per-cron bot that re-ranks the "top-N actionable files" mutation-watcher

--- a/.claude/rules/dev-glossary.md
+++ b/.claude/rules/dev-glossary.md
@@ -138,6 +138,25 @@ Expanded smallest-first so the workflow calibrates triage-time and
 artifact-handling on focused surfaces before tackling large ones. See
 [testing-plan.md](testing-plan.md).
 
+**Mutation-area-picker (strategic)**:
+Monthly bot that owns the `mutate` glob in `stryker.config.json`. Picks ONE
+module per month to add to the scope and opens a PR. Phase 1 follows
+`testing-plan.md`'s procedural next-list verbatim (autonomous but
+human-authored order); Phase 2 (after the list is exhausted) uses
+risk-weighted heuristic signals — AI-pairing density, test/source LOC
+ratio, churn, flake correlation, bug-fix correlation — to pick. Distinct
+from mutation-watcher (which consumes Stryker output) and from the
+mutation-target-prioritiser (tactical, per-cron).
+
+**Mutation-target-prioritiser (tactical)**:
+Per-cron bot that re-ranks the "top-N actionable files" mutation-watcher
+investigates each run. Default ranking today is "highest surviving-mutant
+count first"; this bot widens that with cross-references (module
+importance, mutant class, churn). Designed-but-deferred surface — earns
+its place when actionable-file set grows large enough that count-only
+ranking misses high-value targets. Distinct from mutation-area-picker
+(strategic, monthly).
+
 **Tautological tests**:
 Tests written after observing the implementation's output, asserting on what
 was observed rather than what should be true. Pass without proving anything;

--- a/.claude/rules/testing-plan.md
+++ b/.claude/rules/testing-plan.md
@@ -71,24 +71,21 @@ class of failure that AI-assisted development is structurally prone to.
 | **Mutation testing** (StrykerJS, nightly) | Tests that pass without asserting anything meaningful | [`packages/gazetta/stryker.config.json`](../../packages/gazetta/stryker.config.json) + [`.github/workflows/mutation.yml`](../../.github/workflows/mutation.yml) |
 | **Property-based testing** (fast-check) | Boundary / Unicode / encoding edge cases AI's "safe middle" inputs miss | `packages/gazetta/tests/hash-sidecar-names.test.ts` is the reference example |
 
-**Mutation scope expansion (next):** StrykerJS currently mutates the
+**Mutation scope expansion:** StrykerJS currently mutates the
 admin-API surface (`admin-api/**/*.ts`), `publish.ts`, `publish-rendered.ts`,
 the three history modules (`history-provider.ts`, `history-recorder.ts`,
-`history-restorer.ts`), and `alt/route-handler.ts` — see
-[`packages/gazetta/stryker.config.json`](../../packages/gazetta/stryker.config.json)
-for the current `mutate` glob. Nightly runtime ~1h 45m. Expand to
-AI-heavy modules where tautological tests are most likely.
-**Smallest-first** so the workflow calibrates (mutants-per-module, triage
-time, artifact retention) on a focused surface before tackling the
-largest:
+`history-restorer.ts`), `alt/route-handler.ts`, and `hooks/registry.ts` —
+see [`packages/gazetta/stryker.config.json`](../../packages/gazetta/stryker.config.json)
+for the current `mutate` glob. Nightly runtime ~1h 45m; hard ceiling 3h
+workflow timeout.
 
-1. `packages/gazetta/src/hooks/registry.ts` — priority dispatch, error taxonomy. Smallest module; pure logic.
-2. `packages/gazetta/src/archive/` — helpers, aliases. Recent feature, all cuts AI-paired; focused surface.
-3. `packages/gazetta/src/audit/` — recorder dispatcher. Cross-cutting; medium surface.
-4. `packages/gazetta/src/validation/` — validators, scanner, save-delta. Largest surface; tackle once triage workflow is proven.
-
-Each lands as a separate `stryker.config.json` `mutate` glob extension, not a
-batch — survived mutants from one module need triage before adding the next.
+**Scope expansion is autonomous via `mutation-area-picker` bot** (per
+[`design-mutation-area-picker.md`](design-mutation-area-picker.md)). Weekly
+cron picks one module to ADD / SWAP / REMOVE from the portfolio under a
+runtime budget, using five risk-weighted signals (AI-pairing density,
+test/source LOC ratio, churn, flake correlation, bug-fix correlation).
+The bot opens a draft PR when its judgment says scope should change;
+exits silently otherwise. No human-curated next-list.
 
 Don't gate on score yet — observational metric until each module's baseline
 stabilises. Treat survived mutants as test-quality bugs.

--- a/bots/README.md
+++ b/bots/README.md
@@ -102,6 +102,12 @@ GITHUB_REPOSITORY=gazetta-studio/gazetta-studio GH_TOKEN=$(gh auth token) \
 | `discovery-prep-bot` | Daily 04:00 UTC + workflow_dispatch | `enhancement` AND lacks all of `ready-for-human`, `ready-for-agent`, `wontfix`, `needs-info` | Research comment + `ready-for-human` label | Researcher |
 | `fix-bot` | Daily 04:00 UTC + workflow_dispatch | `bug` + `ready-for-agent` AND lacks all of `ready-for-human`, `wontfix`, `needs-info` AND no `fix-bot-attempted` since reopen AND no skip-list match | PR (two commits: failing test + fix) on approve, skip-list entry on reject/needs-human, OR stuck-comment + `ready-for-human` on stuck path | Implementer — generator-critic reviewer loop + durable memory + lessons-learned |
 
+**Designed, not yet shipped:**
+
+| Bot | Trigger | Input | Output | Role |
+|---|---|---|---|---|
+| `mutation-area-picker` | Weekly Sun after Mutation run + workflow_dispatch | `stryker.config.json` + Stryker results + git/GitHub cross-references | Draft PR adding/swapping/removing one module in `mutate` glob, OR silent NOOP | **Strategic portfolio manager** — owns mutation scope under runtime budget. Design: [`.claude/rules/design-mutation-area-picker.md`](../.claude/rules/design-mutation-area-picker.md) |
+
 **Producer bots vs triage-bot.** Producer bots (`flake-watcher`,
 `mutation-watcher`, `dead-code-watcher`) consume CI signal or
 static-analysis output and self-classify their output, bypassing

--- a/docs/adr/0014-mutation-eviction-by-empirical-evidence.md
+++ b/docs/adr/0014-mutation-eviction-by-empirical-evidence.md
@@ -1,0 +1,27 @@
+# Mutation-area-picker evicts modules by empirical evidence, not by time
+
+> Full architectural model + foundational checks live in [`.claude/rules/design-mutation-area-picker.md`](../../.claude/rules/design-mutation-area-picker.md). This ADR captures the load-bearing eviction-trigger choice; the design doc captures everything else.
+
+The mutation-area-picker bot evicts a scoped module from `stryker.config.json`'s `mutate` glob ONLY when two empirical conditions both hold: kill ratio above 0.85 sustained across the last 4 weekly Stryker runs, AND more than 70% of mutation-watcher issues for that module are closed-merged within the last 90 days.
+
+Modules are NOT evicted by time alone. A module that's been in the mutate glob for 6 months with kill ratio 0.5 stays in scope.
+
+We picked this two-condition empirical trigger over time-bound eviction because time alone measures effort spent, not test quality achieved. A long-mutated module with low kill ratio means tests are still weak — graduating it would explicitly drop coverage where coverage is most needed. The bot's job is to manage the portfolio of mutation testing toward effectiveness; time-bound rotation is fairness logic that doesn't compose with that goal.
+
+We picked kill-ratio AND fix-rate combined over either alone because each signal in isolation can mislead. Kill ratio alone can be high because nobody added new code recently (stale module): mutants happen to live in already-covered branches. Fix-rate alone tracks human responsiveness, not test quality — a module where humans diligently close every mutation-watcher issue might still have weak underlying tests. Combined, they triangulate: high kill ratio (the tests are rigorous) AND high fix-rate (humans are actively maintaining them) means mutation testing has done its job and budget should rotate elsewhere.
+
+The thresholds (0.85 kill ratio, 70% fix rate, 4-week sustainment window, 90-day fix-rate window) are env-overridable defaults. They're initial guesses informed by Stryker's documented "high" threshold (80%) plus headroom for variance — but the design treats these as calibratable rather than locked. After 6-12 months of bot operation, accumulated data on which evictions correctly graduated modules vs. which left coverage degraded will let us re-anchor the defaults.
+
+## Consequences
+
+A long-mutated module with low kill ratio stays in the portfolio indefinitely. This is intentional: low kill ratio is the signal that tests need work, and removing the module would hide the signal. The corollary is that humans wanting to retire a module must improve its tests first (raising kill ratio), then the bot will rotate it out. Mutation testing becomes a forcing function for test quality.
+
+Bootstrap means the bot cannot evict during its first 4 weeks of operation — the eviction rule requires 4 weekly Stryker runs of history. During bootstrap, the bot can only ADD or NOOP. After week 4, full decision tree fires.
+
+Operators wanting time-bound rotation (e.g. for fairness or to ensure all modules get cycles) can implement it by manually removing modules from the glob; the bot won't propose adding them back unless their inclusion score qualifies. The bot's design accepts manual operator intervention via the standard config-PR pathway — operators commit to `stryker.config.json` directly when needed.
+
+If empirical-only eviction proves too conservative (modules accumulate in the portfolio faster than they graduate), the future direction is to lower thresholds rather than introduce time-bound rotation. Time-bound rotation would re-couple effort-spent to graduation, which is exactly the coupling this ADR rejects.
+
+When kill ratio briefly dips below 0.85 (e.g. someone adds new code; mutation testing finds new gaps), the sustained-across-4-weeks rule prevents thrashing — a module's graduation only completes when the high kill ratio holds across a full month of Stryker runs.
+
+The fix-rate signal depends on mutation-watcher continuing to file issues and humans continuing to close them. If mutation-watcher's filing stalls (e.g. the time-bound suppression from PR #395 mis-fires), fix-rate sinks artificially and no module can graduate. This is a soft coupling: graduation pauses but doesn't break. Recovery is restoring mutation-watcher's filing.


### PR DESCRIPTION
## Design-only PR

No implementation. This PR captures the locked design for a weekly bot that takes over scope management of `stryker.config.json`'s `mutate` glob from humans.

## The decision the bot makes

Currently a human picks the next module to add to the mutate glob, following `testing-plan.md`'s ordered next-list. This works but doesn't scale: as coverage matures the question shifts from "add" to "swap" to "remove" — and humans don't naturally compute the cross-references (AI-pairing density, test/source ratio, churn, flake correlation, bug-fix correlation) that predict where surviving mutants will accumulate.

The bot owns the **portfolio** of mutated modules under a **runtime budget** (currently ~1h 45m; hard ceiling 3h workflow timeout). Every Sunday after the weekly Stryker run completes, it computes inclusion scores for un-mutated modules and eviction scores for scoped modules, then opens a draft PR proposing ADD / SWAP / REMOVE — or exits silently when no change is justified.

## Locked decisions

| Decision | Choice |
|---|---|
| Cadence | Weekly (post-Stryker) |
| Decision tree | ADD / SWAP / REMOVE / NOOP per cron |
| Inclusion score | 5-signal weighted (AI-pairing 0.30, LOC ratio 0.25, churn 0.20, flake 0.15, bug-fix 0.10) |
| **Eviction trigger** | **Empirical: kill ratio > 0.85 sustained 4w AND > 70% issue close rate (NOT time-bound)** |
| Bootstrap | First 4 weeks: ADD-only (no eviction history yet) |
| Fate of next-list | Deleted (bot owns the decision) |
| Memory | Per-bot skip-list + reviewer-log via GH Actions cache (ADR-0011 pattern) |
| Reviewer agent | None — mutation testing IS the empirical reviewer (next Stryker run validates the pick) |
| PR shape | Draft, one per acting week (zero on NOOP weeks) |

## Why eviction is empirical, not time-bound (the ADR)

A module mutated for 6 months with kill ratio 0.5 should STAY in the portfolio — weak tests are exactly when mutation testing earns its place. Time-bound rotation would graduate weak coverage; empirical eviction graduates only when tests have objectively matured. See [ADR-0014](docs/adr/0014-mutation-eviction-by-empirical-evidence.md).

## What's in this PR

- **`.claude/rules/design-mutation-area-picker.md`** — full design doc with decision tree, scoring formulas, memory shape, foundational checks, UX check, open implementation questions, future direction
- **`docs/adr/0014-mutation-eviction-by-empirical-evidence.md`** — the load-bearing eviction-trigger choice
- **`.claude/rules/testing-plan.md`** — replaced "Mutation scope expansion (next)" list with one-liner pointing at the bot
- **`.claude/rules/dev-glossary.md`** — added `Mutation-area-picker` and `Mutation-target-prioritiser` (deferred sibling) terms
- **`bots/README.md`** — added designed-not-shipped row

## When to ship

After PR #395 (time-bound closed-issue suppression for mutation-watcher) has been running for at least one full week. The empirical eviction signals depend on mutation-watcher continuing to file issues correctly; we want confidence in that chain before layering autonomous scope management on top.

## Grilling history

Designed through the `grill-with-docs` skill. Walked seven questions:

1. Strategic vs tactical — locked: both, this is the strategic bot
2. Inclusion-score strategy (procedural vs risk-weighted) — locked: risk-weighted from day 1
3. PR shape (draft vs ready) — locked: draft
4. PR body contents — locked: top-3 candidates, computed signals, runtime estimate
5. Does bot update testing-plan.md too? — locked: yes, same PR, atomic
6. Decision criterion — initially "risk threshold," revised after user surfaced the runtime constraint
7. Eviction trigger — locked: empirical composite (kill ratio AND fix rate), not time-bound

The runtime-budget constraint reframed everything: the bot manages a portfolio, not just an ever-growing list. That's the load-bearing insight from the grilling session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)