### PR TITLE
feat(feature-bot): Cut 1 — skeleton + skip-list + reviewer-log infrastructure

### DIFF
--- a/bots/feature-bot/index.ts
+++ b/bots/feature-bot/index.ts
@@ -1,0 +1,158 @@
+/**
+ * feature-bot — implements `enhancement + ready-for-agent` cut sub-issues.
+ *
+ * Per design-feature-bot.md, feature-bot is a producer bot that reads
+ * cut sub-issues from GitHub (per Q1: cuts live in tracking issues +
+ * sub-issues, not in `.claude/rules/design-*-implementation.md` tables)
+ * and ships one PR per cut via a generator-critic loop (per Q6: Agent A
+ * implements, Agent B reviews, three-tier escalation
+ * APPROVE / NEEDS_INPUT / NEEDS_HUMAN).
+ *
+ * # Cut 1 status (this file)
+ *
+ * Cut 1 ships the **skeleton + supporting infrastructure** as a
+ * standalone PR per the design's Cut sequence:
+ *
+ *   - bots/feature-bot/index.ts        ← this file (cron banner +
+ *                                        candidate query + DRY_RUN exit
+ *                                        + manual-mode plumbing)
+ *   - bots/feature-bot/skip-list.ts    ← extended SkipReason union
+ *                                        (8 values per Q7)
+ *   - bots/feature-bot/reviewer-log.ts ← peer of fix-bot's, paths rebound
+ *   - bots/feature-bot/skip-list.json  ← empty initial state
+ *   - bots/feature-bot/prompts/        ← per-cut.md + reviewer.md
+ *                                        placeholders (Cut 3 writes the
+ *                                        bodies)
+ *   - bots/feature-bot/lessons-learned.md ← empty placeholder
+ *
+ * Cut 1 deliberately **does not invoke Claude**. The skeleton prints the
+ * banner, queries candidates, logs them, and exits. The parser ships in
+ * Cut 2; the generator-critic loop ships in Cut 3; the workflow ships in
+ * Cut 4. Each cut is independently rollback-able per team-preferences
+ * rule 17.
+ *
+ * # Two trigger modes (same shape as fix-bot)
+ *
+ *   1. Cron (default): scans for `enhancement + ready-for-agent` issues
+ *      that lack `ready-for-human` / `wontfix` / `needs-info`. Per Q1,
+ *      this is the canonical input — disjoint from fix-bot's
+ *      `bug + ready-for-agent` queue, disjoint from discovery-prep-bot's
+ *      `enhancement` (lacking `ready-for-agent`) queue.
+ *
+ *   2. Manual via `ISSUE_NUMBER` env: attempt a single specific sub-issue,
+ *      regardless of label state. Useful for re-attempts after prompt
+ *      iteration once Cut 3 ships.
+ *
+ * # Run locally
+ *
+ *   # Cron mode — scan all enhancement + ready-for-agent sub-issues:
+ *   GITHUB_REPOSITORY=gazetta-studio/gazetta-studio \
+ *     GH_TOKEN=$(gh auth token) npm run feature-bot -w @gazetta/bots
+ *
+ *   # Manual one-issue mode:
+ *   ISSUE_NUMBER=501 GITHUB_REPOSITORY=gazetta-studio/gazetta-studio \
+ *     GH_TOKEN=$(gh auth token) npm run feature-bot -w @gazetta/bots
+ *
+ *   # Skeleton-validating mode (no GitHub access needed in cron mode if
+ *   # GH_TOKEN is set):
+ *   DRY_RUN=1 GITHUB_REPOSITORY=gazetta-studio/gazetta-studio \
+ *     GH_TOKEN=$(gh auth token) npm run feature-bot -w @gazetta/bots
+ *
+ * # Run in CI
+ *
+ * .github/workflows/feature-bot.yml — lands in Cut 4.
+ */
+import { findIssuesByLabels, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
+import { printBanner, printCandidateList, printNotice, printWarning } from '../_lib/ui.js'
+
+const DRY_RUN = process.env.DRY_RUN === '1'
+
+async function main(): Promise<void> {
+  const repo = repoFromEnv()
+  const octokit = octokitFromEnv()
+
+  // Manual one-issue mode short-circuits the cron scan. Validate the env
+  // var shape early so a typo'd ISSUE_NUMBER fails loud rather than
+  // cascading through the Cut 2/3 parser as a malformed candidate.
+  const issueNumberStr = process.env.ISSUE_NUMBER
+  if (issueNumberStr) {
+    if (!/^\d+$/.test(issueNumberStr)) {
+      console.error(`ISSUE_NUMBER='${issueNumberStr}' must be a positive integer`)
+      process.exit(2)
+    }
+    printBanner({
+      name: 'feature-bot',
+      tagline: 'implementer (Cut 1 skeleton)',
+      purpose: 'Manual one-cut mode — placeholder until Cut 3 wires the generator-critic loop.',
+      inputs: [`Sub-issue #${issueNumberStr} (manual override)`],
+      outputs: ['skeleton — parser and loop ship in Cuts 2/3'],
+    })
+    printNotice(
+      `Manual mode targets sub-issue #${issueNumberStr}. Skeleton stops here; Cut 3 wires the generator-critic loop.`,
+    )
+    return
+  }
+
+  printBanner({
+    name: 'feature-bot',
+    tagline: 'implementer (Cut 1 skeleton)',
+    purpose: 'Implement `enhancement + ready-for-agent` cut sub-issues with TDD-first commit ordering.',
+    inputs: [
+      'Open issues with `enhancement` AND `ready-for-agent`',
+      'AND no `ready-for-human` / `wontfix` / `needs-info`',
+    ],
+    outputs: [
+      'skeleton — parser and loop ship in Cuts 2/3',
+      'Cut 2 adds: cut-sub-issue parser (**Feature** + **Depends on**)',
+      'Cut 3 adds: generator-critic loop with 3-tier escalation',
+      'Cut 4 adds: GitHub Actions workflow + cron',
+    ],
+  })
+
+  printNotice(`Scanning ${repo.owner}/${repo.repo} for enhancement+ready-for-agent cut sub-issues`)
+
+  // Q1 lock: feature-bot's input is `enhancement + ready-for-agent` with
+  // standard exclusions. Disjoint from fix-bot (which requires `bug`) and
+  // from discovery-prep-bot (which excludes `ready-for-agent`). Tracking
+  // issues (no `ready-for-agent`) are invisible to this query.
+  const allCandidates = await findIssuesByLabels(octokit, repo, {
+    requireAll: ['enhancement', 'ready-for-agent'],
+    excludeAny: ['ready-for-human', 'wontfix', 'needs-info'],
+  })
+
+  if (allCandidates.length === 0) {
+    printNotice('No feature-bot candidates found. Inbox zero — nothing to do. ✨')
+    return
+  }
+
+  // Q4 lock: oldest-first sort, deterministic tiebreaker by issue number.
+  // No priority label in v1 — matches fix-bot's pattern.
+  const candidates = [...allCandidates].sort((a, b) => {
+    if (a.createdAt !== b.createdAt) return a.createdAt.localeCompare(b.createdAt)
+    return a.number - b.number
+  })
+
+  printCandidateList({
+    noun: 'cut sub-issue',
+    candidates: candidates.map(c => ({ ref: `#${c.number}`, label: c.title })),
+  })
+
+  if (DRY_RUN) {
+    printNotice(`DRY_RUN=1 — exiting before any work (${candidates.length} would be considered).`)
+    return
+  }
+
+  // Cut 1 stops here. Future cuts:
+  //   Cut 2 — parse `**Feature**:` + `**Depends on**:` from each body;
+  //           validate referenced numbers; loud-fail on bad refs
+  //   Cut 3 — generator-critic loop (Agent A + Agent B + three-tier
+  //           escalation per Q6)
+  //   Cut 4 — .github/workflows/feature-bot.yml (cron + cache + concurrency)
+  printWarning('skeleton — parser and loop ship in Cuts 2/3')
+  printNotice(`Cut 1 ships skeleton only; ${candidates.length} candidates listed above are not processed yet.`)
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err)
+  process.exit(1)
+})

