### PR TITLE
feat(_lib/cut-parser): Cut 2 — cut-sub-issue parser + validator

### DIFF
--- a/bots/_lib/cut-parser.ts
+++ b/bots/_lib/cut-parser.ts
@@ -1,0 +1,235 @@
+/**
+ * Cut-sub-issue body parser + validator — Cut 2 of feature-bot.
+ *
+ * Per design-feature-bot.md Q2 (just-markdown body shape) + Q3 (dependency
+ * mechanism: regex-parse `**Depends on**:` with cron-tick validation) +
+ * Cut 5 refinement (four sections: Spec / Acceptance / SOLID / Tests;
+ * SOLID conditional).
+ *
+ * Pure module — no Octokit / GitHub queries. Cron-tick validation of
+ * referenced issue numbers (does #501 exist? is it a cut sub-issue?
+ * not closed-merged?) lives in the orchestrator (Cut 3) — those checks
+ * need GitHub queries this parser deliberately avoids.
+ *
+ * Why split parse + validate from the orchestrator:
+ *   - SRP: this module owns "interpret the cut sub-issue body";
+ *     orchestrator owns "validate refs against the live issue tree
+ *     + take action."
+ *   - Testability: the parser + structural validator are pure
+ *     functions over a string + a number; unit-testable without
+ *     mocking Octokit.
+ *   - Symmetric audit (rule 38): bots that grow similar shapes can
+ *     copy this pattern; the structural-vs-network split is the
+ *     cargo-cult-able piece.
+ */
+
+/** Result of parsing a cut sub-issue body. */
+export interface ParsedCut {
+  /** Feature slug from `**Feature**: <slug>` line. Null if missing. */
+  feature: string | null
+  /** Issue numbers from `**Depends on**: #N, #M` line. Empty array if "none", empty, or missing line. */
+  dependsOn: readonly number[]
+  /** Raw body for the `## Spec` section; missing → undefined. */
+  spec: string | undefined
+  /** Raw body for the `## Acceptance` section; missing → undefined. */
+  acceptance: string | undefined
+  /** Raw body for the `## SOLID` section; missing → undefined. Conditionally required (see validator). */
+  solid: string | undefined
+  /** Raw body for the `## Tests` section; missing → undefined. */
+  tests: string | undefined
+}
+
+/**
+ * Validation error categorized by failure mode. Orchestrator uses
+ * this to format the loud-fail comment per Q3 + Q6.
+ *
+ * `not-found` and `not-a-cut` reasons are NOT emitted by
+ * `validateParsedCut` — they require GitHub queries. Orchestrator
+ * threads them through this same error shape after looking up refs
+ * against the live issue tree (Cut 3 work).
+ */
+export type ValidationError =
+  | { kind: 'missing-feature' }
+  | { kind: 'invalid-dep-ref'; depNumber: number; reason: 'not-found' | 'not-a-cut' | 'self-reference' }
+  | { kind: 'missing-required-section'; section: 'spec' | 'acceptance' | 'tests' }
+
+/**
+ * Parse a cut sub-issue body into typed fields.
+ *
+ * Conservative parser: never throws. Missing fields return null /
+ * undefined / empty array so the validator can surface them
+ * structurally rather than the parser bailing out.
+ *
+ * Locked behavior per Q2 + Q3 + Cut 5:
+ *
+ * - `**Feature**: <slug>` — one regex against the whole body
+ *   (multiline). Captured text is trimmed.
+ * - `**Depends on**: <text>` — same approach. Captured text is
+ *   scanned for `#N` tokens; "none" / empty / missing line ALL
+ *   resolve to an empty `dependsOn` array (NOT an error). Cuts
+ *   with no deps are common.
+ * - Section parsing — split on lines beginning `## `, match heading
+ *   case-insensitively against the four recognized names. The
+ *   section body is the prose between that heading and the next
+ *   `## ` or end-of-string, trimmed. Non-recognized headings
+ *   (`## Notes`, `## Implementation Notes`, etc.) are silently
+ *   dropped — the orchestrator doesn't pass them to Agent A.
+ */
+export function parseCutBody(body: string): ParsedCut {
+  const feature = parseFeature(body)
+  const dependsOn = parseDependsOn(body)
+  const sections = parseSections(body)
+
+  return {
+    feature,
+    dependsOn,
+    spec: sections.spec,
+    acceptance: sections.acceptance,
+    solid: sections.solid,
+    tests: sections.tests,
+  }
+}
+
+function parseFeature(body: string): string | null {
+  const match = body.match(/^\*\*Feature\*\*:\s*(.+)$/m)
+  if (!match) return null
+  const slug = match[1].trim()
+  return slug.length === 0 ? null : slug
+}
+
+function parseDependsOn(body: string): readonly number[] {
+  const match = body.match(/^\*\*Depends on\*\*:\s*(.*)$/m)
+  if (!match) return []
+  const captured = match[1].trim()
+  if (captured.length === 0) return []
+  if (captured.toLowerCase() === 'none') return []
+  const numbers: number[] = []
+  for (const ref of captured.matchAll(/#(\d+)/g)) {
+    numbers.push(Number(ref[1]))
+  }
+  return numbers
+}
+
+interface ParsedSections {
+  spec: string | undefined
+  acceptance: string | undefined
+  solid: string | undefined
+  tests: string | undefined
+}
+
+/**
+ * The four recognized H2 headings. Matching is case-insensitive
+ * (Q2's lock allows `## spec` and `## SPEC` to parse identically).
+ * Unrecognized headings are silently dropped.
+ */
+const RECOGNIZED_HEADINGS: Record<string, keyof ParsedSections> = {
+  spec: 'spec',
+  acceptance: 'acceptance',
+  solid: 'solid',
+  tests: 'tests',
+}
+
+function parseSections(body: string): ParsedSections {
+  const result: ParsedSections = {
+    spec: undefined,
+    acceptance: undefined,
+    solid: undefined,
+    tests: undefined,
+  }
+
+  // Walk the body line by line. When we hit `## Heading`, capture
+  // the lines that follow up to the next `## ` or end-of-string.
+  // Splitting on `/^## /m` and matching the first token would be
+  // terser but loses the heading text + body separation; this
+  // iterative shape is the readable form.
+  const lines = body.split('\n')
+  let currentField: keyof ParsedSections | null = null
+  let currentBuffer: string[] = []
+
+  const flush = (): void => {
+    if (currentField === null) return
+    const text = currentBuffer.join('\n').trim()
+    // Only write when we haven't already captured this section.
+    // (If a body had duplicate `## Spec` headings, the first wins;
+    // the parser doesn't try to be cleverer than the documented
+    // convention.)
+    if (result[currentField] === undefined) {
+      result[currentField] = text
+    }
+  }
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^## (.+)$/)
+    if (headingMatch) {
+      flush()
+      const headingText = headingMatch[1].trim().toLowerCase()
+      const field = RECOGNIZED_HEADINGS[headingText]
+      if (field) {
+        currentField = field
+        currentBuffer = []
+      } else {
+        // Unrecognized heading — drop the section.
+        currentField = null
+        currentBuffer = []
+      }
+    } else if (currentField !== null) {
+      currentBuffer.push(line)
+    }
+  }
+  flush()
+
+  return result
+}
+
+/**
+ * Pure-TS structural validation of a parsed cut body.
+ *
+ * Does NOT detect `not-found` or `not-a-cut` — those need GitHub
+ * queries; the orchestrator handles validation against the live
+ * issue tree.
+ *
+ * Detects:
+ * - `missing-feature` — `**Feature**:` line absent or empty
+ * - `missing-required-section` — Spec / Acceptance / Tests absent
+ *   (SOLID is conditional per Q6 lock; never an error here)
+ * - `invalid-dep-ref` with `reason: 'self-reference'` — when
+ *   `ownIssueNumber` is supplied and the dep list contains it
+ *
+ * @param parsed   The parsed body, from `parseCutBody`.
+ * @param ownIssueNumber  Optional — the issue number of the cut
+ *   sub-issue itself. When supplied, the validator emits
+ *   self-reference errors. Threaded through by the orchestrator
+ *   per-cut at cron-tick time (Cut 3 work).
+ */
+export function validateParsedCut(parsed: ParsedCut, ownIssueNumber?: number): readonly ValidationError[] {
+  const errors: ValidationError[] = []
+
+  if (parsed.feature === null) {
+    errors.push({ kind: 'missing-feature' })
+  }
+
+  // Spec / Acceptance / Tests are always required.
+  // SOLID is conditionally required (Q6 lock) — the validator
+  // returns it as absent but does NOT raise an error. Agent A's
+  // "fail-loud-on-vague-spec" path handles the judgment of
+  // whether SOLID was needed for THIS cut.
+  if (parsed.spec === undefined) {
+    errors.push({ kind: 'missing-required-section', section: 'spec' })
+  }
+  if (parsed.acceptance === undefined) {
+    errors.push({ kind: 'missing-required-section', section: 'acceptance' })
+  }
+  if (parsed.tests === undefined) {
+    errors.push({ kind: 'missing-required-section', section: 'tests' })
+  }
+
+  if (ownIssueNumber !== undefined) {
+    for (const dep of parsed.dependsOn) {
+      if (dep === ownIssueNumber) {
+        errors.push({ kind: 'invalid-dep-ref', depNumber: dep, reason: 'self-reference' })
+      }
+    }
+  }
+
+  return errors
+}

