### PR TITLE
feat(feature-bot): Cut 3 — generator-critic loop + 3-tier escalation

### DIFF
--- a/bots/feature-bot/agent-a-signal.ts
+++ b/bots/feature-bot/agent-a-signal.ts
@@ -1,0 +1,119 @@
+/**
+ * Agent A signal parser — Cut 3 of feature-bot.
+ *
+ * Per design-feature-bot.md Q6, Agent A has THREE terminal states:
+ *
+ *   1. APPROVE_IMPLICIT — commits exist on the branch, no signal block
+ *      in final text. Orchestrator invokes Agent B next.
+ *   2. NEEDS_INPUT block in final text:
+ *        NEEDS_INPUT: <one-line question>
+ *        Options:
+ *          - <option 1 with reasoning>
+ *          - <option 2 with reasoning>
+ *        Recommendation: <option N because ...>
+ *      Orchestrator posts the question as a comment with outcome tag,
+ *      applies `needs-info`, resets working tree.
+ *   3. NEEDS_HUMAN block in final text:
+ *        NEEDS_HUMAN: <one-line reason>
+ *        Reason-code: <one of: missing-prereq | spec-too-vague | files-conflict | needs-human>
+ *      Orchestrator escalates to skip-list + ready-for-human.
+ *
+ * Why this is a separate module from bots/_lib/reviewer-verdict.ts:
+ *   - Different grammars (NEEDS_INPUT block vs VERDICT line)
+ *   - Different consumers (this parses Agent A; reviewer-verdict parses Agent B)
+ *   - SRP per rule 18: each parser owns one signal shape
+ *
+ * Last-occurrence semantic mirrors reviewer-verdict's: if Agent A
+ * thought out loud ("NEEDS_INPUT: ... actually no, NEEDS_HUMAN: ...")
+ * the LATER block wins. Matches Claude's natural revision pattern.
+ */
+
+/** Closed enum of reason codes Agent A may emit on the NEEDS_HUMAN path. */
+export type AgentAReasonCode = 'missing-prereq' | 'spec-too-vague' | 'files-conflict' | 'needs-human'
+
+const VALID_REASON_CODES: readonly AgentAReasonCode[] = [
+  'missing-prereq',
+  'spec-too-vague',
+  'files-conflict',
+  'needs-human',
+]
+
+export type AgentASignal =
+  | { kind: 'approve-implicit' }
+  | { kind: 'needs-input'; question: string; body: string }
+  | { kind: 'needs-human'; reason: string; reasonCode: AgentAReasonCode }
+
+/**
+ * Parse Agent A's final assistant text into a terminal-state signal.
+ *
+ * Approve-implicit is the default — no signal block means Agent A
+ * committed work and expects Agent B's review.
+ *
+ * NEEDS_INPUT and NEEDS_HUMAN blocks are detected by matching the
+ * "<KEYWORD>: " prefix at line start. The orchestrator passes the
+ * MATCHED block's body verbatim onto the GitHub comment (NEEDS_INPUT)
+ * or into the skip-list entry's reason-note (NEEDS_HUMAN).
+ *
+ * When both block types appear (Agent A revised mid-stream), the LAST
+ * one wins — same last-occurrence semantic as reviewer-verdict.
+ */
+export function parseAgentASignal(text: string): AgentASignal {
+  // Find the last occurrence of each signal keyword. Whichever has the
+  // higher index wins.
+  const lastInput = findLastBlockStart(text, 'NEEDS_INPUT:')
+  const lastHuman = findLastBlockStart(text, 'NEEDS_HUMAN:')
+
+  if (lastInput === -1 && lastHuman === -1) {
+    return { kind: 'approve-implicit' }
+  }
+
+  if (lastHuman > lastInput) {
+    return parseNeedsHuman(text, lastHuman)
+  }
+  return parseNeedsInput(text, lastInput)
+}
+
+/**
+ * Find the start index of the LAST line that begins with `marker`.
+ * Returns -1 when not found. Lines may have leading whitespace, but the
+ * marker itself must be at column N where everything to the left is
+ * pure whitespace — same shape as reviewer-verdict's regex.
+ */
+function findLastBlockStart(text: string, marker: string): number {
+  const pattern = new RegExp(`^[\\s]*${escapeRegex(marker)}`, 'gm')
+  const matches = [...text.matchAll(pattern)]
+  if (matches.length === 0) return -1
+  const last = matches.at(-1)!
+  return last.index ?? -1
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function parseNeedsInput(text: string, startIdx: number): AgentASignal {
+  // Extract the question from the NEEDS_INPUT: line (up to next newline).
+  const tail = text.slice(startIdx)
+  const headerMatch = tail.match(/^[\s]*NEEDS_INPUT:\s*(.*)/)
+  const question = headerMatch?.[1]?.trim() ?? ''
+  // Body is everything from the NEEDS_INPUT line onward (orchestrator
+  // posts the whole block as a comment so authors see options +
+  // recommendation).
+  const body = tail.trim()
+  return { kind: 'needs-input', question, body }
+}
+
+function parseNeedsHuman(text: string, startIdx: number): AgentASignal {
+  const tail = text.slice(startIdx)
+  // Match NEEDS_HUMAN: <reason>\n[optional Reason-code: <code>]
+  const headerMatch = tail.match(/^[\s]*NEEDS_HUMAN:\s*(.*)/)
+  const reason = headerMatch?.[1]?.trim() ?? ''
+  const codeMatch = tail.match(/^[\s]*Reason-code:\s*([a-zA-Z-]+)\s*$/m)
+  const rawCode = codeMatch?.[1]?.trim() ?? ''
+  const reasonCode: AgentAReasonCode = isValidReasonCode(rawCode) ? rawCode : 'needs-human'
+  return { kind: 'needs-human', reason, reasonCode }
+}
+
+function isValidReasonCode(code: string): code is AgentAReasonCode {
+  return (VALID_REASON_CODES as readonly string[]).includes(code)
+}

--- a/bots/feature-bot/idempotency.ts
+++ b/bots/feature-bot/idempotency.ts
@@ -1,0 +1,45 @@
+/**
+ * Idempotency decision — should we re-attempt a cut sub-issue that
+ * already has the `feature-bot-attempted` label?
+ *
+ * Mirrors fix-bot's auto-clear-on-reopen pattern. The orchestrator
+ * looks up the label-applied-at timestamp + the most-recent reopen
+ * timestamp via bots/_lib/github.ts helpers, then calls this pure
+ * function to decide.
+ *
+ * Split as a pure function so the rule can be tested without mocking
+ * octokit. Rule 18 (SOLID at module creation): I/O lives in the
+ * orchestrator; the decision rule lives here.
+ */
+
+export interface IdempotencyInput {
+  /**
+   * ISO timestamp when `feature-bot-attempted` was most recently
+   * applied. Null when the label has never been applied OR is not
+   * currently on the issue.
+   */
+  attemptedAt: string | null
+  /**
+   * ISO timestamp of the most recent `reopened` event on the issue.
+   * Null when the issue has never been closed-and-reopened.
+   */
+  reopenedAt: string | null
+}
+
+export type IdempotencyDecision = { kind: 'proceed' } | { kind: 'skip' } | { kind: 'proceed-after-reopen' }
+
+export function decideIdempotency(input: IdempotencyInput): IdempotencyDecision {
+  if (input.attemptedAt === null) {
+    return { kind: 'proceed' }
+  }
+  if (input.reopenedAt === null) {
+    return { kind: 'skip' }
+  }
+  // Reopen at or after the label-applied time means the maintainer
+  // signaled a re-attempt request. Tie favors proceeding (rare clock
+  // tie should not strand the issue).
+  if (input.reopenedAt >= input.attemptedAt) {
+    return { kind: 'proceed-after-reopen' }
+  }
+  return { kind: 'skip' }
+}

--- a/bots/feature-bot/index.ts
+++ b/bots/feature-bot/index.ts
@@ -8,113 +8,123 @@
  * implements, Agent B reviews, three-tier escalation
  * APPROVE / NEEDS_INPUT / NEEDS_HUMAN).
  *
- * # Cut 1 status (this file)
+ * # Cut 3 status (this file)
  *
- * Cut 1 ships the **skeleton + supporting infrastructure** as a
- * standalone PR per the design's Cut sequence:
+ * Cut 3 ships the full generator-critic loop + three-tier escalation.
+ * Cuts 1+2 shipped the skeleton + cut-parser respectively. Cut 4 will
+ * ship the workflow + cron.
  *
- *   - bots/feature-bot/index.ts        ← this file (cron banner +
- *                                        candidate query + DRY_RUN exit
- *                                        + manual-mode plumbing)
- *   - bots/feature-bot/skip-list.ts    ← extended SkipReason union
- *                                        (8 values per Q7)
- *   - bots/feature-bot/reviewer-log.ts ← peer of fix-bot's, paths rebound
- *   - bots/feature-bot/skip-list.json  ← empty initial state
- *   - bots/feature-bot/prompts/        ← per-cut.md + reviewer.md
- *                                        placeholders (Cut 3 writes the
- *                                        bodies)
- *   - bots/feature-bot/lessons-learned.md ← empty placeholder
- *
- * Cut 1 deliberately **does not invoke Claude**. The skeleton prints the
- * banner, queries candidates, logs them, and exits. The parser ships in
- * Cut 2; the generator-critic loop ships in Cut 3; the workflow ships in
- * Cut 4. Each cut is independently rollback-able per team-preferences
- * rule 17.
- *
- * # Two trigger modes (same shape as fix-bot)
+ * # Two trigger modes
  *
  *   1. Cron (default): scans for `enhancement + ready-for-agent` issues
- *      that lack `ready-for-human` / `wontfix` / `needs-info`. Per Q1,
- *      this is the canonical input — disjoint from fix-bot's
- *      `bug + ready-for-agent` queue, disjoint from discovery-prep-bot's
- *      `enhancement` (lacking `ready-for-agent`) queue.
+ *      that lack `ready-for-human` / `wontfix` / `needs-info`.
+ *   2. Manual via `ISSUE_NUMBER` env: attempt a single specific sub-issue.
  *
- *   2. Manual via `ISSUE_NUMBER` env: attempt a single specific sub-issue,
- *      regardless of label state. Useful for re-attempts after prompt
- *      iteration once Cut 3 ships.
- *
- * # Run locally
- *
- *   # Cron mode — scan all enhancement + ready-for-agent sub-issues:
- *   GITHUB_REPOSITORY=gazetta-studio/gazetta-studio \
- *     GH_TOKEN=$(gh auth token) npm run feature-bot -w @gazetta/bots
- *
- *   # Manual one-issue mode:
- *   ISSUE_NUMBER=501 GITHUB_REPOSITORY=gazetta-studio/gazetta-studio \
- *     GH_TOKEN=$(gh auth token) npm run feature-bot -w @gazetta/bots
- *
- *   # Skeleton-validating mode (no GitHub access needed in cron mode if
- *   # GH_TOKEN is set):
- *   DRY_RUN=1 GITHUB_REPOSITORY=gazetta-studio/gazetta-studio \
- *     GH_TOKEN=$(gh auth token) npm run feature-bot -w @gazetta/bots
- *
- * # Run in CI
- *
- * .github/workflows/feature-bot.yml — lands in Cut 4.
+ * # Per-cut, the bot:
+ *   1. Validates the cut sub-issue body + dep refs via
+ *      `validateCutSubIssue` (pre-Claude gate per Q3).
+ *   2. Checks idempotency via `decideIdempotency`.
+ *   3. Loads lessons-learned (currently empty placeholder).
+ *   4. Generator-critic loop (MAX_ATTEMPTS=5):
+ *      - Agent A reads design doc + cut body, commits TDD-first.
+ *      - Agent A signals: APPROVE_IMPLICIT (commits) / NEEDS_INPUT / NEEDS_HUMAN.
+ *      - On APPROVE_IMPLICIT: Agent B reviews + verdicts.
+ *      - `routeAttemptOutcome` decides the next step.
+ *   5. Routes to: push-and-pr / retry-with-note / post-input-question /
+ *      escalate-needs-human / escalate-failure.
  */
-import { findIssuesByLabels, octokitFromEnv, repoFromEnv } from '../_lib/github.js'
-import { printBanner, printCandidateList, printNotice, printWarning } from '../_lib/ui.js'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { runClaude } from '../_lib/claude.js'
+import { branchHasCommits, captureCommitMessages, captureDiff, resetToMain } from '../_lib/git-tree.js'
+import {
+  addLabel,
+  findIssuesByLabels,
+  getLabelAppliedAt,
+  getReopenedAt,
+  octokitFromEnv,
+  removeLabel,
+  repoFromEnv,
+  type RepoIdentity,
+} from '../_lib/github.js'
+import { parseReviewerTranscript } from '../_lib/reviewer-verdict.js'
+import { collectAssistantTexts, extractSummary } from '../_lib/transcript.js'
+import {
+  printBanner,
+  printCandidateHeader,
+  printCandidateList,
+  printNotice,
+  printRunSummary,
+  printTranscriptPath,
+  printWarning,
+} from '../_lib/ui.js'
+import { parseAgentASignal } from './agent-a-signal.js'
+import { decideIdempotency } from './idempotency.js'
+import { appendReviewerLog, REVIEWER_LOG_PATH } from './reviewer-log.js'
+import { routeAttemptOutcome, type AttemptOutcome, type RouteContext, type RouteDecision } from './route-attempt.js'
+import {
+  appendEntry,
+  findSkipMatch,
+  type IssueFingerprint,
+  readSkipList,
+  type SkipList,
+  type SkipListEntry,
+  type SkipReason,
+  SKIP_LIST_PATH,
+  writeSkipList,
+} from './skip-list.js'
+import { validateCutSubIssue } from './validate-cut-sub-issue.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const PROMPT_PATH = resolve(HERE, 'prompts/per-cut.md')
+const REVIEWER_PROMPT_PATH = resolve(HERE, 'prompts/reviewer.md')
+const REPO_ROOT = resolve(HERE, '../..')
+const SKIP_LIST_ABS = resolve(REPO_ROOT, SKIP_LIST_PATH)
+const REVIEWER_LOG_ABS = resolve(REPO_ROOT, REVIEWER_LOG_PATH)
+const LESSONS_PATH = 'bots/feature-bot/lessons-learned.md'
+const LESSONS_ABS = resolve(REPO_ROOT, LESSONS_PATH)
 
 const DRY_RUN = process.env.DRY_RUN === '1'
