### PR TITLE
fix(feature-bot): run Biome format before impl commit (closes #462)

### DIFF
--- a/bots/feature-bot/index.ts
+++ b/bots/feature-bot/index.ts
@@ -407,7 +407,7 @@ COMMIT_MESSAGES=
 ${commitMessages}
 
 AGENT_A_SUMMARY=
-${agentASummary || '(no SUMMARY block captured from Agent A — REJECT with note: your run did not emit a SUMMARY block; emit one per the per-cut prompt APPROVE-path step 9)'}
+${agentASummary || '(no SUMMARY block captured from Agent A — REJECT with note: your run did not emit a SUMMARY block; emit one per the per-cut prompt APPROVE-path step 10)'}
 
 RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
 

--- a/bots/feature-bot/prompts/per-cut.md
+++ b/bots/feature-bot/prompts/per-cut.md
@@ -181,8 +181,8 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
      emit `NEEDS_INPUT` per Q6 lock, citing the discovered edge case.
      Don't guess; ask.
 
-   **Capture the exercise output in your `SUMMARY:` block** under a
-   `Runtime exercise:` heading. Show each acceptance bullet, then each
+   **Capture the exercise output in your `SUMMARY:` block** (step 10) under
+   a `Runtime exercise:` heading. Show each acceptance bullet, then each
    path of that bullet with its input + actual output. Use brief prose;
    the orchestrator surfaces this in the PR body for maintainer review.
 
@@ -193,7 +193,24 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    the new test cases — keep them in the failing-test commit so the
    TDD-first ordering is preserved.
 
-8. Commit:
+8. **Format the diff with Biome** before committing the impl. Per
+   [team-preferences.md rule 30](../../.claude/rules/team-preferences.md),
+   format must run before commit — otherwise CI's `format` check
+   fails and the maintainer has to push a follow-up format-only
+   commit (which adds noise + bypasses the CI gate). Run:
+   ```bash
+   npm run format
+   ```
+   Biome reformats unstaged + staged files in place (~150ms). If
+   Biome touched the failing-test file (step 7's amend already
+   landed), re-amend the test commit to roll the reformat into it
+   — DO NOT make a separate format commit:
+   ```bash
+   git add <test files>
+   git commit --amend --no-edit
+   ```
+
+9. Commit:
    ```bash
    git add <impl files>
    git commit -m "feat(<area>): cut #$ISSUE_NUMBER — <short summary>
@@ -204,7 +221,7 @@ Closes #$ISSUE_NUMBER
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    ```
-9. End with a `SUMMARY:` block as your last output:
+10. End with a `SUMMARY:` block as your last output:
 
    ```
    SUMMARY:


### PR DESCRIPTION
## Summary

Closes #462. Adds step 8 (\`npm run format\`) between test refinement and impl commit in the feature-bot per-cut prompt. Per [team-preferences rule 30](.claude/rules/team-preferences.md), format must run BEFORE commit — running it after CI fails forces a maintainer-side cleanup commit.

PR #461 (cut #446) had two format violations Biome reformatted in maintainer commit \`024bb8b\`. Without this fix every feature-bot PR would repeat the pattern.

## Changes

- **\`bots/feature-bot/prompts/per-cut.md\`** — new step 8 \"Format the diff with Biome\"; renumber subsequent SUMMARY step 9 → 10. Instructions for re-amending the test commit if format touches it (no separate format commit).
- **\`bots/feature-bot/index.ts\`** — fallback message updates step-9 → step-10 cross-reference.

## Test plan

- [x] Biome accepts the prompt edit on the format check (verified locally; \`npm run format\` reported no fixes applied)
- [x] Step numbering in APPROVE path is sequential 1→10 with no duplicates
- [x] Cross-references checked: reviewer.md step-6 reference still points at runtime-exercise (unchanged); index.ts step reference points at SUMMARY block (now 10)
- [ ] CI green
- [ ] Next feature-bot run produces a PR that passes \`format\` on first try (will verify by clearing \`feature-bot-attempted\` on the next cut after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)