### PR TITLE
feat(feature-bot): require runtime exercise as proof per execution path

### DIFF
--- a/bots/feature-bot/prompts/per-cut.md
+++ b/bots/feature-bot/prompts/per-cut.md
@@ -103,7 +103,97 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    ```
 4. Implement the cut. Verify GREEN.
 5. Run the wider test suite. Confirm no regressions.
-6. Commit:
+6. **RUNTIME EXERCISE — prove the code works on every execution path.**
+
+   After tests pass, run the code with concrete inputs that prove EACH
+   execution path the acceptance criteria imply. Most acceptance bullets
+   have more than one path: the happy path, every error / refusal /
+   rejection path, and any branching the spec describes (validation
+   modes, capability gates, conflict outcomes, etc.). Each path is its
+   own proof; one happy-path run isn't enough.
+
+   This is comprehension-grounding, not tautology-creating: declare
+   expected outputs FROM acceptance criteria BEFORE running; iterate
+   impl if observed ≠ expected.
+
+   For each acceptance bullet, enumerate the paths it implies:
+   - **Happy path** — the bullet's primary success surface
+   - **Error / rejection paths** — every error code, refusal, 4xx, or
+     "blocks when" the bullet (or its referenced spec) names
+   - **Conditional branches** — when the bullet says "if X then A else
+     B," both arms are paths
+   - **State-shape variants** — if the bullet exercises a structure
+     that varies (locale variants, archived vs. live, capability
+     present vs. absent), each variant is a path
+
+   For each path:
+   - Construct an input that exercises specifically that path
+   - Write down the EXPECTED output derived from the bullet (status
+     code, response shape, file contents, error message, audit entry,
+     whatever the bullet promises for that path)
+   - Run the code. **Use whatever runs the code** — pick the cheapest
+     shape that exercises the path:
+     - `node -e '...'` one-liner against an exported helper
+     - `node --input-type=module -e '...'` for ESM-only modules
+     - A `tmp-exercise.ts` / `tmp-exercise.mjs` script that boots
+       `createAdminApp()` and fires requests, logging responses
+     - A direct CLI invocation (`npx gazetta <command>`) for CLI cuts
+     - A shell pipeline orchestrating multiple steps
+     - Anything else that gets real bytes through the code
+     **Do NOT use vitest / unit tests as the runtime exercise.** Tests
+     are the TDD contract (committed, kept, run by CI); the runtime
+     exercise is comprehension-grounding (throwaway, never committed).
+     Mixing them defeats the anti-tautology purpose — the test you
+     would have written to "prove" the path is the same test that
+     might be tautological in the first place.
+     If you create temp files for the exercise, prefix them `tmp-` (or
+     put them under `/tmp/`) and **delete them before committing** —
+     they MUST NOT appear in the diff. The exercise output goes in
+     the `SUMMARY:` block; whatever produced it is throwaway.
+   - Capture the ACTUAL output (paste verbatim into your notes)
+   - Compare actual ≠ expected → impl is wrong on this path → iterate
+   - Compare actual = expected → path validated
+
+   A bullet is only proved when **every path it implies has its own
+   captured input + actual output**. A bullet with three error paths
+   needs at least four exercises (one happy + three error). A bullet
+   with no errors and no branches may be one exercise.
+
+   **Use the exercise to discover edge cases the spec didn't enumerate.**
+   While exercising the cut, probe boundaries the acceptance bullets
+   don't mention explicitly. Common edge cases worth a try:
+   - Empty / null / undefined inputs
+   - Boundary values (0, max, off-by-one)
+   - Unicode / encoding edge cases
+   - Concurrent / race conditions (when multi-instance discipline applies)
+   - Locale variants (when `design-i18n.md` applies)
+   - Theme variants (when `design-themes.md` applies)
+   - Every error path the acceptance criteria implies (one input per
+     error code)
+
+   For each edge case the exercise surfaces:
+   - **Spec-addressed + test-covered**: nothing to do; the exercise just
+     confirms behavior matches the existing test.
+   - **Spec-silent + behavior obvious + low-risk**: add a test for it
+     (this strengthens the test suite without dragging in spec
+     ambiguity).
+   - **Spec-silent + behavior uncertain OR contradicts another rule**:
+     emit `NEEDS_INPUT` per Q6 lock, citing the discovered edge case.
+     Don't guess; ask.
+
+   **Capture the exercise output in your `SUMMARY:` block** under a
+   `Runtime exercise:` heading. Show each acceptance bullet, then each
+   path of that bullet with its input + actual output. Use brief prose;
+   the orchestrator surfaces this in the PR body for maintainer review.
+
+7. **Refine your tests** if the exercise surfaced edge cases worth
+   covering. Tests-first (per rule 31) pinned the acceptance contract;
+   tests added after the exercise pin the edge cases the spec didn't
+   enumerate. Amend the test commit (`git commit --amend`) to include
+   the new test cases — keep them in the failing-test commit so the
+   TDD-first ordering is preserved.
+
+8. Commit:
    ```bash
    git add <impl files>
    git commit -m "feat(<area>): cut #$ISSUE_NUMBER — <short summary>