+const TRANSCRIPTS_DIR = resolve(HERE, '../transcripts')
+const RUN_TIMESTAMP = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')
+
+const PER_RUN_BUDGET_MS = Number(process.env.BUDGET_MS ?? 50 * 60 * 1000)
+const MAX_ATTEMPTS = Number(process.env.MAX_ATTEMPTS ?? '5')
+const MAX_INPUT_CYCLES = Number(process.env.MAX_INPUT_CYCLES ?? '2')
 
 async function main(): Promise<void> {
   const repo = repoFromEnv()
   const octokit = octokitFromEnv()
 
-  // Manual one-issue mode short-circuits the cron scan. Validate the env
-  // var shape early so a typo'd ISSUE_NUMBER fails loud rather than
-  // cascading through the Cut 2/3 parser as a malformed candidate.
   const issueNumberStr = process.env.ISSUE_NUMBER
   if (issueNumberStr) {
     if (!/^\d+$/.test(issueNumberStr)) {
       console.error(`ISSUE_NUMBER='${issueNumberStr}' must be a positive integer`)
       process.exit(2)
     }
-    printBanner({
-      name: 'feature-bot',
-      tagline: 'implementer (Cut 1 skeleton)',
-      purpose: 'Manual one-cut mode — placeholder until Cut 3 wires the generator-critic loop.',
-      inputs: [`Sub-issue #${issueNumberStr} (manual override)`],
-      outputs: ['skeleton — parser and loop ship in Cuts 2/3'],
-    })
-    printNotice(
-      `Manual mode targets sub-issue #${issueNumberStr}. Skeleton stops here; Cut 3 wires the generator-critic loop.`,
-    )
+    await fixOneCut(octokit, repo, Number(issueNumberStr))
     return
   }
 
   printBanner({
     name: 'feature-bot',
-    tagline: 'implementer (Cut 1 skeleton)',
+    tagline: 'implementer (Cut 3 — generator-critic loop)',
     purpose: 'Implement `enhancement + ready-for-agent` cut sub-issues with TDD-first commit ordering.',
     inputs: [
       'Open issues with `enhancement` AND `ready-for-agent`',
       'AND no `ready-for-human` / `wontfix` / `needs-info`',
     ],
     outputs: [
-      'skeleton — parser and loop ship in Cuts 2/3',
-      'Cut 2 adds: cut-sub-issue parser (**Feature** + **Depends on**)',
-      'Cut 3 adds: generator-critic loop with 3-tier escalation',
-      'Cut 4 adds: GitHub Actions workflow + cron',
+      'EITHER draft PR (commit 1: failing test, commit 2: impl)',
+      'OR NEEDS_INPUT comment + `needs-info` label (design question)',
+      'OR escalation comment + `ready-for-human` label + skip-list PR',
     ],
   })
 
   printNotice(`Scanning ${repo.owner}/${repo.repo} for enhancement+ready-for-agent cut sub-issues`)
 
-  // Q1 lock: feature-bot's input is `enhancement + ready-for-agent` with
-  // standard exclusions. Disjoint from fix-bot (which requires `bug`) and
-  // from discovery-prep-bot (which excludes `ready-for-agent`). Tracking
-  // issues (no `ready-for-agent`) are invisible to this query.
   const allCandidates = await findIssuesByLabels(octokit, repo, {
     requireAll: ['enhancement', 'ready-for-agent'],
     excludeAny: ['ready-for-human', 'wontfix', 'needs-info'],
@@ -126,7 +136,6 @@ async function main(): Promise<void> {
   }
 
   // Q4 lock: oldest-first sort, deterministic tiebreaker by issue number.
-  // No priority label in v1 — matches fix-bot's pattern.
   const candidates = [...allCandidates].sort((a, b) => {
     if (a.createdAt !== b.createdAt) return a.createdAt.localeCompare(b.createdAt)
     return a.number - b.number
@@ -138,21 +147,787 @@ async function main(): Promise<void> {
   })
 
   if (DRY_RUN) {
-    printNotice(`DRY_RUN=1 — exiting before any work (${candidates.length} would be considered).`)
+    printNotice(`DRY_RUN=1 — exiting before invoking Claude (${candidates.length} would be processed).`)
     return
   }
 
-  // Cut 1 stops here. Future cuts:
-  //   Cut 2 — parse `**Feature**:` + `**Depends on**:` from each body;
-  //           validate referenced numbers; loud-fail on bad refs
-  //   Cut 3 — generator-critic loop (Agent A + Agent B + three-tier
-  //           escalation per Q6)
-  //   Cut 4 — .github/workflows/feature-bot.yml (cron + cache + concurrency)
-  printWarning('skeleton — parser and loop ship in Cuts 2/3')
-  printNotice(`Cut 1 ships skeleton only; ${candidates.length} candidates listed above are not processed yet.`)
+  const runStart = Date.now()
+  let processed = 0
+  for (const candidate of candidates) {
+    const elapsed = Date.now() - runStart
+    if (elapsed > PER_RUN_BUDGET_MS) {
+      const remaining = candidates.length - processed
+      printWarning(
+        `Per-run budget exhausted (${Math.round(elapsed / 1000)}s > ${Math.round(PER_RUN_BUDGET_MS / 1000)}s). Stopping with ${remaining} unprocessed; tomorrow's run picks them up.`,
+      )
+      for (const skipped of candidates.slice(processed)) {
+        console.log(`     ⏭  #${skipped.number} "${skipped.title}"`)
+      }
+      break
+    }
+
+    printCandidateHeader({
+      index: processed + 1,
+      total: candidates.length,
+      label: `#${candidate.number} · ${candidate.title}`,
+      elapsedSec: Math.round(elapsed / 1000),
+    })
+
+    try {
+      await fixOneCut(octokit, repo, candidate.number)
+    } catch (err) {
+      printWarning(`Cut attempt for #${candidate.number} threw: ${err}; continuing.`)
+    }
+    processed++
+  }
+
+  const totalSec = Math.round((Date.now() - runStart) / 1000)
+  printRunSummary({
+    verb: 'Processed',
+    processed,
+    total: candidates.length,
+    skipped: candidates.length - processed,
+    elapsedSec: totalSec,
+  })
+}
+
+/**
+ * Attempt to implement one cut sub-issue. Used by cron mode (per-candidate
+ * loop) and manual one-issue mode.
+ */
+async function fixOneCut(
+  octokit: ReturnType<typeof octokitFromEnv>,
+  repo: ReturnType<typeof repoFromEnv>,
+  issueNumber: number,
+): Promise<void> {
+  const { data: issue } = await octokit.issues.get({ ...repo, issue_number: issueNumber })
+  if (issue.pull_request) {
+    printNotice(`#${issueNumber} is a pull request, not an issue. Skipping.`)
+    return
+  }
+  if (issue.state !== 'open') {
+    printNotice(`#${issueNumber} is ${issue.state}; nothing to do.`)
+    return
+  }
+  const labels = issue.labels.map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean)
+  if (!labels.includes('enhancement') || !labels.includes('ready-for-agent')) {
+    printNotice(`#${issueNumber} lacks 'enhancement' + 'ready-for-agent' (current: [${labels.join(', ')}]); skipping.`)
+    return
+  }
+  if (labels.includes('ready-for-human') || labels.includes('wontfix') || labels.includes('needs-info')) {
+    printNotice(`#${issueNumber} has terminal-state label; skipping.`)
+    return
+  }
+
+  // Idempotency: skip if the `feature-bot-attempted` label is present AND
+  // the issue hasn't been reopened since the label was applied.
+  // Mirrors fix-bot's auto-clear-on-reopen pattern (rule 38 symmetric audit).
+  const attemptedAt = await getLabelAppliedAt(octokit, repo, issueNumber, 'feature-bot-attempted')
+  const reopenedAt = attemptedAt !== null ? await getReopenedAt(octokit, repo, issueNumber) : null
+  const idempotencyDecision = decideIdempotency({ attemptedAt, reopenedAt })
+  if (idempotencyDecision.kind === 'skip') {
+    printNotice(
+      `#${issueNumber}: feature-bot-attempted label present and no reopen since. To re-attempt, remove the label OR reopen the issue.`,
+    )
+    return
+  }
+  if (idempotencyDecision.kind === 'proceed-after-reopen') {
+    printNotice(
+      `#${issueNumber}: prior feature-bot-attempted (${attemptedAt}); reopened at ${reopenedAt}. Re-attempting.`,
+    )
+  }
+
+  // Pre-Claude gate: parse body + validate deps. Loud-fail on bad refs.
+  const issueBody = issue.body ?? ''
+  const validation = await validateCutSubIssue(octokit as never, repo, issueNumber, issueBody)
+
+  if (validation.kind === 'body-error') {
+    await postBodyErrorComment(octokit, repo, issueNumber, validation.errors)
+    await applyLabelBestEffort(octokit, repo, issueNumber, 'needs-info')
+    await applyLabelBestEffort(octokit, repo, issueNumber, 'feature-bot-attempted')
+    return
+  }
+
+  if (validation.kind === 'self-reference') {
+    const skipList = readSkipList(SKIP_LIST_ABS)
+    await escalateToHuman(
+      octokit,
+      repo,
+      issueNumber,
+      skipList,
+      { issueNumber },
+      {
+        reason: 'spec-too-vague',
+        reasonNote: `Cut body references its own issue number in **Depends on**. This is a structurally broken spec.`,
+      },
+    )
+    return
+  }
+
+  if (validation.kind === 'dep-invalid') {
+    await postDepInvalidComment(octokit, repo, issueNumber, validation.depNumber, validation.reason)
+    await applyLabelBestEffort(octokit, repo, issueNumber, 'needs-info')
+    await applyLabelBestEffort(octokit, repo, issueNumber, 'feature-bot-attempted')
+    return
+  }
+
+  if (validation.kind === 'dep-rejected') {
+    const skipList = readSkipList(SKIP_LIST_ABS)
+    await escalateToHuman(
+      octokit,
+      repo,
+      issueNumber,
+      skipList,
+      { issueNumber },
+      {
+        reason: 'missing-prereq',
+        reasonNote: `Cut depends on #${validation.depNumber} which was closed without merging. The prerequisite work was rejected; this cut may need re-scoping.`,
+      },
+    )
+    return
+  }
+
+  if (validation.kind === 'dep-open') {
+    // No labels applied — bot retries next cron when dep closes.
+    await postDepOpenComment(octokit, repo, issueNumber, validation.openDeps)
+    return
+  }
+
+  // validation.kind === 'ready'
+  const parsed = validation.parsed
+  const featureSlug = parsed.feature ?? 'unknown'
+
+  // Skip-list check (durable memory of "don't try this again").
+  const skipList = readSkipList(SKIP_LIST_ABS)
+  const fingerprint: IssueFingerprint = { issueNumber }
+  const skipMatch = findSkipMatch(skipList, fingerprint)
+  if (skipMatch) {
+    printNotice(`#${issueNumber}: skip-list match (${skipMatch.reason}); skipping.`)
+    return
+  }
+
+  // Lessons-learned — loaded once, inlined into every Agent A + reviewer prompt.
+  const lessonsLearned = existsSync(LESSONS_ABS) ? readFileSync(LESSONS_ABS, 'utf-8') : ''
+  printNotice(`Lessons file: ${lessonsLearned ? `${lessonsLearned.length} bytes` : 'absent'}`)
+
+  // Count prior NEEDS_INPUT cycles via outcome-tag query on existing comments.
+  const priorInputCycles = await countPriorInputCycles(octokit, repo, issueNumber)
+  if (priorInputCycles > 0) {
+    printNotice(`#${issueNumber}: ${priorInputCycles} prior NEEDS_INPUT cycle(s) recorded.`)
+  }
+
+  const branchName = `feat/cut-${issueNumber}`
+
+  const agentAPromptTemplate = readFileSync(PROMPT_PATH, 'utf-8')
+  const reviewerPromptTemplate = readFileSync(REVIEWER_PROMPT_PATH, 'utf-8')
+
+  mkdirSync(TRANSCRIPTS_DIR, { recursive: true })
+  let priorReviewerNote: string | null = null
+  let finalOutcome: 'approved' | 'escalated' | 'needs-input-posted' | 'loop-exhausted' = 'loop-exhausted'
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    printNotice(`Attempt ${attempt}/${MAX_ATTEMPTS}: invoking Agent A…`)
+    resetToMain(branchName, { cwd: REPO_ROOT })
+
+    const agentATranscript = resolve(
+      TRANSCRIPTS_DIR,
+      `${RUN_TIMESTAMP}-feature-cut-${issueNumber}-attempt${attempt}-A.jsonl`,
+    )
+    printTranscriptPath(agentATranscript)
+
+    const agentAPrompt = `${agentAPromptTemplate}
+
+ISSUE_NUMBER=${issueNumber}
+ISSUE_TITLE=${issue.title}
+FEATURE_SLUG=${featureSlug}
+ISSUE_BODY=
+${issueBody}
+
+BRANCH_NAME=${branchName}
+ATTEMPT=${attempt}
+MAX_ATTEMPTS=${MAX_ATTEMPTS}
+${priorReviewerNote ? `PRIOR_REVIEWER_NOTE=${priorReviewerNote}\n\n` : ''}LESSONS_LEARNED=
+${lessonsLearned}
+RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
+
+    const aResult = await runClaude({
+      prompt: agentAPrompt,
+      transcriptPath: agentATranscript,
+      allowedTools: ['Bash', 'Read', 'Grep', 'Glob', 'Write', 'Edit'],
+    })
+
+    const ctx: RouteContext = {
+      attempt,
+      maxAttempts: MAX_ATTEMPTS,
+      priorInputCycles,
+      maxInputCycles: MAX_INPUT_CYCLES,
+    }
+
+    let outcome: AttemptOutcome
+    if (!aResult.success) {
+      outcome = { kind: 'agent-a-failure', exitCode: aResult.exitCode }
+    } else {
+      const agentATexts = collectAssistantTexts(agentATranscript)
+      const lastText = agentATexts.at(-1) ?? ''
+      const signal = parseAgentASignal(lastText)
+
+      if (signal.kind === 'needs-input' || signal.kind === 'needs-human') {
+        outcome = { kind: 'agent-a-signaled', signal }
+      } else {
+        // approve-implicit — Agent A should have committed work.
+        const hasCommits = branchHasCommits(branchName, { cwd: REPO_ROOT })
+        if (!hasCommits) {
+          outcome = { kind: 'agent-a-no-output' }
+        } else {
+          // Invoke Agent B.
+          printNotice(`Attempt ${attempt}/${MAX_ATTEMPTS}: invoking Agent B (reviewer)…`)
+          const diff = captureDiff(branchName, { cwd: REPO_ROOT })
+          const commitMessages = captureCommitMessages(branchName, { cwd: REPO_ROOT })
+          const reviewerTranscript = resolve(
+            TRANSCRIPTS_DIR,
+            `${RUN_TIMESTAMP}-feature-cut-${issueNumber}-attempt${attempt}-B.jsonl`,
+          )
+          printTranscriptPath(reviewerTranscript)
+
+          const reviewerPrompt = `${reviewerPromptTemplate}
+
+ISSUE_NUMBER=${issueNumber}
+ISSUE_TITLE=${issue.title}
+FEATURE_SLUG=${featureSlug}
+ISSUE_BODY=
+${issueBody}
+
+BRANCH_NAME=${branchName}
+ATTEMPT=${attempt}
+${priorReviewerNote ? `PRIOR_REVIEWER_NOTE=${priorReviewerNote}\n` : ''}DIFF=
+${diff}
+
+COMMIT_MESSAGES=
+${commitMessages}
+
+RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
+
+          const bResult = await runClaude({
+            prompt: reviewerPrompt,
+            transcriptPath: reviewerTranscript,
+            allowedTools: ['Bash', 'Read', 'Skill'],
+          })
+          if (!bResult.success) {
+            printWarning(`Agent B exited ${bResult.exitCode} on attempt ${attempt}; treating as needs-human.`)
+            await escalateToHuman(octokit, repo, issueNumber, skipList, fingerprint, {
+              reason: 'needs-human',
+              reasonNote: `Reviewer crashed on attempt ${attempt}. See transcript ${reviewerTranscript}.`,
+            })
+            finalOutcome = 'escalated'
+            break
+          }
+
+          const reviewerTexts = collectAssistantTexts(reviewerTranscript)
+          const verdict = parseReviewerTranscript(reviewerTexts)
+
+          try {
+            appendReviewerLog(REVIEWER_LOG_ABS, {
+              ts: new Date().toISOString(),
+              runId: process.env.GITHUB_RUN_ID ?? 'local',
+              fingerprint,
+              fingerprintLabel: `#${issueNumber}`,
+              attempt,
+              verdict:
+                verdict.kind === 'approve' ? 'approve' : verdict.kind === 'needs-human' ? 'needs-human' : 'reject',
+              reasoning: verdict.kind === 'approve' ? verdict.reasoning : verdict.note,
+              agentASummary: extractSummary(agentATranscript),
+            })
+          } catch (err) {
+            printWarning(`reviewer-log append failed (non-fatal): ${err}`)
+          }
+
+          outcome = { kind: 'agent-b-judged', signal, verdict }
+        }
+      }
+    }
+
+    const decision = routeAttemptOutcome(outcome, ctx)
+
+    if (decision.kind === 'push-and-pr') {
+      printNotice(`✅ Reviewer APPROVED on attempt ${attempt}/${MAX_ATTEMPTS}: ${decision.reasoning.slice(0, 120)}`)
+      pushBranch(branchName)
+      openCutPR(
+        repo,
+        issueNumber,
+        issue.title,
+        featureSlug,
+        branchName,
+        decision.reasoning,
+        extractSummary(
+          resolve(TRANSCRIPTS_DIR, `${RUN_TIMESTAMP}-feature-cut-${issueNumber}-attempt${attempt}-A.jsonl`),
+        ),
+      )
+      finalOutcome = 'approved'
+      break
+    }
+
+    if (decision.kind === 'retry-with-note') {
+      printNotice(`Reviewer REJECTED on attempt ${attempt}/${MAX_ATTEMPTS}: ${decision.note.slice(0, 120)}`)
+      priorReviewerNote = decision.note
+      continue
+    }
+
+    if (decision.kind === 'post-input-question') {
+      printNotice(`Agent A asked NEEDS_INPUT: ${decision.question.slice(0, 120)}`)
+      await postInputQuestion(octokit, repo, issueNumber, decision.body)
+      await applyLabelBestEffort(octokit, repo, issueNumber, 'needs-info')
+      resetToMain(branchName, { cwd: REPO_ROOT })
+      finalOutcome = 'needs-input-posted'
+      break
+    }
+
+    if (decision.kind === 'escalate-needs-human') {
+      printWarning(`⚠ Escalating to NEEDS_HUMAN (reason=${decision.reason}): ${decision.reasonNote.slice(0, 120)}`)
+      await escalateToHuman(octokit, repo, issueNumber, skipList, fingerprint, {
+        reason: decision.reason,
+        reasonNote: decision.reasonNote,
+      })
+      finalOutcome = 'escalated'
+      break
+    }
+
+    if (decision.kind === 'escalate-failure') {
+      printWarning(`Agent A exited ${decision.exitCode} on attempt ${attempt}; escalating.`)
+      await escalateToHuman(octokit, repo, issueNumber, skipList, fingerprint, {
+        reason: 'needs-human',
+        reasonNote: `Agent A's Claude invocation exited ${decision.exitCode} on attempt ${attempt}. See transcript.`,
+      })
+      finalOutcome = 'escalated'
+      break
+    }
+  }
+
+  // If we fell through without break, the loop hit MAX_ATTEMPTS with all
+  // REJECT verdicts (handled inside the loop on the last iteration via
+  // attempt >= maxAttempts in routeAttemptOutcome). But the no-break path
+  // here is defense-in-depth.
+  if (finalOutcome === 'loop-exhausted') {
+    printWarning(`Loop exhausted after ${MAX_ATTEMPTS} attempts.`)
+    await escalateToHuman(octokit, repo, issueNumber, skipList, fingerprint, {
+      reason: 'needs-human',
+      reasonNote: `Loop exhausted after ${MAX_ATTEMPTS} attempts. Last reviewer note: ${priorReviewerNote ?? '(none)'}`,
+    })
+  }
+
+  await applyLabelBestEffort(octokit, repo, issueNumber, 'feature-bot-attempted')
+}
+
+/**
+ * Count prior NEEDS_INPUT cycles for this cut sub-issue.
+ *
+ * Reads existing comments and counts those with the outcome tag
+ * `<!-- feature-bot: needs-input issue=N run=R -->`. Used to enforce
+ * MAX_INPUT_CYCLES per Q6 lock.
+ */
+async function countPriorInputCycles(
+  octokit: ReturnType<typeof octokitFromEnv>,
+  repo: RepoIdentity,
+  issueNumber: number,
+): Promise<number> {
+  const { data: comments } = await octokit.issues.listComments({
+    ...repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  })
+  const marker = `feature-bot: needs-input issue=${issueNumber}`
+  return comments.filter(c => (c.body ?? '').includes(marker)).length
+}
+
+function pushBranch(branchName: string): void {
+  try {
+    execFileSync('git', ['push', '-u', 'origin', branchName], { cwd: REPO_ROOT, stdio: 'inherit' })
+  } catch (err) {
+    printWarning(`git push ${branchName} failed: ${err}`)
+  }
+}
+
+function openCutPR(
+  _repo: RepoIdentity,
+  issueNumber: number,
+  issueTitle: string,
+  featureSlug: string,
+  branchName: string,
+  reviewerReasoning: string,
+  agentASummary: string,
+): void {
+  const body = `## Summary
+
+Implements cut #${issueNumber} for the \`${featureSlug}\` feature.
+
+Closes #${issueNumber}.
+
+After implementation by Agent A and independent review by Agent B
+(both Claude Code sessions), this PR ships the cut as a TDD-first
+two-commit contract.
+
+## What Agent A did
+
+${agentASummary || '(no Agent A summary captured)'}
+
+## Reviewer's assessment
+
+${reviewerReasoning || '(no reviewer reasoning captured)'}
+
+The reviewer ran the tautology check (revert impl → tests fail; re-apply
+→ tests pass), verified each cut sub-issue \`## Acceptance\` bullet is
+pinned, checked the \`## SOLID\` declarations (when present), and
+verified the diff implements the design doc's Locked decisions.
+
+## Verification
+
+This PR has two commits:
+
+1. **Failing tests** — pin the cut's acceptance criteria
+2. **Implementation** — minimal change that turns tests green
+
+CI re-verifies both commits.
+
+## What if this is wrong?
+
+Close the PR. The bot's feedback loop will read the close reason from
+your comment and add a skip-list entry so it doesn't re-attempt the
+same cut shape.
+
+<!-- feature-bot: issue=${issueNumber} run=${process.env.GITHUB_RUN_ID ?? 'local'} -->`
+  try {
+    execFileSync(
+      'gh',
+      [
+        'pr',
+        'create',
+        '--draft',
+        '--title',
+        `feat: cut #${issueNumber} — ${issueTitle}`,
+        '--body',
+        body,
+        '--head',
+        branchName,
+      ],
+      { cwd: REPO_ROOT, stdio: 'inherit' },
+    )
+  } catch (err) {
+    printWarning(`gh pr create failed for #${issueNumber}: ${err}`)
+  }
+}
+
+/**
+ * Post the structured NEEDS_INPUT question as a sub-issue comment + apply
+ * `needs-info` label. The body is Agent A's verbatim block (question +
+ * options + recommendation). Maintainer's answer (any non-bot reply OR
+ * removing `needs-info`) re-enters the queue.
+ */
+async function postInputQuestion(
+  octokit: ReturnType<typeof octokitFromEnv>,
+  repo: RepoIdentity,
+  issueNumber: number,
+  body: string,
+): Promise<void> {
+  const runId = process.env.GITHUB_RUN_ID ?? 'local'
+  const commentBody = `> *This was generated by AI during triage.*
+
+⚠ **Feature-bot needs your input to proceed.**
+
+Agent A reached a design decision that the cut spec + design doc don't
+answer. Choosing one path without your input would either contradict the
+design doc OR commit the project to a path you might reject.
+
+${body}
+
+**To resolve:**
+
+1. Read the question + Agent A's recommendation
+2. Reply with your answer (or just remove the \`needs-info\` label if
+   Agent A's recommendation is correct)
+3. The next cron picks up this cut with your input in context
+
+If Agent A asks the same question twice without resolution, I'll escalate
+to \`ready-for-human\` (per the MAX_INPUT_REQUESTS=2 cap).
+
+<!-- feature-bot: needs-input issue=${issueNumber} run=${runId} -->`
+
+  try {
+    await octokit.issues.createComment({ ...repo, issue_number: issueNumber, body: commentBody })
+  } catch (err) {
+    printWarning(`Could not post NEEDS_INPUT comment on #${issueNumber}: ${err}`)
+  }
+}
+
+async function postBodyErrorComment(
+  octokit: ReturnType<typeof octokitFromEnv>,
+  repo: RepoIdentity,
+  issueNumber: number,
+  errors: readonly { kind: string; section?: string }[],
+): Promise<void> {
+  const sections = errors
+    .filter(e => e.kind === 'missing-required-section')
+    .map(e => e.section)
+    .filter(Boolean)
+    .map(s => `\`## ${s![0].toUpperCase() + s!.slice(1)}\``)
+    .join(', ')
+  const hasMissingFeature = errors.some(e => e.kind === 'missing-feature')
+  const lines = [
+    '> *This was generated by AI during triage.*',
+    '',
+    '⚠ **Cut sub-issue body is missing required fields.**',
+    '',
+  ]
+  if (hasMissingFeature) {
+    lines.push('- Missing `**Feature**: <slug>` field at the top of the body')
+  }
+  if (sections) {
+    lines.push(`- Missing required section(s): ${sections}`)
+  }
+  lines.push(
+    '',
+    'Per `design-feature-bot.md` Q2 + Cut 5 refinement, the cut sub-issue body must contain:',
+    '',
+    '```markdown',
+    '**Feature**: <slug>',
+    '**Depends on**: #N, #M  (or empty/none)',
+    '',
+    '## Spec',
+    '...narrative...',
+    '',
+    '## Acceptance',
+    '- ...',
+    '',
+    '## SOLID (when applicable)',
+    '...',
+    '',
+    '## Tests',
+    '- bots/.../tests/foo.test.ts',
+    '```',
+    '',
+    'Edit the body to add the missing fields, then remove the `needs-info` label to re-queue.',
+    '',
+    `<!-- feature-bot: body-error issue=${issueNumber} run=${process.env.GITHUB_RUN_ID ?? 'local'} -->`,
+  )
+  try {
+    await octokit.issues.createComment({ ...repo, issue_number: issueNumber, body: lines.join('\n') })
+  } catch (err) {
+    printWarning(`Could not post body-error comment on #${issueNumber}: ${err}`)
+  }
+}
+
+async function postDepInvalidComment(
+  octokit: ReturnType<typeof octokitFromEnv>,
+  repo: RepoIdentity,
+  issueNumber: number,
+  depNumber: number,
+  reason: 'not-found' | 'not-a-cut',
+): Promise<void> {
+  const why =
+    reason === 'not-found'
+      ? `#${depNumber} doesn't exist in this repository.`
+      : `#${depNumber} exists but isn't labeled \`enhancement\` — it's not a cut sub-issue.`
+  const body = `> *This was generated by AI during triage.*
+
+⚠ **Cut sub-issue references an invalid dependency.**
+
+The \`**Depends on**:\` line cites #${depNumber}, but ${why}
+
+Fix the dependency reference in the body, then remove the \`needs-info\`
+label to re-queue.
+
+<!-- feature-bot: dep-invalid issue=${issueNumber} dep=${depNumber} run=${process.env.GITHUB_RUN_ID ?? 'local'} -->`
+  try {
+    await octokit.issues.createComment({ ...repo, issue_number: issueNumber, body })
+  } catch (err) {
+    printWarning(`Could not post dep-invalid comment on #${issueNumber}: ${err}`)
+  }
+}
+
+async function postDepOpenComment(
+  octokit: ReturnType<typeof octokitFromEnv>,
+  repo: RepoIdentity,
+  issueNumber: number,
+  openDeps: readonly number[],
+): Promise<void> {
+  // Skip if we've already posted a wait-for-dep comment on this cut for
+  // these same deps — avoid spamming the issue on every cron tick.
+  const marker = `feature-bot: dep-waiting issue=${issueNumber}`
+  try {
+    const { data: comments } = await octokit.issues.listComments({
+      ...repo,
+      issue_number: issueNumber,
+      per_page: 100,
+    })
+    if (comments.some(c => (c.body ?? '').includes(marker))) {
+      printNotice(`#${issueNumber}: dep-waiting comment already posted; staying quiet this cron.`)
+      return
+    }
+  } catch {
+    // best-effort
+  }
+  const depList = openDeps.map(n => `#${n}`).join(', ')
+  const body = `> *This was generated by AI during triage.*
+
+ℹ **Waiting for dependencies to close.**
+
+This cut depends on ${depList} which ${openDeps.length === 1 ? 'is' : 'are'} still open. I'll retry on the next cron after ${openDeps.length === 1 ? 'it closes' : 'they close'}.
+
+<!-- feature-bot: dep-waiting issue=${issueNumber} run=${process.env.GITHUB_RUN_ID ?? 'local'} -->`
+  try {
+    await octokit.issues.createComment({ ...repo, issue_number: issueNumber, body })
+  } catch (err) {
+    printWarning(`Could not post dep-waiting comment on #${issueNumber}: ${err}`)
+  }
+}
+
+async function applyLabelBestEffort(
+  octokit: ReturnType<typeof octokitFromEnv>,
+  repo: RepoIdentity,
+  issueNumber: number,
+  label: string,
+): Promise<void> {
+  try {
+    await addLabel(octokit, repo, issueNumber, label)
+  } catch (err) {
+    printWarning(`Could not apply '${label}' to #${issueNumber}: ${err}`)
+  }
+}
+
+/**
+ * Reviewer-loop escalation. Mirrors fix-bot's escalateToHuman shape
+ * (rule 38 symmetric audit) — four steps:
+ *
+ *   1. Append entry to skip-list.json locally
+ *   2. Open a draft PR with that skip-list entry (so next run honors it
+ *      even after runner-local fs is gone)
+ *   3. Post a stuck-comment on the sub-issue explaining why
+ *   4. Apply `ready-for-human` + close the sub-issue
+ *
+ * Without steps 2-4, the only memory of the bot's reviewer loop is the
+ * runner-local skip-list.json that vanishes on workflow teardown.
+ */
+async function escalateToHuman(
+  octokit: ReturnType<typeof octokitFromEnv>,
+  repo: ReturnType<typeof repoFromEnv>,
+  issueNumber: number,
+  skipList: SkipList,
+  fingerprint: IssueFingerprint,
+  opts: { reason: SkipReason; reasonNote: string },
+): Promise<void> {
+  // Step 1: write skip-list locally
+  const entry: SkipListEntry = {
+    fingerprint,
+    reason: opts.reason,
+    reasonNote: opts.reasonNote,
+    addedAt: new Date().toISOString(),
+    addedBy: 'bot',
+  }
+  const added = appendEntry(skipList, entry)
+  if (added) {
+    writeSkipList(SKIP_LIST_ABS, skipList)
+    printNotice(`Recorded skip-list entry for #${fingerprint.issueNumber} (${opts.reason})`)
+  }
+
+  // Step 2: open draft PR for the skip-list change so it lands on main.
+  const dateStr = new Date().toISOString().slice(0, 10)
+  const skipBranch = `feature-bot-skip/${dateStr}-cut-${issueNumber}`
+  try {
+    execFileSync('git', ['checkout', '-b', skipBranch], { cwd: REPO_ROOT, stdio: 'inherit' })
+    execFileSync('git', ['add', SKIP_LIST_PATH], { cwd: REPO_ROOT, stdio: 'inherit' })
+    execFileSync(
+      'git',
+      [
+        'commit',
+        '-m',
+        `chore(skip-list): record ${opts.reason} for #${issueNumber}\n\n${opts.reasonNote.slice(0, 500)}`,
+      ],
+      { cwd: REPO_ROOT, stdio: 'inherit' },
+    )
+    execFileSync('git', ['push', '-u', 'origin', skipBranch], { cwd: REPO_ROOT, stdio: 'inherit' })
+    execFileSync(
+      'gh',
+      [
+        'pr',
+        'create',
+        '--draft',
+        '--title',
+        `chore(skip-list): record ${opts.reason} for #${issueNumber}`,
+        '--body',
+        `> *This was generated by AI during triage.*
+
+Adds a skip-list entry so feature-bot doesn't re-attempt cut #${issueNumber} on every cron.
+
+**Reason:** \`${opts.reason}\`
+
+**Note from the reviewer loop:**
+
+> ${opts.reasonNote.slice(0, 1500)}
+
+**What to do next:**
+
+Read the comment feature-bot just posted on #${issueNumber}. If the reasoning looks right, either merge this PR (durable skip), close the underlying issue, or open the cut yourself based on the analysis. If the reasoning was wrong, close this PR and reopen #${issueNumber} (or remove the \`ready-for-human\` label) to let feature-bot retry.
+
+<!-- feature-bot: skip-entry issue=${issueNumber} reason=${opts.reason} run=${process.env.GITHUB_RUN_ID ?? 'local'} -->`,
+      ],
+      { cwd: REPO_ROOT, stdio: 'inherit' },
+    )
+    printNotice(`Opened skip-list-entry PR for #${issueNumber}`)
+  } catch (err) {
+    printWarning(`Couldn't open skip-list PR for #${issueNumber}: ${err}`)
+  } finally {
+    try {
+      execFileSync('git', ['checkout', 'main'], { cwd: REPO_ROOT, stdio: 'inherit' })
+    } catch {
+      // best-effort
+    }
+  }
+
+  // Step 3 + 4: post stuck-comment + apply ready-for-human + close.
+  try {
+    const ghServer = process.env.GITHUB_SERVER_URL ?? 'https://github.com'
+    const repoSlug = `${repo.owner}/${repo.repo}`
+    const runId = process.env.GITHUB_RUN_ID ?? 'local'
+    const workflowRunUrl =
+      runId === 'local' ? '(local run — no workflow URL)' : `${ghServer}/${repoSlug}/actions/runs/${runId}`
+
+    const body = `> *This was generated by AI during triage.*
+
+⚠ **Feature-bot escalation — needs human attention.**
+
+**Reason:** \`${opts.reason}\`
+
+**Note from the loop:**
+
+> ${opts.reasonNote.slice(0, 2000)}
+
+**Workflow run:** ${workflowRunUrl}
+
+I've stopped attempting this cut and applied \`ready-for-human\` (removing it from my queue). Next steps for the maintainer:
+
+1. **Read the reasoning** above + the workflow run's transcript artifact (\`bots/transcripts/\`) for the full analysis
+2. **If the reasoning is right** — close this cut OR implement it manually based on the analysis
+3. **If you want me to retry** — remove the \`ready-for-human\` label AND remove (or clear) the skip-list entry (the PR I just opened). Then the next cron picks this cut up again.
+
+<!-- feature-bot: escalation issue=${issueNumber} reason=${opts.reason} run=${runId} -->`
+
+    await octokit.issues.createComment({ ...repo, issue_number: issueNumber, body })
+    await addLabel(octokit, repo, issueNumber, 'ready-for-human')
+    // Remove ready-for-agent since we've terminally escalated. Cron's
+    // exclude filter handles ready-for-human, but clearing ready-for-agent
+    // makes the maintainer's intent clearer when they re-queue.
+    await removeLabel(octokit, repo, issueNumber, 'ready-for-agent').catch(() => {})
+    printNotice(`Posted escalation comment + applied ready-for-human on #${issueNumber}`)
+  } catch (err) {
+    printWarning(`Could not post escalation comment on #${issueNumber}: ${err}`)
+  }
 }
 
 main().catch(err => {
   console.error('Fatal error:', err)
   process.exit(1)
 })
