### PR TITLE
fix(feature-bot): give reviewer Agent A's SUMMARY directly, not via gh pr view

### DIFF
--- a/bots/_lib/tests/transcript.test.ts
+++ b/bots/_lib/tests/transcript.test.ts
@@ -112,6 +112,21 @@ describe('extractSummary', () => {
     expect(extractSummary(path)).toBe('The cut shipped clean.\n\nRuntime exercise:\nAll 4 paths passed.')
   })
 
+  it('ignores in-prose SUMMARY: mentions and uses the conventional line-start marker', () => {
+    // Reproduces the bug surfaced by feature-bot attempt 3 of cut #445:
+    // Agent A's narration referenced the marker in a backtick-quoted
+    // phrase ("the proper `SUMMARY:` block...") BEFORE emitting the
+    // real one at line-start. The first-match regex grabbed the
+    // in-prose mention and returned garbage. Line-anchored (^...\m)
+    // + take-last-match fixes both axes.
+    const path = writeJsonl([
+      assistant(
+        'I will now emit the proper `SUMMARY:` block.\n\n```\nSUMMARY:\nThe cut shipped clean.\n\nRuntime exercise:\nAll paths verified.\n```',
+      ),
+    ])
+    expect(extractSummary(path)).toBe('The cut shipped clean.\n\nRuntime exercise:\nAll paths verified.\n```')
+  })
+
   it('returns empty string when no assistant text exists', () => {
     expect(extractSummary(writeJsonl([]))).toBe('')
   })

--- a/bots/_lib/transcript.ts
+++ b/bots/_lib/transcript.ts
@@ -80,12 +80,19 @@ export function extractSummary(transcriptPath: string): string {
   const all = collectAssistantTexts(transcriptPath)
   for (let i = all.length - 1; i >= 0; i--) {
     const text = all[i]
-    const idx = text.search(/SUMMARY:\s*\n?/i)
-    if (idx === -1) continue
-    const afterMarker = text
-      .slice(idx)
-      .replace(/^SUMMARY:\s*\n?/i, '')
-      .trim()
+    // Match the LAST `SUMMARY:` marker at line-start (anchored via \m).
+    // Two refinements over the naive search:
+    //   1) Line-start anchor (`^...\m`) excludes in-prose mentions like
+    //      "I'll emit the `SUMMARY:` block now" — those have backticks
+    //      or other characters in front, not a newline.
+    //   2) LAST occurrence (we iterate right-to-left over matches) —
+    //      agents sometimes preview the marker in prose then re-emit it
+    //      as the conventional terminator.
+    const matches = [...text.matchAll(/^SUMMARY:\s*\n?/gim)]
+    if (matches.length === 0) continue
+    const last = matches[matches.length - 1]
+    const start = (last.index ?? 0) + last[0].length
+    const afterMarker = text.slice(start).trim()
     if (afterMarker) return afterMarker
   }
   return all.at(-1) ?? ''

--- a/bots/feature-bot/index.ts
+++ b/bots/feature-bot/index.ts
@@ -389,6 +389,7 @@ RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
           )
           printTranscriptPath(reviewerTranscript)
 
+          const agentASummary = extractSummary(agentATranscript)
           const reviewerPrompt = `${reviewerPromptTemplate}
 
 ISSUE_NUMBER=${issueNumber}
@@ -404,6 +405,9 @@ ${diff}
 
 COMMIT_MESSAGES=
 ${commitMessages}
+
+AGENT_A_SUMMARY=
+${agentASummary || '(no SUMMARY block captured from Agent A — REJECT with note: your run did not emit a SUMMARY block; emit one per the per-cut prompt APPROVE-path step 9)'}
 
 RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
 

--- a/bots/feature-bot/prompts/reviewer.md
+++ b/bots/feature-bot/prompts/reviewer.md
@@ -42,6 +42,13 @@ You issue one of three verdicts at the END of your output:
   was supposed to address
 - `DIFF` — `git diff main..$BRANCH_NAME` output (snapshot Agent A produced)
 - `COMMIT_MESSAGES` — `git log main..$BRANCH_NAME --format=%B%n---`
+- `AGENT_A_SUMMARY` — the `SUMMARY:` block Agent A emitted at the end
+  of its run (lead prose + `Runtime exercise:` subsection). This is
+  YOUR source of truth for the runtime-exercise check. **There is no
+  open PR yet** — the orchestrator opens the PR only after you
+  APPROVE. Do NOT call `gh pr view` looking for the exercise; do NOT
+  inspect closed PRs from prior attempts (those carry stale bodies
+  from rejected attempts and will mislead you).
 - `RUN_ID` — diagnostic only
 
 ## READ these BEFORE judging
@@ -153,12 +160,19 @@ comprehension by running the code in a SECOND shape (a `tmp-` script,
 a `node -e` invocation, a CLI call) — the same shape that produced
 the tests can't also prove them.
 
-If Agent A's SUMMARY has no `Runtime exercise:` subsection, REJECT —
+If `AGENT_A_SUMMARY` has no `Runtime exercise:` subsection, REJECT —
 even when tests cover every path. Agent A may have skipped the exercise
 entirely (vs. surfaced it).
 
-Read Agent A's final `SUMMARY:` block. Look for the `Runtime exercise:`
-subsection. For each acceptance bullet:
+**Where to find the SUMMARY**: read the `AGENT_A_SUMMARY` block in the
+inputs appended below. That IS Agent A's final SUMMARY, extracted from
+its transcript. **Do not** `gh pr view` looking for the exercise — no
+PR exists yet (the orchestrator opens it AFTER you APPROVE). **Do not**
+inspect closed PRs from prior attempts on this branch — those carry
+stale bodies from rejected attempts and will mislead you.
+
+In `AGENT_A_SUMMARY`, look for the `Runtime exercise:` subsection. For
+each acceptance bullet:
 
 1. **Enumerate the paths the bullet implies.** Re-read the bullet (and
    the spec it references). List the paths:


### PR DESCRIPTION
## Summary

Run #26695345255 (the re-run of #445 after #457's prompt fixes) hung at attempt 3 in a generator-critic loop. Root cause: Agent B's reviewer prompt told it to read Agent A's \`SUMMARY:\` block, but the prompt only had \`ISSUE_BODY\`/\`DIFF\`/\`COMMIT_MESSAGES\` inputs — no \`AGENT_A_SUMMARY\`. The reviewer reached for \`gh pr view\` as a fallback, found CLOSED PR #456 from a prior attempt, and rejected on its stale \"tests double as exercise\" body. Each retry hit the same stale artifact.

## Fixes

- **\`bots/feature-bot/index.ts\`** — pass \`extractSummary(agentATranscript)\` into the reviewer prompt as \`AGENT_A_SUMMARY=...\`. Same extraction the PR-body code already uses; reviewer now sees the runtime exercise before approving.
- **\`bots/feature-bot/prompts/reviewer.md\`** — document \`AGENT_A_SUMMARY\` as the source of truth for the runtime-exercise check. Explicitly forbid \`gh pr view\` (no PR exists yet — the orchestrator opens it AFTER APPROVE) and explicitly forbid inspecting closed PRs from prior attempts (they carry stale rejected bodies).

## Test plan

- [ ] CI green
- [ ] Clear \`feature-bot-attempted\` label from #445, re-trigger feature-bot
- [ ] Verify Agent B's transcript shows it reading \`AGENT_A_SUMMARY\` (not \`gh pr view\`)
- [ ] Verify the resulting PR body carries Agent A's \`Runtime exercise:\` subsection
- [ ] Verify Agent B's APPROVE reasoning cites the runtime-exercise paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)