### PR TITLE
fix(mutation-area-picker): use ESM writeFileSync, not CJS require

### DIFF
--- a/bots/mutation-area-picker/index.ts
+++ b/bots/mutation-area-picker/index.ts
@@ -41,7 +41,7 @@
  *   .github/workflows/mutation-area-picker.yml (weekly Sun after Mutation)
  */
 import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { printBanner, printNotice, printRunSummary, printWarning } from '../_lib/ui.js'
@@ -379,8 +379,7 @@ function applyScopeChange(
 
   // Write with 2-space indent + trailing newline to match current file format.
   const written = `${JSON.stringify(parsed, null, 2)}\n`
-  // Avoid require here — use readFileSync's sister write
-  require('node:fs').writeFileSync(path, written)
+  writeFileSync(path, written)
   printNotice(`Updated stryker.config.json: ${currentGlob.length} → ${parsed.mutate.length} entries`)
 }
 


### PR DESCRIPTION
## What happened

Run 25993792615 confirmed PR #398's calibration fix worked end-to-end:

\`\`\`
Runtime calibration: 7871 scoped LOC ÷ 105 min observed runtime = 0.0133 min/line
Estimated current portfolio runtime: 105.0 min (budget 150)
Decision: ADD
Top candidate scored 0.866 (≥ threshold 0.4). Budget headroom:
estimated 33.6 min + current 105.0 ≤ budget 150.
\`\`\`

Then it crashed at the write step:

\`\`\`
Fatal error: ReferenceError: require is not defined
  at applyScopeChange (index.ts:383:3)
\`\`\`

The \`bots/\` package is ESM (\`"type": "module"\`); CJS \`require()\` is unavailable. I'd written:

\`\`\`ts
// Avoid require here — use readFileSync's sister write
require('node:fs').writeFileSync(path, written)
\`\`\`

Comment said the right thing; code did the opposite. Pure carelessness in the original Cut 6 wire-up — \`writeFileSync\` is already imported at the top of the file; just needed to add it to the import statement and call it directly.

## What's not in this PR

A smoke test that exercises \`applyScopeChange\` would have caught this. Currently \`applyScopeChange\` only runs in the non-DRY_RUN path; DRY_RUN exits before the write step. Mocking \`gh pr create\` and adding a "non-DRY but doesn't actually push" mode is a future-direction item — the decision-tree is already well-tested; this is the LAST mile before the PR opens.

## Test plan

- [x] \`npm test -w @gazetta/bots\` — 362/362 pass (unchanged)
- [x] \`npm run format\` clean
- [x] \`npx tsc --noEmit\` clean
- [ ] After merge: re-dispatch, expect first ADD PR to land

🤖 Generated with [Claude Code](https://claude.com/claude-code)