+
+// Re-export the routing types so external consumers (replay tooling, future
+// compactor) can read the orchestrator's decision-making vocabulary without
+// reaching into private modules. Cargo-cult-free per rule 19 — these are
+// already the names tests use.
+export type { AttemptOutcome, RouteContext, RouteDecision }

--- a/bots/feature-bot/prompts/per-cut.md
+++ b/bots/feature-bot/prompts/per-cut.md
@@ -1,30 +1,233 @@
-<!--
-  Feature-bot per-cut prompt — placeholder for Cut 1.
+# Feature-bot — per-cut prompt (Agent A)
 
-  The full Agent A prompt body lands in Cut 3 (generator-critic loop
-  wiring) per design-feature-bot.md "Cut sequence". This file is a
-  placeholder so Cut 3 has a foundation to extend; the placeholder
-  shape preserves the Q5 lock so future readers see the intended
-  structure even before the body lands.
+You are attempting to implement one feature **cut sub-issue** labeled
+`enhancement` + `ready-for-agent` + `area: X`. The maintainer has
+designed the feature, locked decisions, and decomposed it into cuts;
+your job is to ship ONE cut.
 
-  Q5 lock (design-feature-bot.md): the orchestrator does NOT inline
-  the design doc in Agent A's prompt. Instead the prompt names the
-  design doc path (derived from the cut sub-issue's **Feature**:
-  field → .claude/rules/design-{feature}.md) and instructs Agent A
-  to read it before implementing.
--->
+**You are NOT the merge gate.** You commit locally on a branch; the
+orchestrator pushes and opens the PR after Agent B (reviewer) approves.
+The maintainer reviews and merges (or rejects) the PR. Per project
+rule 33 (no direct main commits), you must never push to main.
 
