### PR TITLE
fix(mutation-area-picker): self-calibrate runtime estimation from observed nightly

### DIFF
--- a/.github/workflows/mutation-area-picker.yml
+++ b/.github/workflows/mutation-area-picker.yml
@@ -20,7 +20,11 @@ on:
   workflow_dispatch:
     inputs:
       budget_minutes:
-        description: 'Override MUTATION_BUDGET_MINUTES (default 105). Total nightly Stryker runtime budget.'
+        description: 'Override MUTATION_BUDGET_MINUTES (default 150). Max runtime the bot will grow the portfolio to.'
+        required: false
+        default: '150'
+      current_runtime_minutes:
+        description: 'Override MUTATION_CURRENT_RUNTIME_MINUTES (default 105). Observed nightly Stryker runtime — anchor for calibration.'
         required: false
         default: '105'
       inclusion_threshold:
@@ -95,7 +99,8 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           # Fallback literals here MUST match the TypeScript defaults
           # in bots/mutation-area-picker/index.ts.
-          MUTATION_BUDGET_MINUTES: ${{ inputs.budget_minutes || '105' }}
+          MUTATION_BUDGET_MINUTES: ${{ inputs.budget_minutes || '150' }}
+          MUTATION_CURRENT_RUNTIME_MINUTES: ${{ inputs.current_runtime_minutes || '105' }}
           INCLUSION_THRESHOLD: ${{ inputs.inclusion_threshold || '0.4' }}
           EVICTION_THRESHOLD: ${{ inputs.eviction_threshold || '0.7' }}
         run: npm run mutation-area-picker -w @gazetta/bots

--- a/bots/mutation-area-picker/discover.ts
+++ b/bots/mutation-area-picker/discover.ts
@@ -111,14 +111,35 @@ export function expandGlob(globEntries: string[], allFiles: string[]): string[] 
 }
 
 /**
- * Estimate per-module runtime contribution in minutes.
- * Proxy heuristic: `srcLOC * 0.05` minutes per file. A 200-line
- * file ≈ 10 min of mutation time; a 50-line file ≈ 2.5 min. Real
- * Stryker timings vary by mutant density + test runner overhead;
- * this is a conservative upper bound for budget management. The
- * Future-direction note in the design doc is to read actual
- * per-file timing from Stryker's JSON output.
+ * Estimate per-module runtime in minutes. The factor argument is
+ * minutes-per-line, calibrated by the caller from the current
+ * scoped set's known runtime: `KNOWN_RUNTIME_MIN / SUM(LOC scoped)`.
+ *
+ * The first run on 2026-05-17 used a hardcoded `0.05` and produced
+ * 393 min estimate against a 105 min actual budget — ~3.75× too
+ * high. Self-calibration grounds the estimate in real data instead
+ * of guessing. Future direction is to read Stryker's per-file
+ * timing report directly; this is the simpler interim.
+ *
+ * Default factor when no calibration data exists: `0.013` —
+ * empirically derived from the first run (105 / 7870 LOC across
+ * the 8-entry mutate glob, expanded to 47 files). Used during
+ * bootstrap weeks before the bot has its own data; replaced by
+ * self-calibration once any scoped LOC sum is observed.
  */