--- a/bots/feature-bot/lessons-learned.md
+++ b/bots/feature-bot/lessons-learned.md
@@ -1,0 +1,17 @@
+# Feature-bot lessons learned
+
+Lessons learned will be distilled by a future monthly compactor from
+`bots/feature-bot/reviewer-log.jsonl` entries.
+
+Deliberately deferred in v1 (per `design-feature-bot.md` "Memory"
+section and Q7 lock): at feature-bot's expected cadence of ~52
+decisions/year, signal volume is too thin to justify a compactor.
+The portfolio self-compacts via SKIP / NEEDS_HUMAN entries on each
+cron; what a compactor WOULD do — distilling cross-decision patterns
+into prose — earns its place when skip-list growth or reviewer-log
+volume crosses concrete thresholds (mirrors mutation-area-picker's
+deferred-compactor rationale).
+
+Loaded into Agent A's prompt each run by `index.ts` once Cut 3
+ships the generator-critic loop. Until then, this file is an empty
+placeholder — Agent A simply sees zero lessons.

--- a/bots/feature-bot/prompts/per-cut.md
+++ b/bots/feature-bot/prompts/per-cut.md
@@ -1,0 +1,30 @@
+<!--
+  Feature-bot per-cut prompt — placeholder for Cut 1.
+
+  The full Agent A prompt body lands in Cut 3 (generator-critic loop
+  wiring) per design-feature-bot.md "Cut sequence". This file is a
+  placeholder so Cut 3 has a foundation to extend; the placeholder
+  shape preserves the Q5 lock so future readers see the intended
+  structure even before the body lands.
+
+  Q5 lock (design-feature-bot.md): the orchestrator does NOT inline
+  the design doc in Agent A's prompt. Instead the prompt names the
+  design doc path (derived from the cut sub-issue's **Feature**:
+  field → .claude/rules/design-{feature}.md) and instructs Agent A
+  to read it before implementing.
+-->
+
+(prompt body lands in Cut 3)
+
+Read these in this order BEFORE implementing:
+
+1. The cut sub-issue body (provided below by the orchestrator).
+2. The design doc at `.claude/rules/design-{feature}.md` — pay
+   special attention to Scope, Locked decisions, Foundational
+   checks, Distinctive choices.
+3. Any companion docs the design doc references (typically other
+   `.claude/rules/design-*.md` or `docs/adr/*.md`).
+4. The implementation files listed or implied by the cut spec.
+
+Only AFTER reading 1-3 do you begin writing code. The design doc's
+Locked decisions are NOT negotiable — implement to match them.