-(prompt body lands in Cut 3)
+## You are Agent A in a generator-critic loop
 
-Read these in this order BEFORE implementing:
+A separate Claude session (Agent B, the reviewer) will inspect your
+commits after you finish. Their checks include:
 
-1. The cut sub-issue body (provided below by the orchestrator).
-2. The design doc at `.claude/rules/design-{feature}.md` — pay
-   special attention to Scope, Locked decisions, Foundational
-   checks, Distinctive choices.
-3. Any companion docs the design doc references (typically other
+1. **Tautology detection** (4-step runtime check): revert your impl
+   commit, run tests, tests must FAIL; re-apply, tests must PASS.
+2. **Acceptance check**: did your implementation satisfy each bullet
+   in the cut sub-issue's `## Acceptance` section?
+3. **SOLID check** (when `## SOLID` section is present in the sub-issue
+   body): did your implementation honor each declared SOLID lens?
+4. **Project-rule check**: does the diff respect the locked decisions
+   in the design doc and the foundational checks?
+
+This changes your work: **commit locally on `$BRANCH_NAME` but DO NOT
+push or open the PR.** The orchestrator pushes + opens the PR after
+the reviewer approves.
+
+## Inputs (appended below this prompt)
+
+- `ISSUE_NUMBER` — the GitHub cut sub-issue number
+- `ISSUE_TITLE` — for context
+- `ISSUE_BODY` — the full cut sub-issue body (**Feature**, **Depends on**,
+  `## Spec`, `## Acceptance`, optional `## SOLID`, `## Tests`)
+- `FEATURE_SLUG` — parsed from the body's `**Feature**:` field; tells you
+  which design doc to read
+- `BRANCH_NAME` — the branch the orchestrator expects (`feat/cut-NNN`)
+- `ATTEMPT` — 1 for first attempt, 2+ if Agent B rejected your last attempt
+- `MAX_ATTEMPTS` — the cap. After this attempt, the orchestrator escalates
+- `PRIOR_REVIEWER_NOTE` — present only when `ATTEMPT > 1`. The reviewer's
+  specific feedback from your last attempt. Address it.
+- `MAINTAINER_INPUT` — present when the maintainer replied to a prior
+  NEEDS_INPUT comment. Treat this as resolution of the open question.
+- `LESSONS_LEARNED` — cross-cut patterns the bot has accumulated from past
+  maintainer rejections (currently empty; future compactor populates).
+- `RUN_ID` — the workflow run ID (referenced in commits for traceability)
+
+## READ these BEFORE writing code (per Q5 lock)
+
+This is non-negotiable. Read these in this order:
+
+1. **The cut sub-issue body** (provided below). Pay special attention to
+   `## Spec` (what to build), `## Acceptance` (testable outcomes you
+   must satisfy), `## SOLID` (declared lenses, when present), `## Tests`
+   (specific test files to write).
+2. **The design doc at `.claude/rules/design-{FEATURE_SLUG}.md`** — pay
+   special attention to Scope, Locked decisions, Foundational checks,
+   Distinctive choices, UX check, Cut sequence. The Locked decisions
+   are NOT negotiable; implement to match them.
+3. **Any companion docs the design doc references** (typically other
    `.claude/rules/design-*.md` or `docs/adr/*.md`).
-4. The implementation files listed or implied by the cut spec.
+4. **The implementation files listed or implied by `## Tests` and `## Spec`**.
 
 Only AFTER reading 1-3 do you begin writing code. The design doc's
-Locked decisions are NOT negotiable — implement to match them.
+Locked decisions are the contract you implement.
+
+## TDD-FIRST CONTRACT
+
+**Your first commit MUST be a failing test that pins the cut's
+acceptance criteria** (per `team-preferences.md` rule 31).
+
+Read the cut sub-issue body's `## Tests` section — it names the
+specific test files to write. Write those tests first. Verify they
+FAIL locally. Then implement. Verify they PASS locally. Two commits,
+in this order: test, then implementation.
+
+DO NOT modify the failing tests during implementation. The orchestrator
+verifies via reviewer that reverting the impl commit re-fails the tests
+— if you weakened the assertions to make red → green, the reviewer's
+tautology check will catch it and REJECT.
+
+## Three terminal states (per Q6 lock)
+
+You have three ways to end your run. Pick the right one for what you
+discovered.
+
+### APPROVE path (most common — happy path)
+
+1. Read inputs + design doc + companion docs (mandatory).
+2. Write failing tests per `## Tests`. Verify RED.
+3. Commit:
+   ```bash
+   git checkout -b $BRANCH_NAME 2>/dev/null || git checkout $BRANCH_NAME
+   git add <test files>
+   git commit -m "test: failing tests for cut #$ISSUE_NUMBER ($FEATURE_SLUG)
+
+Captures the acceptance criteria from cut #$ISSUE_NUMBER as failing tests.
+The impl follows in the next commit; this commit is RED in CI.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+   ```
+4. Implement the cut. Verify GREEN.
+5. Run the wider test suite. Confirm no regressions.
+6. Commit:
+   ```bash
+   git add <impl files>
+   git commit -m "feat(<area>): cut #$ISSUE_NUMBER — <short summary>
+
+<one-paragraph what changed + why per the design doc>
+
+Closes #$ISSUE_NUMBER
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+   ```
+7. End with a `SUMMARY:` block as your last output:
+
+   ```
+   SUMMARY:
+   <2-4 sentences: what the cut delivered, how the failing test pins it,
+   which design-doc locked decisions it implements. Plain prose; no
+   headings, no bullets, no code blocks inside the summary.>
+   ```
+
+The orchestrator extracts `SUMMARY:` and puts it in the PR body.
+
+### NEEDS_INPUT path (when a design decision is required)
+
+Trigger: while implementing, you discover the design doc + cut spec
+don't answer a load-bearing question. Two or more reasonable choices
+exist, and picking one without input would either contradict the
+design doc OR commit the project to a path the maintainer might
+reject.
+
+Examples:
+- The design doc says "Schema refinement: template conditionally
+  optional when archived" but doesn't specify `.refine` vs
+  `z.discriminatedUnion`; the choice has visible API consequences
+  for consumers.
+- The cut's `## Acceptance` says "fix the bug" but two distinct fix
+  locations exist with different blast radii.
+
+Do NOT commit code. Reset your working tree. End with:
+
+```
+NEEDS_INPUT: <one-line question>
+Options:
+  - <option 1 with reasoning>
+  - <option 2 with reasoning>
+  - <option 3 if applicable>
+Recommendation: <option N because ...>
+```
+
+The orchestrator posts this verbatim as a sub-issue comment with the
+`needs-info` label. The maintainer answers; next cron picks up the
+sub-issue with `MAINTAINER_INPUT` in your context.
+
+**MAX_INPUT_REQUESTS=2 per cut** — after two NEEDS_INPUT cycles
+without resolution, the orchestrator escalates to NEEDS_HUMAN.
+
+### NEEDS_HUMAN path (terminal — cannot proceed)
+
+Trigger: you discovered the cut can't be implemented as specified,
+EVEN with maintainer input.
+
+Three documented reasons:
+
+- **missing-prereq** — required infrastructure isn't in the codebase
+  despite all `**Depends on**:` refs being closed. (The depending PRs
+  closed without shipping what this cut expects.)
+- **spec-too-vague** — the cut sub-issue's `## Spec` or `## Acceptance`
+  is missing or so vague you cannot identify what to build. Do NOT
+  guess; emit NEEDS_HUMAN.
+- **files-conflict** — your implementation would touch files currently
+  modified in an OPEN PR from another cut. (The orchestrator's
+  pre-flight should have caught this; this is defense in depth.)
+- **needs-human** — generic catch-all when none of the above fits.
+
+Do NOT commit code. Reset your working tree. End with:
+
+```
+NEEDS_HUMAN: <one-line reason>
+Reason-code: <missing-prereq | spec-too-vague | files-conflict | needs-human>
+```
+
+The orchestrator records a skip-list entry with the reason code, posts
+an escalation comment, applies `ready-for-human`, closes the sub-issue.
+Future crons honor the skip-list and don't re-attempt.
+
+## Anti-tautology discipline
+
+The failing tests you commit are the spec. They MUST fail when the
+impl commit is reverted. If your "fix" is just "edit the test until it
+matches the code," the reviewer's tautology check will catch it and
+REJECT. The reviewer runs:
+
+```bash
+git revert HEAD --no-edit              # revert impl
+cd packages/gazetta && npx vitest run  # tests MUST fail here
+git reset --hard origin/$BRANCH_NAME   # re-apply
+cd packages/gazetta && npx vitest run  # tests MUST pass here
+```
+
+Both halves must hold. Write tests that exercise BEHAVIOR — call the
+function, assert on its output, on its side effects, on errors it
+throws. Don't assert on observed strings from your own impl.
+
+## Conventions
+
+- Every comment you post on the sub-issue MUST start with
+  `> *This was generated by AI during triage.*`
+- Decision-log convention: before each non-trivial decision, emit a
+  one-line `> Decision: <why>` text block.
+- Stay minimal. Don't refactor adjacent code. Don't add features.
+  Don't update other tests unless the cut legitimately requires it.
+- Run tests locally before claiming green. Run the wider test suite
+  to confirm no regressions.
+
+## Rules
+
+- **TDD-first is non-negotiable.** Failing test commit BEFORE impl
+  commit, always.
+- **DO NOT modify the failing tests during impl.** That's tautology.
+- **DO NOT push or open the PR.** The orchestrator does that after
+  reviewer approval.
+- **Never push to main.** Always to `$BRANCH_NAME`.
+- **Read the design doc.** Locked decisions are non-negotiable.
+- **One cut per PR.** Don't bundle multiple cuts.
+- **Don't ask the user questions in chat.** You're headless. If you
+  need input, emit a NEEDS_INPUT block per the format above.
+- **Don't @mention anyone.** PR notification + issue comment are
+  enough.

--- a/bots/feature-bot/prompts/reviewer.md
+++ b/bots/feature-bot/prompts/reviewer.md
@@ -1,15 +1,256 @@
-<!--
-  Feature-bot reviewer prompt — placeholder for Cut 1.
+# Feature-bot reviewer (Agent B)
 
-  The full Agent B prompt body lands in Cut 3 (generator-critic loop
-  wiring) per design-feature-bot.md "Cut sequence". Cut 3 forks
-  fix-bot's reviewer.md and adds the "did Agent A satisfy the cut's
-  acceptance criteria?" check (per "Open questions for implementation"
-  in the design doc).
+You are reviewing a proposed cut implementation from Agent A (a
+different Claude session). Your job: independent judgment on whether
+the implementation:
 