-export function estimateRuntimeMinutes(srcLOC: number): number {
-  return srcLOC * 0.05
+export function estimateRuntimeMinutes(srcLOC: number, minutesPerLine = 0.013): number {
+  return srcLOC * minutesPerLine
+}
+
+/**
+ * Compute the calibration factor from the current scoped set's
+ * total LOC and a known total runtime. Returns minutes-per-line.
+ *
+ * If the total LOC is 0 (degenerate; empty mutate glob), returns
+ * the conservative default 0.013 so subsequent calls don't divide
+ * by zero.
+ */
+export function computeRuntimeCalibration(totalScopedLOC: number, knownRuntimeMin: number): number {
+  if (totalScopedLOC === 0) return 0.013
+  return knownRuntimeMin / totalScopedLOC
 }

--- a/bots/mutation-area-picker/index.ts
+++ b/bots/mutation-area-picker/index.ts
@@ -46,7 +46,7 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { printBanner, printNotice, printRunSummary, printWarning } from '../_lib/ui.js'
 import { decide, type Decision, type ScopedModule, type UnMutatedCandidate } from './decision.js'
-import { discoverCandidates, estimateRuntimeMinutes, expandGlob } from './discover.js'
+import { computeRuntimeCalibration, discoverCandidates, estimateRuntimeMinutes, expandGlob } from './discover.js'
 import {
   appendReviewerLog,
   countWeeklyRuns,
@@ -85,8 +85,22 @@ const PER_RUN_BUDGET_MS = Number(process.env.BUDGET_MS ?? 10 * 60 * 1000)
  */
 const BOOTSTRAP_WEEKS = Number(process.env.BOOTSTRAP_WEEKS ?? '4')
 
-/** Total nightly Stryker budget in minutes. Hard ceiling is 180 (workflow timeout). */
-const BUDGET_MINUTES = Number(process.env.MUTATION_BUDGET_MINUTES ?? '105')
+/**
+ * Total nightly Stryker BUDGET in minutes — the max the bot is willing
+ * to let the portfolio grow to. Hard ceiling is 180 (workflow timeout);
+ * default 150 leaves 30 min variance margin.
+ */
+const BUDGET_MINUTES = Number(process.env.MUTATION_BUDGET_MINUTES ?? '150')
+
+/**
+ * The bot's anchor for runtime calibration: what the CURRENT nightly
+ * actually takes. The calibration factor is CURRENT ÷ scoped LOC; that
+ * factor then estimates per-module runtime consistently across scoped
+ * and candidate. Default 105 min = the observed 1h 45m nightly today.
+ * Operators bump this only when Stryker's true runtime changes
+ * meaningfully (different runner, different test suite).
+ */
+const CURRENT_RUNTIME_MINUTES = Number(process.env.MUTATION_CURRENT_RUNTIME_MINUTES ?? '105')
 
 /** Min inclusion score required to ADD a module. Default 0.4 per design doc. */
 const INCLUSION_THRESHOLD = Number(process.env.INCLUSION_THRESHOLD ?? '0.4')
@@ -161,32 +175,51 @@ async function main(): Promise<void> {
 
   // Compose scores across the candidate set
   const inclusionScores = composeInclusionScores(inclusionRawSignals)
-  // Pre-fetch LOC for runtime estimation
+  // Pre-fetch LOC for both candidates AND scoped (need scoped LOC FIRST for runtime calibration)
   const candidateLOCs = await Promise.all(candidatePaths.map(p => env.countLines(resolve(REPO_ROOT, p))))
+
+  // Step 5: Evaluate scoped modules. Compute the runtime-calibration
+  // factor BEFORE estimating any per-module runtime — calibration is
+  // anchored to the known nightly Stryker runtime against the current
+  // scoped LOC sum, so estimates stay grounded in reality instead of
+  // hardcoded LOC×constant guesses (the original 0.05 produced ~4×
+  // over-estimates; see first-run log 2026-05-17).
+  //
+  // Per-bot kill-ratio history is bootstrap-empty; in production this
+  // reads from the last N weekly Stryker run artifacts. For now we
+  // pass empty history per scoped module — evaluateEviction returns
+  // "history too short" which keeps everything in scope. The proper
+  // wire-up to gh run download lands as a future-direction item per
+  // the design doc.
+  const scopedFiles = expandGlob(currentGlob, await listAllSrcTsFiles())
+  printNotice(`Scoped modules (expanded from ${currentGlob.length} glob entries): ${scopedFiles.length}`)
+
+  // Compute calibration: KNOWN current nightly runtime / sum of scoped LOC.
+  // Anchored to actual observed runtime (CURRENT_RUNTIME_MINUTES), NOT
+  // the bot's growth budget. This way the factor stays grounded even
+  // as the bot expands the portfolio toward BUDGET.
+  const scopedLOCs = await Promise.all(scopedFiles.map(p => env.countLines(resolve(REPO_ROOT, p))))
+  const totalScopedLOC = scopedLOCs.reduce((a, b) => a + b, 0)
+  const minutesPerLine = computeRuntimeCalibration(totalScopedLOC, CURRENT_RUNTIME_MINUTES)
+  printNotice(
+    `Runtime calibration: ${totalScopedLOC} scoped LOC ÷ ${CURRENT_RUNTIME_MINUTES} min observed runtime = ${minutesPerLine.toFixed(4)} min/line`,
+  )
+
+  // Now build candidates + scoped with the calibrated factor.
   const unMutated: UnMutatedCandidate[] = candidatePaths.map((path, i) => ({
     modulePath: path,
     inclusionScore: inclusionScores[i],
-    estimatedRuntimeMinutes: estimateRuntimeMinutes(candidateLOCs[i]),
+    estimatedRuntimeMinutes: estimateRuntimeMinutes(candidateLOCs[i], minutesPerLine),
   }))
 
-  // Step 5: Evaluate eviction for each scoped module.
-  // Per-bot kill-ratio history is bootstrap-empty; in production this
-  // reads from the last N weekly Stryker run artifacts. For Cut 6 we
-  // pass empty history per scoped module — evaluateEviction returns
-  // "history too short" which keeps everything in scope. The proper
-  // wire-up to gh run download lands in Cut 7+ as a future-direction
-  // item per the design doc.
-  const scopedFiles = expandGlob(currentGlob, await listAllSrcTsFiles())
-  printNotice(`Scoped modules (expanded from ${currentGlob.length} glob entries): ${scopedFiles.length}`)
   const scoped: ScopedModule[] = await Promise.all(
-    scopedFiles.map(async path => {
+    scopedFiles.map(async (path, i) => {
       const evictionSignals = await collectEvictionSignals(env, path, [])
       const evaluation = evaluateEviction(evictionSignals)
-      const loc = await env.countLines(resolve(REPO_ROOT, path))
       return {
         modulePath: path,
         eviction: evaluation,
-        estimatedRuntimeMinutes: estimateRuntimeMinutes(loc),
+        estimatedRuntimeMinutes: estimateRuntimeMinutes(scopedLOCs[i], minutesPerLine),
       }
     }),
   )


### PR DESCRIPTION
## What happened

First production run of mutation-area-picker (2026-05-17 14:32 UTC, run 25993615780) NOOPed unexpectedly:

\`\`\`
Estimated current portfolio runtime: 393.5 min (budget 105)
Decision: NOOP — bootstrap mode + top candidate would exceed budget
\`\`\`

393.5 min for 47 scoped files came from the proxy formula \`LOC × 0.05 min/line\` (a guess in PR #397). Actual nightly Stryker runtime is 105 min — proxy was **~3.75× too high**. Bot saw its phantom-393-min portfolio as already over budget before considering any real headroom.

The decision tree was correct under bad input (took the safe NOOP path). The fix corrects the input.

## Two structural fixes

### 1. Self-calibration

The runtime proxy now computes its \`minutes-per-line\` factor from \`CURRENT_RUNTIME ÷ sum(scoped LOC)\` each cron. Grounded in real data, no hardcoded guesses.

- New helper \`computeRuntimeCalibration(totalLOC, runtime)\` captures the math
- \`estimateRuntimeMinutes(loc, factor)\` takes the calibrated factor so both scoped + candidate estimates use the same anchor
- Default \`0.013\` only kicks in when scoped is empty (degenerate; never happens once seeded)

### 2. Separate "current usage" from "budget"

Previously \`MUTATION_BUDGET_MINUTES=105\` meant both "what nightly takes today" AND "max growth allowed." Those are different things. Now:

| Env var | Default | Meaning |
|---|---|---|
| \`MUTATION_CURRENT_RUNTIME_MINUTES\` | 105 | Observed nightly runtime — calibration anchor |
| \`MUTATION_BUDGET_MINUTES\` | 150 | Max the bot will grow the portfolio to (30 min margin under 180 min timeout) |

Real headroom = 150 - 105 = **45 min** to grow the portfolio. Without separating these, current usage = budget = 0 headroom, so the bot would NOOP forever even in bootstrap mode.

## Math check

After this fix:
- Calibration produces \`105 / totalScopedLOC\` = real-world rate
- Current portfolio totals to ~105 min by construction (✓ matches reality)
- ADD has 45 min of headroom for candidate modules
- Top candidate \`cli/index.ts\` (score 0.866 from previous run, ~600 LOC) will estimate at ~8 min — well within headroom

## Test plan

- [x] \`npm test -w @gazetta/bots\` — 362/362 pass (unchanged; the decision-tree tests use direct minutes, not the proxy)
- [x] \`npm run format\` clean
- [x] \`npx tsc --noEmit\` clean
- [x] DRY_RUN smoke — exits before signal collection (no regression on dry-run path)
- [ ] After merge: re-dispatch to see calibrated decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)