--- a/bots/feature-bot/prompts/reviewer.md
+++ b/bots/feature-bot/prompts/reviewer.md
@@ -1,0 +1,15 @@
+<!--
+  Feature-bot reviewer prompt — placeholder for Cut 1.
+
+  The full Agent B prompt body lands in Cut 3 (generator-critic loop
+  wiring) per design-feature-bot.md "Cut sequence". Cut 3 forks
+  fix-bot's reviewer.md and adds the "did Agent A satisfy the cut's
+  acceptance criteria?" check (per "Open questions for implementation"
+  in the design doc).
+
+  Until Cut 3 lands, this file is a placeholder so Cut 1 can ship
+  the skeleton without inventing a reviewer body that would be torn
+  out and rewritten.
+-->
+
+(reviewer prompt body lands in Cut 3)

--- a/bots/feature-bot/reviewer-log.ts
+++ b/bots/feature-bot/reviewer-log.ts
@@ -1,0 +1,78 @@
+/**
+ * Reviewer-log — durable record of every Agent B verdict for feature-bot.
+ *
+ * Append-only JSONL (`bots/feature-bot/reviewer-log.jsonl`). One line per
+ * Agent B verdict: APPROVE, REJECT, NEEDS_INPUT, or NEEDS_HUMAN. Persists
+ * the reviewer's reasoning so a future monthly compactor can surface
+ * cross-cut patterns into lessons-learned.md (deferred — see
+ * design-feature-bot.md "Memory" section + Q7 lock).
+ *
+ * Distinct from skip-list (per-cut rejection memory, gates future runs)
+ * and lessons-learned.md (compacted prose loaded into Agent A's prompt).
+ * The reviewer-log is the RAW SIGNAL the future compactor would read.
+ *
+ * Why per-bot: bot-specific fingerprint shape (`{ issueNumber }` here,
+ * peer-rooted from fix-bot's) — same rule as skip-list. Rule 38
+ * (symmetric-bot audits) keeps the file shape identical to fix-bot's so
+ * the future compactor can be lifted across bots when it earns its place.
+ */
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import type { IssueFingerprint } from './skip-list.js'
+
+export interface ReviewerLogEntry {
+  ts: string
+  runId: string
+  fingerprint: IssueFingerprint
+  fingerprintLabel: string
+  attempt: number
+  /**
+   * Feature-bot has four terminal states per Q6 (APPROVE / NEEDS_INPUT /
+   * NEEDS_HUMAN) plus the within-loop REJECT-with-retry. The log records
+   * the verdict-as-emitted so the compactor can later separate
+   * NEEDS_INPUT (recoverable; maintainer answers) from NEEDS_HUMAN
+   * (terminal; cut closed + skip-list).
+   */
+  verdict: 'approve' | 'reject' | 'needs-input' | 'needs-human'
+  reasoning: string
+  agentASummary: string
+}
+
+export function appendReviewerLog(absolutePath: string, entry: ReviewerLogEntry): void {
+  appendFileSync(absolutePath, `${JSON.stringify(entry)}\n`)
+}
+
+export function readReviewerLog(absolutePath: string): ReviewerLogEntry[] {
+  if (!existsSync(absolutePath)) return []
+  const raw = readFileSync(absolutePath, 'utf-8')
+  const entries: ReviewerLogEntry[] = []
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue
+    try {
+      entries.push(JSON.parse(line) as ReviewerLogEntry)
+    } catch {
+      // malformed — skip
+    }
+  }
+  return entries
+}
+
+export function tailReviewerLog(absolutePath: string, n: number): ReviewerLogEntry[] {
+  return readReviewerLog(absolutePath).slice(-n)
+}
+
+/**
+ * Truncate the file to the last `keepLast` entries — the future compactor
+ * calls this AFTER producing its lessons-learned rewrite, so the cached
+ * file stays bounded across months. Per ADR-0011 (cache-based
+ * persistence), a future artifact-upload path is the place for
+ * raw-history preservation if it ever earns its keep.
+ */
+export function pruneReviewerLog(absolutePath: string, keepLast: number): { dropped: number; kept: number } {
+  const all = readReviewerLog(absolutePath)
+  if (all.length <= keepLast) return { dropped: 0, kept: all.length }
+  const kept = all.slice(-keepLast)
+  writeFileSync(absolutePath, `${kept.map(e => JSON.stringify(e)).join('\n')}\n`)
+  return { dropped: all.length - keepLast, kept: kept.length }
+}
+
+export const REVIEWER_LOG_PATH = 'bots/feature-bot/reviewer-log.jsonl'

