### PR TITLE
chore(mutation): skip-list barrel files; add invariant test

### DIFF
--- a/bots/mutation-area-picker/skip-list.json
+++ b/bots/mutation-area-picker/skip-list.json
@@ -9,6 +9,15 @@
       "reasonNote": "CLI entrypoint (#!/usr/bin/env node) executed only as a spawned subprocess by e2e and CLI-smoke tests. Stryker's vitest runner instruments in-process, so it never observes this file's mutants — every one survives as NoCoverage (0% kill ratio). Mutating it produces noise, not signal.",
       "addedAt": "2026-05-19T00:00:00.000Z",
       "addedBy": "maintainer"
+    },
+    {
+      "fingerprint": {
+        "path": "packages/gazetta/src/index.ts"
+      },
+      "reason": "never-mutate",
+      "reasonNote": "Pure public-API re-export barrel. 259 lines, ~62 export statements, zero direct `export const`/`export function`/`export async function`. Every line is `export { X } from './foo.js'` or `export type { Y } from './foo.js'`. Stryker mutates string literals in the `from` paths, but no behavior test could catch those — the public-surface contract is 'this name is re-exported', covered by typecheck + import, not by runtime behavior. Mutants surface as NoCoverage noise without finding real test gaps. Same wrong-pick class as cli/index.ts but different mechanism: cli was shebang/subprocess invisibility; this is no-logic-to-mutate. Rejection context in #422.",
+      "addedAt": "2026-05-24T00:00:00.000Z",
+      "addedBy": "maintainer"
     }
   ],
   "rules": []

--- a/packages/gazetta/tests/stryker-config.test.ts
+++ b/packages/gazetta/tests/stryker-config.test.ts
@@ -36,4 +36,38 @@ describe('stryker mutation scope', () => {
     })
     expect(shebangEntrypoints).toEqual([])
   })
+
+  it('no literal mutate path is a pure re-export barrel', () => {
+    // A barrel file (every line is `export { X } from './foo.js'` or
+    // `export type { Y } from './foo.js'`) has no behavioral surface
+    // to mutate. Stryker mutates the `from` string literals, but no
+    // behavior test could catch those — the public-surface contract
+    // is "this name is re-exported," covered by typecheck + import,
+    // not by runtime behavior. Mutants survive as NoCoverage noise
+    // without finding real test gaps.
+    const literals = config.mutate.filter(entry => !entry.includes('*'))
+    const barrels = literals.filter(entry => {
+      const url = new URL(`../${entry}`, import.meta.url)
+      if (!existsSync(url)) return false
+      const source = readFileSync(url, 'utf-8')
+      // Strip comments + blank lines, then check every remaining line
+      // is a re-export of the form `export ... from '...'`.
+      const codeLines = source
+        .split('\n')
+        .map(l => l.replace(/\/\/.*$/, '').trim())
+        .filter(l => l.length > 0 && !l.startsWith('/*') && !l.startsWith('*') && !l.startsWith('//'))
+      if (codeLines.length === 0) return false
+      // Allow multi-line re-exports: join by semicolons-or-braces, then check.
+      // Heuristic: a barrel has ZERO `export const`, `export function`,
+      // `export class`, `export async function`, `export default`.
+      const hasDirectExport = /^export\s+(const|function|class|async\s+function|default)\s/m.test(source)
+      if (hasDirectExport) return false
+      // And every export must be a re-export (has `from '...'`).
+      const exportLines = source.match(/^\s*export\s+/gm) ?? []
+      const reExportLines = source.match(/^\s*export\s+(\*|type\s+\{|\{)[^]*?from\s+['"]/gm) ?? []
+      // If every export statement has a `from` clause, it's a barrel.
+      return exportLines.length > 0 && exportLines.length === reExportLines.length
+    })
+    expect(barrels).toEqual([])
+  })
 })


### PR DESCRIPTION
## Summary

- Add `packages/gazetta/src/index.ts` to `bots/mutation-area-picker/skip-list.json` with `never-mutate` reason (rejection context: closed #422)
- Add a new invariant in `stryker-config.test.ts` that flags any literal mutate path containing only re-export statements (no direct `export const`/`function`/`class`/`default`)

## Why

PR #422 (closed) proposed adding `src/index.ts` to the Stryker mutate glob. It's a 259-line pure re-export barrel — 62 export statements, zero direct exports. Mutating barrels generates NoCoverage noise without finding real test gaps: Stryker mutates the `from './foo.js'` string literals, but no behavior test could catch those (public-surface contract is "this name is re-exported," covered by typecheck + import, not by runtime behavior).

Same wrong-pick class as cli/index.ts (#400 → #409) but different mechanism:
- **cli**: shebang/subprocess invisibility (caught by existing shebang invariant)
- **barrel files**: no-logic-to-mutate (caught by this new invariant)

## Two complementary guards

1. **Skip-list entry** — prevents mutation-area-picker from re-proposing the file. The bot's `past-pr.ts` feedback loop also reads the #422 close reason and would add an entry to its own memory, but a committed skip-list is the durable record.
2. **Invariant test** — heuristic that flags any literal mutate path that's pure re-exports. Catches future manual additions even if they bypass the bot.

## Test plan

- [x] `npx vitest run tests/stryker-config.test.ts` (4 tests pass)
- [x] Detector verified against `src/index.ts` standalone: would flag it as a barrel
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)