-  Until Cut 3 lands, this file is a placeholder so Cut 1 can ship
-  the skeleton without inventing a reviewer body that would be torn
-  out and rewritten.
--->
+1. **Pins the cut's acceptance criteria** as a real, non-tautological test
+2. **Honors the cut's declared SOLID lenses** (when `## SOLID` was present)
+3. **Implements the design doc's locked decisions** correctly
+4. **Stays within scope** of the one cut
 
-(reviewer prompt body lands in Cut 3)
+Agent A's TDD contract already gates "tests pass after fix." That's
+necessary but not sufficient. The failure modes you catch:
+
+| Failure | What it looks like |
+|---|---|
+| **Tautological test** | The test was shaped to match the impl, not the acceptance criterion. Reverting the impl → test still passes |
+| **Missed acceptance bullet** | One of the cut's `## Acceptance` items isn't pinned by any test or isn't implemented |
+| **SOLID violation** | The `## SOLID` section names SRP/OCP/etc lenses Agent A didn't honor (god module, fused concerns, stub-that-throws on an interface) |
+| **Locked-decision deviation** | The diff contradicts a `## Locked decisions` row in the design doc |
+| **Scope creep** | Diff includes unrelated refactors / renamings / "while I'm here" cleanups |
+| **Misleading commit messages** | Commit subjects misrepresent the change shape |
+| **Wrong-area implementation** | Cut spec said "file X module Y"; Agent A implemented in "file Z module W" |
+
+You issue one of three verdicts at the END of your output:
+
+| Verdict | When |
+|---|---|
+| `APPROVE` | All checks pass: tautology, acceptance bullets pinned, SOLID lenses honored, locked decisions match, scope tight. |
+| `REJECT` | One or more checks fail AND Agent A can fix on retry. Provide `Note:` with specific guidance. |
+| `NEEDS_HUMAN` | Structural problem; retry won't help. Maintainer should look. |
+
+## Inputs (appended below)
+
+- `ISSUE_NUMBER` — the cut sub-issue
+- `ISSUE_TITLE` / `ISSUE_BODY` — the cut spec (Spec / Acceptance / SOLID / Tests)
+- `FEATURE_SLUG` — the design doc to read (`.claude/rules/design-{slug}.md`)
+- `BRANCH_NAME` — Agent A's commits live here
+- `ATTEMPT` — 1 for first review, 2+ if Agent A retried after prior REJECT
+- `PRIOR_REVIEWER_NOTE` — present only when `ATTEMPT > 1`; what Agent A
+  was supposed to address
+- `DIFF` — `git diff main..$BRANCH_NAME` output (snapshot Agent A produced)
+- `COMMIT_MESSAGES` — `git log main..$BRANCH_NAME --format=%B%n---`
+- `RUN_ID` — diagnostic only
+
+## READ these BEFORE judging
+
+1. The cut sub-issue body — especially `## Spec`, `## Acceptance`,
+   `## SOLID`, `## Tests`. These are the contract Agent A had to honor.
+2. The design doc at `.claude/rules/design-{FEATURE_SLUG}.md` — pay
+   special attention to Locked decisions, Distinctive choices, and the
+   `## Cut sequence` row for THIS cut.
+3. The diff + commit messages.
+
+## Decision-log convention
+
+Articulate every non-trivial check with `> Decision: ...` text.
+Especially the tautology-check procedure (steps 1-4 below) — emit a
+Decision line per step so the maintainer reading the transcript can
+follow your verification.
+
+## The tautology check — required for every review
+
+Run this procedure every time, in this exact order:
+
+### Step 1: confirm both commits exist on the branch
+
+```bash
+git log main..$BRANCH_NAME --oneline
+```
+
+Expected: 2 commits — one prefixed `test:`, `failing test:`, or
+similar; one prefixed `feat:`/`fix:`/`refactor:`/etc. If anything else
+(1 commit, 3+ commits, commits in wrong order): **REJECT** with a note
+explaining the commit shape was wrong.
+
+### Step 2: revert the impl commit; test must FAIL
+
+```bash
+git revert --no-edit HEAD
+cd packages/gazetta && npx vitest run <path-to-the-new-test-files>
+```
+
+**Expected: the tests FAIL.** That proves the tests exercise behavior
+the impl changes — a real spec, not a tautology.
+
+If tests PASS after reverting: **REJECT** with a Note that names the
+specific assertion: "The test on line N still passes after reverting
+the impl on line M. Please write a test that asserts behavior that
+fails without the impl."
+
+### Step 3: verify the failure matches the cut's acceptance criteria
+
+When tests fail in step 2, the error message should align with what
+the cut's `## Acceptance` describes. Examples:
+
+- Acceptance says "POST /api/redirects returns 201 with correct body" →
+  test failure should show a 4xx or wrong-body assertion
+- Acceptance says "audit event records create-redirect with metadata.aliasOf" →
+  test failure should show missing audit event or missing field
+
+If the failure mode is generic (timeout, "undefined is not a function")
+and doesn't match acceptance: the test might exercise the wrong thing.
+**REJECT** with a Note describing the mismatch.
+
+### Step 4: re-apply the impl; tests must PASS
+
+```bash
+git reset --hard origin/$BRANCH_NAME
+cd packages/gazetta && npx vitest run <path-to-the-new-test-files>
+```
+
+**Expected: tests PASS.** Confirms the impl actually implements the
+spec and Agent A didn't push a broken state.
+
+If tests fail on re-application: state bug, not something Agent A can
+fix on retry. **NEEDS_HUMAN**.
+
+## The acceptance check (Cut 5 refinement)
+
+Read the cut sub-issue's `## Acceptance` section. For each bullet,
+ask: "is this satisfied by the diff?" Pin the answer.
+
+| State | Effect |
+|---|---|
+| All bullets satisfied | OK for this check |
+| Some bullets NOT pinned by any test in the diff | **REJECT** — name the missing bullets |
+| Some bullets visibly NOT implemented in source | **REJECT** — name what's missing |
+| Some bullets ambiguous | Cite the ambiguity in `Reasoning:`; if all else is fine, APPROVE; if structural, **NEEDS_HUMAN** |
+
+The acceptance section is the cut's contract with the maintainer.
+Skipping a bullet is grounds for REJECT regardless of how clean the
+diff otherwise looks.
+
+## The SOLID check (Cut 5 refinement)
+
+If the cut sub-issue has a `## SOLID` section, read it. The section
+names which SOLID lenses Agent A committed to honoring. Common shapes:
+
+- "SRP — `redirects.ts` owns the route; doesn't reach into archive internals"
+- "OCP via the validator registry — adding a new validator is one new file"
+- "ISP — narrow `WorkerCapableDeployAdapter` interface; not every adapter implements it"
+- "DIP — route depends on suggester abstraction, not on adapter internals"
+
+For each lens declared, look at the diff. Did Agent A honor it?
+
+| State | Effect |
+|---|---|
+| All declared lenses honored | OK |
+| A declared lens visibly violated (e.g., SRP — module fuses two concerns) | **REJECT** — cite the lens + the file |
+| Stub-that-throws on an interface (LSP violation) | **REJECT** — name the stub + suggest splitting via capability interface |
+
+When `## SOLID` is absent, this check is N/A — pure-data-shape and
+pure-docs cuts often don't have SOLID concerns.
+
+## The locked-decisions check
+
+Read the design doc's `## Locked decisions` (or "Q1 / Q2 / ..." section).
+For each decision that touches the area Agent A's diff modifies, ask:
+"does the diff implement THIS decision, OR does it deviate?"
+
+Deviations are not always wrong — sometimes the design doc was wrong
+and Agent A's choice is better. But a deviation must be a deliberate,
+articulated choice. If Agent A silently implemented something
+different from the locked decision, that's:
+
+- **REJECT** if the deviation is small and Agent A can fix on retry
+- **NEEDS_HUMAN** if the design doc needs to change for Agent A's
+  choice to be correct (maintainer judgment required)
+
+## The non-mechanical checks
+
+After the four above pass, also check:
+
+### Scope creep
+
+`git diff main..$BRANCH_NAME --stat` — how many files changed?
+
+- ≤4 files (tests + sources) → almost certainly fine
+- 5-8 files → check whether the extra changes are required by the cut
+- 9+ files → **REJECT** unless the cut unambiguously requires touching
+  all of them. The cut prompt explicitly forbids "while I'm here"
+  cleanups.
+
+### Commit message accuracy
+
+Read the commit messages (`git log main..$BRANCH_NAME --format=%B`).
+
+- Commit 1 (failing test): subject signals "failing" / "test:" / "RED"
+- Commit 2 (impl): subject should match the cut's actual shape (`feat`,
+  `fix`, `refactor`, etc. — and NOT use the wrong scope)
+
+**Don't nitpick wording.** REJECT only when the message is materially
+wrong (says one thing but the diff does another).
+
+## Process
+
+1. Run the 4-step tautology check
+2. Run the acceptance check (every bullet pinned)
+3. Run the SOLID check (when `## SOLID` is present)
+4. Run the locked-decisions check (against the design doc)
+5. Run the non-mechanical checks (scope, commit messages)
+6. Form your verdict and emit the verdict line at the END:
+
+```
+VERDICT: APPROVE
+Reasoning: <one paragraph why the cut is sound — name the load-bearing
+checks that passed>
+```
+
+```
+VERDICT: REJECT
+Note: <specific, actionable feedback Agent A can use on retry — cite
+the failing check + the location>
+```
+
+```
+VERDICT: NEEDS_HUMAN
+Note: <why a human needs to look — what's structurally questionable>
+```
+
+## When to REJECT vs NEEDS_HUMAN
+
+- **REJECT** — the problem has a concrete fix Agent A can apply on retry
+  within the same cut's scope:
+  - "Acceptance bullet 3 ('audit event records create-redirect') isn't
+    pinned by any test. Please add a test that asserts the audit event
+    fires with `action: 'create-redirect'`."
+  - "Diff modifies `archive.ts` in addition to `redirects.ts`; this cut
+    only adds the redirect route — please remove the unrelated change."
+  - "Test on line 42 still passes after revert. The assertion checks
+    that `response.status` is truthy; please assert `=== 201`."
+
+- **NEEDS_HUMAN** — structural problem retry can't fix:
+  - "Locked decision Q4 says 'hard-refuse on live-name collision' but
+    Agent A's implementation silently archives + replaces. The design
+    doc needs review."
+  - "After reverting + re-applying, tests fail — branch state is
+    inconsistent."
+  - On `ATTEMPT == MAX_ATTEMPTS`: Agent A and reviewer still
+    disagreeing → escalate.
+
+## Rules
+
+- DO NOT push, comment on PRs, or open new PRs. Your output IS the
+  verdict; the orchestrator acts on it.
+- DO NOT modify code. You have `Bash` + `Read` only; no `Write` or `Edit`.
+- DO NOT approve when uncertain. REJECT or NEEDS_HUMAN are safer
+  defaults.
+- DO emit the `VERDICT:` line as your FINAL output. The orchestrator
+  parses it via regex.
+- DO cite specific files + line numbers when REJECT-ing. Vague Notes
+  don't help Agent A retry.
+
+You're the second pair of eyes — independent judgment, no
+rubber-stamping.