--- a/bots/feature-bot/skip-list.json
+++ b/bots/feature-bot/skip-list.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "entries": []
+}

--- a/bots/feature-bot/skip-list.ts
+++ b/bots/feature-bot/skip-list.ts
@@ -1,0 +1,143 @@
+/**
+ * Feature-bot skip-list — durable memory of "don't try this cut sub-issue again."
+ *
+ * Mirrors fix-bot's skip-list shape but extends the SkipReason union with
+ * 4 feature-bot-specific reasons per design-feature-bot.md Q7. The
+ * fingerprint shape (`{ issueNumber }`) is identical to fix-bot's because
+ * both bots key off GitHub issue numbers — fix-bot reads bug+ready-for-agent
+ * issues; feature-bot reads enhancement+ready-for-agent cut sub-issues
+ * (per Q1: cuts live in tracking issues + sub-issues; no new labels).
+ *
+ * Why each bot has its own skip-list module (per team-preferences rule 19,
+ * extract shared code when 3+ callers exist): two callers today and the
+ * SkipReason unions diverge enough that a generic refactor would touch
+ * fix-bot's working v1 for minimal long-term win. Each bot owns its memory
+ * so the unions can grow independently.
+ *
+ * Entries vs (no) rules: feature-bot's skip-list only ships entries in v1.
+ * Cuts are unique (one sub-issue per cut); rule-shaped generalizations
+ * (matching by label or title-regex) wait until the compactor surfaces
+ * concrete demand — feature-bot has ~52 decisions/year, too thin for a
+ * v1 compactor (mirroring mutation-area-picker's deferred-compactor
+ * rationale).
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+
+/**
+ * Fingerprint for a feature-bot finding — just the GitHub cut sub-issue number.
+ *
+ * Stored as a number rather than a string to keep JSON cleaner and
+ * to gate against typos (e.g. `"501"` vs `501`).
+ */
+export interface IssueFingerprint {
+  issueNumber: number
+}
+
+/**
+ * Skip reasons — drive future-cron decisions on the same cut sub-issue.
+ *
+ * Per design-feature-bot.md Q7 (8 values total):
+ *
+ *   - 4 values REUSED from fix-bot (Agent B's reviewer runs the same
+ *     checks across both bots, so the reason shape is shared):
+ *     `needs-human`, `maintainer-rejected`, `tautological-test`,
+ *     `wrong-root-cause`
+ *
+ *   - 4 values ADDED by feature-bot (concrete scenarios surfaced during
+ *     Q6 grilling, not speculative):
+ *     `missing-prereq` — Agent A found required infrastructure absent
+ *         despite closed deps
+ *     `spec-too-vague` — cut spec doesn't describe enough for Agent A
+ *         to interpret
+ *     `input-cycles-exceeded` — MAX_INPUT_REQUESTS=2 hit without
+ *         resolution
+ *     `files-conflict` — cut's files overlap with another in-flight
+ *         cut's open PR
+ *
+ * Per Q7: typed enum (not free-text) so the future compactor can
+ * pattern-match cross-cut failure modes; outcome tags in PR + comment
+ * bodies include the reason for forensic queries
+ * (`gh issue list --search "feature-bot: skip-entry reason=missing-prereq"`).
+ */
+export type SkipReason =
+  // Reused from fix-bot
+  | 'needs-human'
+  | 'maintainer-rejected'
+  | 'tautological-test'
+  | 'wrong-root-cause'
+  // Feature-bot additions per Q7
+  | 'missing-prereq'
+  | 'spec-too-vague'
+  | 'input-cycles-exceeded'
+  | 'files-conflict'
+
+export interface SkipListEntry {
+  fingerprint: IssueFingerprint
+  reason: SkipReason
+  /** Free-text detail accompanying the typed reason. */
+  reasonNote: string
+  /** ISO-8601. */
+  addedAt: string
+  /** Bot = autocaptured from feedback loop; maintainer = manual edit. */
+  addedBy: 'bot' | 'maintainer'
+  /** The PR number whose closing surfaced this rejection (when addedBy=bot). */
+  refPR?: number
+}
+
+export interface SkipList {
+  version: 1
+  entries: SkipListEntry[]
+}
+
+/** Disk-storage path relative to repo root. */
+export const SKIP_LIST_PATH = 'bots/feature-bot/skip-list.json'
+
+export function emptySkipList(): SkipList {
+  return { version: 1, entries: [] }
+}
+
+export function readSkipList(absolutePath: string): SkipList {
+  if (!existsSync(absolutePath)) return emptySkipList()
+  const raw = readFileSync(absolutePath, 'utf-8')
+  const parsed = JSON.parse(raw) as SkipList
+  if (parsed.version !== 1) {
+    throw new Error(`Skip-list at ${absolutePath} has unknown version ${parsed.version}`)
+  }
+  // Defensive: a hand-edited file or legacy shape may omit entries entirely.
+  if (!Array.isArray(parsed.entries)) {
+    return { version: 1, entries: [] }
+  }
+  return parsed
+}
+
+export function writeSkipList(absolutePath: string, list: SkipList): void {
+  writeFileSync(absolutePath, `${JSON.stringify(list, null, 2)}\n`)
+}
+
+/**
+ * Match a fingerprint against the skip-list.
+ *
+ * v1 ships entries only — no rule-shape matching. Cuts are unique enough
+ * that per-issue gates are sufficient; rules wait until the compactor
+ * earns its place. Mirror the fix-bot ergonomic of returning the matched
+ * entry (so callers can render the reason in the skip notice) or null.
+ */
+export function findSkipMatch(list: SkipList, fp: IssueFingerprint): SkipListEntry | null {
+  for (const entry of list.entries) {
+    if (entry.fingerprint.issueNumber === fp.issueNumber) return entry
+  }
+  return null
+}
+
+/**
+ * Append a fresh entry. Idempotent: if an entry with the same issue
+ * number already exists, the existing one is kept unchanged and the
+ * call returns false. Mirrors fix-bot's contract so symmetric audits
+ * (rule 38) compose cleanly.
+ */
+export function appendEntry(list: SkipList, entry: SkipListEntry): boolean {
+  const existing = list.entries.find(e => e.fingerprint.issueNumber === entry.fingerprint.issueNumber)
+  if (existing) return false
+  list.entries.push(entry)
+  return true
+}