@@ -114,13 +204,19 @@ Closes #$ISSUE_NUMBER
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    ```
-7. End with a `SUMMARY:` block as your last output:
+9. End with a `SUMMARY:` block as your last output:
 
    ```
    SUMMARY:
    <2-4 sentences: what the cut delivered, how the failing test pins it,
    which design-doc locked decisions it implements. Plain prose; no
    headings, no bullets, no code blocks inside the summary.>
+
+   Runtime exercise:
+   <For each acceptance bullet, list each execution path it implies
+   (happy + every error / branch / variant) with the input you ran and
+   the actual output. Keep it under ~50 lines total. The orchestrator
+   includes this in the PR body for maintainer review.>
    ```
 
 The orchestrator extracts `SUMMARY:` and puts it in the PR body.

--- a/bots/feature-bot/prompts/reviewer.md
+++ b/bots/feature-bot/prompts/reviewer.md
@@ -16,6 +16,7 @@ necessary but not sufficient. The failure modes you catch:
 |---|---|
 | **Tautological test** | The test was shaped to match the impl, not the acceptance criterion. Reverting the impl → test still passes |
 | **Missed acceptance bullet** | One of the cut's `## Acceptance` items isn't pinned by any test or isn't implemented |
+| **Missing or unconvincing runtime exercise** | Agent A's `SUMMARY:` doesn't include a `Runtime exercise:` section, OR a bullet has no exercise, OR a bullet's exercise only covers the happy path while the bullet implies error / branch / variant paths, OR a captured "actual output" doesn't match what the bullet promises. Each path is its own proof — partial coverage is unproved coverage |
 | **SOLID violation** | The `## SOLID` section names SRP/OCP/etc lenses Agent A didn't honor (god module, fused concerns, stub-that-throws on an interface) |
 | **Locked-decision deviation** | The diff contradicts a `## Locked decisions` row in the design doc |
 | **Scope creep** | Diff includes unrelated refactors / renamings / "while I'm here" cleanups |
@@ -26,7 +27,7 @@ You issue one of three verdicts at the END of your output:
 
 | Verdict | When |
 |---|---|
-| `APPROVE` | All checks pass: tautology, acceptance bullets pinned, SOLID lenses honored, locked decisions match, scope tight. |
+| `APPROVE` | All checks pass: tautology, acceptance bullets pinned, runtime exercise proves each bullet, SOLID lenses honored, locked decisions match, scope tight. |
 | `REJECT` | One or more checks fail AND Agent A can fix on retry. Provide `Note:` with specific guidance. |
 | `NEEDS_HUMAN` | Structural problem; retry won't help. Maintainer should look. |
 
@@ -132,6 +133,48 @@ The acceptance section is the cut's contract with the maintainer.
 Skipping a bullet is grounds for REJECT regardless of how clean the
 diff otherwise looks.
 
