### PR TITLE
chore(mutation): kill reformatting churn — Biome pass-through + _comment cleanup

### DIFF
--- a/bots/mutation-area-picker/index.ts
+++ b/bots/mutation-area-picker/index.ts
@@ -377,9 +377,19 @@ function applyScopeChange(
     ]
   }
 
-  // Write with 2-space indent + trailing newline to match current file format.
+  // Write with 2-space indent + trailing newline. Biome's formatter
+  // single-lines short arrays where JSON.stringify multi-lines them,
+  // so the raw stringify output churns against the repo's canonical
+  // shape on every run. Pass through Biome to normalise.
   const written = `${JSON.stringify(parsed, null, 2)}\n`
   writeFileSync(path, written)
+  try {
+    execFileSync('npx', ['biome', 'format', '--write', path], { cwd: REPO_ROOT, stdio: 'inherit' })
+  } catch (err) {
+    // Non-fatal — file is committed in JSON.stringify shape if format fails.
+    // Maintainer can run biome locally before merge if it matters.
+    printWarning(`Biome format on stryker.config.json failed (non-fatal): ${err}`)
+  }
   printNotice(`Updated stryker.config.json: ${currentGlob.length} → ${parsed.mutate.length} entries`)
 }
 

--- a/packages/gazetta/stryker.config.json
+++ b/packages/gazetta/stryker.config.json
@@ -1,16 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/stryker-mutator/stryker-js/master/packages/core/schema/stryker-schema.json",
-  "_comment": "Mutation testing for high-stakes modules — history + admin-api + publish + alt/route-handler + hooks/registry. alt/route-handler.ts added per docs/audits/test-quality-with-ai.md cycle 1's adjacent finding (suggest-alt orchestration lives there, not in admin-api/routes/assets.ts). hooks/registry.ts added per testing-plan.md mutation-scope-expansion item 1 (priority dispatch + error taxonomy). See testing-plan.md.",
+  "_comment": "The mutate glob below is owned by the mutation-area-picker bot (per .claude/rules/design-mutation-area-picker.md). The bot makes weekly ADD/SWAP/REMOVE decisions under a runtime budget. Manual edits are fine but the bot will reconsider them on its next cron — propose a 'never-mutate' skip-list entry in bots/mutation-area-picker/skip-list.json if you want a module permanently off the table. Rationale for any individual module lives in the bot's reviewer-log.jsonl and lessons-learned.md; this file is just the working glob.",
   "packageManager": "npm",
-  "reporters": [
-    "html",
-    "clear-text",
-    "progress"
-  ],
+  "reporters": ["html", "clear-text", "progress"],
   "testRunner": "vitest",
-  "checkers": [
-    "typescript"
-  ],
+  "checkers": ["typescript"],
   "tsconfigFile": "tsconfig.json",
   "coverageAnalysis": "perTest",
   "_comment_inPlace": "inPlace:true skips the sandbox copy. Several tests reference ../../examples/starter and ../../../apps — sandbox would orphan those paths. Stryker keeps originals in .stryker-tmp and restores them on exit.",


### PR DESCRIPTION
## What

Two related fixes for `packages/gazetta/stryker.config.json`. Both surface from PR #400's review.

### 1. Biome pass-through after the bot writes

\`JSON.stringify(parsed, null, 2)\` produces multi-line short arrays (\`["html",\\n "clear-text",\\n "progress"]\`). Biome's formatter single-lines them. The two shapes are both valid JSON — but every bot run + every Biome run flips back and forth, masking the actual config diff with noise.

Fix: after writing the file, run \`npx biome format --write\` so the bot's output matches the repo's canonical shape.

\`\`\`ts
writeFileSync(path, written)
try {
  execFileSync('npx', ['biome', 'format', '--write', path], { cwd: REPO_ROOT, stdio: 'inherit' })
} catch (err) {
  printWarning(\`Biome format on stryker.config.json failed (non-fatal): \${err}\`)
}
\`\`\`

Non-fatal on failure: file is valid JSON either way; maintainer can run Biome locally before merge.

### 2. \`_comment\` cleanup

The existing comment listed which modules were in the \`mutate\` glob (\`history + admin-api + publish + alt/route-handler + hooks/registry\`). The bot adds modules weekly — that list falls stale on every ADD/SWAP/REMOVE.

Fix: replace with a description of WHO owns the glob (the bot) and WHERE to look for rationale (skip-list, reviewer-log, lessons-learned). The comment is now invariant under bot edits.

## Why this matters

PR #400's diff included \`["html", "clear-text", "progress"]\` → multi-line as noise. Without these fixes, every future weekly bot PR would carry the same noise — and the maintainer would have to mentally filter "is this real or just formatting?" on every review.

The \`_comment\` fix is preventive (bot would falsify it on every cron). The Biome fix is curative (already happening; prevent recurrence).

## Test plan

- [x] \`npm test -w @gazetta/bots\` — 362/362 pass
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run format\` clean
- [ ] After merge: next bot run will Biome-format its output. Diff should show ONLY the mutate-array addition/removal, not formatting churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)