--- a/bots/feature-bot/tests/skip-list.test.ts
+++ b/bots/feature-bot/tests/skip-list.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Feature-bot skip-list tests — failing-test commit per rule 31 TDD-first ordering.
+ *
+ * Mirrors fix-bot's skip-list contract but extends the SkipReason union
+ * with 4 feature-bot-specific reasons per design-feature-bot.md Q7:
+ *   - missing-prereq
+ *   - spec-too-vague
+ *   - input-cycles-exceeded
+ *   - files-conflict
+ *
+ * Plus the 4 reasons reused from fix-bot:
+ *   - needs-human
+ *   - maintainer-rejected
+ *   - tautological-test
+ *   - wrong-root-cause
+ *
+ * Total: 8 values. Compile-time check via `satisfies` confirms every
+ * value is reachable from the union.
+ */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  appendEntry,
+  emptySkipList,
+  findSkipMatch,
+  readSkipList,
+  type SkipList,
+  type SkipReason,
+  writeSkipList,
+} from '../skip-list.js'
+
+let tmp: string
+beforeEach(() => {
+  tmp = mkdtempSync(resolve(tmpdir(), 'feature-bot-skip-list-'))
+})
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('readSkipList', () => {
+  it('returns empty when file is missing', () => {
+    const list = readSkipList(resolve(tmp, 'does-not-exist.json'))
+    expect(list).toEqual(emptySkipList())
+    expect(list.entries).toEqual([])
+  })
+
+  it('returns parsed entries from existing JSON', () => {
+    const path = resolve(tmp, 'skip-list.json')
+    const seed: SkipList = {
+      version: 1,
+      entries: [
+        {
+          fingerprint: { issueNumber: 501 },
+          reason: 'spec-too-vague',
+          reasonNote: 'Cut spec missed Acceptance section',
+          addedAt: '2026-05-30T00:00:00Z',
+          addedBy: 'bot',
+        },
+      ],
+    }
+    writeSkipList(path, seed)
+    const read = readSkipList(path)
+    expect(read.entries).toHaveLength(1)
+    expect(read.entries[0].fingerprint.issueNumber).toBe(501)
+    expect(read.entries[0].reason).toBe('spec-too-vague')
+  })
+})
+
+describe('writeSkipList', () => {
+  it('round-trips through readSkipList', () => {
+    const path = resolve(tmp, 'skip-list.json')
+    const original: SkipList = {
+      version: 1,
+      entries: [
+        {
+          fingerprint: { issueNumber: 502 },
+          reason: 'missing-prereq',
+          reasonNote: 'Required infrastructure not present despite closed deps',
+          addedAt: '2026-05-30T01:00:00Z',
+          addedBy: 'bot',
+        },
+        {
+          fingerprint: { issueNumber: 503 },
+          reason: 'input-cycles-exceeded',
+          reasonNote: 'Two NEEDS_INPUT cycles on same cut',
+          addedAt: '2026-05-30T02:00:00Z',
+          addedBy: 'bot',
+        },
+      ],
+    }
+    writeSkipList(path, original)
+    const round = readSkipList(path)
+    expect(round).toEqual(original)
+  })
+})
+
+describe('appendEntry', () => {
+  it('adds an entry; subsequent findSkipMatch finds it by issueNumber', () => {
+    const list = emptySkipList()
+    const added = appendEntry(list, {
+      fingerprint: { issueNumber: 600 },
+      reason: 'files-conflict',
+      reasonNote: 'Cut overlaps with another in-flight cut',
+      addedAt: '2026-05-30T03:00:00Z',
+      addedBy: 'bot',
+    })
+    expect(added).toBe(true)
+    expect(list.entries).toHaveLength(1)
+
+    const match = findSkipMatch(list, { issueNumber: 600 })
+    expect(match).not.toBeNull()
+    expect(match?.reason).toBe('files-conflict')
+  })
+
+  it('is idempotent on duplicate fingerprint+reason', () => {
+    const list = emptySkipList()
+    const first = appendEntry(list, {
+      fingerprint: { issueNumber: 700 },
+      reason: 'tautological-test',
+      reasonNote: 'Reviewer caught fake-pass test',
+      addedAt: '2026-05-30T04:00:00Z',
+      addedBy: 'bot',
+    })
+    const second = appendEntry(list, {
+      fingerprint: { issueNumber: 700 },
+      reason: 'tautological-test',
+      reasonNote: 'Different note but same fingerprint',
+      addedAt: '2026-05-30T05:00:00Z',
+      addedBy: 'bot',
+    })
+    expect(first).toBe(true)
+    expect(second).toBe(false)
+    expect(list.entries).toHaveLength(1)
+  })
+
+  it('returns null from findSkipMatch when no entry matches', () => {
+    const list = emptySkipList()
+    expect(findSkipMatch(list, { issueNumber: 9999 })).toBeNull()
+  })
+})
+
+describe('SkipReason union (Q7 lock — 8 values)', () => {
+  it('accepts all 8 reason values from design-feature-bot.md Q7', () => {
+    // Compile-time check via `satisfies`: TypeScript narrows the array
+    // literal to the exact union, so missing/extra values fail to compile.
+    // Runtime sanity check: every value can be assigned and read.
+    const reasons = [
+      // Reused from fix-bot
+      'needs-human',
+      'maintainer-rejected',
+      'tautological-test',
+      'wrong-root-cause',
+      // Feature-bot additions
+      'missing-prereq',
+      'spec-too-vague',
+      'input-cycles-exceeded',
+      'files-conflict',
+    ] as const satisfies readonly SkipReason[]
+
+    expect(reasons).toHaveLength(8)
+
+    // Each value must round-trip through an entry to confirm the
+    // SkipReason union admits it (and not, say, a typo'd variant).
+    for (const reason of reasons) {
+      const list = emptySkipList()
+      const added = appendEntry(list, {
+        fingerprint: { issueNumber: 1000 + reasons.indexOf(reason) },
+        reason,
+        reasonNote: `Test entry for reason=${reason}`,
+        addedAt: '2026-05-30T00:00:00Z',
+        addedBy: 'bot',
+      })
+      expect(added).toBe(true)
+      expect(list.entries[0].reason).toBe(reason)
+    }
+  })
+})

