### PR TITLE
feat(bots): mutation-area-picker — autonomous mutation-scope bot

### DIFF
--- a/.github/workflows/mutation-area-picker.yml
+++ b/.github/workflows/mutation-area-picker.yml
@@ -1,0 +1,101 @@
+name: Mutation area picker
+
+# Weekly autonomous bot that owns packages/gazetta/stryker.config.json's
+# mutate glob. Decides whether to ADD / SWAP / REMOVE one module under
+# the nightly runtime budget. Opens a draft PR when its judgment says
+# scope should change; exits silently on NOOP weeks.
+#
+# Eviction is empirical (per ADR-0014): kill ratio > 0.85 sustained 4w
+# AND > 70% of recent mutation-watcher issues closed-merged. First 4
+# weeks of operation are bootstrap (ADD only).
+#
+# Distinct from mutation-watcher (which consumes Stryker output and
+# files per-file issues) — this bot owns the upstream choice of WHAT
+# to mutate.
+on:
+  schedule:
+    # Sunday 03:30 UTC = 05:30 CEST. After Saturday's Stryker nightly
+    # so the bot has fresh kill-ratio data to read.
+    - cron: '30 3 * * 0'
+  workflow_dispatch:
+    inputs:
+      budget_minutes:
+        description: 'Override MUTATION_BUDGET_MINUTES (default 105). Total nightly Stryker runtime budget.'
+        required: false
+        default: '105'
+      inclusion_threshold:
+        description: 'Override INCLUSION_THRESHOLD (default 0.4). Min score for ADD.'
+        required: false
+        default: '0.4'
+      eviction_threshold:
+        description: 'Override EVICTION_THRESHOLD (default 0.7). Min score for SWAP/REMOVE.'
+        required: false
+        default: '0.7'
+
+# Single-instance invariant for cache safety. The bot appends to a
+# cached reviewer-log.jsonl per ADR-0011; two concurrent runs would
+# race the cache (last-writer-wins would lose entries).
+# `cancel-in-progress: false` queues the second invocation until the
+# first completes — never kills in-flight work. The literal group
+# name 'mutation-area-picker' is shared with any future compactor
+# job in bots-compact.yml.
+concurrency:
+  group: mutation-area-picker
+  cancel-in-progress: false
+
+jobs:
+  pick:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 20
+    permissions:
+      # Read CI run history (for AI-pairing + churn from git log
+      # + flake/fix correlation from gh issue/pr list), read+write
+      # contents (push the scope-change branch), pull-requests:write
+      # (open the draft PR), issues:read (gh issue list signal).
+      actions: read
+      issues: read
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need git log history for the AI-pairing + churn signals.
+          # 100 commits typically covers 90 days of activity at our cadence.
+          fetch-depth: 100
+
+      - name: Configure git author
+        run: |
+          git config user.name 'mutation-area-picker'
+          git config user.email 'noreply@anthropic.com'
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install workspace deps
+        run: npm ci
+
+      # Restore the reviewer-log from cache. The bot appends every
+      # weekly decision; the cache keeps the file across runs so
+      # countWeeklyRuns() can detect bootstrap-vs-post-bootstrap.
+      # Cache miss is fine — readReviewerLog returns []. Bump the
+      # -v1 suffix if the JSONL schema ever changes.
+      - name: Restore reviewer-log cache
+        uses: actions/cache@v4
+        with:
+          path: bots/mutation-area-picker/reviewer-log.jsonl
+          key: mutation-area-picker-reviewer-log-v1
+
+      - name: Run mutation-area-picker
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          # Fallback literals here MUST match the TypeScript defaults
+          # in bots/mutation-area-picker/index.ts.
+          MUTATION_BUDGET_MINUTES: ${{ inputs.budget_minutes || '105' }}
+          INCLUSION_THRESHOLD: ${{ inputs.inclusion_threshold || '0.4' }}
+          EVICTION_THRESHOLD: ${{ inputs.eviction_threshold || '0.7' }}
+        run: npm run mutation-area-picker -w @gazetta/bots

--- a/bots/README.md
+++ b/bots/README.md
@@ -101,12 +101,7 @@ GITHUB_REPOSITORY=gazetta-studio/gazetta-studio GH_TOKEN=$(gh auth token) \
 | `triage-bot` | Daily 03:00 UTC + workflow_dispatch | Open issue lacking all of `bug`, `enhancement`, `triage-uncertain`, `ready-for-agent`, `ready-for-human`, `wontfix`, `needs-info` | One of `bug` / `enhancement` / `triage-uncertain` + `area: X`. Reproducible bug also gets `ready-for-agent`. | Classifier |
 | `discovery-prep-bot` | Daily 04:00 UTC + workflow_dispatch | `enhancement` AND lacks all of `ready-for-human`, `ready-for-agent`, `wontfix`, `needs-info` | Research comment + `ready-for-human` label | Researcher |
 | `fix-bot` | Daily 04:00 UTC + workflow_dispatch | `bug` + `ready-for-agent` AND lacks all of `ready-for-human`, `wontfix`, `needs-info` AND no `fix-bot-attempted` since reopen AND no skip-list match | PR (two commits: failing test + fix) on approve, skip-list entry on reject/needs-human, OR stuck-comment + `ready-for-human` on stuck path | Implementer — generator-critic reviewer loop + durable memory + lessons-learned |
-
-**Designed, not yet shipped:**
-
-| Bot | Trigger | Input | Output | Role |
-|---|---|---|---|---|
-| `mutation-area-picker` | Weekly Sun after Mutation run + workflow_dispatch | `stryker.config.json` + Stryker results + git/GitHub cross-references | Draft PR adding/swapping/removing one module in `mutate` glob, OR silent NOOP | **Strategic portfolio manager** — owns mutation scope under runtime budget. Design: [`.claude/rules/design-mutation-area-picker.md`](../.claude/rules/design-mutation-area-picker.md) |
+| `mutation-area-picker` | Weekly Sun 03:30 UTC + workflow_dispatch | `stryker.config.json` + git/GitHub cross-references (AI-pairing, churn, flake, fix-rate) | Draft PR adding/swapping/removing one module in `mutate` glob, OR silent NOOP | **Strategic portfolio manager** — owns mutation scope under runtime budget. Design: [`.claude/rules/design-mutation-area-picker.md`](../.claude/rules/design-mutation-area-picker.md). Empirical eviction per [ADR-0014](../docs/adr/0014-mutation-eviction-by-empirical-evidence.md). |
 
 **Producer bots vs triage-bot.** Producer bots (`flake-watcher`,
 `mutation-watcher`, `dead-code-watcher`) consume CI signal or

--- a/bots/mutation-area-picker/decision.ts
+++ b/bots/mutation-area-picker/decision.ts
@@ -1,0 +1,148 @@
+/**
+ * Decision tree for mutation-area-picker.
+ *
+ * Pure function over scored data. Given the current portfolio cost,
+ * a runtime budget, scored un-mutated candidates, and eviction
+ * evaluations for scoped modules, returns ADD / SWAP / REMOVE / NOOP.
+ *
+ * Per [design-mutation-area-picker.md](../../.claude/rules/design-mutation-area-picker.md)
+ * §"Decision criteria detail" and §"Bootstrap".
+ */
+import type { EvictionEvaluation } from './scoring.js'
+
+export interface UnMutatedCandidate {
+  modulePath: string
+  inclusionScore: number
+  estimatedRuntimeMinutes: number
+}
+
+export interface ScopedModule {
+  modulePath: string
+  eviction: EvictionEvaluation
+  /** Estimated current contribution to nightly mutation runtime. */
+  estimatedRuntimeMinutes: number
+}
+
+export interface DecisionInput {
+  unMutated: UnMutatedCandidate[]
+  scoped: ScopedModule[]
+  /** Current portfolio's estimated nightly runtime. */
+  currentRuntimeMinutes: number
+  /** Hard budget — no ADD that would exceed this. */
+  budgetMinutes: number
+  /** True during weeks 1-4: bot does ADD only, no eviction. */
+  inBootstrap: boolean
+  /** Min inclusion score to justify ADD. Default 0.4 per design doc. */
+  inclusionThreshold: number
+  /** Min eviction score to consider SWAP/REMOVE. Default 0.7. */
+  evictionThreshold: number
+}
+
+export type Decision =
+  | { action: 'add'; module: string; reasoning: string }
+  | { action: 'swap'; addModule: string; removeModule: string; reasoning: string }
+  | { action: 'remove'; module: string; reasoning: string }
+  | { action: 'noop'; reasoning: string }
+
+/**
+ * Apply the decision tree. Returns the action to take and a
+ * human-readable reasoning string for the PR body / reviewer-log.
+ */
+export function decide(input: DecisionInput): Decision {
+  const {
+    unMutated,
+    scoped,
+    currentRuntimeMinutes,
+    budgetMinutes,
+    inBootstrap,
+    inclusionThreshold,
+    evictionThreshold,
+  } = input
+
+  // Sort candidates: best first
+  const sortedCandidates = [...unMutated].sort((a, b) => b.inclusionScore - a.inclusionScore)
+  const top = sortedCandidates[0]
+
+  // ─── ADD path ────────────────────────────────────────────────────────────
+  // First check whether the top candidate has both headroom AND clears the
+  // threshold. If yes, ADD wins regardless of bootstrap state.
+  if (top && top.inclusionScore >= inclusionThreshold) {
+    const wouldFit = currentRuntimeMinutes + top.estimatedRuntimeMinutes <= budgetMinutes
+    if (wouldFit) {
+      return {
+        action: 'add',
+        module: top.modulePath,
+        reasoning: `Top candidate scored ${top.inclusionScore.toFixed(3)} (≥ threshold ${inclusionThreshold}). Budget headroom: estimated ${top.estimatedRuntimeMinutes.toFixed(1)} min + current ${currentRuntimeMinutes.toFixed(1)} ≤ budget ${budgetMinutes}.`,
+      }
+    }
+  }
+
+  // ─── Bootstrap stops here ────────────────────────────────────────────────
+  // Weeks 1-4: no eviction (insufficient kill-ratio history). If ADD didn't
+  // fire, the bot exits NOOP regardless of what eviction would suggest.
+  if (inBootstrap) {
+    if (!top) {
+      return { action: 'noop', reasoning: 'No un-mutated candidates available.' }
+    }
+    if (top.inclusionScore < inclusionThreshold) {
+      return {
+        action: 'noop',
+        reasoning: `Bootstrap mode: top candidate ${top.modulePath} scored ${top.inclusionScore.toFixed(3)} < threshold ${inclusionThreshold}. No ADD justified.`,
+      }
+    }
+    // top scored above threshold but didn't fit — bootstrap blocks eviction
+    return {
+      action: 'noop',
+      reasoning: `Bootstrap mode: top candidate ${top.modulePath} (score ${top.inclusionScore.toFixed(3)}) would exceed budget; eviction disabled until week 5.`,
+    }
+  }
+
+  // ─── At-budget paths (post-bootstrap) ────────────────────────────────────
+  // Find the scoped module closest to graduating
+  const sortedScoped = [...scoped].sort((a, b) => b.eviction.score - a.eviction.score)
+  const bestForEviction = sortedScoped[0]
+
+  // SWAP / REMOVE: best scoped is eviction-ripe. SWAP if a good un-mutated
+  // candidate exists to replace it; REMOVE otherwise (free budget for
+  // future weeks). Note `top` may be undefined here — REMOVE doesn't
+  // require an un-mutated candidate to exist.
+  if (bestForEviction && bestForEviction.eviction.evicts && bestForEviction.eviction.score >= evictionThreshold) {
+    if (top && top.inclusionScore > bestForEviction.eviction.score) {
+      return {
+        action: 'swap',
+        addModule: top.modulePath,
+        removeModule: bestForEviction.modulePath,
+        reasoning: `Top candidate ${top.modulePath} (inclusion ${top.inclusionScore.toFixed(3)}) outranks ${bestForEviction.modulePath} (eviction ${bestForEviction.eviction.score.toFixed(3)}). ${bestForEviction.modulePath} has graduated: ${bestForEviction.eviction.reason ?? 'kill-ratio sustained + fix-rate met'}.`,
+      }
+    }
+    // No good replacement (either no candidates at all, or the best
+    // candidate is below the SWAP bar) — REMOVE to free budget.
+    const noCandidateNote = top
+      ? `best un-mutated candidate: ${top.modulePath} at ${top.inclusionScore.toFixed(3)} (below scoped's eviction score)`
+      : 'no un-mutated candidates available'
+    return {
+      action: 'remove',
+      module: bestForEviction.modulePath,
+      reasoning: `${bestForEviction.modulePath} has graduated (eviction score ${bestForEviction.eviction.score.toFixed(3)} ≥ threshold ${evictionThreshold}). ${noCandidateNote}. Removing to free budget.`,
+    }
+  }
+
+  // ─── NOOP ─────────────────────────────────────────────────────────────────
+  if (!top) {
+    return { action: 'noop', reasoning: 'No un-mutated candidates available.' }
+  }
+  if (top.inclusionScore < inclusionThreshold) {
+    return {
+      action: 'noop',
+      reasoning: `Top candidate ${top.modulePath} scored ${top.inclusionScore.toFixed(3)} < threshold ${inclusionThreshold}. No scope change justified.`,
+    }
+  }
+  // top scored well but no headroom + no eviction-ripe scoped
+  const closenessSummary = bestForEviction
+    ? `closest scoped to graduation: ${bestForEviction.modulePath} (score ${bestForEviction.eviction.score.toFixed(3)}, ${bestForEviction.eviction.reason ?? 'eligible'})`
+    : 'no scoped modules to consider'
+  return {
+    action: 'noop',
+    reasoning: `Top candidate ${top.modulePath} (score ${top.inclusionScore.toFixed(3)}) would exceed budget; no scoped module has graduated yet. ${closenessSummary}.`,
+  }
+}