--- a/bots/feature-bot/route-attempt.ts
+++ b/bots/feature-bot/route-attempt.ts
@@ -1,0 +1,120 @@
+/**
+ * Attempt routing — pure decision function for the generator-critic loop.
+ *
+ * Given the outcome of one attempt (Agent A signal + optionally Agent B
+ * verdict + attempt context), decide what the orchestrator should do
+ * next:
+ *
+ *   - push-and-pr — Agent A approve-implicit + Agent B approve
+ *   - retry-with-note — Agent A approve-implicit + Agent B reject + attempts remain
+ *   - post-input-question — Agent A needs-input + cycle count under cap
+ *   - escalate-needs-human — terminal escalation with a SkipReason
+ *   - escalate-failure — Agent A non-zero exit; surface failure diagnostic
+ *
+ * Per design-feature-bot.md Q6 (three-tier escalation) + Q7 (extended
+ * skip-list reason codes).
+ *
+ * Pure routing: the orchestrator owns I/O (gh CLI, octokit, git, claude
+ * invocation). This module decides what to do given the inputs. Split per
+ * rule 18: I/O and decision logic are different reasons-to-change.
+ */
+import type { SkipReason } from './skip-list.js'
+import type { AgentASignal } from './agent-a-signal.js'
+import type { ReviewerVerdict } from '../_lib/reviewer-verdict.js'
+
+/** What the orchestrator just observed at the end of one attempt. */
+export type AttemptOutcome =
+  /** Agent A's claude invocation exited non-zero. */
+  | { kind: 'agent-a-failure'; exitCode: number }
+  /** Agent A's invocation succeeded but produced no commits AND no signal. */
+  | { kind: 'agent-a-no-output' }
+  /** Agent A emitted a NEEDS_INPUT or NEEDS_HUMAN signal (no commits expected). */
+  | { kind: 'agent-a-signaled'; signal: Extract<AgentASignal, { kind: 'needs-input' | 'needs-human' }> }
+  /** Agent A committed work (approve-implicit) AND Agent B has rendered a verdict. */
+  | { kind: 'agent-b-judged'; signal: Extract<AgentASignal, { kind: 'approve-implicit' }>; verdict: ReviewerVerdict }
+
+export interface RouteContext {
+  /** Current attempt number (1-indexed). */
+  attempt: number
+  /** Cap on attempts before forcing escalate-needs-human. */
+  maxAttempts: number
+  /** How many NEEDS_INPUT cycles this cut has already gone through. */
+  priorInputCycles: number
+  /** Max NEEDS_INPUT cycles before escalating (per Q6 lock; default 2). */
+  maxInputCycles: number
+}
+
+export type RouteDecision =
+  | { kind: 'push-and-pr'; reasoning: string }
+  | { kind: 'retry-with-note'; note: string }
+  | { kind: 'post-input-question'; body: string; question: string }
+  | { kind: 'escalate-needs-human'; reason: SkipReason; reasonNote: string }
+  | { kind: 'escalate-failure'; exitCode: number }
+
+export function routeAttemptOutcome(outcome: AttemptOutcome, ctx: RouteContext): RouteDecision {
+  switch (outcome.kind) {
+    case 'agent-a-failure':
+      return { kind: 'escalate-failure', exitCode: outcome.exitCode }
+
+    case 'agent-a-no-output':
+      return {
+        kind: 'escalate-needs-human',
+        reason: 'needs-human',
+        reasonNote: 'Agent A produced no commits and no signal block; cannot proceed.',
+      }
+
+    case 'agent-a-signaled':
+      return routeAgentASignal(outcome.signal, ctx)
+
+    case 'agent-b-judged':
+      return routeAgentBVerdict(outcome.verdict, ctx)
+  }
+}
+
+function routeAgentASignal(
+  signal: Extract<AgentASignal, { kind: 'needs-input' | 'needs-human' }>,
+  ctx: RouteContext,
+): RouteDecision {
+  if (signal.kind === 'needs-input') {
+    // Cycle-count check: priorInputCycles already includes ALL prior
+    // NEEDS_INPUT events on this cut. The cap is reached when
+    // priorInputCycles >= maxInputCycles.
+    if (ctx.priorInputCycles >= ctx.maxInputCycles) {
+      return {
+        kind: 'escalate-needs-human',
+        reason: 'input-cycles-exceeded',
+        reasonNote: `Agent A asked NEEDS_INPUT ${ctx.priorInputCycles} times without resolution; escalating per Q6 MAX_INPUT_REQUESTS=${ctx.maxInputCycles} cap.`,
+      }
+    }
+    return { kind: 'post-input-question', body: signal.body, question: signal.question }
+  }
+
+  // signal.kind === 'needs-human' — passthrough the reason-code as the SkipReason.
+  return {
+    kind: 'escalate-needs-human',
+    reason: signal.reasonCode,
+    reasonNote: signal.reason,
+  }
+}
+
+function routeAgentBVerdict(verdict: ReviewerVerdict, ctx: RouteContext): RouteDecision {
+  if (verdict.kind === 'approve') {
+    return { kind: 'push-and-pr', reasoning: verdict.reasoning }
+  }
+  if (verdict.kind === 'needs-human') {
+    return {
+      kind: 'escalate-needs-human',
+      reason: 'wrong-root-cause',
+      reasonNote: verdict.note,
+    }
+  }
+  // verdict.kind === 'reject'
+  if (ctx.attempt >= ctx.maxAttempts) {
+    return {
+      kind: 'escalate-needs-human',
+      reason: 'needs-human',
+      reasonNote: `Loop exhausted after ${ctx.maxAttempts} attempts. Last reviewer note: ${verdict.note}`,
+    }
+  }
+  return { kind: 'retry-with-note', note: verdict.note }
+}

--- a/bots/feature-bot/tests/agent-a-signal.test.ts
+++ b/bots/feature-bot/tests/agent-a-signal.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Agent A signal parser tests — failing-test commit per rule 31 TDD-first ordering.
+ *
+ * Per design-feature-bot.md Q6, Agent A has THREE terminal states emitted
+ * as structured blocks in its final assistant text:
+ *
+ *   - APPROVE_IMPLICIT — commits exist, no signal block
+ *   - NEEDS_INPUT block:
+ *       NEEDS_INPUT: <one-line question>
+ *       Options:
+ *         - <option 1 with reasoning>
+ *         - <option 2 with reasoning>
+ *       Recommendation: <option N because ...>
+ *   - NEEDS_HUMAN block:
+ *       NEEDS_HUMAN: <one-line reason>
+ *       Reason-code: <one of: missing-prereq, spec-too-vague, files-conflict, needs-human>
+ *
+ * Parser is separate from `reviewer-verdict.ts` (which parses Agent B's
+ * APPROVE/REJECT/NEEDS_HUMAN). Different shape, different parser per SRP.
+ */
+import { describe, expect, it } from 'vitest'
+import { parseAgentASignal } from '../agent-a-signal.js'
+
+describe('parseAgentASignal — APPROVE_IMPLICIT path', () => {
+  it('returns approve-implicit when no signal block is present', () => {
+    const text = 'Done. Committed test + impl on the branch.\n\nSUMMARY:\nAdded redirect route with validation.'
+    const result = parseAgentASignal(text)
+    expect(result.kind).toBe('approve-implicit')
+  })
+
+  it('returns approve-implicit on empty text', () => {
+    const result = parseAgentASignal('')
+    expect(result.kind).toBe('approve-implicit')
+  })
+
+  it('returns approve-implicit when text mentions VERDICT but no Agent A signal', () => {
+    // Reviewer verdict markers should NOT trip Agent A's parser.
+    const text = 'Working through this... thinking about VERDICT: APPROVE would be wrong here.'
+    const result = parseAgentASignal(text)
+    expect(result.kind).toBe('approve-implicit')
+  })
+})
+
+describe('parseAgentASignal — NEEDS_INPUT path', () => {
+  it('parses a well-formed NEEDS_INPUT block with options and recommendation', () => {
+    const text = `Looked at the spec. Two paths possible.
+
+NEEDS_INPUT: Should the new endpoint return 201 or 200 on idempotent re-creation?
+Options:
+  - 201 with Location header — REST-idiomatic but breaks existing client retry semantics
+  - 200 with body unchanged — matches existing /api/archive behavior
+Recommendation: 200 because the existing /api/archive route uses the same shape and operator scripts rely on it.`
+    const result = parseAgentASignal(text)
+    expect(result.kind).toBe('needs-input')
+    if (result.kind === 'needs-input') {
+      expect(result.question).toContain('201 or 200')
+      expect(result.body).toContain('Options:')
+      expect(result.body).toContain('Recommendation:')
+    }
+  })
+
+  it('treats NEEDS_INPUT without Options as still valid (orchestrator posts verbatim)', () => {
+    // Parser is permissive about block contents — Q6 schema is for Agent A
+    // to follow; the orchestrator posts the comment verbatim.
+    const text = 'NEEDS_INPUT: vague question without options'
+    const result = parseAgentASignal(text)
+    expect(result.kind).toBe('needs-input')
+  })
+
+  it('NEEDS_HUMAN takes precedence when both blocks appear (last wins)', () => {
+    // If Agent A confused itself and emitted both, the last block is the
+    // committed terminal state — same as reviewer-verdict's last-wins.
+    const text = `NEEDS_INPUT: first thought
+Options:
+  - foo
+Recommendation: foo
+
+Actually no.
+
+NEEDS_HUMAN: cut spec is too vague for me to proceed
+Reason-code: spec-too-vague`
+    const result = parseAgentASignal(text)
+    expect(result.kind).toBe('needs-human')
+    if (result.kind === 'needs-human') {
+      expect(result.reasonCode).toBe('spec-too-vague')
+    }
+  })
+})
+
+describe('parseAgentASignal — NEEDS_HUMAN path', () => {
+  it('parses NEEDS_HUMAN with missing-prereq reason-code', () => {
+    const text = `Found that the validator framework isn't wired into the route despite #501 being merged.
+
+NEEDS_HUMAN: required validation infrastructure absent from the codebase
+Reason-code: missing-prereq`
+    const result = parseAgentASignal(text)
+    expect(result.kind).toBe('needs-human')
+    if (result.kind === 'needs-human') {
+      expect(result.reasonCode).toBe('missing-prereq')
+      expect(result.reason).toContain('validation infrastructure')
+    }
+  })
+
+  it('parses NEEDS_HUMAN with spec-too-vague reason-code', () => {
+    const text = `NEEDS_HUMAN: the cut sub-issue body has Spec=TBD and no Acceptance items
+Reason-code: spec-too-vague`
+    const result = parseAgentASignal(text)
+    expect(result.kind).toBe('needs-human')
+    if (result.kind === 'needs-human') {
+      expect(result.reasonCode).toBe('spec-too-vague')
+    }
+  })
+
+  it('parses NEEDS_HUMAN with files-conflict reason-code', () => {
+    const text = `NEEDS_HUMAN: files I would touch are open in PR #890
+Reason-code: files-conflict`
+    const result = parseAgentASignal(text)
+    expect(result.kind).toBe('needs-human')
+    if (result.kind === 'needs-human') {
+      expect(result.reasonCode).toBe('files-conflict')
+    }
+  })
+
+  it('defaults reason-code to needs-human when omitted', () => {
+    const text = 'NEEDS_HUMAN: generic escalation without explicit code'
+    const result = parseAgentASignal(text)
+    expect(result.kind).toBe('needs-human')
+    if (result.kind === 'needs-human') {
+      expect(result.reasonCode).toBe('needs-human')
+    }
+  })
+
+  it('defaults reason-code to needs-human when Reason-code is malformed', () => {
+    const text = `NEEDS_HUMAN: stuck
+Reason-code: bogus-not-in-enum`
+    const result = parseAgentASignal(text)
+    expect(result.kind).toBe('needs-human')
+    if (result.kind === 'needs-human') {
+      expect(result.reasonCode).toBe('needs-human')
+    }
+  })
+})

