### PR TITLE
fix(bots): getLabelAppliedAt checks current state, not historical events

### DIFF
--- a/bots/_lib/github.ts
+++ b/bots/_lib/github.ts
@@ -298,7 +298,21 @@ export async function getLabelAppliedAt(
   issueNumber: number,
   label: string,
 ): Promise<string | null> {
-  const { data } = await octokit.issues.listEvents({
+  // Idempotency check: the label must be CURRENTLY applied. A label
+  // applied historically then removed must NOT cause the caller to
+  // think the bot was attempted — that's the bug from 2026-05-29
+  // where removing `fix-bot-attempted` from issues #414/#415 didn't
+  // unblock retries because this helper kept returning the historical
+  // "labeled" timestamp.
+  const { data: issue } = await octokit.issues.get({ ...repo, issue_number: issueNumber })
+  const currentlyApplied = issue.labels.some(l => (typeof l === 'string' ? l : l.name) === label)
+  if (!currentlyApplied) return null
+
+  // Label is on the issue today; find when it was most recently applied
+  // (timeline can include multiple labeled/unlabeled pairs; the latest
+  // labeled event is the one that matters for the "since" comparison
+  // against issue reopens).
+  const { data: events } = await octokit.issues.listEvents({
     ...repo,
     issue_number: issueNumber,
     per_page: 100,
@@ -306,13 +320,17 @@ export async function getLabelAppliedAt(
   // Iterate newest-first; the most recent `labeled` event for this label wins.
   // Octokit's response is a union over event types; narrow via a shape check
   // since the discriminated-union narrowing isn't precise enough for TS.
-  for (let i = data.length - 1; i >= 0; i--) {
-    const ev = data[i] as { event: string; label?: { name?: string }; created_at: string }
+  for (let i = events.length - 1; i >= 0; i--) {
+    const ev = events[i] as { event: string; label?: { name?: string }; created_at: string }
     if (ev.event === 'labeled' && ev.label?.name === label) {
       return ev.created_at
     }
   }
-  return null
+  // Label is present on the issue but no labeled event matched in the
+  // last 100 events. Edge case: a very long timeline that exceeds the
+  // page size. Defensive — treat as "label applied at issue creation"
+  // by returning the issue's createdAt.
+  return issue.created_at
 }
 
 /**

--- a/bots/_lib/tests/github-label-idempotency.test.ts
+++ b/bots/_lib/tests/github-label-idempotency.test.ts
@@ -3,9 +3,34 @@ import { getLabelAppliedAt, getReopenedAt, removeLabel } from '../github.js'
 
 const REPO = { owner: 'gazetta-studio', repo: 'gazetta-studio' }
 
-function makeOctokit(events: Array<{ event: string; label?: { name: string }; created_at: string }>) {
+/**
+ * Build a fake octokit. `currentLabels` is the issue's CURRENT labels
+ * (what `issues.get` returns); `events` is the historical timeline.
+ *
+ * The default `currentLabels` infers from the events — every `labeled`
+ * minus every later `unlabeled` for the same name. Tests that don't
+ * care about the current-state check can omit `currentLabels` and get
+ * the "current state matches history" behaviour.
+ */
+function makeOctokit(
+  events: Array<{ event: string; label?: { name: string }; created_at: string }>,
+  currentLabels?: string[],
+) {
+  const inferredLabels: string[] = (() => {
+    const set = new Set<string>()
+    for (const ev of events) {
+      if (!ev.label) continue
+      if (ev.event === 'labeled') set.add(ev.label.name)
+      else if (ev.event === 'unlabeled') set.delete(ev.label.name)
+    }
+    return [...set]
+  })()
+  const labels = currentLabels ?? inferredLabels
   return {
     issues: {
+      get: vi
+        .fn()
+        .mockResolvedValue({ data: { labels: labels.map(name => ({ name })), created_at: '2026-05-01T00:00:00Z' } }),
       listEvents: vi.fn().mockResolvedValue({ data: events }),
       removeLabel: vi.fn().mockResolvedValue({}),
     },
@@ -60,6 +85,45 @@ describe('getLabelAppliedAt', () => {
     ])
     const result = await getLabelAppliedAt(octokit, REPO, 288, 'fix-bot-attempted')
     expect(result).toBe('2026-05-11T08:00:00Z')
+  })
+
+  it('returns null when the label was applied historically but is NOT currently on the issue', async () => {
+    // Regression for the 2026-05-29 bug. After fix-bot's first attempt on
+    // #414 and #415 (May 23), the bot recorded `fix-bot-attempted`. On
+    // May 29 the maintainer removed the label to allow a retry. The
+    // helper kept returning the historical "labeled" timestamp because
+    // it only walked timeline events without checking the current label
+    // set — and the orchestrator's idempotency check (`if (attemptedAt)`)
+    // treated that as "label present, do not retry."
+    //
+    // Fix: check the issue's current labels first; only walk the timeline
+    // if the label is actually applied today.
+    const octokit = makeOctokit(
+      [
+        { event: 'labeled', label: { name: 'fix-bot-attempted' }, created_at: '2026-05-23T06:54:00Z' },
+        { event: 'unlabeled', label: { name: 'fix-bot-attempted' }, created_at: '2026-05-29T13:44:00Z' },
+      ],
+      ['bug', 'ready-for-agent'], // current labels — fix-bot-attempted has been removed
+    )
+    const result = await getLabelAppliedAt(octokit, REPO, 288, 'fix-bot-attempted')
+    expect(result).toBeNull()
+  })
+
+  it('returns the latest labeled timestamp when label was removed and re-applied', async () => {
+    // Maintainer removed → bot re-applied. Label IS currently on the
+    // issue. Should return the LATEST labeled event so the
+    // reopened-since-attempt comparison uses the right anchor.
+    const octokit = makeOctokit(
+      [
+        { event: 'labeled', label: { name: 'fix-bot-attempted' }, created_at: '2026-05-23T06:54:00Z' },
+        { event: 'unlabeled', label: { name: 'fix-bot-attempted' }, created_at: '2026-05-29T13:44:00Z' },
+        { event: 'labeled', label: { name: 'fix-bot-attempted' }, created_at: '2026-05-29T14:15:00Z' },
+      ],
+      // `currentLabels` defaults to the inferred set from the events;
+      // after labeled→unlabeled→labeled the inferred set has it.
+    )
+    const result = await getLabelAppliedAt(octokit, REPO, 288, 'fix-bot-attempted')
+    expect(result).toBe('2026-05-29T14:15:00Z')
   })
 })
 


### PR DESCRIPTION
## Summary

`getLabelAppliedAt` walked timeline events without checking whether the label is currently on the issue. A label that was applied historically then removed kept returning the historical timestamp, so fix-bot's idempotency guard (`if (attemptedAt)`) treated removed labels as "still attempted, do not retry."

This is the third stacked bug behind the May 22–29 fix-bot silent-failure on #414 and #415. After PR #429 fixed the parser + persistence layers, the labels were manually cleared on both issues to allow retry — but run 26640846455 still skipped both because of this idempotency miss.

## Fix

`getLabelAppliedAt` now calls `issues.get` first and returns `null` when the label isn't currently applied. Only walks the timeline when the label is genuinely on the issue.

## Test plan

- [x] Two new regression tests in `bots/_lib/tests/github-label-idempotency.test.ts`:
  - `returns null when the label was applied historically but is NOT currently on the issue` (the May 29 case)
  - `returns the latest labeled timestamp when label was removed and re-applied`
- [x] Existing tests updated — `makeOctokit` now mocks `issues.get` alongside `listEvents`; default `currentLabels` inferred from events so existing tests keep their semantics
- [x] All 374 tests pass; tsc --noEmit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)