+## The runtime-exercise check
+
+**Agent A must prove the code works on every execution path** — not
+just that tests pass, but that real inputs produce the outputs the
+acceptance bullets promise, for each path each bullet implies. The
+`Runtime exercise:` section in Agent A's `SUMMARY:` block is that
+proof. A bullet with three error paths needs four proofs (happy + three
+error). A bullet with two branches needs two proofs. One per path.
+
+Read Agent A's final `SUMMARY:` block. Look for the `Runtime exercise:`
+subsection. For each acceptance bullet:
+
+1. **Enumerate the paths the bullet implies.** Re-read the bullet (and
+   the spec it references). List the paths:
+   - The happy path (always)
+   - Each error / refusal / rejection the bullet names
+   - Each conditional arm (when the bullet says "if X then A else B,"
+     both A and B are paths)
+   - Each state-shape variant (locale, archived vs. live, capability
+     present vs. absent — when the bullet's surface varies by these)
+2. **Check coverage.** Does Agent A's exercise show each path with its
+   own input + actual output?
+3. **Check correctness.** For each captured output, does it match what
+   the bullet promises for that specific path?
+4. **Check input quality.** A trivial smoke ("function returned without
+   throwing") doesn't prove a path. The path's discriminator should be
+   visible in the input.
+
+| State | Effect |
+|---|---|
+| Every bullet's every path has its own exercise + outputs match promises | OK |
+| `Runtime exercise:` section missing entirely | **REJECT** — "Re-run with the runtime exercise per the per-cut prompt's APPROVE-path step 6. The exercise IS the proof the cut delivers." |
+| Some bullets have no exercise | **REJECT** — name which bullets are unproven |
+| A bullet has happy-path proof but error / branch / variant paths are unproven | **REJECT** — list the unproven paths ("Bullet 2 implies 409 on live-name collision + 409 on archived-name collision + 409 on missing alias target; only the happy path was exercised") |
+| A captured output doesn't match its bullet's promise | **REJECT** — name the path + cite the mismatch ("Bullet 3 says 201 on success; exercise showed 200") |
+| Exercise present but trivial / unconvincing | **REJECT** — name what a real exercise would show |
+
+The runtime exercise is the bridge between "tests pass" (which can be
+tautological) and "the cut actually delivers what was promised on every
+path it touches." Agent A demonstrates comprehension by proving each
+path; the reviewer verifies the demonstration was real and complete.
+
 ## The SOLID check (Cut 5 refinement)
 
 If the cut sub-issue has a `## SOLID` section, read it. The section
@@ -182,6 +225,24 @@ After the four above pass, also check:
   all of them. The cut prompt explicitly forbids "while I'm here"
   cleanups.
 
+Also check for leftover runtime-exercise scratch:
+- Files starting with `tmp-` (e.g. `tmp-exercise.ts`, `tmp-exercise.mjs`,
+  `tmp-exercise.sh`)
+- Any obvious throwaway harness whose only purpose is exercising the
+  cut at runtime
+
+These MUST NOT appear in the diff. **REJECT** with note to remove
+them — they belonged in Agent A's local working tree only.
+
+Separately: if a test file in the diff looks like it was written as
+the runtime exercise rather than as a real TDD test (e.g.,
+`tests/exercise-cut.test.ts` with only `console.log` style assertions,
+or a test that just prints values rather than asserting on them), that
+violates the anti-tautology discipline. The runtime exercise is
+throwaway proof; tests are the durable spec. **REJECT** with note to
+either delete the file (it was a runtime exercise) or rewrite it as
+real assertions (it was meant to be a test).
+
 ### Commit message accuracy
 
 Read the commit messages (`git log main..$BRANCH_NAME --format=%B`).
@@ -197,15 +258,17 @@ wrong (says one thing but the diff does another).
 
 1. Run the 4-step tautology check
 2. Run the acceptance check (every bullet pinned)
-3. Run the SOLID check (when `## SOLID` is present)
-4. Run the locked-decisions check (against the design doc)
-5. Run the non-mechanical checks (scope, commit messages)
-6. Form your verdict and emit the verdict line at the END:
+3. Run the runtime-exercise check (Agent A proved the code works)
+4. Run the SOLID check (when `## SOLID` is present)
+5. Run the locked-decisions check (against the design doc)
+6. Run the non-mechanical checks (scope, commit messages)
+7. Form your verdict and emit the verdict line at the END:
 
 ```
 VERDICT: APPROVE
 Reasoning: <one paragraph why the cut is sound — name the load-bearing
-checks that passed>
+checks that passed, including which runtime-exercise outputs prove
+which acceptance bullets>
 ```
 
 ```


### PR DESCRIPTION
## Summary

- Agent A must prove the code works on every execution path each acceptance bullet implies — happy path AND each error / branch / variant. One per path, not one per bullet.
- Latitude on the exercise mechanism: `node -e`, `tmp-exercise.*` scripts, CLI invocations, shell pipelines. **Not** vitest — tests are the TDD contract; the exercise is throwaway comprehension-grounding; mixing them defeats the anti-tautology purpose.
- Temp files prefixed `tmp-`, deleted before commit.
- Agent B verifies path coverage per bullet AND output correctness; rejects on missing paths, leftover scratch files, or test files shaped like runtime exercises.

## Why

Existing TDD contract proves "tests pass" — which can still be tautological per [team-preferences rule 31](.claude/rules/team-preferences.md). The runtime exercise closes the gap: real inputs, real outputs, captured in the PR body for maintainer review. A bullet with three error paths needs four proofs (happy + three error). Partial coverage is unproved coverage.

## Test plan

- [ ] Trigger feature-bot manually against cut sub-issue #445 (Cut 2: Audit enum extension) — small enough to validate the new discipline without a full credential-heavy cut
- [ ] Verify Agent A's `SUMMARY:` includes a `Runtime exercise:` subsection with input + actual output per acceptance bullet
- [ ] Verify Agent B's reviewer output cites the runtime-exercise check as a load-bearing pass in its APPROVE reasoning (or rejects with specific path-coverage feedback)
- [ ] Confirm no `tmp-*` files leak into the PR diff
- [ ] If the bot run completes APPROVE → admin-merge the resulting cut PR; if REJECT → iterate prompt based on the reviewer's specific feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)