--- a/bots/package.json
+++ b/bots/package.json
@@ -12,6 +12,7 @@
     "discovery-prep-bot": "tsx discovery-prep-bot/index.ts",
     "fix-bot": "tsx fix-bot/index.ts",
     "fix-bot:compact": "tsx fix-bot/compact.ts",
+    "feature-bot": "tsx feature-bot/index.ts",
     "dead-code-watcher": "tsx dead-code-watcher/index.ts",
     "dead-code-watcher:compact": "tsx dead-code-watcher/compact.ts",
     "mutation-area-picker": "tsx mutation-area-picker/index.ts",


### PR DESCRIPTION
## Summary

Cut 1 of feature-bot's 8-cut implementation sequence (per [`.claude/rules/design-feature-bot.md`](https://github.com/gazetta-studio/gazetta-studio/blob/main/.claude/rules/design-feature-bot.md) "Cut sequence"). Ships the skeleton + supporting infrastructure that Cuts 2-4 build on. **Does not invoke Claude yet** — the parser ships in Cut 2 and the generator-critic loop ships in Cut 3.

Position in the cut sequence:
- **Cut 1 (this PR)** — skeleton + skip-list + reviewer-log infrastructure
- Cut 2 — `bots/_lib/cut-parser.ts` (`**Feature**:` + `**Depends on**:` regex)
- Cut 3 — generator-critic loop (Agent A + Agent B + three-tier escalation per Q6)
- Cut 4 — `.github/workflows/feature-bot.yml` (cron + cache + concurrency)
- Cuts 5-8 — process-doc rewrite, ADR-0015, first migration, `bots/README.md` row