--- a/bots/feature-bot/tests/escalation.test.ts
+++ b/bots/feature-bot/tests/escalation.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Escalation routing tests — failing-test commit per rule 31 TDD-first ordering.
+ *
+ * Tests the pure routing logic that decides what to do given:
+ *   - Agent A's signal (approve-implicit / needs-input / needs-human)
+ *   - Agent B's verdict (approve / reject / needs-human) — when Agent A
+ *     was approve-implicit and committed work
+ *
+ * The orchestrator is an I/O layer (file system, octokit, git, claude
+ * invocations); separating the routing logic from I/O lets us test the
+ * three-tier escalation Q6 lock without mocking the entire world.
+ *
+ * Per design-feature-bot.md Q6:
+ *   - APPROVE_IMPLICIT + Agent B APPROVE → push branch + open PR
+ *   - APPROVE_IMPLICIT + Agent B REJECT → reset + retry up to MAX_ATTEMPTS
+ *   - APPROVE_IMPLICIT + Agent B NEEDS_HUMAN → escalate (reason: wrong-root-cause)
+ *   - NEEDS_INPUT (cycle count < MAX_INPUT_REQUESTS) → post structured Q +
+ *     needs-info label, reset working tree
+ *   - NEEDS_INPUT (cycle count >= MAX_INPUT_REQUESTS) → escalate
+ *     (reason: input-cycles-exceeded)
+ *   - NEEDS_HUMAN → escalate with the reason-code from the signal
+ */
+import { describe, expect, it } from 'vitest'
+import type { AgentASignal } from '../agent-a-signal.js'
+import { routeAttemptOutcome, type RouteContext, type RouteDecision } from '../route-attempt.js'
+import type { ReviewerVerdict } from '../../_lib/reviewer-verdict.js'
+
+const baseCtx: RouteContext = {
+  attempt: 1,
+  maxAttempts: 5,
+  priorInputCycles: 0,
+  maxInputCycles: 2,
+}
+
+describe('routeAttemptOutcome — agent-a-failure', () => {
+  it('routes agent-a non-zero exit → escalate needs-human', () => {
+    const decision = routeAttemptOutcome({ kind: 'agent-a-failure', exitCode: 1 }, baseCtx)
+    expect(decision.kind).toBe('escalate-failure')
+  })
+
+  it('routes agent-a no-commits + no-signal → escalate needs-human', () => {
+    // Agent A produced nothing — no commits, no NEEDS_INPUT, no NEEDS_HUMAN.
+    // Treat as agent-a-failure with reason `needs-human` (catch-all).
+    const decision = routeAttemptOutcome({ kind: 'agent-a-no-output' }, baseCtx)
+    expect(decision.kind).toBe('escalate-needs-human')
+    if (decision.kind === 'escalate-needs-human') {
+      expect(decision.reason).toBe('needs-human')
+    }
+  })
+})
+
+describe('routeAttemptOutcome — APPROVE_IMPLICIT + reviewer verdict', () => {
+  it('Agent B APPROVE → push-and-pr', () => {
+    const signal: AgentASignal = { kind: 'approve-implicit' }
+    const verdict: ReviewerVerdict = { kind: 'approve', reasoning: 'fix is minimal and the test pins it' }
+    const decision = routeAttemptOutcome({ kind: 'agent-b-judged', signal, verdict }, baseCtx)
+    expect(decision.kind).toBe('push-and-pr')
+  })
+
+  it('Agent B REJECT and attempts remain → retry-with-note', () => {
+    const signal: AgentASignal = { kind: 'approve-implicit' }
+    const verdict: ReviewerVerdict = { kind: 'reject', note: 'test is tautological' }
+    const decision = routeAttemptOutcome({ kind: 'agent-b-judged', signal, verdict }, baseCtx)
+    expect(decision.kind).toBe('retry-with-note')
+    if (decision.kind === 'retry-with-note') {
+      expect(decision.note).toBe('test is tautological')
+    }
+  })
+
+  it('Agent B REJECT on final attempt → escalate-needs-human', () => {
+    const signal: AgentASignal = { kind: 'approve-implicit' }
+    const verdict: ReviewerVerdict = { kind: 'reject', note: 'still tautological' }
+    const decision = routeAttemptOutcome(
+      { kind: 'agent-b-judged', signal, verdict },
+      { ...baseCtx, attempt: 5, maxAttempts: 5 },
+    )
+    expect(decision.kind).toBe('escalate-needs-human')
+    if (decision.kind === 'escalate-needs-human') {
+      expect(decision.reason).toBe('needs-human')
+    }
+  })
+
+  it('Agent B NEEDS_HUMAN → escalate-needs-human (reason: wrong-root-cause)', () => {
+    const signal: AgentASignal = { kind: 'approve-implicit' }
+    const verdict: ReviewerVerdict = { kind: 'needs-human', note: 'fix is at wrong layer' }
+    const decision = routeAttemptOutcome({ kind: 'agent-b-judged', signal, verdict }, baseCtx)
+    expect(decision.kind).toBe('escalate-needs-human')
+    if (decision.kind === 'escalate-needs-human') {
+      expect(decision.reason).toBe('wrong-root-cause')
+    }
+  })
+})
+
+describe('routeAttemptOutcome — NEEDS_INPUT cycles', () => {
+  it('cycle count under cap → post-input-question', () => {
+    const signal: AgentASignal = {
+      kind: 'needs-input',
+      question: 'should it 200 or 201?',
+      body: 'NEEDS_INPUT: should it 200 or 201?\nOptions:\n  - 200\n  - 201\nRecommendation: 200',
+    }
+    const decision = routeAttemptOutcome({ kind: 'agent-a-signaled', signal }, { ...baseCtx, priorInputCycles: 0 })
+    expect(decision.kind).toBe('post-input-question')
+  })
+
+  it('cycle count = cap - 1 → post-input-question (last allowed)', () => {
+    const signal: AgentASignal = {
+      kind: 'needs-input',
+      question: 'q',
+      body: 'NEEDS_INPUT: q',
+    }
+    const decision = routeAttemptOutcome(
+      { kind: 'agent-a-signaled', signal },
+      { ...baseCtx, priorInputCycles: 1, maxInputCycles: 2 },
+    )
+    expect(decision.kind).toBe('post-input-question')
+  })
+
+  it('cycle count = cap → escalate-needs-human (reason: input-cycles-exceeded)', () => {
+    const signal: AgentASignal = {
+      kind: 'needs-input',
+      question: 'q',
+      body: 'NEEDS_INPUT: q',
+    }
+    const decision = routeAttemptOutcome(
+      { kind: 'agent-a-signaled', signal },
+      { ...baseCtx, priorInputCycles: 2, maxInputCycles: 2 },
+    )
+    expect(decision.kind).toBe('escalate-needs-human')
+    if (decision.kind === 'escalate-needs-human') {
+      expect(decision.reason).toBe('input-cycles-exceeded')
+    }
+  })
+})
+
+describe('routeAttemptOutcome — NEEDS_HUMAN from Agent A', () => {
+  it('Agent A NEEDS_HUMAN with missing-prereq → escalate with that reason', () => {
+    const signal: AgentASignal = {
+      kind: 'needs-human',
+      reason: 'infrastructure absent',
+      reasonCode: 'missing-prereq',
+    }
+    const decision = routeAttemptOutcome({ kind: 'agent-a-signaled', signal }, baseCtx)
+    expect(decision.kind).toBe('escalate-needs-human')
+    if (decision.kind === 'escalate-needs-human') {
+      expect(decision.reason).toBe('missing-prereq')
+    }
+  })
+
+  it('Agent A NEEDS_HUMAN with spec-too-vague → escalate with that reason', () => {
+    const signal: AgentASignal = {
+      kind: 'needs-human',
+      reason: 'spec missing acceptance items',
+      reasonCode: 'spec-too-vague',
+    }
+    const decision = routeAttemptOutcome({ kind: 'agent-a-signaled', signal }, baseCtx)
+    if (decision.kind === 'escalate-needs-human') {
+      expect(decision.reason).toBe('spec-too-vague')
+    } else {
+      throw new Error(`expected escalate-needs-human, got ${decision.kind}`)
+    }
+  })
+
+  it('Agent A NEEDS_HUMAN with files-conflict → escalate with that reason', () => {
+    const signal: AgentASignal = {
+      kind: 'needs-human',
+      reason: 'files open in another PR',
+      reasonCode: 'files-conflict',
+    }
+    const decision = routeAttemptOutcome({ kind: 'agent-a-signaled', signal }, baseCtx)
+    expect(decision.kind).toBe('escalate-needs-human')
+    if (decision.kind === 'escalate-needs-human') {
+      expect(decision.reason).toBe('files-conflict')
+    }
+  })
+
+  it('Agent A NEEDS_HUMAN with generic (no reason-code) → escalate needs-human', () => {
+    const signal: AgentASignal = {
+      kind: 'needs-human',
+      reason: 'generic',
+      reasonCode: 'needs-human',
+    }
+    const decision: RouteDecision = routeAttemptOutcome({ kind: 'agent-a-signaled', signal }, baseCtx)
+    expect(decision.kind).toBe('escalate-needs-human')
+    if (decision.kind === 'escalate-needs-human') {
+      expect(decision.reason).toBe('needs-human')
+    }
+  })
+})

--- a/bots/feature-bot/tests/idempotency.test.ts
+++ b/bots/feature-bot/tests/idempotency.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Idempotency tests — failing-test commit per rule 31 TDD-first ordering.
+ *
+ * Mirrors fix-bot's auto-clear-on-reopen pattern (label `feature-bot-attempted`).
+ *
+ * Decision rules:
+ *   - No `feature-bot-attempted` label → proceed (fresh)
+ *   - Label present + no reopen since → skip (already attempted)
+ *   - Label present + reopened after label-applied-time → proceed (retry)
+ */
+import { describe, expect, it } from 'vitest'
+import { decideIdempotency } from '../idempotency.js'
+
+describe('decideIdempotency', () => {
+  it('proceeds when label has never been applied', () => {
+    const result = decideIdempotency({ attemptedAt: null, reopenedAt: null })
+    expect(result.kind).toBe('proceed')
+  })
+
+  it('skips when label is present and issue has not been reopened', () => {
+    const result = decideIdempotency({ attemptedAt: '2026-05-20T00:00:00Z', reopenedAt: null })
+    expect(result.kind).toBe('skip')
+  })
+
+  it('skips when label is present and reopen is older than label-applied', () => {
+    const result = decideIdempotency({
+      attemptedAt: '2026-05-25T00:00:00Z',
+      reopenedAt: '2026-05-20T00:00:00Z',
+    })
+    expect(result.kind).toBe('skip')
+  })
+
+  it('proceeds when reopen is newer than label-applied', () => {
+    const result = decideIdempotency({
+      attemptedAt: '2026-05-20T00:00:00Z',
+      reopenedAt: '2026-05-25T00:00:00Z',
+    })
+    expect(result.kind).toBe('proceed-after-reopen')
+  })
+
+  it('proceeds when reopen is exactly equal to label-applied (edge case: tie → reopen wins)', () => {
+    // Reasonable tie-break: equal timestamps mean the reopen event was at
+    // least as recent as the attempt; favor proceeding rather than skipping
+    // forever on a millisecond race.
+    const ts = '2026-05-20T00:00:00Z'
+    const result = decideIdempotency({ attemptedAt: ts, reopenedAt: ts })
+    expect(result.kind).toBe('proceed-after-reopen')
+  })
+})

--- a/bots/feature-bot/tests/parse-and-validate.test.ts
+++ b/bots/feature-bot/tests/parse-and-validate.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Orchestrator parse + dep-validation tests — failing-test commit per
+ * rule 31 TDD-first ordering.
+ *
+ * These tests cover the orchestrator's PRE-CLAUDE gate: parse the cut
+ * sub-issue body, validate referenced deps against the live issue tree,
+ * loud-fail on bad refs without invoking Claude.
+ *
+ * Per design-feature-bot.md Q3:
+ *   - body with missing **Feature** → comment + needs-info label
+ *   - body with missing required section → comment + needs-info label
+ *   - self-reference → ready-for-human + skip-list entry (spec-too-vague)
+ *   - dep number doesn't exist → comment + needs-info label
+ *   - dep issue not labeled `enhancement` → same as not-found
+ *   - dep open → comment "wait for dep" + NO labels applied
+ *   - dep closed-not-merged → ready-for-human + skip-list entry
+ *   - all deps closed-merged → proceed
+ *
+ * The orchestrator is mocked here at the seam — we test the validate
+ * function directly, which the orchestrator dispatches to before
+ * invoking Claude. No real GitHub access; octokit is mocked.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { validateCutSubIssue, type CutValidationResult } from '../validate-cut-sub-issue.js'
+
+// Minimal octokit-shaped mock. Each test wires its own per-issue handler.
+type FakeIssue = {
+  number: number
+  state: 'open' | 'closed'
+  state_reason?: 'completed' | 'not_planned' | 'reopened' | null
+  labels: Array<string | { name?: string }>
+  pull_request?: { merged_at?: string | null }
+}
+
+function makeOctokit(issuesByNumber: Record<number, FakeIssue | 'not-found'>) {
+  return {
+    issues: {
+      get: vi.fn(async ({ issue_number }: { issue_number: number }) => {
+        const issue = issuesByNumber[issue_number]
+        if (!issue || issue === 'not-found') {
+          const err: Error & { status?: number } = new Error('Not Found')
+          err.status = 404
+          throw err
+        }
+        return { data: issue }
+      }),
+    },
+  }
+}
+
+const REPO = { owner: 'gazetta-studio', repo: 'gazetta-studio' }
+
+describe('validateCutSubIssue — body-level errors', () => {
+  it('reports body-error when **Feature** field is missing', async () => {
+    const body = `## Spec
+do the thing
+
+## Acceptance
+- it works
+
+## Tests
+- bots/feature-bot/tests/foo.test.ts`
+    const octokit = makeOctokit({})
+    const result = await validateCutSubIssue(octokit as never, REPO, 500, body)
+    expect(result.kind).toBe('body-error')
+    if (result.kind === 'body-error') {
+      expect(result.errors.some(e => e.kind === 'missing-feature')).toBe(true)
+    }
+    expect(octokit.issues.get).not.toHaveBeenCalled()
+  })
+
+  it('reports body-error when ## Spec section is missing', async () => {
+    const body = `**Feature**: redirect-ui
+
+## Acceptance
+- it works
+
+## Tests
+- bots/feature-bot/tests/foo.test.ts`
+    const octokit = makeOctokit({})
+    const result = await validateCutSubIssue(octokit as never, REPO, 500, body)
+    expect(result.kind).toBe('body-error')
+    if (result.kind === 'body-error') {
+      expect(result.errors.some(e => e.kind === 'missing-required-section')).toBe(true)
+    }
+  })
+
+  it('reports body-error when ## Acceptance section is missing', async () => {
+    const body = `**Feature**: redirect-ui
+
+## Spec
+do the thing
+
+## Tests
+- bots/feature-bot/tests/foo.test.ts`
+    const octokit = makeOctokit({})
+    const result = await validateCutSubIssue(octokit as never, REPO, 500, body)
+    expect(result.kind).toBe('body-error')
+  })
+
+  it('reports body-error when ## Tests section is missing', async () => {
+    const body = `**Feature**: redirect-ui
+
+## Spec
+do the thing
+
+## Acceptance
+- it works`
+    const octokit = makeOctokit({})
+    const result = await validateCutSubIssue(octokit as never, REPO, 500, body)
+    expect(result.kind).toBe('body-error')
+  })
+
+  it('reports self-reference as spec-too-vague (skip-list entry)', async () => {
+    const body = `**Feature**: redirect-ui
+**Depends on**: #500
+
+## Spec
+do the thing
+
+## Acceptance
+- it works
+
+## Tests
+- foo.test.ts`
+    const octokit = makeOctokit({})
+    const result = await validateCutSubIssue(octokit as never, REPO, 500, body)
+    expect(result.kind).toBe('self-reference')
+  })
+})
+
+describe('validateCutSubIssue — dependency validation', () => {
+  function validBody(deps: string): string {
+    return `**Feature**: redirect-ui
+**Depends on**: ${deps}
+
+## Spec
+do the thing
+
+## Acceptance
+- it works
+
+## Tests
+- bots/feature-bot/tests/foo.test.ts`
+  }
+
+  it('returns ready when all deps are closed-merged', async () => {
+    const octokit = makeOctokit({
+      501: {
+        number: 501,
+        state: 'closed',
+        state_reason: 'completed',
+        labels: ['enhancement', 'ready-for-agent'],
+      },
+      502: {
+        number: 502,
+        state: 'closed',
+        state_reason: 'completed',
+        labels: ['enhancement', 'ready-for-agent'],
+      },
+    })
+    const result = await validateCutSubIssue(octokit as never, REPO, 503, validBody('#501, #502'))
+    expect(result.kind).toBe('ready')
+    if (result.kind === 'ready') {
+      expect(result.parsed.feature).toBe('redirect-ui')
+      expect(result.parsed.dependsOn).toEqual([501, 502])
+    }
+  })
+
+  it('returns ready when there are no deps', async () => {
+    const octokit = makeOctokit({})
+    const result = await validateCutSubIssue(octokit as never, REPO, 503, validBody('none'))
+    expect(result.kind).toBe('ready')
+    expect(octokit.issues.get).not.toHaveBeenCalled()
+  })
+
+  it('returns dep-open when any dep is still open (no labels applied)', async () => {
+    const octokit = makeOctokit({
+      501: {
+        number: 501,
+        state: 'open',
+        labels: ['enhancement', 'ready-for-agent'],
+      },
+    })
+    const result = await validateCutSubIssue(octokit as never, REPO, 503, validBody('#501'))
+    expect(result.kind).toBe('dep-open')
+    if (result.kind === 'dep-open') {
+      expect(result.openDeps).toContain(501)
+    }
+  })
+
+  it('returns dep-rejected when dep is closed-not-merged', async () => {
+    const octokit = makeOctokit({
+      501: {
+        number: 501,
+        state: 'closed',
+        state_reason: 'not_planned',
+        labels: ['enhancement', 'ready-for-agent'],
+      },
+    })
+    const result = await validateCutSubIssue(octokit as never, REPO, 503, validBody('#501'))
+    expect(result.kind).toBe('dep-rejected')
+  })
+
+  it('returns dep-invalid when dep number does not exist', async () => {
+    const octokit = makeOctokit({
+      501: 'not-found',
+    })
+    const result = await validateCutSubIssue(octokit as never, REPO, 503, validBody('#501'))
+    expect(result.kind).toBe('dep-invalid')
+  })
+
+  it('returns dep-invalid when dep lacks the enhancement label', async () => {
+    const octokit = makeOctokit({
+      501: {
+        number: 501,
+        state: 'closed',
+        state_reason: 'completed',
+        labels: ['bug', 'ready-for-agent'], // bug, not enhancement
+      },
+    })
+    const result = await validateCutSubIssue(octokit as never, REPO, 503, validBody('#501'))
+    expect(result.kind).toBe('dep-invalid')
+  })
+
+  it('aggregates errors when one dep is open AND another is invalid', async () => {
+    // The orchestrator should not invoke Claude when ANY dep fails.
+    // Open-dep wins over invalid-dep here? Actually both should be reported,
+    // but the orchestrator action is determined by the most-blocking error.
+    // dep-invalid is more terminal (needs-info / ready-for-human) than
+    // dep-open (just wait). So when both present, return dep-invalid.
+    const octokit = makeOctokit({
+      501: {
+        number: 501,
+        state: 'open',
+        labels: ['enhancement', 'ready-for-agent'],
+      },
+      502: 'not-found',
+    })
+    const result: CutValidationResult = await validateCutSubIssue(octokit as never, REPO, 503, validBody('#501, #502'))
+    // dep-invalid is more terminal; orchestrator returns the worse error first.
+    expect(result.kind).toBe('dep-invalid')
+  })
+})

