### PR TITLE
fix(feature-bot): surface Runtime exercise in PR body + reject test-as-exercise

### DIFF
--- a/bots/_lib/tests/transcript.test.ts
+++ b/bots/_lib/tests/transcript.test.ts
@@ -89,13 +89,27 @@ describe('extractSummary', () => {
     )
   })
 
-  it('stops at the first blank-line boundary inside the SUMMARY block', () => {
-    // Prevents trailing chatter ("Now I will...") from being included
-    // when the agent keeps talking after the marker.
+  it('captures the full block including subsections separated by blank lines', () => {
+    // Per PR #456 fix: the SUMMARY block carries subsections (e.g.
+    // `Runtime exercise:`) separated from the lead prose by blank lines.
+    // The whole block must reach the PR body so the maintainer sees
+    // the per-path proof, not just the prose intro.
     const path = writeJsonl([
-      assistant('SUMMARY:\nRemoved foo.ts; no callers.\n\nNow I will run the tests and commit.'),
+      assistant('SUMMARY:\nRemoved foo.ts; no callers.\n\nRuntime exercise:\nBullet 1, happy path: input=X, output=Y'),
     ])
-    expect(extractSummary(path)).toBe('Removed foo.ts; no callers.')
+    expect(extractSummary(path)).toBe(
+      'Removed foo.ts; no callers.\n\nRuntime exercise:\nBullet 1, happy path: input=X, output=Y',
+    )
+  })
+
+  it('extracts SUMMARY when it appears mid-message followed by other content', () => {
+    // The SUMMARY marker can sit inside a longer assistant message.
+    // We capture from the marker to the end of THAT message — trailing
+    // narration after the marker is intentional content (e.g., subsections).
+    const path = writeJsonl([
+      assistant('Working on it.\n\nSUMMARY:\nThe cut shipped clean.\n\nRuntime exercise:\nAll 4 paths passed.'),
+    ])
+    expect(extractSummary(path)).toBe('The cut shipped clean.\n\nRuntime exercise:\nAll 4 paths passed.')
   })
 
   it('returns empty string when no assistant text exists', () => {

--- a/bots/_lib/transcript.ts
+++ b/bots/_lib/transcript.ts
@@ -56,25 +56,37 @@ export function extractLastAssistantText(transcriptPath: string): string {
  *   SUMMARY:
  *   <2-4 sentences describing the change>
  *
- * We walk every assistant `text` block (newest first) and return the
- * content after the LAST `SUMMARY:` marker. Falls back to the final
- * assistant message when no marker is present — keeps the bot working
- * against older transcripts and against responses that miss the
- * convention (which still happens occasionally in practice).
+ *   Runtime exercise:
+ *   <per-bullet, per-path input + actual output>
+ *
+ * We walk every assistant `text` block (newest first) and return all
+ * content after the LAST `SUMMARY:` marker — including subsections
+ * like `Runtime exercise:` that are separated from the lead prose by
+ * blank lines. Falls back to the final assistant message when no
+ * marker is present — keeps the bot working against older transcripts
+ * and against responses that miss the convention (which still happens
+ * occasionally in practice).
  *
  * History: the dead-code-watcher v2 run on 2026-05-14 (PR #376) showed
- * why this matters. Agent A's last text block was "Committed locally
- * on ... not pushing per generator-critic instructions" — agent
- * narrating its own protocol. The substantive summary was in an
- * EARLIER block, so the PR body led with protocol verbiage instead
- * of the change description. The SUMMARY: marker fixes the positional
- * ambiguity.
+ * why the marker matters — Agent A's last text block was protocol
+ * narration ("Committed locally..."), so the substantive summary in
+ * an earlier block was lost. The feature-bot run on 2026-05-30
+ * (PR #456) showed why we need the WHOLE block, not just the lead
+ * paragraph: Agent A's `Runtime exercise:` subsection — the proof
+ * that the cut works on every path — was truncated because the
+ * regex stopped at the first blank line.
  */
 export function extractSummary(transcriptPath: string): string {
   const all = collectAssistantTexts(transcriptPath)
   for (let i = all.length - 1; i >= 0; i--) {
-    const match = all[i].match(/SUMMARY:\s*\n?([\s\S]*?)(?:\n\n|\n*$)/i)
-    if (match?.[1]?.trim()) return match[1].trim()
+    const text = all[i]
+    const idx = text.search(/SUMMARY:\s*\n?/i)
+    if (idx === -1) continue
+    const afterMarker = text
+      .slice(idx)
+      .replace(/^SUMMARY:\s*\n?/i, '')
+      .trim()
+    if (afterMarker) return afterMarker
   }
   return all.at(-1) ?? ''
 }

--- a/bots/feature-bot/prompts/reviewer.md
+++ b/bots/feature-bot/prompts/reviewer.md
@@ -16,7 +16,7 @@ necessary but not sufficient. The failure modes you catch:
 |---|---|
 | **Tautological test** | The test was shaped to match the impl, not the acceptance criterion. Reverting the impl → test still passes |
 | **Missed acceptance bullet** | One of the cut's `## Acceptance` items isn't pinned by any test or isn't implemented |
-| **Missing or unconvincing runtime exercise** | Agent A's `SUMMARY:` doesn't include a `Runtime exercise:` section, OR a bullet has no exercise, OR a bullet's exercise only covers the happy path while the bullet implies error / branch / variant paths, OR a captured "actual output" doesn't match what the bullet promises. Each path is its own proof — partial coverage is unproved coverage |
+| **Missing or unconvincing runtime exercise** | Agent A's `SUMMARY:` doesn't include a `Runtime exercise:` section, OR claims unit tests "double as" the exercise (forbidden — tests are TDD contract, exercise is throwaway proof), OR a bullet has no exercise, OR a bullet's exercise only covers the happy path while the bullet implies error / branch / variant paths, OR a captured "actual output" doesn't match what the bullet promises. Each path is its own proof — partial coverage is unproved coverage |
 | **SOLID violation** | The `## SOLID` section names SRP/OCP/etc lenses Agent A didn't honor (god module, fused concerns, stub-that-throws on an interface) |
 | **Locked-decision deviation** | The diff contradicts a `## Locked decisions` row in the design doc |
 | **Scope creep** | Diff includes unrelated refactors / renamings / "while I'm here" cleanups |
@@ -141,6 +141,21 @@ acceptance bullets promise, for each path each bullet implies. The
 `Runtime exercise:` section in Agent A's `SUMMARY:` block is that
 proof. A bullet with three error paths needs four proofs (happy + three
 error). A bullet with two branches needs two proofs. One per path.
+
+**Unit tests are NOT the runtime exercise.** Tests are the TDD contract
+(committed, kept, run by CI); the exercise is throwaway proof Agent A
+ran the code outside the test harness. Even if Agent A's tests are
+exhaustive, you cannot accept "the Zod-parse tests double as the
+runtime exercise" or "the tests cover each path so no separate
+exercise is needed" as substitute for an explicit `Runtime exercise:`
+subsection. The exercise's purpose is anti-tautology: it proves
+comprehension by running the code in a SECOND shape (a `tmp-` script,
+a `node -e` invocation, a CLI call) — the same shape that produced
+the tests can't also prove them.
+
+If Agent A's SUMMARY has no `Runtime exercise:` subsection, REJECT —
+even when tests cover every path. Agent A may have skipped the exercise
+entirely (vs. surfaced it).
 
 Read Agent A's final `SUMMARY:` block. Look for the `Runtime exercise:`
 subsection. For each acceptance bullet:


### PR DESCRIPTION
## Summary

PR #456 (the first run of #445 under the runtime-exercise discipline shipped in #455) surfaced two prompt holes:

1. **Orchestrator truncated Agent A's SUMMARY** — \`extractSummary()\`'s regex stopped at the first blank line, dropping the \`Runtime exercise:\` subsection. The PR body got the lead paragraph but lost the per-path proof.
2. **Reviewer accepted \"tests double as the exercise\"** — Agent B's APPROVE reasoning on #456 literally said \"The Zod-parse tests double as the runtime exercise for this type-only cut,\" which the per-cut prompt forbids.

Cut #445 itself was sound — Agent A did run \`/tmp/exercise-cut-445.mjs\` against 14 paths — but the prompts didn't surface or enforce the discipline.

## Fixes

- **\`bots/_lib/transcript.ts\`** — \`extractSummary()\` now returns the full block from \`SUMMARY:\` to end-of-message, including blank-line-separated subsections. The PR body will carry the \`Runtime exercise:\` section verbatim.
- **\`bots/_lib/tests/transcript.test.ts\`** — replaced the \"stops at first blank line\" test (wrong contract) with two new tests pinning the widened behavior.
- **\`bots/feature-bot/prompts/reviewer.md\`** — added explicit \"Unit tests are NOT the runtime exercise\" paragraph; widened the failure-mode row to call out the tests-double-as-exercise anti-pattern.

## Test plan

- [ ] CI: 12 transcript tests pass
- [ ] Re-trigger feature-bot against #445 after merge
- [ ] Verify Agent A's \`Runtime exercise:\` subsection now appears verbatim in the new PR body's \"What Agent A did\" section
- [ ] Verify Agent B's reviewer reasoning no longer claims tests substitute for the exercise

🤖 Generated with [Claude Code](https://claude.com/claude-code)