## What ships

- `bots/feature-bot/index.ts` — cron mode (queries `enhancement + ready-for-agent` per Q1; sorts oldest-first per Q4) + manual mode via `ISSUE_NUMBER` env. Prints banner, lists candidates, exits with "skeleton — parser and loop ship in Cuts 2/3".
- `bots/feature-bot/skip-list.ts` — extended `SkipReason` union with 8 values per Q7: 4 reused from fix-bot (`needs-human`, `maintainer-rejected`, `tautological-test`, `wrong-root-cause`) + 4 feature-bot-specific (`missing-prereq`, `spec-too-vague`, `input-cycles-exceeded`, `files-conflict`).
- `bots/feature-bot/skip-list.json` — empty initial state `{ "version": 1, "entries": [] }`.
- `bots/feature-bot/reviewer-log.ts` — peer of fix-bot's, paths rebound; `verdict` widened to include `'needs-input'` per Q6's three-tier escalation.
- `bots/feature-bot/prompts/per-cut.md` — placeholder containing the Q5 "READ these files first" directive structure.
- `bots/feature-bot/prompts/reviewer.md` — placeholder; Cut 3 forks fix-bot's reviewer.
- `bots/feature-bot/lessons-learned.md` — empty placeholder (compactor deferred per Q7).
- `bots/package.json` — adds `"feature-bot": "tsx feature-bot/index.ts"` script.