--- a/bots/feature-bot/validate-cut-sub-issue.ts
+++ b/bots/feature-bot/validate-cut-sub-issue.ts
@@ -1,0 +1,176 @@
+/**
+ * Validate-cut-sub-issue — orchestrator's pre-Claude gate.
+ *
+ * Per design-feature-bot.md Q3, the orchestrator MUST loud-fail on bad
+ * cut sub-issue bodies + bad dep refs without invoking Claude. This
+ * module combines Cut 2's parser (`bots/_lib/cut-parser.ts`) with
+ * cron-tick GitHub queries against the live issue tree.
+ *
+ * Returns a tagged-union result the orchestrator routes on:
+ *
+ *   - ready — parser + all dep refs valid + all deps closed-merged
+ *   - body-error — Spec/Acceptance/Tests missing or **Feature** missing
+ *   - self-reference — body refs its own issue number (spec-too-vague)
+ *   - dep-invalid — a referenced issue doesn't exist OR lacks `enhancement`
+ *   - dep-open — at least one dep is still open (wait for it)
+ *   - dep-rejected — at least one dep is closed-not-merged
+ *
+ * Pure orchestration over `parseCutBody` + `validateParsedCut` + per-dep
+ * octokit lookups. Octokit type is imported narrowly to avoid pulling
+ * the entire Octokit surface into a tested module — we only need
+ * `.issues.get`.
+ */
+import { parseCutBody, validateParsedCut, type ParsedCut, type ValidationError } from '../_lib/cut-parser.js'
+import type { RepoIdentity } from '../_lib/github.js'
+
+/**
+ * Narrow octokit surface — what this validator needs. Defined locally
+ * so tests can mock just the `issues.get` shape without depending on
+ * Octokit's full type. ISP per rule 18.
+ */
+export interface IssuesGetClient {
+  issues: {
+    get: (opts: { owner: string; repo: string; issue_number: number }) => Promise<{
+      data: {
+        number: number
+        state: 'open' | 'closed'
+        state_reason?: 'completed' | 'not_planned' | 'reopened' | null
+        labels: Array<string | { name?: string }>
+        pull_request?: { merged_at?: string | null }
+      }
+    }>
+  }
+}
+
+export type CutValidationResult =
+  | { kind: 'ready'; parsed: ParsedCut }
+  | { kind: 'body-error'; parsed: ParsedCut; errors: readonly ValidationError[] }
+  | { kind: 'self-reference'; parsed: ParsedCut }
+  | { kind: 'dep-invalid'; parsed: ParsedCut; depNumber: number; reason: 'not-found' | 'not-a-cut' }
+  | { kind: 'dep-open'; parsed: ParsedCut; openDeps: readonly number[] }
+  | { kind: 'dep-rejected'; parsed: ParsedCut; depNumber: number }
+
+/**
+ * Validate a cut sub-issue body + dep references against the live tree.
+ *
+ * Step 1: parse the body.
+ * Step 2: structural validation via cut-parser's `validateParsedCut`.
+ *         - self-reference → return immediately with spec-too-vague.
+ *         - other body errors → return body-error.
+ * Step 3: per-dep lookup via octokit.
+ *         - 404 → dep-invalid (not-found)
+ *         - not labeled `enhancement` → dep-invalid (not-a-cut)
+ *         - state: 'open' → dep-open (wait, no labels applied by caller)
+ *         - closed-not-merged → dep-rejected
+ * Step 4: all deps OK → return ready.
+ *
+ * The orchestrator routes each result to a distinct action:
+ *   - body-error → comment + `needs-info` label
+ *   - self-reference → `ready-for-human` + skip-list (spec-too-vague)
+ *   - dep-invalid → comment + `needs-info`
+ *   - dep-open → comment "wait for #N" + NO labels (retry next cron)
+ *   - dep-rejected → `ready-for-human` + skip-list
+ *   - ready → proceed to generator-critic loop
+ *
+ * Error priority when multiple deps fail: dep-invalid > dep-rejected >
+ * dep-open. Most-terminal first matches the orchestrator's action
+ * granularity (invalid/rejected require maintainer; open just needs
+ * patience).
+ */
+export async function validateCutSubIssue(
+  octokit: IssuesGetClient,
+  repo: RepoIdentity,
+  ownIssueNumber: number,
+  body: string,
+): Promise<CutValidationResult> {
+  const parsed = parseCutBody(body)
+  const errors = validateParsedCut(parsed, ownIssueNumber)
+
+  // Self-reference is a more terminal failure than missing-required-section —
+  // it implies the author intended the cut to depend on itself, which is
+  // structurally broken. Surface it as spec-too-vague.
+  const selfRef = errors.find(e => e.kind === 'invalid-dep-ref' && e.reason === 'self-reference')
+  if (selfRef) {
+    return { kind: 'self-reference', parsed }
+  }
+
+  // Other body errors (missing-feature, missing-required-section) → body-error.
+  // These need a maintainer to edit the sub-issue body.
+  const bodyErrors = errors.filter(e => e.kind !== 'invalid-dep-ref')
+  if (bodyErrors.length > 0) {
+    return { kind: 'body-error', parsed, errors: bodyErrors }
+  }
+
+  // No body errors. Validate deps against live tree.
+  const openDeps: number[] = []
+  let firstInvalid: { depNumber: number; reason: 'not-found' | 'not-a-cut' } | null = null
+  let firstRejected: number | null = null
+
+  for (const depNumber of parsed.dependsOn) {
+    const lookup = await lookupDep(octokit, repo, depNumber)
+    if (lookup.kind === 'not-found' || lookup.kind === 'not-a-cut') {
+      if (firstInvalid === null) {
+        firstInvalid = { depNumber, reason: lookup.kind }
+      }
+      continue
+    }
+    if (lookup.kind === 'open') {
+      openDeps.push(depNumber)
+      continue
+    }
+    if (lookup.kind === 'closed-not-merged') {
+      if (firstRejected === null) {
+        firstRejected = depNumber
+      }
+      continue
+    }
+    // closed-merged — proceed.
+  }
+
+  // Priority: invalid > rejected > open.
+  if (firstInvalid !== null) {
+    return { kind: 'dep-invalid', parsed, depNumber: firstInvalid.depNumber, reason: firstInvalid.reason }
+  }
+  if (firstRejected !== null) {
+    return { kind: 'dep-rejected', parsed, depNumber: firstRejected }
+  }
+  if (openDeps.length > 0) {
+    return { kind: 'dep-open', parsed, openDeps }
+  }
+  return { kind: 'ready', parsed }
+}
+
+type DepLookup =
+  | { kind: 'not-found' }
+  | { kind: 'not-a-cut' }
+  | { kind: 'open' }
+  | { kind: 'closed-merged' }
+  | { kind: 'closed-not-merged' }
+
+async function lookupDep(octokit: IssuesGetClient, repo: RepoIdentity, depNumber: number): Promise<DepLookup> {
+  try {
+    const { data } = await octokit.issues.get({
+      owner: repo.owner,
+      repo: repo.repo,
+      issue_number: depNumber,
+    })
+    const labels = data.labels.map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean)
+    if (!labels.includes('enhancement')) {
+      return { kind: 'not-a-cut' }
+    }
+    if (data.state === 'open') {
+      return { kind: 'open' }
+    }
+    // closed. `state_reason: 'completed'` = merged-via-PR; anything else
+    // ('not_planned' / null) = closed without merging.
+    if (data.state_reason === 'completed') {
+      return { kind: 'closed-merged' }
+    }
+    return { kind: 'closed-not-merged' }
+  } catch (err) {
+    if ((err as { status?: number }).status === 404) {
+      return { kind: 'not-found' }
+    }
+    throw err
+  }
+}


### PR DESCRIPTION
## Summary

Cut 3 of feature-bot per [design-feature-bot.md](.claude/rules/design-feature-bot.md).
Replaces the Cut 1 skeleton with the full generator-critic loop wiring
Agent A (per-cut.md) → Agent B (reviewer.md) → three-tier escalation
(APPROVE / NEEDS_INPUT / NEEDS_HUMAN).

Two commits, TDD-first per [rule 31](.claude/rules/team-preferences.md):

1. **`test(feature-bot)`** — failing tests pinning the four contracts
   (agent-a-signal parser, route-attempt routing, validate-cut-sub-issue
   dep validation, decideIdempotency rule).
2. **`feat(feature-bot)`** — implementation.

## Q-locks honored

- **Q3** — pre-Claude validation gate (`validateCutSubIssue`) loud-fails
  on missing **Feature**, missing required sections, invalid dep refs,
  self-reference. No Claude invocation on body errors.
- **Q5** — `prompts/per-cut.md` instructs Agent A to read the design doc
  at `.claude/rules/design-{FEATURE_SLUG}.md` BEFORE writing code. No
  design-doc inlining.
- **Q6** — three-tier escalation:
  - APPROVE → push branch + open draft PR
  - NEEDS_INPUT (cycle < MAX_INPUT_CYCLES=2) → post structured question +
    `needs-info` label + reset working tree
  - NEEDS_INPUT (cycle = MAX_INPUT_CYCLES) → escalate `input-cycles-exceeded`
  - NEEDS_HUMAN → escalate with reason-code (`missing-prereq` /
    `spec-too-vague` / `files-conflict` / `needs-human`)
- **Q7** — 8-value `SkipReason` union threaded through the orchestrator;
  outcome tags on escalation comments + skip-list PRs include the reason
  for forensic queries.
- **Rule 38** (audit symmetric bots) — `escalateToHuman` matches fix-bot's
  4-step shape (local skip-list write → draft PR → escalation comment →
  ready-for-human label). `decideIdempotency` mirrors fix-bot's
  auto-clear-on-reopen rule.

## Test plan

- [x] All 48 feature-bot tests pass (7 existing + 41 new)
- [x] All 448 bot tests pass (no regression)
- [x] `tsc --noEmit` clean (`npx tsc -p bots/tsconfig.json --noEmit`)
- [x] `npm run format:check` clean
- [x] Verified TDD-revertibility: stashing impl files re-fails the 4 new
      test files at the import boundary

## Boundaries

- Did NOT touch `bots/_lib/cut-parser.ts` (Cut 2's lock)
- Did NOT touch fix-bot or any other existing bot
- Did NOT add `.github/workflows/feature-bot.yml` (Cut 4 scope)
- Did NOT touch `.claude/rules/` files (Cuts 5+6 already shipped)

## Reviewer notes

The structural choice this PR makes: **split agent-a-signal parsing from
reviewer-verdict parsing** rather than extending the existing union.
Different signal grammars (NEEDS_INPUT block vs `VERDICT:` line),
different consumers (parses Agent A vs Agent B), so SRP wins. Pure
modules with no I/O — orchestrator owns the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)