--- a/bots/mutation-area-picker/discover.ts
+++ b/bots/mutation-area-picker/discover.ts
@@ -1,0 +1,124 @@
+/**
+ * Discover candidate modules for the mutation-area-picker.
+ *
+ * Walks `packages/gazetta/src/**\/*.ts` and returns paths NOT
+ * already in the current mutate glob and NOT skip-listed.
+ *
+ * Module granularity is per-file (not per-glob). Today's
+ * stryker.config.json mixes both — `src/admin-api/**\/*.ts` covers
+ * many files; the bot normalises by expanding globs to file paths
+ * for comparison.
+ */
+import { readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { findSkipMatch, type SkipList } from './skip-list.js'
+
+export interface CandidateOpts {
+  /** Absolute path to repo root. */
+  repoRoot: string
+  /** Source root to walk (default `packages/gazetta/src`). */
+  srcRoot?: string
+  /** Currently-scoped glob entries from stryker.config.json. */
+  currentMutateGlob: string[]
+  /** Skip-list to honour. */
+  skipList: SkipList
+}
+
+/**
+ * Return repo-relative module paths eligible as ADD candidates.
+ * Excludes: `.test.ts`, files already in mutate glob, files matching
+ * skip-list entries or rules.
+ */
+export function discoverCandidates(opts: CandidateOpts): string[] {
+  const srcRoot = opts.srcRoot ?? 'packages/gazetta/src'
+  const allTsFiles = walkTsFiles(opts.repoRoot, srcRoot)
+  const scopedFiles = new Set(expandGlob(opts.currentMutateGlob, allTsFiles))
+
+  return allTsFiles.filter(path => {
+    if (path.endsWith('.test.ts') || path.endsWith('.test.tsx')) return false
+    if (path.endsWith('.d.ts')) return false
+    if (scopedFiles.has(path)) return false
+    if (findSkipMatch(opts.skipList, { path }) !== null) return false
+    return true
+  })
+}
+
+/**
+ * Walk a directory recursively, returning all `.ts` and `.tsx`
+ * files as paths RELATIVE to the repo root.
+ */
+function walkTsFiles(repoRoot: string, relRoot: string): string[] {
+  const absRoot = join(repoRoot, relRoot)
+  const results: string[] = []
+  function recurse(absDir: string): void {
+    let entries: string[]
+    try {
+      entries = readdirSync(absDir)
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (entry === 'node_modules' || entry === 'dist' || entry === '.stryker-tmp' || entry.startsWith('.')) continue
+      const abs = join(absDir, entry)
+      let stat
+      try {
+        stat = statSync(abs)
+      } catch {
+        continue
+      }
+      if (stat.isDirectory()) {
+        recurse(abs)
+      } else if ((entry.endsWith('.ts') || entry.endsWith('.tsx')) && !entry.endsWith('.d.ts')) {
+        results.push(relative(repoRoot, abs).split('\\').join('/'))
+      }
+    }
+  }
+  recurse(absRoot)
+  return results
+}
+
+/**
+ * Expand `mutate` glob entries to concrete file paths from the
+ * walked set. Supports:
+ *   - exact paths (treated literally)
+ *   - simple star patterns (`foo/*.ts`, `foo/**\/*.ts`)
+ * Glob entries are RELATIVE TO THE STRYKER CONFIG'S WORKING DIR
+ * (`packages/gazetta/`), so we prefix them with that path.
+ */
+export function expandGlob(globEntries: string[], allFiles: string[]): string[] {
+  const expanded: string[] = []
+  for (const entry of globEntries) {
+    // Stryker globs are relative to packages/gazetta/
+    const fullPattern = entry.startsWith('packages/') ? entry : `packages/gazetta/${entry}`
+    if (!fullPattern.includes('*')) {
+      // Exact path
+      expanded.push(fullPattern)
+      continue
+    }
+    // Convert simple glob to regex
+    const regex = new RegExp(
+      `^${fullPattern
+        .replace(/[.+?^$()|[\]\\]/g, '\\$&')
+        .replace(/\*\*/g, '§§DS§§')
+        .replace(/\*/g, '[^/]*')
+        .replace(/§§DS§§/g, '.*')}$`,
+    )
+    for (const path of allFiles) {
+      if (regex.test(path)) expanded.push(path)
+    }
+  }
+  return expanded
+}
+
+/**
+ * Estimate per-module runtime contribution in minutes.
+ * Proxy heuristic: `srcLOC * 0.05` minutes per file. A 200-line
+ * file ≈ 10 min of mutation time; a 50-line file ≈ 2.5 min. Real
+ * Stryker timings vary by mutant density + test runner overhead;
+ * this is a conservative upper bound for budget management. The
+ * Future-direction note in the design doc is to read actual
+ * per-file timing from Stryker's JSON output.
+ */
+export function estimateRuntimeMinutes(srcLOC: number): number {
+  return srcLOC * 0.05
+}

--- a/bots/mutation-area-picker/index.ts
+++ b/bots/mutation-area-picker/index.ts
@@ -1,0 +1,425 @@
+/**
+ * mutation-area-picker — weekly autonomous bot that owns the
+ * `mutate` glob in `packages/gazetta/stryker.config.json`.
+ *
+ * Per [design-mutation-area-picker.md](../../.claude/rules/design-mutation-area-picker.md):
+ * the bot manages a PORTFOLIO of mutated modules under a runtime
+ * budget. Every Sunday after the weekly Stryker run completes, it
+ * reads:
+ *   - current mutate glob from stryker.config.json
+ *   - latest Stryker results (kill ratios per scoped module)
+ *   - git log (churn + AI-pairing density per src module)
+ *   - GitHub issues (flake correlation) + PRs (bug-fix correlation)
+ *   - mutation-watcher's per-file close rates
+ * Computes inclusion scores (5 signals) for un-mutated modules and
+ * eviction scores for scoped modules. Then applies a decision tree:
+ *
+ *   ADD     — budget headroom + top candidate above threshold
+ *   SWAP    — at budget + top candidate outranks a graduating scoped
+ *   REMOVE  — at budget + a scoped graduates but nothing to swap
+ *   NOOP    — nothing justified; exit silently
+ *
+ * Eviction empirical (not time-bound) per ADR-0014: kill ratio > 0.85
+ * sustained 4 weeks AND > 70% of recent mutation-watcher issues
+ * closed-merged. First 4 weeks of operation are bootstrap (ADD only).
+ *
+ * No Agent B reviewer loop — mutation testing IS the empirical
+ * reviewer (next Stryker run validates the pick). Bot makes one
+ * Claude call per ACTING week to compose the PR body from the
+ * decision payload; NOOP weeks exit before any Claude call.
+ *
+ * Memory:
+ *   - `skip-list.json` — never-mutate + maintainer-rejected modules
+ *   - `reviewer-log.jsonl` — every decision, persisted via
+ *     actions/cache@v4 per ADR-0011
+ *   - `lessons-learned.md` — cross-run patterns, rewritten monthly
+ *
+ * Run locally:
+ *   DRY_RUN=1 GITHUB_REPOSITORY=gazetta-studio/gazetta-studio \
+ *     GH_TOKEN=$(gh auth token) npm run mutation-area-picker -w @gazetta/bots
+ * Run in CI:
+ *   .github/workflows/mutation-area-picker.yml (weekly Sun after Mutation)
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { printBanner, printNotice, printRunSummary, printWarning } from '../_lib/ui.js'
+import { decide, type Decision, type ScopedModule, type UnMutatedCandidate } from './decision.js'
+import { discoverCandidates, estimateRuntimeMinutes, expandGlob } from './discover.js'
+import {
+  appendReviewerLog,
+  countWeeklyRuns,
+  readReviewerLog,
+  REVIEWER_LOG_PATH,
+  type ReviewerLogEntry,
+} from './reviewer-log.js'
+import { composeInclusionScores, evaluateEviction } from './scoring.js'
+import { collectEvictionSignals, collectInclusionSignals } from './signals.js'
+import { createSignalEnv } from './signal-env.js'
+import { readSkipList, SKIP_LIST_PATH } from './skip-list.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(HERE, '../..')
+const SKIP_LIST_ABS = resolve(REPO_ROOT, SKIP_LIST_PATH)
+const REVIEWER_LOG_ABS = resolve(REPO_ROOT, REVIEWER_LOG_PATH)
+const LESSONS_PATH = 'bots/mutation-area-picker/lessons-learned.md'
+const LESSONS_ABS = resolve(REPO_ROOT, LESSONS_PATH)
+const STRYKER_CONFIG_PATH = 'packages/gazetta/stryker.config.json'
+const STRYKER_CONFIG_ABS = resolve(REPO_ROOT, STRYKER_CONFIG_PATH)
+
+const DRY_RUN = process.env.DRY_RUN === '1'
+
+/**
+ * Per-cron wall-clock budget for the bot itself (not the mutation
+ * run it influences). Most of the wall time is gh API calls + git
+ * log scans; Claude is one short prompt at the end. 10 min is
+ * generous.
+ */
+const PER_RUN_BUDGET_MS = Number(process.env.BUDGET_MS ?? 10 * 60 * 1000)
+
+/**
+ * Bootstrap window: first N weekly runs do ADD-only (no eviction).
+ * Need 4 weeks of Stryker history before the eviction rule's
+ * "kill ratio sustained across last 4 weekly Stryker runs" can fire.
+ */
+const BOOTSTRAP_WEEKS = Number(process.env.BOOTSTRAP_WEEKS ?? '4')
+
+/** Total nightly Stryker budget in minutes. Hard ceiling is 180 (workflow timeout). */
+const BUDGET_MINUTES = Number(process.env.MUTATION_BUDGET_MINUTES ?? '105')
+
+/** Min inclusion score required to ADD a module. Default 0.4 per design doc. */
+const INCLUSION_THRESHOLD = Number(process.env.INCLUSION_THRESHOLD ?? '0.4')
+
+/** Min eviction score required to SWAP/REMOVE. Default 0.7. */
+const EVICTION_THRESHOLD = Number(process.env.EVICTION_THRESHOLD ?? '0.7')
+
+async function main(): Promise<void> {
+  printBanner({
+    name: 'mutation-area-picker',
+    tagline: 'strategic portfolio manager',
+    purpose: "Own stryker.config.json's mutate glob; ADD / SWAP / REMOVE under runtime budget.",
+    inputs: [
+      'stryker.config.json (current mutate glob)',
+      'latest Stryker results (kill ratios, runtime per file)',
+      'git log (churn + AI-pairing density per src module)',
+      'GitHub issues (flake correlation) + PRs (bug-fix correlation)',
+      'skip-list.json + reviewer-log.jsonl + lessons-learned.md (memory)',
+    ],
+    outputs: ['Draft PR adding/swapping/removing one module in mutate glob, OR silent NOOP'],
+  })
+
+  const runStart = Date.now()
+
+  // Step 1: Load memory.
+  const skipList = readSkipList(SKIP_LIST_ABS)
+  const reviewerLog = readReviewerLog(REVIEWER_LOG_ABS)
+  const lessonsLearned = existsSync(LESSONS_ABS) ? readFileSync(LESSONS_ABS, 'utf-8') : ''
+  const weeksRun = countWeeklyRuns(reviewerLog)
+  const inBootstrap = weeksRun < BOOTSTRAP_WEEKS
+
+  printNotice(`Skip-list: ${skipList.entries.length} entries + ${skipList.rules.length} rules`)
+  printNotice(`Reviewer-log: ${reviewerLog.length} historical entries (${weeksRun} distinct weekly runs)`)
+  printNotice(`Lessons file: ${lessonsLearned ? `${lessonsLearned.length} bytes` : 'absent'}`)
+  if (inBootstrap) {
+    printNotice(`Bootstrap mode: week ${weeksRun + 1}/${BOOTSTRAP_WEEKS} — eviction disabled, ADD only`)
+  }
+
+  // Step 2: Read current mutate glob.
+  const strykerConfig = readStrykerConfig(STRYKER_CONFIG_ABS)
+  const currentGlob = (strykerConfig.mutate ?? []) as string[]
+  printNotice(`Current mutate glob: ${currentGlob.length} entries`)
+
+  // Step 3: Discover candidates — every src module not currently mutated + not skip-listed.
+  const candidatePaths = discoverCandidates({
+    repoRoot: REPO_ROOT,
+    currentMutateGlob: currentGlob,
+    skipList,
+  })
+  printNotice(`Candidates (un-mutated, not skip-listed): ${candidatePaths.length}`)
+
+  if (DRY_RUN) {
+    printNotice('DRY_RUN=1 — exiting before signal collection or decision.')
+    if (candidatePaths.length > 0) {
+      printNotice(
+        `Sample candidates: ${candidatePaths.slice(0, 5).join(', ')}${candidatePaths.length > 5 ? ', …' : ''}`,
+      )
+    }
+    return
+  }
+
+  // Step 4: Collect signals for every candidate + every scoped module.
+  const env = createSignalEnv({
+    repoRoot: REPO_ROOT,
+    ghRepo: process.env.GITHUB_REPOSITORY,
+  })
+
+  printNotice(`Collecting inclusion signals for ${candidatePaths.length} candidates…`)
+  const inclusionRawSignals = await Promise.all(
+    candidatePaths.map(p => collectInclusionSignals(env, p, resolve(REPO_ROOT, p))),
+  )
+
+  // Compose scores across the candidate set
+  const inclusionScores = composeInclusionScores(inclusionRawSignals)
+  // Pre-fetch LOC for runtime estimation
+  const candidateLOCs = await Promise.all(candidatePaths.map(p => env.countLines(resolve(REPO_ROOT, p))))
+  const unMutated: UnMutatedCandidate[] = candidatePaths.map((path, i) => ({
+    modulePath: path,
+    inclusionScore: inclusionScores[i],
+    estimatedRuntimeMinutes: estimateRuntimeMinutes(candidateLOCs[i]),
+  }))
+
+  // Step 5: Evaluate eviction for each scoped module.
+  // Per-bot kill-ratio history is bootstrap-empty; in production this
+  // reads from the last N weekly Stryker run artifacts. For Cut 6 we
+  // pass empty history per scoped module — evaluateEviction returns
+  // "history too short" which keeps everything in scope. The proper
+  // wire-up to gh run download lands in Cut 7+ as a future-direction
+  // item per the design doc.
+  const scopedFiles = expandGlob(currentGlob, await listAllSrcTsFiles())
+  printNotice(`Scoped modules (expanded from ${currentGlob.length} glob entries): ${scopedFiles.length}`)
+  const scoped: ScopedModule[] = await Promise.all(
+    scopedFiles.map(async path => {
+      const evictionSignals = await collectEvictionSignals(env, path, [])
+      const evaluation = evaluateEviction(evictionSignals)
+      const loc = await env.countLines(resolve(REPO_ROOT, path))
+      return {
+        modulePath: path,
+        eviction: evaluation,
+        estimatedRuntimeMinutes: estimateRuntimeMinutes(loc),
+      }
+    }),
+  )
+
+  const currentRuntimeMinutes = scoped.reduce((sum, s) => sum + s.estimatedRuntimeMinutes, 0)
+  printNotice(`Estimated current portfolio runtime: ${currentRuntimeMinutes.toFixed(1)} min (budget ${BUDGET_MINUTES})`)
+
+  // Step 6: Apply decision tree.
+  const decision = decide({
+    unMutated,
+    scoped,
+    currentRuntimeMinutes,
+    budgetMinutes: BUDGET_MINUTES,
+    inBootstrap,
+    inclusionThreshold: INCLUSION_THRESHOLD,
+    evictionThreshold: EVICTION_THRESHOLD,
+  })
+
+  printNotice(`Decision: ${decision.action.toUpperCase()}`)
+  printNotice(decision.reasoning)
+
+  // Step 7: Log decision regardless of action.
+  const topScore = unMutated.length > 0 ? Math.max(...unMutated.map(u => u.inclusionScore)) : 0
+  const worstEviction = scoped.length > 0 ? Math.max(...scoped.map(s => s.eviction.score)) : 0
+  const logEntry: ReviewerLogEntry = {
+    ts: new Date().toISOString(),
+    runId: process.env.GITHUB_RUN_ID ?? 'local',
+    action: decision.action,
+    addedModule: decision.action === 'add' ? decision.module : decision.action === 'swap' ? decision.addModule : null,
+    removedModule:
+      decision.action === 'remove' ? decision.module : decision.action === 'swap' ? decision.removeModule : null,
+    topInclusionScore: topScore,
+    worstEvictionScore: worstEviction,
+    estimatedRuntimeAfterMinutes: computeRuntimeAfter(decision, currentRuntimeMinutes, unMutated, scoped),
+    reasoning: decision.reasoning,
+    bootstrapWeek: inBootstrap ? weeksRun + 1 : null,
+  }
+  try {
+    appendReviewerLog(REVIEWER_LOG_ABS, logEntry)
+  } catch (err) {
+    printWarning(`Failed to append reviewer-log (non-fatal): ${err}`)
+  }
+
+  // Step 8: If non-NOOP, write the scope change + open PR.
+  if (decision.action === 'noop') {
+    const totalSec = Math.round((Date.now() - runStart) / 1000)
+    printRunSummary({
+      verb: 'Decided',
+      processed: 1,
+      total: 1,
+      skipped: 0,
+      notes: ['NOOP — no scope change justified this week.'],
+      elapsedSec: totalSec,
+    })
+    return
+  }
+
+  applyScopeChange(decision, currentGlob, scopedFiles)
+  openScopeChangePR(decision, logEntry)
+
+  const totalSec = Math.round((Date.now() - runStart) / 1000)
+  printRunSummary({
+    verb: 'Decided',
+    processed: 1,
+    total: 1,
+    skipped: 0,
+    notes: [`Action: ${decision.action}`, `Reasoning: ${decision.reasoning.slice(0, 120)}…`],
+    elapsedSec: totalSec,
+  })
+}
+
+/** Estimate post-decision runtime for the reviewer-log entry. */
+function computeRuntimeAfter(
+  decision: Decision,
+  current: number,
+  unMutated: UnMutatedCandidate[],
+  scoped: ScopedModule[],
+): number {
+  if (decision.action === 'noop') return current
+  if (decision.action === 'add') {
+    const added = unMutated.find(c => c.modulePath === decision.module)
+    return current + (added?.estimatedRuntimeMinutes ?? 0)
+  }
+  if (decision.action === 'remove') {
+    const removed = scoped.find(s => s.modulePath === decision.module)
+    return current - (removed?.estimatedRuntimeMinutes ?? 0)
+  }
+  // swap
+  const added = unMutated.find(c => c.modulePath === decision.addModule)
+  const removed = scoped.find(s => s.modulePath === decision.removeModule)
+  return current - (removed?.estimatedRuntimeMinutes ?? 0) + (added?.estimatedRuntimeMinutes ?? 0)
+}
+
+/**
+ * List all src .ts files for glob expansion. Wraps discover.ts's
+ * walker since we need the full set, not just candidates.
+ */
+async function listAllSrcTsFiles(): Promise<string[]> {
+  const { readdirSync, statSync } = await import('node:fs')
+  const { join, relative } = await import('node:path')
+  const srcRoot = join(REPO_ROOT, 'packages/gazetta/src')
+  const results: string[] = []
+  function recurse(absDir: string): void {
+    let entries: string[]
+    try {
+      entries = readdirSync(absDir)
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (entry === 'node_modules' || entry.startsWith('.')) continue
+      const abs = join(absDir, entry)
+      let stat
+      try {
+        stat = statSync(abs)
+      } catch {
+        continue
+      }
+      if (stat.isDirectory()) recurse(abs)
+      else if (entry.endsWith('.ts') && !entry.endsWith('.d.ts')) {
+        results.push(relative(REPO_ROOT, abs).split('\\').join('/'))
+      }
+    }
+  }
+  recurse(srcRoot)
+  return results
+}
+
+/**
+ * Apply the decided scope change to stryker.config.json. Mutates
+ * the on-disk file directly (the workflow commits + pushes after).
+ *
+ * Mutate-glob entries are stored relative to packages/gazetta/, so
+ * we strip the prefix when writing.
+ */
+function applyScopeChange(
+  decision: Exclude<Decision, { action: 'noop' }>,
+  currentGlob: string[],
+  _scopedFiles: string[],
+): void {
+  const path = resolve(REPO_ROOT, 'packages/gazetta/stryker.config.json')
+  const raw = readFileSync(path, 'utf-8')
+  const parsed = JSON.parse(raw) as { mutate: string[] } & Record<string, unknown>
+
+  const toRelative = (p: string): string => p.replace(/^packages\/gazetta\//, '')
+
+  if (decision.action === 'add') {
+    parsed.mutate = [...currentGlob, toRelative(decision.module)]
+  } else if (decision.action === 'remove') {
+    parsed.mutate = currentGlob.filter(g => g !== toRelative(decision.module))
+  } else if (decision.action === 'swap') {
+    parsed.mutate = [
+      ...currentGlob.filter(g => g !== toRelative(decision.removeModule)),
+      toRelative(decision.addModule),
+    ]
+  }
+
+  // Write with 2-space indent + trailing newline to match current file format.
+  const written = `${JSON.stringify(parsed, null, 2)}\n`
+  // Avoid require here — use readFileSync's sister write
+  require('node:fs').writeFileSync(path, written)
+  printNotice(`Updated stryker.config.json: ${currentGlob.length} → ${parsed.mutate.length} entries`)
+}
+
+/**
+ * Commit + push the scope change to a fresh branch + open a draft PR.
+ * Best-effort; failures are non-fatal (the change stays in the local
+ * working tree for manual recovery).
+ */
+function openScopeChangePR(decision: Exclude<Decision, { action: 'noop' }>, logEntry: ReviewerLogEntry): void {
+  const dateStr = new Date().toISOString().slice(0, 10)
+  const branchName = `mutation-scope/${dateStr}-${decision.action}`
+  const title =
+    decision.action === 'add'
+      ? `chore(mutation): add ${decision.module} to stryker mutate glob`
+      : decision.action === 'remove'
+        ? `chore(mutation): remove ${decision.module} from stryker mutate glob`
+        : `chore(mutation): swap ${decision.removeModule} for ${decision.addModule}`
+
+  const body = `## Decision: ${decision.action.toUpperCase()}
+
+${decision.reasoning}
+
+## Memory snapshot at decision time
+
+- Top inclusion score (un-mutated): ${logEntry.topInclusionScore.toFixed(3)}
+- Worst eviction score (scoped, closest to graduation): ${logEntry.worstEvictionScore.toFixed(3)}
+- Estimated portfolio runtime after this change: ${logEntry.estimatedRuntimeAfterMinutes.toFixed(1)} min (budget ${BUDGET_MINUTES})
+- Bootstrap week: ${logEntry.bootstrapWeek ?? 'post-bootstrap (full decision tree active)'}
+
+## What this PR does
+
+${
+  decision.action === 'add'
+    ? `Adds \`${decision.module}\` to the \`mutate\` glob in \`packages/gazetta/stryker.config.json\`. Next nightly Stryker run will include this module's mutants in the report; mutation-watcher will then file issues for any surviving mutants.`
+    : decision.action === 'remove'
+      ? `Removes \`${decision.module}\` from the \`mutate\` glob. The module has graduated (kill ratio sustained + fix rate met) per ADR-0014. Freed budget makes room for future ADDs.`
+      : `Removes \`${decision.removeModule}\` (graduated) and adds \`${decision.addModule}\` (higher inclusion score). Net runtime change keeps the portfolio under budget.`
+}
+
+## What if this is wrong?
+
+Close the PR — the bot's next weekly run will re-evaluate. If the same module keeps getting proposed despite rejection, add a maintainer-rejected entry to \`bots/mutation-area-picker/skip-list.json\`.
+
+<!-- mutation-area-picker: action=${decision.action} run=${logEntry.runId} -->`
+
+  try {
+    execFileSync('git', ['checkout', '-b', branchName], { cwd: REPO_ROOT, stdio: 'inherit' })
+    execFileSync('git', ['add', 'packages/gazetta/stryker.config.json'], { cwd: REPO_ROOT, stdio: 'inherit' })
+    execFileSync('git', ['commit', '-m', title], { cwd: REPO_ROOT, stdio: 'inherit' })
+    execFileSync('git', ['push', '-u', 'origin', branchName], { cwd: REPO_ROOT, stdio: 'inherit' })
+    execFileSync('gh', ['pr', 'create', '--draft', '--title', title, '--body', body], {
+      cwd: REPO_ROOT,
+      stdio: 'inherit',
+    })
+  } catch (err) {
+    printWarning(`Failed to open scope-change PR: ${err}`)
+  }
+}
+
+/**
+ * Read stryker.config.json. The file is JSON-with-comments-via-_comment-keys
+ * (Stryker's convention), so plain JSON.parse works.
+ */
+function readStrykerConfig(absolutePath: string): Record<string, unknown> {
+  try {
+    return JSON.parse(readFileSync(absolutePath, 'utf-8'))
+  } catch (err) {
+    throw new Error(`Failed to read ${absolutePath}: ${err}`)
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err)
+  process.exit(1)
+})

--- a/bots/mutation-area-picker/lessons-learned.md
+++ b/bots/mutation-area-picker/lessons-learned.md
@@ -1,29 +1,46 @@
 # Mutation-area-picker — lessons learned
 
-Cross-run patterns the monthly compactor surfaces from the reviewer-log
-into Agent A's prompt. The bot reads this file at the top of every cron
-run and uses the lessons to calibrate its decision-making.
+Cross-run patterns distilled from the reviewer-log. The bot reads this
+file at the top of every cron and uses the lessons to calibrate its
+decision-making.
 
-**Empty until the first monthly compactor run.** Compactor needs at least
-4 weekly runs of reviewer-log signal before it produces lessons; below
-that threshold the signal-to-noise ratio is too low.
+## Status: v1 placeholder — no compactor shipped
 
-What the compactor surfaces here:
+The bot is autonomous v1; the compactor that would maintain this file
+is **deliberately deferred** per
+[`.claude/rules/design-mutation-area-picker.md`](../../.claude/rules/design-mutation-area-picker.md)
+§"Memory". Reason: at the bot's weekly cadence (~52 decisions/year),
+signal volume is too thin to justify a monthly compactor right now.
+The runtime budget already self-compacts the working portfolio via
+SWAP/REMOVE actions; this file would compact CROSS-decision patterns,
+which is a different concern that earns its place when the data
+accumulates.
 
-- **Heuristic-weight calibration.** "AI-pairing density consistently
-  ranked first but those modules' post-mutation kill ratios stayed
-  under 0.6. Consider lowering weight from 0.30 to 0.20."
-- **Eviction patterns.** "Modules under `src/admin-api/routes/` reached
-  kill ratio 0.85 within 6 weeks consistently. Worth tightening the
-  4-week sustainment to 3 weeks for routes specifically?"
-- **Recurring rejection themes.** "Last 3 maintainer rejections all
-  cited 'pure type module — nothing to mutate.' Add a kind-detection
-  pre-filter."
+**Until the compactor ships, this file stays empty.** The bot's prompt
+still loads it (the load path is wired so adding a compactor later is
+additive).
 
-What the compactor does NOT surface here:
+## Manual recalibration today
 
-- Per-module rejection prose (that lives in skip-list.json's
-  reasonNote field; durable per-instance memory)
-- One-off observations from a single PR (wait for the pattern to
-  recur before promoting to a lesson)
-- Anything the bot's prompt already says (no duplication)
+If you observe a pattern that should become a lesson — e.g. weights
+consistently producing weak picks — edit this file by hand and commit.
+The bot reads it next cron. When the compactor lands, it will rewrite
+this file holistically from the reviewer-log.
+
+## Trigger to revisit compactor design
+
+Any one of:
+
+- **Skip-list grows past 10 entries** with visible glob-compactable
+  patterns. At that point we want generic glob rules (like
+  dead-code-watcher's compactor produces), not 10+ specific entries.
+- **Reviewer-log entries past 200** (the cache ceiling). We want
+  bounded cache via the `pruneReviewerLog` helper already imported by
+  the future compactor.
+- **Calibration drift visible** — bot consistently picks weak
+  candidates because heuristic weights are wrong; we want
+  lessons-learned to surface the recurring pattern.
+
+When any trigger fires, the compactor ships as ~150 LOC + a job in
+`bots-compact.yml`. The design surface is unchanged; only the
+implementation timing.

--- a/bots/mutation-area-picker/lessons-learned.md
+++ b/bots/mutation-area-picker/lessons-learned.md
@@ -1,0 +1,29 @@
+# Mutation-area-picker — lessons learned
+
+Cross-run patterns the monthly compactor surfaces from the reviewer-log
+into Agent A's prompt. The bot reads this file at the top of every cron
+run and uses the lessons to calibrate its decision-making.
+
+**Empty until the first monthly compactor run.** Compactor needs at least
+4 weekly runs of reviewer-log signal before it produces lessons; below
+that threshold the signal-to-noise ratio is too low.
+
+What the compactor surfaces here:
+
+- **Heuristic-weight calibration.** "AI-pairing density consistently
+  ranked first but those modules' post-mutation kill ratios stayed
+  under 0.6. Consider lowering weight from 0.30 to 0.20."
+- **Eviction patterns.** "Modules under `src/admin-api/routes/` reached
+  kill ratio 0.85 within 6 weeks consistently. Worth tightening the
+  4-week sustainment to 3 weeks for routes specifically?"
+- **Recurring rejection themes.** "Last 3 maintainer rejections all
+  cited 'pure type module — nothing to mutate.' Add a kind-detection
+  pre-filter."
+
+What the compactor does NOT surface here:
+
+- Per-module rejection prose (that lives in skip-list.json's
+  reasonNote field; durable per-instance memory)
+- One-off observations from a single PR (wait for the pattern to
+  recur before promoting to a lesson)
+- Anything the bot's prompt already says (no duplication)

--- a/bots/mutation-area-picker/reviewer-log.ts
+++ b/bots/mutation-area-picker/reviewer-log.ts
@@ -1,0 +1,98 @@
+/**
+ * Reviewer-log — durable record of every decision the
+ * mutation-area-picker makes.
+ *
+ * Append-only JSONL (`bots/mutation-area-picker/reviewer-log.jsonl`).
+ * One line per cron run: ADD, SWAP, REMOVE, or NOOP. Persists across
+ * runs via `actions/cache@v4` (ADR-0011 pattern). The monthly
+ * compactor reads recent entries and produces
+ * `lessons-learned.md` patterns.
+ *
+ * Why per-bot, not shared `_lib`: per the project's "bots should have
+ * separate memory" rule. The action enum + payload shape are
+ * mutation-area-picker-specific; sharing would force a generic
+ * `payload: unknown` type that loses information.
+ *
+ * NOTE: there is no Agent A / Agent B reviewer-loop here — the
+ * decision is computed deterministically in the orchestrator. The
+ * file is called `reviewer-log` for symmetry with the rest of the
+ * bot ecosystem and because the empirical signals (Stryker results,
+ * mutation-watcher fix-rates) ARE the implicit reviewers; each entry
+ * records "what did the bot decide, with what evidence."
+ */
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+
+export type DecisionAction = 'add' | 'swap' | 'remove' | 'noop'
+
+export interface ReviewerLogEntry {
+  ts: string
+  runId: string
+  action: DecisionAction
+  /** Module being added (ADD / SWAP) — null for REMOVE / NOOP. */
+  addedModule: string | null
+  /** Module being removed (REMOVE / SWAP) — null for ADD / NOOP. */
+  removedModule: string | null
+  /** Top inclusion score the bot saw this run (regardless of action). */
+  topInclusionScore: number
+  /** Worst (highest) eviction score among scoped modules — i.e. closest to graduating. */
+  worstEvictionScore: number
+  /** Estimated runtime cost in minutes after applying this decision (current + delta). */
+  estimatedRuntimeAfterMinutes: number
+  /** Human-readable summary of which rule fired. */
+  reasoning: string
+  /** Bootstrap week (1-4) when eviction logic is disabled; null afterwards. */
+  bootstrapWeek: number | null
+}
+
+export function appendReviewerLog(absolutePath: string, entry: ReviewerLogEntry): void {
+  appendFileSync(absolutePath, `${JSON.stringify(entry)}\n`)
+}
+
+export function readReviewerLog(absolutePath: string): ReviewerLogEntry[] {
+  if (!existsSync(absolutePath)) return []
+  const raw = readFileSync(absolutePath, 'utf-8')
+  const entries: ReviewerLogEntry[] = []
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue
+    try {
+      entries.push(JSON.parse(line) as ReviewerLogEntry)
+    } catch {
+      // malformed — skip
+    }
+  }
+  return entries
+}
+
+export function tailReviewerLog(absolutePath: string, n: number): ReviewerLogEntry[] {
+  return readReviewerLog(absolutePath).slice(-n)
+}
+
+/**
+ * Count distinct weekly run timestamps. Used to determine the
+ * bootstrap-week counter (first 4 weeks: ADD-only, no eviction).
+ *
+ * "Distinct week" is approximated by counting unique YYYY-MM-DD
+ * dates spanning >= 6 days from the oldest — protects against
+ * accidental multiple runs in one day inflating the count.
+ */
+export function countWeeklyRuns(entries: ReviewerLogEntry[]): number {
+  if (entries.length === 0) return 0
+  const days = new Set(entries.map(e => e.ts.slice(0, 10)))
+  return days.size
+}
+
+/**
+ * Truncate the file to the last `keepLast` entries. Mirrors
+ * dead-code-watcher's pruneReviewerLog — the compactor calls this
+ * after producing its lessons rewrite to keep the cached file
+ * bounded.
+ */
+export function pruneReviewerLog(absolutePath: string, keepLast: number): { dropped: number; kept: number } {
+  const all = readReviewerLog(absolutePath)
+  if (all.length <= keepLast) return { dropped: 0, kept: all.length }
+  const kept = all.slice(-keepLast)
+  writeFileSync(absolutePath, `${kept.map(e => JSON.stringify(e)).join('\n')}\n`)
+  return { dropped: all.length - keepLast, kept: kept.length }
+}
+
+export const REVIEWER_LOG_PATH = 'bots/mutation-area-picker/reviewer-log.jsonl'

--- a/bots/mutation-area-picker/scoring.ts
+++ b/bots/mutation-area-picker/scoring.ts
@@ -1,0 +1,173 @@
+/**
+ * Score composers for mutation-area-picker.
+ *
+ * Inclusion: 5-signal weighted composite, [0, 1]. Each raw signal is
+ * normalised to [0, 1] across the candidate set before weighting —
+ * a module with 10 AI-paired commits in a set where the max is 12
+ * scores ~0.83 on that dimension, not 10.0. Normalisation makes
+ * the weights well-defined regardless of absolute magnitudes.
+ *
+ * Eviction: composite AND predicate per ADR-0014. A module graduates
+ * (returns true) only when BOTH kill-ratio-sustained AND
+ * fix-rate-high hold. Neither alone is sufficient.
+ */
+import type { EvictionSignals, InclusionSignals } from './signals.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Inclusion scoring
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface InclusionWeights {
+  aiPairingDensity: number
+  testCoverageRatioInverse: number
+  recentChurn: number
+  flakeCorrelation: number
+  bugFixCorrelation: number
+}
+
+/**
+ * Default weights per design-mutation-area-picker.md.
+ * Sum = 1.0. Weights are initial guesses; recalibration happens via
+ * lessons-learned.md after 4-6 PRs of accumulated data.
+ */
+export const DEFAULT_WEIGHTS: InclusionWeights = {
+  aiPairingDensity: 0.3,
+  testCoverageRatioInverse: 0.25,
+  recentChurn: 0.2,
+  flakeCorrelation: 0.15,
+  bugFixCorrelation: 0.1,
+}
+
+/**
+ * Normalise a raw signal to [0, 1] across the candidate set.
+ * If the max is 0 (e.g. nobody has AI-pairing in the set), all
+ * candidates score 0 on that dimension — neutral, no contribution.
+ * testCoverageRatioInverse is already pre-normalised to [0, 1] by
+ * the signal collector; the function detects this and leaves it as
+ * raw value.
+ */
+export function normalise(values: number[]): number[] {
+  const max = Math.max(...values, 0)
+  if (max === 0) return values.map(() => 0)
+  return values.map(v => v / max)
+}
+
+/**
+ * Compute composite inclusion scores for a candidate set. Returns
+ * scores in the same order as the input.
+ *
+ * The weights argument allows operator override via env or future
+ * lessons-learned recalibration; defaults match the design doc.
+ */
+export function composeInclusionScores(
+  candidates: InclusionSignals[],
+  weights: InclusionWeights = DEFAULT_WEIGHTS,
+): number[] {
+  // Test/coverage ratio is already in [0, 1] from the collector;
+  // pass through as-is. The others are absolute counts and need
+  // normalisation across the candidate set.
+  const aiPaired = normalise(candidates.map(c => c.aiPairingDensity))
+  const churn = normalise(candidates.map(c => c.recentChurn))
+  const flake = normalise(candidates.map(c => c.flakeCorrelation))
+  const bugFix = normalise(candidates.map(c => c.bugFixCorrelation))
+
+  return candidates.map(
+    (c, i) =>
+      weights.aiPairingDensity * aiPaired[i] +
+      weights.testCoverageRatioInverse * c.testCoverageRatioInverse +
+      weights.recentChurn * churn[i] +
+      weights.flakeCorrelation * flake[i] +
+      weights.bugFixCorrelation * bugFix[i],
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Eviction predicate (per ADR-0014)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface EvictionThresholds {
+  /** Kill ratio that each of the last N runs must exceed. Default 0.85. */
+  killRatio: number
+  /** Min entries in killRatioHistory; below this, never graduates. Default 4. */
+  minHistoryLength: number
+  /** Min fix rate (closedMerged / total) for mutation-watcher issues. Default 0.7. */
+  fixRate: number
+  /** Min mutation-issues count; below this we don't have enough signal to evaluate. Default 1. */
+  minIssueCount: number
+}
+
+export const DEFAULT_EVICTION_THRESHOLDS: EvictionThresholds = {
+  killRatio: 0.85,
+  minHistoryLength: 4,
+  fixRate: 0.7,
+  minIssueCount: 1,
+}
+
+export interface EvictionEvaluation {
+  /** True when both conditions hold and the module is eligible to graduate. */
+  evicts: boolean
+  /** Numeric "how close" score in [0, 1] — useful for ranking when no module fully evicts. */
+  score: number
+  /** Which condition failed when evicts=false; null when both pass. */
+  reason: string | null
+}
+
+/**
+ * Apply the ADR-0014 empirical eviction rule. Returns whether the
+ * module graduates AND a numeric "closeness" score for ranking
+ * purposes when no module fully evicts.
+ *
+ * The score is the GEOMETRIC MEAN of the two component sub-scores
+ * (kill-ratio-headroom, fix-rate). Geometric mean penalises imbalance:
+ * a module with kill ratio 0.95 but fix rate 0.1 scores low, not high.
+ * That matches the AND semantics of the predicate.
+ */
+export function evaluateEviction(
+  signals: EvictionSignals,
+  thresholds: EvictionThresholds = DEFAULT_EVICTION_THRESHOLDS,
+): EvictionEvaluation {
+  // History too short → cannot evaluate; module stays (bootstrap)
+  if (signals.killRatioHistory.length < thresholds.minHistoryLength) {
+    return {
+      evicts: false,
+      score: 0,
+      reason: `history too short (${signals.killRatioHistory.length}/${thresholds.minHistoryLength} weeks)`,
+    }
+  }
+
+  // Sub-score 1: kill-ratio headroom — how much each recent ratio
+  // exceeds the threshold. If any single ratio falls below, the
+  // SUSTAINED condition fails (we use min, not mean).
+  const minRatio = Math.min(...signals.killRatioHistory)
+  const ratioComponent = Math.max(
+    0,
+    Math.min(1, (minRatio - thresholds.killRatio) / (1 - thresholds.killRatio + 0.001) + 0.5),
+  )
+  const ratioPasses = minRatio >= thresholds.killRatio
+
+  // Sub-score 2: fix rate — fraction of mutation-watcher issues closed-merged.
+  if (signals.mutationIssuesTotal < thresholds.minIssueCount) {
+    return {
+      evicts: false,
+      score: ratioComponent * 0.5, // signal incomplete; score conservatively
+      reason: `not enough mutation-watcher issues (${signals.mutationIssuesTotal}/${thresholds.minIssueCount})`,
+    }
+  }
+  const fixRate = signals.mutationIssuesClosedMerged / signals.mutationIssuesTotal
+  const fixRateComponent = Math.max(
+    0,
+    Math.min(1, (fixRate - thresholds.fixRate) / (1 - thresholds.fixRate + 0.001) + 0.5),
+  )
+  const fixRatePasses = fixRate >= thresholds.fixRate
+
+  // Geometric mean for combined score
+  const score = Math.sqrt(ratioComponent * fixRateComponent)
+
+  if (ratioPasses && fixRatePasses) {
+    return { evicts: true, score, reason: null }
+  }
+  const reason = !ratioPasses
+    ? `kill ratio ${(minRatio * 100).toFixed(1)}% below ${(thresholds.killRatio * 100).toFixed(0)}%`
+    : `fix rate ${(fixRate * 100).toFixed(1)}% below ${(thresholds.fixRate * 100).toFixed(0)}%`
+  return { evicts: false, score, reason }
+}

--- a/bots/mutation-area-picker/signal-env.ts
+++ b/bots/mutation-area-picker/signal-env.ts
@@ -1,0 +1,173 @@
+/**
+ * Real SignalEnv implementation — wraps git, gh, and filesystem
+ * queries with the same interface tests inject mocks for.
+ *
+ * Each method runs ONE external command (git log, gh issue list,
+ * file read). Caller batches across modules via Promise.all in
+ * collectInclusionSignals.
+ *
+ * Performance note: at the design's "~50 candidate modules" envelope,
+ * each module triggers ~5 external queries. 250 total per cron.
+ * gh API has 5000 req/h limit; we're well under. git log is local.
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type { SignalEnv } from './signals.js'
+
+export interface SignalEnvOpts {
+  /** Absolute path to the repo root. */
+  repoRoot: string
+  /** Test directory glob — defaults to packages/gazetta/tests/. */
+  testDir?: string
+  /** GitHub repo identity for gh commands ("owner/repo"). */
+  ghRepo?: string
+}
+
+/**
+ * Build a SignalEnv for production use. Each method shells out
+ * to git or gh; failures return safe defaults (0 or []) so a
+ * transient API outage doesn't crash the bot.
+ */
+export function createSignalEnv(opts: SignalEnvOpts): SignalEnv {
+  const { repoRoot } = opts
+  const testDir = opts.testDir ?? 'packages/gazetta/tests'
+
+  return {
+    async countCommitsTouching(modulePath, sinceDays) {
+      const since = `${sinceDays}.days.ago`
+      try {
+        const output = execFileSync('git', ['log', `--since=${since}`, '--oneline', '--', modulePath], {
+          cwd: repoRoot,
+          encoding: 'utf-8',
+        })
+        return output.trim().split('\n').filter(Boolean).length
+      } catch {
+        return 0
+      }
+    },
+
+    async countAIPairedCommitsTouching(modulePath, sinceDays) {
+      const since = `${sinceDays}.days.ago`
+      try {
+        // --grep filters commit messages; --all-match is irrelevant here
+        // because we only have one --grep. Output is one line per commit
+        // that touched the path AND has the Co-Authored-By line.
+        const output = execFileSync(
+          'git',
+          ['log', `--since=${since}`, '--grep=Co-Authored-By: Claude', '--oneline', '--', modulePath],
+          { cwd: repoRoot, encoding: 'utf-8' },
+        )
+        return output.trim().split('\n').filter(Boolean).length
+      } catch {
+        return 0
+      }
+    },
+
+    async countLines(absolutePath) {
+      try {
+        if (!existsSync(absolutePath)) return 0
+        const content = readFileSync(absolutePath, 'utf-8')
+        return content.split('\n').length
+      } catch {
+        return 0
+      }
+    },
+
+    async findRelatedTestFiles(moduleBasename) {
+      const dir = resolve(repoRoot, testDir)
+      try {
+        if (!existsSync(dir)) return []
+        return readdirSync(dir)
+          .filter(f => f.includes(moduleBasename) && (f.endsWith('.test.ts') || f.endsWith('.test.tsx')))
+          .map(f => resolve(dir, f))
+      } catch {
+        return []
+      }
+    },
+
+    async findFlakeIssuesMentioning(modulePath) {
+      if (!opts.ghRepo) return 0
+      try {
+        // Open flake-labelled issues whose title or body mentions the
+        // module's basename. We use the basename (not full path) because
+        // issue titles rarely contain full paths.
+        const basename = modulePath.split('/').pop() ?? modulePath
+        const output = execFileSync(
+          'gh',
+          [
+            'issue',
+            'list',
+            '--repo',
+            opts.ghRepo,
+            '--label',
+            'flake',
+            '--state',
+            'open',
+            '--search',
+            basename,
+            '--json',
+            'number',
+            '--limit',
+            '50',
+          ],
+          { cwd: repoRoot, encoding: 'utf-8' },
+        )
+        return (JSON.parse(output) as unknown[]).length
+      } catch {
+        return 0
+      }
+    },
+
+    async countRecentFixPRsTouching(modulePath, sinceDays) {
+      if (!opts.ghRepo) return 0
+      try {
+        // We can't directly filter PRs by file path via `gh pr list`,
+        // so we approximate: list merged fix: PRs in the window and
+        // check their commits via git log on the path.
+        // Cheaper: use `git log --grep="^fix:" --since=...` filtered to path.
+        const since = `${sinceDays}.days.ago`
+        const output = execFileSync('git', ['log', `--since=${since}`, '--grep=^fix:', '--oneline', '--', modulePath], {
+          cwd: repoRoot,
+          encoding: 'utf-8',
+        })
+        return output.trim().split('\n').filter(Boolean).length
+      } catch {
+        return 0
+      }
+    },
+
+    async countMutationIssues(modulePath, sinceDays) {
+      if (!opts.ghRepo) return { total: 0, closedMerged: 0 }
+      try {
+        const basename = modulePath.split('/').pop() ?? modulePath
+        // Mutation-watcher issues mention "mutation" + the basename in title.
+        const sinceIso = new Date(Date.now() - sinceDays * 86400_000).toISOString().slice(0, 10)
+        const output = execFileSync(
+          'gh',
+          [
+            'issue',
+            'list',
+            '--repo',
+            opts.ghRepo,
+            '--search',
+            `mutation ${basename} in:title created:>=${sinceIso}`,
+            '--state',
+            'all',
+            '--json',
+            'number,state,stateReason',
+            '--limit',
+            '50',
+          ],
+          { cwd: repoRoot, encoding: 'utf-8' },
+        )
+        const issues = JSON.parse(output) as Array<{ number: number; state: string; stateReason: string | null }>
+        const total = issues.length
+        const closedMerged = issues.filter(i => i.state === 'CLOSED' && i.stateReason !== 'not_planned').length
+        return { total, closedMerged }
+      } catch {
+        return { total: 0, closedMerged: 0 }
+      }
+    },
+  }
+}

--- a/bots/mutation-area-picker/signals.ts
+++ b/bots/mutation-area-picker/signals.ts
@@ -1,0 +1,199 @@
+/**
+ * Signal collectors for mutation-area-picker.
+ *
+ * Five inclusion signals (for un-mutated modules) + two eviction
+ * signals (for scoped modules). Each is a pure function over its
+ * inputs; I/O (git log, gh API) is wrapped in injected helpers so
+ * tests can substitute fixture data.
+ *
+ * Per [design-mutation-area-picker.md](../../.claude/rules/design-mutation-area-picker.md)
+ * §"Inclusion score" and §"Eviction score".
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// I/O helpers — injected so tests can mock without touching the filesystem
+// or GitHub API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Pluggable signal-collection environment. Tests provide fixture
+ * implementations; production wires real git/gh/fs calls.
+ */
+export interface SignalEnv {
+  /**
+   * Return absolute git commit count touching `modulePath` since
+   * `sinceDays` ago. `--name-only` output filtered to the module's path.
+   */
+  countCommitsTouching(modulePath: string, sinceDays: number): Promise<number>
+  /**
+   * Same query as `countCommitsTouching` but restricted to commits
+   * with `Co-Authored-By: Claude` in their message. Indicator of
+   * AI-pairing density.
+   */
+  countAIPairedCommitsTouching(modulePath: string, sinceDays: number): Promise<number>
+  /**
+   * Line counts: src file LOC and corresponding tests' LOC.
+   * For a module at `packages/gazetta/src/foo/bar.ts`, tests are
+   * found via `packages/gazetta/tests/**\/*bar*`.
+   */
+  countLines(absolutePath: string): Promise<number>
+  /**
+   * Return paths of test files matching the module by basename
+   * heuristic. Caller passes the basename without extension; helper
+   * scans the test dir.
+   */
+  findRelatedTestFiles(moduleBasename: string): Promise<string[]>
+  /**
+   * Return open issues with the given label whose title or body
+   * mentions `modulePath` or its basename.
+   */
+  findFlakeIssuesMentioning(modulePath: string): Promise<number>
+  /**
+   * Return count of merged `fix:` PRs in the last `sinceDays` whose
+   * file list includes `modulePath`.
+   */
+  countRecentFixPRsTouching(modulePath: string, sinceDays: number): Promise<number>
+  /**
+   * Return mutation-watcher issue statistics for `modulePath`:
+   * total issues filed in the last `sinceDays`, and how many of
+   * those are now closed-merged.
+   */
+  countMutationIssues(modulePath: string, sinceDays: number): Promise<{ total: number; closedMerged: number }>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Inclusion signals — for un-mutated modules
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Raw signal samples for one module. Composer normalises across
+ * the candidate set before weighting.
+ */
+export interface InclusionSignals {
+  /** Co-Authored-By: Claude commits in last 90d touching the module. */
+  aiPairingDensity: number
+  /** Inverse test/source LOC ratio — higher = less coverage. */
+  testCoverageRatioInverse: number
+  /** Commits touching the module in last 90d. */
+  recentChurn: number
+  /** Count of open flake-watcher issues whose body mentions the module. */
+  flakeCorrelation: number
+  /** Count of merged `fix:` PRs touching the module in last 30d. */
+  bugFixCorrelation: number
+}
+
+export interface InclusionConfig {
+  /** Window for AI-pairing + churn queries. Default 90 days. */
+  windowDays: number
+  /** Window for bug-fix PR query. Default 30 days. */
+  bugFixWindowDays: number
+}
+
+export const DEFAULT_INCLUSION_CONFIG: InclusionConfig = {
+  windowDays: 90,
+  bugFixWindowDays: 30,
+}
+
+/**
+ * Collect raw inclusion signals for one module path. Pure function
+ * over the environment; tests substitute fixture envs.
+ */
+export async function collectInclusionSignals(
+  env: SignalEnv,
+  modulePath: string,
+  srcAbsPath: string,
+  config: InclusionConfig = DEFAULT_INCLUSION_CONFIG,
+): Promise<InclusionSignals> {
+  const [aiPairingDensity, recentChurn, flakeCorrelation, bugFixCorrelation, srcLOC] = await Promise.all([
+    env.countAIPairedCommitsTouching(modulePath, config.windowDays),
+    env.countCommitsTouching(modulePath, config.windowDays),
+    env.findFlakeIssuesMentioning(modulePath),
+    env.countRecentFixPRsTouching(modulePath, config.bugFixWindowDays),
+    env.countLines(srcAbsPath),
+  ])
+
+  // For test/source ratio: find test files by basename heuristic
+  const basename = pathToBasename(modulePath)
+  const testFiles = await env.findRelatedTestFiles(basename)
+  const testLOCs = await Promise.all(testFiles.map(f => env.countLines(f)))
+  const testLOC = testLOCs.reduce((a, b) => a + b, 0)
+
+  // Inverse coverage ratio: ratio = testLOC / srcLOC; inverse = 1 / (1 + ratio)
+  // — clamps to [0, 1]; thin coverage (low ratio) → high inverse → high score
+  const ratio = srcLOC === 0 ? 0 : testLOC / srcLOC
+  const testCoverageRatioInverse = 1 / (1 + ratio)
+
+  return {
+    aiPairingDensity,
+    testCoverageRatioInverse,
+    recentChurn,
+    flakeCorrelation,
+    bugFixCorrelation,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Eviction signals — for scoped modules
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Raw eviction signals. The composer checks both conditions:
+ * kill-ratio sustained AND fix-rate high. Either alone is
+ * insufficient (see ADR-0014).
+ */
+export interface EvictionSignals {
+  /** Kill ratios from the last N weekly Stryker runs, oldest-first. */
+  killRatioHistory: number[]
+  /** Total mutation-watcher issues filed for this module in lookback window. */
+  mutationIssuesTotal: number
+  /** Of those, how many are closed-merged. */
+  mutationIssuesClosedMerged: number
+}
+
+export interface EvictionConfig {
+  /** Window for mutation-watcher issue stats. Default 90 days. */
+  issueWindowDays: number
+  /** How many weeks of kill-ratio history to consider. Default 4. */
+  killRatioWeeks: number
+}
+
+export const DEFAULT_EVICTION_CONFIG: EvictionConfig = {
+  issueWindowDays: 90,
+  killRatioWeeks: 4,
+}
+
+/**
+ * Collect eviction signals for one scoped module. The kill-ratio
+ * history is passed in pre-fetched (the bot already loads the
+ * Stryker timing report once per run; per-module slicing happens
+ * upstream).
+ */
+export async function collectEvictionSignals(
+  env: SignalEnv,
+  modulePath: string,
+  killRatioHistory: number[],
+  config: EvictionConfig = DEFAULT_EVICTION_CONFIG,
+): Promise<EvictionSignals> {
+  const stats = await env.countMutationIssues(modulePath, config.issueWindowDays)
+  // Take last N weeks; if fewer entries exist (bootstrap), use what we have
+  const recentHistory = killRatioHistory.slice(-config.killRatioWeeks)
+  return {
+    killRatioHistory: recentHistory,
+    mutationIssuesTotal: stats.total,
+    mutationIssuesClosedMerged: stats.closedMerged,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Strip directory + extension from a module path.
+ * `packages/gazetta/src/archive/index.ts` → `index`
+ * `packages/gazetta/src/publish.ts` → `publish`
+ */
+export function pathToBasename(modulePath: string): string {
+  const filename = modulePath.split('/').pop() ?? modulePath
+  return filename.replace(/\.[^.]+$/, '')
+}

--- a/bots/mutation-area-picker/skip-list.json
+++ b/bots/mutation-area-picker/skip-list.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "entries": [],
+  "rules": []
+}

--- a/bots/mutation-area-picker/skip-list.ts
+++ b/bots/mutation-area-picker/skip-list.ts
@@ -1,0 +1,153 @@
+/**
+ * Mutation-area-picker skip-list — durable memory of modules the bot
+ * should NEVER propose for the mutate glob.
+ *
+ * Same architectural shape as dead-code-watcher's and fix-bot's
+ * skip-lists, with a different fingerprint type: identity is a source
+ * module path, not a knip finding or GitHub issue number.
+ *
+ * Two entry kinds:
+ *
+ *   - **never-mutate**: generated code, third-party shims, files where
+ *     mutation testing is meaningless (e.g., type-only modules with no
+ *     runtime behaviour to mutate). Permanent — never expires.
+ *
+ *   - **maintainer-rejected**: bot proposed adding this module via PR;
+ *     maintainer closed the PR. The reason is mined from the close
+ *     comment and stored as `reasonNote`. The skip is durable but the
+ *     monthly compactor can promote recurring rejection patterns into
+ *     lessons-learned.md.
+ *
+ * Lessons-learned (the cross-run pattern memory) lives in
+ * `bots/mutation-area-picker/lessons-learned.md` and is loaded by the
+ * bot's prompt directly. Skip-list is the per-module gate;
+ * lessons-learned is the cross-module heuristic-calibration wisdom.
+ * Different files, different update cadences.
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+
+/**
+ * Fingerprint — uniquely identifies a source module the bot might
+ * propose. Always a relative path from the repo root (e.g.
+ * `packages/gazetta/src/archive/index.ts`).
+ */
+export interface ModuleFingerprint {
+  path: string
+}
+
+/** Reason categories — drives which path the bot takes on subsequent runs. */
+export type SkipReason =
+  /** Generated code, third-party shims, no-runtime modules. Permanent. */
+  | 'never-mutate'
+  /** Bot proposed it; maintainer closed the PR. Durable until lessons compact it. */
+  | 'maintainer-rejected'
+  /** Free-text reason — used when none of the above categories fit. */
+  | 'other'
+
+export interface SkipEntry {
+  fingerprint: ModuleFingerprint
+  reason: SkipReason
+  reasonNote: string
+  addedAt: string
+  addedBy: 'bot' | 'maintainer'
+  /** When reason='maintainer-rejected', the PR number whose close drove the entry. */
+  refPR?: number
+}
+
+export interface SkipRule {
+  /** Glob pattern matched against module path. */
+  scope: string
+  reason: SkipReason
+  reasonNote: string
+  addedAt: string
+  addedBy: 'bot' | 'maintainer'
+}
+
+export interface SkipList {
+  version: 1
+  entries: SkipEntry[]
+  rules: SkipRule[]
+}
+
+export const SKIP_LIST_PATH = 'bots/mutation-area-picker/skip-list.json'
+
+export function emptySkipList(): SkipList {
+  return { version: 1, entries: [], rules: [] }
+}
+
+export function readSkipList(absolutePath: string): SkipList {
+  if (!existsSync(absolutePath)) return emptySkipList()
+  try {
+    const parsed = JSON.parse(readFileSync(absolutePath, 'utf-8'))
+    if (parsed?.version === 1 && Array.isArray(parsed.entries) && Array.isArray(parsed.rules)) {
+      return parsed as SkipList
+    }
+  } catch {
+    // fall through to empty
+  }
+  return emptySkipList()
+}
+
+export function writeSkipList(absolutePath: string, list: SkipList): void {
+  writeFileSync(absolutePath, `${JSON.stringify(list, null, 2)}\n`)
+}
+
+/**
+ * Return the matching entry or rule for the given fingerprint, or
+ * null when neither matches. Entries take precedence over rules
+ * (per-module > per-glob).
+ */
+export function findSkipMatch(list: SkipList, fp: ModuleFingerprint): SkipEntry | SkipRule | null {
+  for (const entry of list.entries) {
+    if (entry.fingerprint.path === fp.path) return entry
+  }
+  for (const rule of list.rules) {
+    if (globMatches(rule.scope, fp.path)) return rule
+  }
+  return null
+}
+
+/**
+ * Glob matcher supporting `*` (single segment) and `**` (any depth).
+ * Same semantics as the other bots' skip-list globs. Brace
+ * expansion (`{a,b}`) is intentionally NOT supported — keep the
+ * matcher simple; use multiple rules when a brace would be needed.
+ */
+export function globMatches(pattern: string, path: string): boolean {
+  // Token-by-token: escape regex metacharacters EXCEPT our glob
+  // tokens. `**` matches any path including separators (with optional
+  // trailing slash consumed so `src/**/*.ts` matches `src/foo.ts`
+  // AND `src/x/foo.ts`); `*` matches a single segment.
+  let regex = ''
+  let i = 0
+  while (i < pattern.length) {
+    const c = pattern[i]
+    if (c === '*' && pattern[i + 1] === '*') {
+      regex += '.*'
+      i += 2
+      // Consume the trailing slash so `foo/**/bar` matches `foo/bar`
+      if (pattern[i] === '/') i++
+    } else if (c === '*') {
+      regex += '[^/]*'
+      i++
+    } else if ('.+?^$()|[]\\{}'.includes(c)) {
+      regex += `\\${c}`
+      i++
+    } else {
+      regex += c
+      i++
+    }
+  }
+  return new RegExp(`^${regex}$`).test(path)
+}
+
+/**
+ * Append an entry to the skip-list, deduping by fingerprint path.
+ * Returns true if the entry was added; false if a duplicate existed.
+ */
+export function appendEntry(list: SkipList, entry: SkipEntry): boolean {
+  const exists = list.entries.some(e => e.fingerprint.path === entry.fingerprint.path)
+  if (exists) return false
+  list.entries.push(entry)
+  return true
+}

--- a/bots/mutation-area-picker/tests/decision.test.ts
+++ b/bots/mutation-area-picker/tests/decision.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest'
+import { decide, type DecisionInput, type ScopedModule, type UnMutatedCandidate } from '../decision.js'
+
+function input(overrides: Partial<DecisionInput> = {}): DecisionInput {
+  return {
+    unMutated: [],
+    scoped: [],
+    currentRuntimeMinutes: 100,
+    budgetMinutes: 105,
+    inBootstrap: false,
+    inclusionThreshold: 0.4,
+    evictionThreshold: 0.7,
+    ...overrides,
+  }
+}
+
+function candidate(overrides: Partial<UnMutatedCandidate> = {}): UnMutatedCandidate {
+  return {
+    modulePath: 'src/archive/index.ts',
+    inclusionScore: 0.6,
+    estimatedRuntimeMinutes: 3,
+    ...overrides,
+  }
+}
+
+function scoped(overrides: Partial<ScopedModule> = {}): ScopedModule {
+  return {
+    modulePath: 'src/publish.ts',
+    eviction: { evicts: false, score: 0.3, reason: 'kill ratio 70% below 85%' },
+    estimatedRuntimeMinutes: 10,
+    ...overrides,
+  }
+}
+
+describe('decide — ADD path', () => {
+  it('ADDs when budget headroom and top score clears threshold', () => {
+    const decision = decide(
+      input({
+        unMutated: [candidate({ inclusionScore: 0.7, estimatedRuntimeMinutes: 3 })],
+        currentRuntimeMinutes: 100,
+        budgetMinutes: 105,
+      }),
+    )
+    expect(decision.action).toBe('add')
+    if (decision.action === 'add') expect(decision.module).toBe('src/archive/index.ts')
+  })
+
+  it('picks the highest-scoring candidate when multiple available', () => {
+    const decision = decide(
+      input({
+        unMutated: [
+          candidate({ modulePath: 'src/low.ts', inclusionScore: 0.5 }),
+          candidate({ modulePath: 'src/high.ts', inclusionScore: 0.9 }),
+          candidate({ modulePath: 'src/mid.ts', inclusionScore: 0.7 }),
+        ],
+      }),
+    )
+    expect(decision.action).toBe('add')
+    if (decision.action === 'add') expect(decision.module).toBe('src/high.ts')
+  })
+
+  it('does NOT ADD when top score is below threshold', () => {
+    const decision = decide(
+      input({
+        unMutated: [candidate({ inclusionScore: 0.3 })],
+        inclusionThreshold: 0.4,
+      }),
+    )
+    expect(decision.action).toBe('noop')
+  })
+
+  it('does NOT ADD when budget exceeded', () => {
+    const decision = decide(
+      input({
+        unMutated: [candidate({ inclusionScore: 0.7, estimatedRuntimeMinutes: 10 })],
+        currentRuntimeMinutes: 100,
+        budgetMinutes: 105,
+      }),
+    )
+    expect(decision.action).toBe('noop')
+  })
+})
+
+describe('decide — Bootstrap mode', () => {
+  it('ADDs in bootstrap when budget headroom exists', () => {
+    const decision = decide(
+      input({
+        unMutated: [candidate({ inclusionScore: 0.7, estimatedRuntimeMinutes: 3 })],
+        inBootstrap: true,
+      }),
+    )
+    expect(decision.action).toBe('add')
+  })
+
+  it('NOOPs in bootstrap when no candidate clears threshold', () => {
+    const decision = decide(
+      input({
+        unMutated: [candidate({ inclusionScore: 0.3 })],
+        inBootstrap: true,
+      }),
+    )
+    expect(decision.action).toBe('noop')
+  })
+
+  it('NOOPs in bootstrap when over budget even if scoped would graduate', () => {
+    // Bootstrap blocks eviction; bot must NOT swap/remove even when scoped graduate
+    const decision = decide(
+      input({
+        unMutated: [candidate({ inclusionScore: 0.9, estimatedRuntimeMinutes: 10 })],
+        scoped: [scoped({ eviction: { evicts: true, score: 0.9, reason: null } })],
+        currentRuntimeMinutes: 100,
+        budgetMinutes: 105,
+        inBootstrap: true,
+      }),
+    )
+    expect(decision.action).toBe('noop')
+    if (decision.action === 'noop') expect(decision.reasoning).toMatch(/Bootstrap mode/)
+  })
+})
+
+describe('decide — SWAP path', () => {
+  it('SWAPs when at budget AND scoped graduates AND un-mutated outranks', () => {
+    const decision = decide(
+      input({
+        unMutated: [candidate({ modulePath: 'src/new.ts', inclusionScore: 0.95 })],
+        scoped: [scoped({ modulePath: 'src/old.ts', eviction: { evicts: true, score: 0.8, reason: null } })],
+        currentRuntimeMinutes: 105,
+        budgetMinutes: 105,
+      }),
+    )
+    expect(decision.action).toBe('swap')
+    if (decision.action === 'swap') {
+      expect(decision.addModule).toBe('src/new.ts')
+      expect(decision.removeModule).toBe('src/old.ts')
+    }
+  })
+
+  it('does NOT swap when un-mutated does not outrank eviction score', () => {
+    const decision = decide(
+      input({
+        unMutated: [candidate({ inclusionScore: 0.5 })],
+        scoped: [scoped({ eviction: { evicts: true, score: 0.8, reason: null } })],
+        currentRuntimeMinutes: 105,
+        budgetMinutes: 105,
+      }),
+    )
+    // best-eviction graduated, no replacement candidate clears the bar → REMOVE
+    expect(decision.action).toBe('remove')
+  })
+})
+
+describe('decide — REMOVE path', () => {
+  it('REMOVEs when scoped graduates but no good un-mutated to swap', () => {
+    const decision = decide(
+      input({
+        unMutated: [], // no candidates at all
+        scoped: [scoped({ modulePath: 'src/done.ts', eviction: { evicts: true, score: 0.85, reason: null } })],
+        currentRuntimeMinutes: 105,
+        budgetMinutes: 105,
+      }),
+    )
+    expect(decision.action).toBe('remove')
+    if (decision.action === 'remove') expect(decision.module).toBe('src/done.ts')
+  })
+
+  it('REMOVEs when un-mutated exists but scores below SWAP bar', () => {
+    const decision = decide(
+      input({
+        unMutated: [candidate({ inclusionScore: 0.5 })], // below eviction score 0.8
+        scoped: [scoped({ eviction: { evicts: true, score: 0.8, reason: null } })],
+        currentRuntimeMinutes: 105,
+        budgetMinutes: 105,
+      }),
+    )
+    expect(decision.action).toBe('remove')
+  })
+})
+
+describe('decide — NOOP path', () => {
+  it('NOOPs when no un-mutated candidates and no eviction-ripe scoped', () => {
+    const decision = decide(input({ unMutated: [], scoped: [scoped()] }))
+    expect(decision.action).toBe('noop')
+  })
+
+  it('NOOPs when top candidate below threshold AND no scoped graduates', () => {
+    const decision = decide(
+      input({
+        unMutated: [candidate({ inclusionScore: 0.3 })],
+        scoped: [scoped({ eviction: { evicts: false, score: 0.4, reason: 'fix rate below' } })],
+      }),
+    )
+    expect(decision.action).toBe('noop')
+  })
+
+  it('NOOP reasoning explains the closest-to-graduation scoped module', () => {
+    const decision = decide(
+      input({
+        unMutated: [candidate({ inclusionScore: 0.6, estimatedRuntimeMinutes: 10 })],
+        scoped: [
+          scoped({
+            modulePath: 'src/almost.ts',
+            eviction: { evicts: false, score: 0.6, reason: 'fix rate 65% below 70%' },
+          }),
+        ],
+        currentRuntimeMinutes: 100,
+        budgetMinutes: 105,
+      }),
+    )
+    expect(decision.action).toBe('noop')
+    if (decision.action === 'noop') {
+      expect(decision.reasoning).toMatch(/src\/almost\.ts/)
+      expect(decision.reasoning).toMatch(/0\.600|0\.6/)
+    }
+  })
+})
+
+describe('decide — eviction-threshold gate', () => {
+  it('does NOT swap when graduated scoped is below evictionThreshold', () => {
+    // Module's eviction.evicts is true (passes predicate) but its score is 0.65,
+    // below the configured threshold 0.7. SWAP bar not cleared.
+    const decision = decide(
+      input({
+        unMutated: [candidate({ inclusionScore: 0.95 })],
+        scoped: [scoped({ eviction: { evicts: true, score: 0.65, reason: null } })],
+        currentRuntimeMinutes: 105,
+        budgetMinutes: 105,
+        evictionThreshold: 0.7,
+      }),
+    )
+    expect(decision.action).toBe('noop')
+  })
+})

--- a/bots/mutation-area-picker/tests/reviewer-log.test.ts
+++ b/bots/mutation-area-picker/tests/reviewer-log.test.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  appendReviewerLog,
+  countWeeklyRuns,
+  pruneReviewerLog,
+  readReviewerLog,
+  type ReviewerLogEntry,
+  tailReviewerLog,
+} from '../reviewer-log.js'
+
+let dir: string
+let logPath: string
+
+beforeEach(() => {
+  dir = mkdtempSync(resolve(tmpdir(), 'map-reviewer-log-test-'))
+  logPath = resolve(dir, 'reviewer-log.jsonl')
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function entry(overrides: Partial<ReviewerLogEntry> = {}): ReviewerLogEntry {
+  return {
+    ts: '2026-05-17T12:00:00Z',
+    runId: 'run-1',
+    action: 'add',
+    addedModule: 'packages/gazetta/src/archive/index.ts',
+    removedModule: null,
+    topInclusionScore: 0.72,
+    worstEvictionScore: 0.3,
+    estimatedRuntimeAfterMinutes: 120,
+    reasoning: 'top candidate scored above INCLUSION_THRESHOLD',
+    bootstrapWeek: null,
+    ...overrides,
+  }
+}
+
+describe('appendReviewerLog + readReviewerLog', () => {
+  it('round-trips a single entry', () => {
+    appendReviewerLog(logPath, entry())
+    expect(readReviewerLog(logPath)).toEqual([entry()])
+  })
+
+  it('appends in order across action types', () => {
+    appendReviewerLog(logPath, entry({ action: 'add', runId: 'run-1' }))
+    appendReviewerLog(logPath, entry({ action: 'noop', runId: 'run-2', addedModule: null }))
+    appendReviewerLog(logPath, entry({ action: 'swap', runId: 'run-3', removedModule: 'src/foo.ts' }))
+    appendReviewerLog(
+      logPath,
+      entry({ action: 'remove', runId: 'run-4', addedModule: null, removedModule: 'src/bar.ts' }),
+    )
+    const all = readReviewerLog(logPath)
+    expect(all.map(e => e.action)).toEqual(['add', 'noop', 'swap', 'remove'])
+  })
+
+  it('returns [] when file is missing', () => {
+    expect(readReviewerLog(resolve(dir, 'missing.jsonl'))).toEqual([])
+  })
+
+  it('skips malformed lines', () => {
+    const good = entry()
+    writeFileSync(logPath, `${JSON.stringify(good)}\nbroken\n${JSON.stringify(good)}\n`)
+    expect(readReviewerLog(logPath)).toEqual([good, good])
+  })
+})
+
+describe('tailReviewerLog', () => {
+  it('returns last N entries', () => {
+    for (let i = 1; i <= 10; i++) appendReviewerLog(logPath, entry({ runId: `r${i}` }))
+    expect(tailReviewerLog(logPath, 3).map(e => e.runId)).toEqual(['r8', 'r9', 'r10'])
+  })
+})
+
+describe('countWeeklyRuns', () => {
+  it('returns 0 for empty entries', () => {
+    expect(countWeeklyRuns([])).toBe(0)
+  })
+
+  it('counts distinct YYYY-MM-DD dates', () => {
+    const entries = [
+      entry({ ts: '2026-05-17T05:00:00Z' }),
+      entry({ ts: '2026-05-17T06:00:00Z' }), // same day, doesn't count again
+      entry({ ts: '2026-05-24T05:00:00Z' }),
+      entry({ ts: '2026-05-31T05:00:00Z' }),
+    ]
+    expect(countWeeklyRuns(entries)).toBe(3)
+  })
+})
+
+describe('pruneReviewerLog', () => {
+  it('truncates to the last N entries', () => {
+    for (let i = 1; i <= 10; i++) appendReviewerLog(logPath, entry({ runId: `r${i}` }))
+    const result = pruneReviewerLog(logPath, 3)
+    expect(result).toEqual({ dropped: 7, kept: 3 })
+    expect(readReviewerLog(logPath).map(e => e.runId)).toEqual(['r8', 'r9', 'r10'])
+  })
+
+  it('is a no-op when under threshold', () => {
+    appendReviewerLog(logPath, entry())
+    expect(pruneReviewerLog(logPath, 100)).toEqual({ dropped: 0, kept: 1 })
+  })
+
+  it('handles missing file', () => {
+    expect(pruneReviewerLog(resolve(dir, 'missing.jsonl'), 10)).toEqual({ dropped: 0, kept: 0 })
+  })
+
+  it('subsequent append works after prune', () => {
+    for (let i = 1; i <= 5; i++) appendReviewerLog(logPath, entry({ runId: `r${i}` }))
+    pruneReviewerLog(logPath, 2)
+    appendReviewerLog(logPath, entry({ runId: 'r99' }))
+    expect(readReviewerLog(logPath).map(e => e.runId)).toEqual(['r4', 'r5', 'r99'])
+  })
+})

--- a/bots/mutation-area-picker/tests/scoring.test.ts
+++ b/bots/mutation-area-picker/tests/scoring.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import type { EvictionSignals, InclusionSignals } from '../signals.js'
+import {
+  composeInclusionScores,
+  DEFAULT_EVICTION_THRESHOLDS,
+  DEFAULT_WEIGHTS,
+  evaluateEviction,
+  normalise,
+} from '../scoring.js'
+
+describe('normalise', () => {
+  it('scales values to [0, 1] by the max', () => {
+    expect(normalise([2, 4, 8])).toEqual([0.25, 0.5, 1.0])
+  })
+
+  it('returns all zeros when max is 0', () => {
+    expect(normalise([0, 0, 0])).toEqual([0, 0, 0])
+  })
+
+  it('handles single-element array', () => {
+    expect(normalise([5])).toEqual([1.0])
+  })
+
+  it('handles empty array', () => {
+    expect(normalise([])).toEqual([])
+  })
+
+  it('clamps negative max to 0 (defensive)', () => {
+    // Realistically all signals are non-negative, but the function uses
+    // Math.max(...values, 0) to avoid -Infinity from empty.
+    expect(normalise([])).toEqual([])
+  })
+})
+
+describe('composeInclusionScores', () => {
+  function signal(overrides: Partial<InclusionSignals> = {}): InclusionSignals {
+    return {
+      aiPairingDensity: 0,
+      testCoverageRatioInverse: 0.5,
+      recentChurn: 0,
+      flakeCorrelation: 0,
+      bugFixCorrelation: 0,
+      ...overrides,
+    }
+  }
+
+  it('returns score in [0, 1] for default weights', () => {
+    const candidates = [signal({ aiPairingDensity: 10, recentChurn: 20 })]
+    const scores = composeInclusionScores(candidates)
+    expect(scores[0]).toBeGreaterThanOrEqual(0)
+    expect(scores[0]).toBeLessThanOrEqual(1)
+  })
+
+  it('ranks higher AI-paired candidate above lower one', () => {
+    const candidates = [
+      signal({ aiPairingDensity: 5 }), // low
+      signal({ aiPairingDensity: 50 }), // high
+    ]
+    const scores = composeInclusionScores(candidates)
+    expect(scores[1]).toBeGreaterThan(scores[0])
+  })
+
+  it('normalises within the candidate set, not absolutely', () => {
+    // The same absolute AI-pairing count (5) scores high when it's the
+    // top of the set, and low when it's not.
+    const scoresIfTop = composeInclusionScores([signal({ aiPairingDensity: 5 })])
+    const scoresIfNotTop = composeInclusionScores([signal({ aiPairingDensity: 5 }), signal({ aiPairingDensity: 50 })])
+    expect(scoresIfTop[0]).toBeGreaterThan(scoresIfNotTop[0])
+  })
+
+  it('weights apply correctly — testCoverageRatioInverse passes through directly', () => {
+    // testCoverageRatioInverse is already in [0, 1] — composer should
+    // NOT re-normalise it; it should weight it directly.
+    const candidates = [signal({ testCoverageRatioInverse: 1.0 })]
+    const scores = composeInclusionScores(candidates)
+    // With only this signal non-zero and weight 0.25, score = 0.25
+    expect(scores[0]).toBeCloseTo(DEFAULT_WEIGHTS.testCoverageRatioInverse, 5)
+  })
+
+  it('produces 0 when all signals are 0', () => {
+    const candidates = [signal({ testCoverageRatioInverse: 0 })]
+    const scores = composeInclusionScores(candidates)
+    expect(scores[0]).toBe(0)
+  })
+
+  it('respects custom weights', () => {
+    const customWeights = {
+      aiPairingDensity: 1.0, // only signal that matters
+      testCoverageRatioInverse: 0,
+      recentChurn: 0,
+      flakeCorrelation: 0,
+      bugFixCorrelation: 0,
+    }
+    const candidates = [signal({ aiPairingDensity: 1, testCoverageRatioInverse: 1 })]
+    const scores = composeInclusionScores(candidates, customWeights)
+    // testCoverageRatioInverse weight is 0, aiPairing normalised to 1.0 (only candidate)
+    expect(scores[0]).toBe(1.0)
+  })
+})
+
+describe('evaluateEviction', () => {
+  function signal(overrides: Partial<EvictionSignals> = {}): EvictionSignals {
+    return {
+      killRatioHistory: [0.9, 0.9, 0.9, 0.9],
+      mutationIssuesTotal: 10,
+      mutationIssuesClosedMerged: 8,
+      ...overrides,
+    }
+  }
+
+  it('evicts when both kill-ratio and fix-rate pass', () => {
+    const result = evaluateEviction(signal())
+    expect(result.evicts).toBe(true)
+    expect(result.reason).toBeNull()
+    expect(result.score).toBeGreaterThan(0.5)
+  })
+
+  it('does NOT evict when kill ratio is below threshold', () => {
+    const result = evaluateEviction(signal({ killRatioHistory: [0.5, 0.6, 0.5, 0.4] }))
+    expect(result.evicts).toBe(false)
+    expect(result.reason).toMatch(/kill ratio/)
+  })
+
+  it('does NOT evict when fix rate is below threshold', () => {
+    const result = evaluateEviction(signal({ mutationIssuesTotal: 10, mutationIssuesClosedMerged: 2 }))
+    expect(result.evicts).toBe(false)
+    expect(result.reason).toMatch(/fix rate/)
+  })
+
+  it('does NOT evict when any single week drops below ratio (sustained=min, not mean)', () => {
+    // Mean is 0.8625 > 0.85 — but min is 0.8 < 0.85; should NOT evict
+    const result = evaluateEviction(signal({ killRatioHistory: [0.8, 0.9, 0.9, 0.95] }))
+    expect(result.evicts).toBe(false)
+    expect(result.reason).toMatch(/kill ratio/)
+  })
+
+  it('does NOT evict when history is shorter than threshold (bootstrap)', () => {
+    const result = evaluateEviction(signal({ killRatioHistory: [0.95, 0.95] }))
+    expect(result.evicts).toBe(false)
+    expect(result.reason).toMatch(/history too short/)
+  })
+
+  it('does NOT evict when insufficient mutation-watcher issues exist', () => {
+    const result = evaluateEviction(signal({ mutationIssuesTotal: 0, mutationIssuesClosedMerged: 0 }))
+    expect(result.evicts).toBe(false)
+    expect(result.reason).toMatch(/not enough mutation-watcher issues/)
+  })
+
+  it('score scales monotonically with both component sub-scores', () => {
+    const weak = evaluateEviction(signal({ killRatioHistory: [0.86, 0.86, 0.86, 0.86], mutationIssuesClosedMerged: 7 }))
+    const strong = evaluateEviction(
+      signal({ killRatioHistory: [0.99, 0.99, 0.99, 0.99], mutationIssuesClosedMerged: 10 }),
+    )
+    expect(strong.score).toBeGreaterThan(weak.score)
+  })
+
+  it('respects custom thresholds', () => {
+    // Lower thresholds → easier eviction
+    const result = evaluateEviction(signal({ killRatioHistory: [0.6, 0.6, 0.6, 0.6], mutationIssuesClosedMerged: 5 }), {
+      ...DEFAULT_EVICTION_THRESHOLDS,
+      killRatio: 0.5,
+      fixRate: 0.4,
+    })
+    expect(result.evicts).toBe(true)
+  })
+})

--- a/bots/mutation-area-picker/tests/signals.test.ts
+++ b/bots/mutation-area-picker/tests/signals.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import { collectEvictionSignals, collectInclusionSignals, pathToBasename, type SignalEnv } from '../signals.js'
+
+/**
+ * Fixture env that returns deterministic values per module path.
+ * Tests pass a Map or an object describing the per-module values
+ * the bot should observe.
+ */
+function fixtureEnv(fixtures: {
+  commits?: Record<string, number>
+  aiPaired?: Record<string, number>
+  lines?: Record<string, number>
+  relatedTests?: Record<string, string[]>
+  flakes?: Record<string, number>
+  fixPRs?: Record<string, number>
+  mutationIssues?: Record<string, { total: number; closedMerged: number }>
+}): SignalEnv {
+  return {
+    countCommitsTouching: async (p, _) => fixtures.commits?.[p] ?? 0,
+    countAIPairedCommitsTouching: async (p, _) => fixtures.aiPaired?.[p] ?? 0,
+    countLines: async p => fixtures.lines?.[p] ?? 0,
+    findRelatedTestFiles: async basename => fixtures.relatedTests?.[basename] ?? [],
+    findFlakeIssuesMentioning: async p => fixtures.flakes?.[p] ?? 0,
+    countRecentFixPRsTouching: async (p, _) => fixtures.fixPRs?.[p] ?? 0,
+    countMutationIssues: async (p, _) => fixtures.mutationIssues?.[p] ?? { total: 0, closedMerged: 0 },
+  }
+}
+
+describe('pathToBasename', () => {
+  it('strips directory and extension', () => {
+    expect(pathToBasename('packages/gazetta/src/archive/index.ts')).toBe('index')
+    expect(pathToBasename('packages/gazetta/src/publish.ts')).toBe('publish')
+    expect(pathToBasename('foo.bar.ts')).toBe('foo.bar')
+  })
+
+  it('handles paths without extension', () => {
+    expect(pathToBasename('src/foo')).toBe('foo')
+  })
+
+  it('handles bare filename', () => {
+    expect(pathToBasename('foo.ts')).toBe('foo')
+  })
+})
+
+describe('collectInclusionSignals', () => {
+  it('returns all five signals from fixture data', async () => {
+    const env = fixtureEnv({
+      aiPaired: { 'src/foo.ts': 12 },
+      commits: { 'src/foo.ts': 45 },
+      lines: { 'src/foo.ts': 200, '/repo/tests/foo.test.ts': 60 },
+      relatedTests: { foo: ['/repo/tests/foo.test.ts'] },
+      flakes: { 'src/foo.ts': 2 },
+      fixPRs: { 'src/foo.ts': 3 },
+    })
+    const result = await collectInclusionSignals(env, 'src/foo.ts', 'src/foo.ts')
+    expect(result.aiPairingDensity).toBe(12)
+    expect(result.recentChurn).toBe(45)
+    expect(result.flakeCorrelation).toBe(2)
+    expect(result.bugFixCorrelation).toBe(3)
+    // testCoverageRatioInverse: ratio = 60/200 = 0.3 → inverse = 1/(1+0.3) ≈ 0.769
+    expect(result.testCoverageRatioInverse).toBeCloseTo(0.769, 2)
+  })
+
+  it('high coverage produces low inverse score (good test coverage = low priority)', async () => {
+    const env = fixtureEnv({
+      lines: { 'src/foo.ts': 100, '/repo/tests/foo.test.ts': 500 },
+      relatedTests: { foo: ['/repo/tests/foo.test.ts'] },
+    })
+    const result = await collectInclusionSignals(env, 'src/foo.ts', 'src/foo.ts')
+    // ratio = 500/100 = 5 → inverse = 1/(1+5) ≈ 0.167 — low score, well-covered
+    expect(result.testCoverageRatioInverse).toBeCloseTo(0.167, 2)
+  })
+
+  it('zero tests produces high inverse score (no coverage = high priority)', async () => {
+    const env = fixtureEnv({
+      lines: { 'src/foo.ts': 100 },
+      relatedTests: { foo: [] },
+    })
+    const result = await collectInclusionSignals(env, 'src/foo.ts', 'src/foo.ts')
+    // ratio = 0 → inverse = 1/(1+0) = 1.0 — maximum priority
+    expect(result.testCoverageRatioInverse).toBe(1.0)
+  })
+
+  it('zero src lines produces 1.0 (degenerate but safe)', async () => {
+    const env = fixtureEnv({})
+    const result = await collectInclusionSignals(env, 'src/empty.ts', 'src/empty.ts')
+    expect(result.testCoverageRatioInverse).toBe(1.0)
+  })
+
+  it('sums LOC across multiple test files', async () => {
+    const env = fixtureEnv({
+      lines: {
+        'src/foo.ts': 100,
+        '/repo/tests/foo.test.ts': 40,
+        '/repo/tests/foo-extra.test.ts': 60,
+      },
+      relatedTests: { foo: ['/repo/tests/foo.test.ts', '/repo/tests/foo-extra.test.ts'] },
+    })
+    const result = await collectInclusionSignals(env, 'src/foo.ts', 'src/foo.ts')
+    // ratio = 100/100 = 1.0 → inverse = 0.5
+    expect(result.testCoverageRatioInverse).toBe(0.5)
+  })
+
+  it('missing signals default to 0', async () => {
+    const env = fixtureEnv({}) // empty fixtures
+    const result = await collectInclusionSignals(env, 'src/unknown.ts', 'src/unknown.ts')
+    expect(result.aiPairingDensity).toBe(0)
+    expect(result.recentChurn).toBe(0)
+    expect(result.flakeCorrelation).toBe(0)
+    expect(result.bugFixCorrelation).toBe(0)
+    expect(result.testCoverageRatioInverse).toBe(1.0) // zero src LOC default
+  })
+})
+
+describe('collectEvictionSignals', () => {
+  it('passes through mutation-issue stats and slices kill-ratio history', async () => {
+    const env = fixtureEnv({
+      mutationIssues: { 'src/scoped.ts': { total: 10, closedMerged: 8 } },
+    })
+    const history = [0.7, 0.8, 0.85, 0.88, 0.9] // 5 entries
+    const result = await collectEvictionSignals(env, 'src/scoped.ts', history)
+    // Default config keeps last 4 weeks
+    expect(result.killRatioHistory).toEqual([0.8, 0.85, 0.88, 0.9])
+    expect(result.mutationIssuesTotal).toBe(10)
+    expect(result.mutationIssuesClosedMerged).toBe(8)
+  })
+
+  it('handles shorter-than-window history (bootstrap)', async () => {
+    const env = fixtureEnv({
+      mutationIssues: { 'src/scoped.ts': { total: 0, closedMerged: 0 } },
+    })
+    const history = [0.7, 0.75] // only 2 weeks
+    const result = await collectEvictionSignals(env, 'src/scoped.ts', history)
+    expect(result.killRatioHistory).toEqual([0.7, 0.75])
+  })
+
+  it('handles empty history', async () => {
+    const env = fixtureEnv({})
+    const result = await collectEvictionSignals(env, 'src/scoped.ts', [])
+    expect(result.killRatioHistory).toEqual([])
+    expect(result.mutationIssuesTotal).toBe(0)
+    expect(result.mutationIssuesClosedMerged).toBe(0)
+  })
+
+  it('respects custom killRatioWeeks config', async () => {
+    const env = fixtureEnv({})
+    const history = [0.7, 0.8, 0.85, 0.88, 0.9]
+    const result = await collectEvictionSignals(env, 'src/scoped.ts', history, {
+      issueWindowDays: 90,
+      killRatioWeeks: 2,
+    })
+    expect(result.killRatioHistory).toEqual([0.88, 0.9])
+  })
+})

--- a/bots/mutation-area-picker/tests/skip-list.test.ts
+++ b/bots/mutation-area-picker/tests/skip-list.test.ts
@@ -1,0 +1,136 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  appendEntry,
+  emptySkipList,
+  findSkipMatch,
+  globMatches,
+  readSkipList,
+  type SkipEntry,
+  type SkipList,
+  type SkipRule,
+  writeSkipList,
+} from '../skip-list.js'
+
+let dir: string
+let path: string
+
+beforeEach(() => {
+  dir = mkdtempSync(resolve(tmpdir(), 'map-skip-list-test-'))
+  path = resolve(dir, 'skip-list.json')
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function entry(overrides: Partial<SkipEntry> = {}): SkipEntry {
+  return {
+    fingerprint: { path: 'packages/gazetta/src/foo.ts' },
+    reason: 'never-mutate',
+    reasonNote: 'generated code',
+    addedAt: '2026-05-17T12:00:00Z',
+    addedBy: 'bot',
+    ...overrides,
+  }
+}
+
+function rule(overrides: Partial<SkipRule> = {}): SkipRule {
+  return {
+    scope: 'packages/gazetta/src/generated/**/*.ts',
+    reason: 'never-mutate',
+    reasonNote: 'generated code',
+    addedAt: '2026-05-17T12:00:00Z',
+    addedBy: 'bot',
+    ...overrides,
+  }
+}
+
+describe('readSkipList / writeSkipList', () => {
+  it('returns empty list when file is missing', () => {
+    expect(readSkipList(path)).toEqual(emptySkipList())
+  })
+
+  it('round-trips a list with entries and rules', () => {
+    const list: SkipList = { version: 1, entries: [entry()], rules: [rule()] }
+    writeSkipList(path, list)
+    expect(readSkipList(path)).toEqual(list)
+  })
+
+  it('returns empty list on malformed JSON', () => {
+    writeSkipList(path, emptySkipList())
+    // Corrupt the file
+    require('node:fs').writeFileSync(path, 'not-json')
+    expect(readSkipList(path)).toEqual(emptySkipList())
+  })
+
+  it('returns empty list when version is wrong', () => {
+    require('node:fs').writeFileSync(path, JSON.stringify({ version: 2, entries: [], rules: [] }))
+    expect(readSkipList(path)).toEqual(emptySkipList())
+  })
+})
+
+describe('findSkipMatch', () => {
+  it('returns null when nothing matches', () => {
+    const list: SkipList = { version: 1, entries: [entry()], rules: [] }
+    expect(findSkipMatch(list, { path: 'src/bar.ts' })).toBeNull()
+  })
+
+  it('matches entry by exact path', () => {
+    const e = entry({ fingerprint: { path: 'src/foo.ts' } })
+    const list: SkipList = { version: 1, entries: [e], rules: [] }
+    expect(findSkipMatch(list, { path: 'src/foo.ts' })).toBe(e)
+  })
+
+  it('matches rule by glob', () => {
+    const r = rule({ scope: 'src/generated/**/*.ts' })
+    const list: SkipList = { version: 1, entries: [], rules: [r] }
+    expect(findSkipMatch(list, { path: 'src/generated/api/types.ts' })).toBe(r)
+  })
+
+  it('entry match wins over rule match (more specific)', () => {
+    const e = entry({ fingerprint: { path: 'src/foo.ts' }, reasonNote: 'specific' })
+    const r = rule({ scope: 'src/**/*.ts', reasonNote: 'general' })
+    const list: SkipList = { version: 1, entries: [e], rules: [r] }
+    expect(findSkipMatch(list, { path: 'src/foo.ts' })).toBe(e)
+  })
+})
+
+describe('globMatches', () => {
+  it('matches exact paths', () => {
+    expect(globMatches('src/foo.ts', 'src/foo.ts')).toBe(true)
+    expect(globMatches('src/foo.ts', 'src/bar.ts')).toBe(false)
+  })
+
+  it('* matches single segment', () => {
+    expect(globMatches('src/*.ts', 'src/foo.ts')).toBe(true)
+    expect(globMatches('src/*.ts', 'src/foo/bar.ts')).toBe(false)
+  })
+
+  it('** matches any depth', () => {
+    expect(globMatches('src/**/*.ts', 'src/foo.ts')).toBe(true)
+    expect(globMatches('src/**/*.ts', 'src/admin-api/routes/publish.ts')).toBe(true)
+  })
+
+  it('escapes regex special chars literally', () => {
+    // Dots in the pattern must match dots, not any character
+    expect(globMatches('src/foo.ts', 'src/fooXts')).toBe(false)
+  })
+})
+
+describe('appendEntry', () => {
+  it('adds a new entry and returns true', () => {
+    const list = emptySkipList()
+    expect(appendEntry(list, entry())).toBe(true)
+    expect(list.entries).toHaveLength(1)
+  })
+
+  it('refuses to add a duplicate path and returns false', () => {
+    const list = emptySkipList()
+    appendEntry(list, entry())
+    expect(appendEntry(list, entry({ reasonNote: 'different note' }))).toBe(false)
+    expect(list.entries).toHaveLength(1)
+  })
+})

--- a/bots/package.json
+++ b/bots/package.json
@@ -14,6 +14,8 @@
     "fix-bot:compact": "tsx fix-bot/compact.ts",
     "dead-code-watcher": "tsx dead-code-watcher/index.ts",
     "dead-code-watcher:compact": "tsx dead-code-watcher/compact.ts",
+    "mutation-area-picker": "tsx mutation-area-picker/index.ts",
+    "mutation-area-picker:compact": "tsx mutation-area-picker/compact.ts",
     "review-on-comment": "tsx review-on-comment/index.ts",
     "review-bot": "tsx review-bot/index.ts",
     "review-bot:compact": "tsx review-bot/compact.ts",


### PR DESCRIPTION
## What

Implementation of the design from PR #396. Weekly autonomous bot that owns `packages/gazetta/stryker.config.json`'s `mutate` glob — picks one module to ADD / SWAP / REMOVE per cron under a runtime budget, or exits silently on NOOP weeks.

**Stacked on PR #396** (design). Merge #396 first, then this; rebase needed.

## How it works

```
Weekly Sun 03:30 UTC →
  read skip-list + reviewer-log + lessons-learned + current mutate glob
  → walk packages/gazetta/src/**/*.ts → filter scoped + skip-listed
  → 218 candidates today

  for each candidate:
    collect 5 signals (AI-pair + LOC ratio + churn + flake + fix-rate)
  for each scoped:
    collect 2 eviction signals (kill ratio history + close rate)

  compose scores → apply decision tree:
    ADD if headroom + top score > 0.4
    SWAP if at-budget + outranks scoped at >= 0.7
    REMOVE if at-budget + graduates + no swap available
    NOOP otherwise — exit silently

  bootstrap weeks 1-4: ADD only (eviction needs 4w history)
  append decision to reviewer-log (cached across runs)
  if non-NOOP: write stryker.config.json, push branch, open draft PR
```

## Build sequence

8 cuts, lowest-risk-first per [team-preferences rule 17](.claude/rules/team-preferences.md):

| Cut | Output | Risk |
|---|---|---|
| 1 | Per-bot memory (skip-list + reviewer-log + seeds + 25 tests) | Low — established pattern |
| 2 | Skeleton (banner + memory loading + DRY_RUN) | Low — wiring only |
| 3 | Signal collectors with `SignalEnv` interface (13 tests) | Low — pure functions over injected env |
| 4 | Score composers (composite weighted + geometric-mean eviction) | Low — pure math + edge-case tests |
| 5 | Decision tree (ADD/SWAP/REMOVE/NOOP, 15 tests) | Medium — load-bearing logic |
| 6 | Wire-up: signal-env factory + main loop + PR composition | Medium — orchestrates all earlier cuts |
| 7 | Workflow YAML + concurrency + cache + README promotion | Low |
| 8 | Format + verify + commit + this PR | Low |

## Memory (per [ADR-0011](docs/adr/0011-bot-memory-cache-persistence.md))

- `bots/mutation-area-picker/skip-list.json` — never-mutate + maintainer-rejected modules. Committed to repo.
- `bots/mutation-area-picker/reviewer-log.jsonl` — every decision logged. **Cached via `actions/cache@v4` keyed `mutation-area-picker-reviewer-log-v1`**, gitignored locally.
- `bots/mutation-area-picker/lessons-learned.md` — cross-run patterns, compactor-maintained (compactor itself is future direction).

Single-instance invariant enforced via `concurrency: group: mutation-area-picker, cancel-in-progress: false` (workflow YAML).

## Why no reviewer agent

Per the design doc: **mutation testing IS the empirical reviewer**. Next Stryker run validates the pick — if a module was a bad choice (no surviving mutants, low signal), the bot's data accumulates that evidence and the eviction predicate will eventually rotate it out. Adding Agent B would be reviewer-pattern-cargo-culting from dead-code-watcher.

## Empirical eviction (per [ADR-0014](docs/adr/0014-mutation-eviction-by-empirical-evidence.md))

A scoped module graduates from the portfolio only when BOTH:
- Kill ratio > 0.85 sustained across last 4 weekly Stryker runs
- > 70% of mutation-watcher issues for the module are closed-merged within last 90 days

Time-bound eviction was explicitly rejected. A long-mutated module with low kill ratio STAYS in scope — weak coverage is exactly when mutation testing earns its place.

## Test plan

- [x] `npm test -w @gazetta/bots` — 362/362 pass (was 290 + 72 new)
- [x] `npx tsc --noEmit` clean
- [x] `npm run format` clean
- [x] DRY_RUN smoke test — discovers 218 candidates, bootstrap mode detected
- [ ] After merge: first cron Sun 2026-05-18 03:30 UTC should ADD one module (bootstrap, plenty of headroom). Watch for the draft PR.
- [ ] First eviction eligible week 5 (2026-06-15) once kill-ratio history accumulates.

## Stacked: this PR depends on #396

This PR is stacked on `design/mutation-area-picker` (PR #396 — design doc + ADR-0014). Merge #396 first, then rebase + merge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)