## TDD ordering (rule 31)

Two commits in one PR:

1. **`9d41b3a` test(feature-bot): failing tests for skip-list infrastructure (Cut 1)** — 7 vitest tests against `../skip-list.js` (module doesn't exist yet).
2. **`c020716` feat(feature-bot): Cut 1 — skeleton + skip-list + reviewer-log infrastructure** — implementation.

**Verification:** removing `bots/feature-bot/skip-list.ts` and re-running tests fails with `Cannot find module '../skip-list.js'`; restoring it passes 7/7. The implementation does not modify the failing tests.

## Boundaries (per the cut spec)

This PR does NOT:
- Implement the parser (`bots/_lib/cut-parser.ts`) — Cut 2.
- Implement the generator-critic loop — Cut 3.
- Add the workflow — Cut 4.
- Update `bots/README.md` — Cut 8.
- Touch `.claude/rules/feature-design-process.md` — Cut 5 (parallel).

## Q-decisions pinned by this Cut

- **Q1** — `enhancement + ready-for-agent` is the input query; no new labels.
- **Q4** — oldest-first sort with deterministic tiebreaker by issue number.
- **Q5** — placeholder `per-cut.md` carries the "READ these files first" directive structure.
- **Q6** — `reviewer-log.ts` admits `'needs-input'` verdict alongside `'needs-human'`.
- **Q7** — `SkipReason` union has all 8 values from the locked enum.

## Test plan

- [x] `cd bots && npx vitest run feature-bot/tests/skip-list.test.ts` → 7/7 pass
- [x] `cd bots && npx vitest run` → 381/381 pass (no regressions)
- [x] `cd bots && npx tsc -p tsconfig.json --noEmit` → clean
- [x] `npm run format:check` → clean
- [x] `npm run feature-bot -w @gazetta/bots` with real `GH_TOKEN` → banner + "Inbox zero" exit (no current candidates)
- [x] `DRY_RUN=1 npm run feature-bot -w @gazetta/bots` → exits before any work
- [x] `ISSUE_NUMBER=501 npm run feature-bot -w @gazetta/bots` → manual-mode banner + skeleton notice
- [x] `ISSUE_NUMBER=not-a-number npm run feature-bot -w @gazetta/bots` → exits 2 with validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)