--- a/bots/_lib/tests/cut-parser.test.ts
+++ b/bots/_lib/tests/cut-parser.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Cut-sub-issue parser tests — failing-test commit per rule 31 TDD-first
+ * ordering. Spec sourced from design-feature-bot.md Q2 (just-markdown body
+ * shape) + Q3 (dependency mechanism: regex-parse `**Depends on**:` with
+ * cron-tick validation) + Cut 5 refinement (four sections: Spec /
+ * Acceptance / SOLID / Tests; SOLID conditional).
+ *
+ * Two surfaces under test:
+ *   - `parseCutBody(body)` — pure regex / split parse over markdown.
+ *     No GitHub queries. Returns `ParsedCut` with `feature`,
+ *     `dependsOn`, and four sections (`spec`, `acceptance`, `solid`,
+ *     `tests`).
+ *   - `validateParsedCut(parsed, ownIssueNumber?)` — pure-TS structural
+ *     validation. Does NOT detect `not-found` or `not-a-cut` (those
+ *     need GitHub queries; orchestrator handles those in Cut 3).
+ *     Detects: missing feature, missing required sections (spec /
+ *     acceptance / tests — but NOT solid; SOLID is conditionally
+ *     required per Q6 lock), and self-reference when `ownIssueNumber`
+ *     matches a depNumber.
+ *
+ * Per rule 31: "do not modify the failing tests" during implementation.
+ * The tests below are the spec.
+ */
+import { describe, expect, it } from 'vitest'
+import { parseCutBody, type ParsedCut, validateParsedCut, type ValidationError } from '../cut-parser.js'
+
+// ---------------------------------------------------------------------------
+// parseCutBody — happy path
+// ---------------------------------------------------------------------------
+
+const FULL_BODY = `**Feature**: redirect-ui
+**Depends on**: #501, #502
+
+## Spec
+
+Build the CreateRedirectDialog.vue component. Reuses the morph-in-place
+pattern from CreatePageDialog.vue. See design-redirect-ui.md Q3 for the
++ New menu entry decision.
+
+## Acceptance
+
+- Dialog opens from SiteTree's "+ New redirect" button
+- From / To inputs accept both \`/path\` and bare names
+- Submit calls POST /api/redirects with correct body shape
+
+## SOLID
+
+- SRP: component owns dialog UX only; reuses ArchivedNameConflictPrompt
+- Composition: consumes shared prompt rather than extending it
+
+## Tests
+
+- apps/admin/tests/CreateRedirectDialog.test.ts — open + close + submit
+- apps/admin/tests/CreateRedirectDialog.test.ts — kind toggle updates body
+- apps/admin/tests/CreateRedirectDialog.test.ts — 409 morph to conflict prompt
+`
+
+describe('parseCutBody — happy path', () => {
+  it('parses a fully-populated body with all four sections', () => {
+    const parsed = parseCutBody(FULL_BODY)
+    expect(parsed.feature).toBe('redirect-ui')
+    expect(parsed.dependsOn).toEqual([501, 502])
+    expect(parsed.spec).toBeDefined()
+    expect(parsed.spec).toContain('CreateRedirectDialog.vue')
+    expect(parsed.acceptance).toBeDefined()
+    expect(parsed.acceptance).toContain('Dialog opens')
+    expect(parsed.solid).toBeDefined()
+    expect(parsed.solid).toContain('SRP')
+    expect(parsed.tests).toBeDefined()
+    expect(parsed.tests).toContain('CreateRedirectDialog.test.ts')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseCutBody — empty / missing front-matter fields
+// ---------------------------------------------------------------------------
+
+describe('parseCutBody — empty body', () => {
+  it('returns null feature, empty deps, undefined sections', () => {
+    const parsed = parseCutBody('')
+    expect(parsed.feature).toBeNull()
+    expect(parsed.dependsOn).toEqual([])
+    expect(parsed.spec).toBeUndefined()
+    expect(parsed.acceptance).toBeUndefined()
+    expect(parsed.solid).toBeUndefined()
+    expect(parsed.tests).toBeUndefined()
+  })
+})
+
+describe('parseCutBody — missing **Feature**: line', () => {
+  it('returns feature: null', () => {
+    const body = `**Depends on**: #501
+
+## Spec
+build the thing
+`
+    const parsed = parseCutBody(body)
+    expect(parsed.feature).toBeNull()
+    expect(parsed.dependsOn).toEqual([501])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseCutBody — **Depends on**: variants (Q3 lock tolerates several)
+// ---------------------------------------------------------------------------
+
+describe('parseCutBody — **Depends on**: variants', () => {
+  it('parses `**Depends on**: none` as empty deps, no error', () => {
+    const body = `**Feature**: foo
+**Depends on**: none
+`
+    const parsed = parseCutBody(body)
+    expect(parsed.dependsOn).toEqual([])
+  })
+
+  it('parses `**Depends on**:` with empty trailing as empty deps', () => {
+    const body = `**Feature**: foo
+**Depends on**:
+`
+    const parsed = parseCutBody(body)
+    expect(parsed.dependsOn).toEqual([])
+  })
+
+  it('returns empty deps when the **Depends on**: line is missing (NOT an error)', () => {
+    const body = `**Feature**: foo
+
+## Spec
+ok
+`
+    const parsed = parseCutBody(body)
+    expect(parsed.dependsOn).toEqual([])
+  })
+
+  it('parses comma-space separated refs: #501, #502', () => {
+    const body = `**Feature**: foo
+**Depends on**: #501, #502
+`
+    const parsed = parseCutBody(body)
+    expect(parsed.dependsOn).toEqual([501, 502])
+  })
+
+  it('parses space-separated refs: #501 #502', () => {
+    const body = `**Feature**: foo
+**Depends on**: #501 #502
+`
+    const parsed = parseCutBody(body)
+    expect(parsed.dependsOn).toEqual([501, 502])
+  })
+
+  it('parses no-space refs: #501,#502', () => {
+    const body = `**Feature**: foo
+**Depends on**: #501,#502
+`
+    const parsed = parseCutBody(body)
+    expect(parsed.dependsOn).toEqual([501, 502])
+  })
+
+  it('parses mixed-separator refs: #501, #502, #503,#504', () => {
+    const body = `**Feature**: foo
+**Depends on**: #501, #502, #503,#504
+`
+    const parsed = parseCutBody(body)
+    expect(parsed.dependsOn).toEqual([501, 502, 503, 504])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseCutBody — section parsing edge cases
+// ---------------------------------------------------------------------------
+
+describe('parseCutBody — section parsing', () => {
+  it('matches headings case-insensitively (## spec → spec field)', () => {
+    const body = `**Feature**: foo
+
+## spec
+lowercased heading
+`
+    const parsed = parseCutBody(body)
+    expect(parsed.spec).toBeDefined()
+    expect(parsed.spec).toContain('lowercased heading')
+  })
+
+  it('matches headings case-insensitively (## SPEC → spec field)', () => {
+    const body = `**Feature**: foo
+
+## SPEC
+uppercased heading
+`
+    const parsed = parseCutBody(body)
+    expect(parsed.spec).toBeDefined()
+    expect(parsed.spec).toContain('uppercased heading')
+  })
+
+  it('trims leading and trailing whitespace from section bodies', () => {
+    const body = `**Feature**: foo
+
+## Spec
+
+
+   body text
+
+
+## Acceptance
+acc
+`
+    const parsed = parseCutBody(body)
+    expect(parsed.spec).toBe('body text')
+  })
+
+  it('captures ## SOLID into the solid field when present', () => {
+    const body = `**Feature**: foo
+
+## Spec
+s
+
+## SOLID
+- SRP per module
+- DIP via injected dispatcher
+
+## Tests
+- foo.test.ts
+`
+    const parsed = parseCutBody(body)
+    expect(parsed.solid).toBeDefined()
+    expect(parsed.solid).toContain('SRP per module')
+    expect(parsed.solid).toContain('DIP via injected dispatcher')
+  })
+
+  it('leaves the solid field undefined when ## SOLID is absent', () => {
+    const body = `**Feature**: foo
+
+## Spec
+s
+
+## Acceptance
+a
+
+## Tests
+t
+`
+    const parsed = parseCutBody(body)
+    expect(parsed.solid).toBeUndefined()
+  })
+
+  it('ignores non-recognized H2 headings (## Notes does not appear in any field)', () => {
+    const body = `**Feature**: foo
+
+## Spec
+s
+
+## Notes
+random aside the parser should ignore
+
+## Tests
+t
+`
+    const parsed = parseCutBody(body)
+    expect(parsed.spec).toBe('s')
+    expect(parsed.tests).toBe('t')
+    // The "Notes" content does not leak into spec or tests.
+    expect(parsed.spec).not.toContain('random aside')
+    expect(parsed.tests).not.toContain('random aside')
+    expect(parsed.solid).toBeUndefined()
+    expect(parsed.acceptance).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateParsedCut — structural validation (NO GitHub queries)
+// ---------------------------------------------------------------------------
+
+function makeParsed(overrides: Partial<ParsedCut> = {}): ParsedCut {
+  return {
+    feature: 'foo',
+    dependsOn: [],
+    spec: 'spec body',
+    acceptance: 'acceptance body',
+    solid: 'solid body',
+    tests: 'tests body',
+    ...overrides,
+  }
+}
+
+describe('validateParsedCut — missing feature', () => {
+  it('emits a missing-feature error when feature is null', () => {
+    const errors = validateParsedCut(makeParsed({ feature: null }))
+    expect(errors).toContainEqual<ValidationError>({ kind: 'missing-feature' })
+  })
+
+  it('does NOT emit missing-feature when feature is present', () => {
+    const errors = validateParsedCut(makeParsed({ feature: 'foo' }))
+    expect(errors).not.toContainEqual<ValidationError>({ kind: 'missing-feature' })
+  })
+})
+
+describe('validateParsedCut — required-section validation', () => {
+  it('emits missing-required-section for absent spec', () => {
+    const errors = validateParsedCut(makeParsed({ spec: undefined }))
+    expect(errors).toContainEqual<ValidationError>({
+      kind: 'missing-required-section',
+      section: 'spec',
+    })
+  })
+
+  it('emits missing-required-section for absent acceptance', () => {
+    const errors = validateParsedCut(makeParsed({ acceptance: undefined }))
+    expect(errors).toContainEqual<ValidationError>({
+      kind: 'missing-required-section',
+      section: 'acceptance',
+    })
+  })
+
+  it('emits missing-required-section for absent tests', () => {
+    const errors = validateParsedCut(makeParsed({ tests: undefined }))
+    expect(errors).toContainEqual<ValidationError>({
+      kind: 'missing-required-section',
+      section: 'tests',
+    })
+  })
+
+  it('does NOT emit an error when solid is absent (SOLID is conditional, not required)', () => {
+    const errors = validateParsedCut(makeParsed({ solid: undefined }))
+    expect(errors).not.toContainEqual<ValidationError>({
+      kind: 'missing-required-section',
+      section: 'solid' as never,
+    })
+    // Also: a happy parse with only solid missing should produce zero errors.
+    expect(errors).toEqual([])
+  })
+
+  it('returns an empty error array when all required sections are present and feature is set', () => {
+    const errors = validateParsedCut(makeParsed())
+    expect(errors).toEqual([])
+  })
+})
+
+describe('validateParsedCut — self-reference detection (Q3 lock)', () => {
+  it('emits invalid-dep-ref / self-reference when ownIssueNumber matches a dep', () => {
+    const parsed = makeParsed({ dependsOn: [501] })
+    const errors = validateParsedCut(parsed, 501)
+    expect(errors).toContainEqual<ValidationError>({
+      kind: 'invalid-dep-ref',
+      depNumber: 501,
+      reason: 'self-reference',
+    })
+  })
+
+  it('does NOT emit self-reference when ownIssueNumber differs from all deps', () => {
+    const parsed = makeParsed({ dependsOn: [502] })
+    const errors = validateParsedCut(parsed, 501)
+    // No self-reference for #502 when own is #501.
+    const selfRefErrors = errors.filter(e => e.kind === 'invalid-dep-ref' && e.reason === 'self-reference')
+    expect(selfRefErrors).toEqual([])
+  })
+
+  it('does NOT emit self-reference when ownIssueNumber is undefined (caller did not thread it)', () => {
+    const parsed = makeParsed({ dependsOn: [501] })
+    const errors = validateParsedCut(parsed)
+    const selfRefErrors = errors.filter(e => e.kind === 'invalid-dep-ref' && e.reason === 'self-reference')
+    expect(selfRefErrors).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Cut 2 of feature-bot's 8-cut implementation per [`design-feature-bot.md`](.claude/rules/design-feature-bot.md).

Lands `bots/_lib/cut-parser.ts` — pure-TS parser + structural validator over cut-sub-issue bodies. Two surfaces:

- **`parseCutBody(body): ParsedCut`** — extracts `**Feature**: <slug>` + `**Depends on**: #N, #M` front-matter (per [Q2 lock](.claude/rules/design-feature-bot.md#q2--cut-sub-issue-body-format-just-markdown)) and four recognized H2 sections: `## Spec`, `## Acceptance`, `## SOLID`, `## Tests` (per [Cut 5 refinement](.claude/rules/design-feature-bot.md)). Tolerates Q3's separator variants (`#501, #502`, `#501 #502`, `#501,#502`, mixed) plus `none` / empty / missing-line all → empty deps (NOT an error per Q3 lock).
- **`validateParsedCut(parsed, ownIssueNumber?): ValidationError[]`** — pure-TS structural validation. Detects `missing-feature`, `missing-required-section` for Spec/Acceptance/Tests (NOT for SOLID — conditional per Q6 lock), and `invalid-dep-ref` with `reason: 'self-reference'` when `ownIssueNumber` matches a dep.

**Cron-tick validation against the live issue tree** (looking up referenced numbers, checking they're open cut sub-issues, not self-references against the wrong type) is deliberately NOT in this module — those checks need GitHub queries and live in the orchestrator (Cut 3). The validator's `ValidationError` shape carries `not-found` and `not-a-cut` reasons that the orchestrator threads through after the live-tree lookup.

## TDD ordering (per [rule 31](.claude/rules/team-preferences.md))

Two commits in one PR:

1. **d3ea072** — `test(_lib/cut-parser): failing tests for cut body parsing + validation` — 26 tests sourced from design-feature-bot.md Q2 + Q3 + Cut 5 refinement
2. **920d68f** — `feat(_lib/cut-parser): Cut 2 — cut-sub-issue parser + validator` — implementation

Verified by reverting commit 2 locally and re-running tests — they fail with `Cannot find module '../cut-parser.js'`. Restored after verification.

## Test plan

- [x] 26 cut-parser tests pass: `cd bots && npx vitest run _lib/tests/cut-parser.test.ts`
- [x] Full bots test suite passes: 407 tests across 28 files
- [x] Type-check clean: `npx tsc -p bots/tsconfig.json --noEmit`
- [x] Format check clean: `npm run format:check`
- [x] Reverting commit 2 fails the tests with "Cannot find module"

## Boundaries

- **Does NOT touch** `bots/feature-bot/index.ts` — Cut 3 wires the parser into the orchestrator.
- **Does NOT add** Octokit / GitHub queries — Cut 3 owns the live-tree validation pass.
- **Does NOT touch** any `.claude/rules/` files — Cut 2 is pure code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)