### PR TITLE
feat(fix-bot): runtime-exercise discipline + mode discrimination + draft PRs + format step

### DIFF
--- a/bots/fix-bot/index.ts
+++ b/bots/fix-bot/index.ts
@@ -397,6 +397,7 @@ RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
     )
     printTranscriptPath(reviewerTranscript)
 
+    const agentASummary = extractSummary(agentATranscript)
     const reviewerPrompt = `${reviewerPromptTemplate}
 
 ISSUE_NUMBER=${issueNumber}
@@ -412,6 +413,9 @@ ${diff}
 
 COMMIT_MESSAGES=
 ${commitMessages}
+
+AGENT_A_SUMMARY=
+${agentASummary || '(no SUMMARY block captured from Agent A — REJECT with note: your run did not emit a SUMMARY block; emit one per the per-issue prompt step 7)'}
 
 RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
 
@@ -457,7 +461,7 @@ RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
         attempt,
         verdict: verdict.kind === 'approve' ? 'approve' : verdict.kind === 'needs-human' ? 'needs-human' : 'reject',
         reasoning: verdict.kind === 'approve' ? verdict.reasoning : verdict.note,
-        agentASummary: extractSummary(agentATranscript),
+        agentASummary,
       })
     } catch (err) {
       printWarning(`reviewer-log append failed (non-fatal): ${err}`)
@@ -466,7 +470,7 @@ RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
     if (verdict.kind === 'approve') {
       printNotice(`✅ Reviewer APPROVED on attempt ${attempt}/${MAX_ATTEMPTS}: ${verdict.reasoning.slice(0, 120)}`)
       pushBranch(branchName)
-      openFixPR(repo, issueNumber, issue.title, branchName, verdict.reasoning, extractSummary(agentATranscript))
+      openFixPR(repo, issueNumber, issue.title, branchName, verdict.reasoning, agentASummary)
       attemptOutcome = 'approved'
       break
     }
@@ -552,8 +556,10 @@ ${agentASummary || '(no Agent A summary captured)'}
 ${reviewerReasoning || '(no reviewer reasoning captured)'}
 
 The reviewer ran the tautology check (revert fix → test must fail; re-apply
-fix → test must pass) plus the non-mechanical checks (root cause, scope
-creep, commit message) and the project-rule check.
+fix → test must pass), verified Agent A's declared \`Mode:\` matches the
+diff (behavioral / structural / mixed), checked the runtime exercise
+proves each fix-touched path (when behavioral), and ran the non-mechanical
+checks (root cause, scope creep, commit message).
 
 ## Verification
 
@@ -573,7 +579,17 @@ fix shape.
   try {
     execFileSync(
       'gh',
-      ['pr', 'create', '--title', `fix: ${issueTitle} (#${issueNumber})`, '--body', body, '--head', branchName],
+      [
+        'pr',
+        'create',
+        '--draft',
+        '--title',
+        `fix: ${issueTitle} (#${issueNumber})`,
+        '--body',
+        body,
+        '--head',
+        branchName,
+      ],
       { cwd: REPO_ROOT, stdio: 'inherit' },
     )
   } catch (err) {

--- a/bots/fix-bot/prompts/per-issue.md
+++ b/bots/fix-bot/prompts/per-issue.md
@@ -249,6 +249,121 @@ cd packages/gazetta && npx vitest run
 If anything else turned red, your fix is too broad. Either narrow it
 or stop and escalate (step 8).
 
+### 5.5. RUNTIME EXERCISE — prove the fix works on the fix-touched paths
+
+After tests pass, you need to **prove the fix actually does what the
+issue describes** — not just that your test passes (which can be
+tautological). The proof discipline depends on what kind of fix this
+is.
+
+**First, declare the mode in your head (and later in your SUMMARY):**
+
+- **`Mode: behavioral`** — the fix changes runtime behavior. Example:
+  fixing a 500 → 201 status code; changing default values; correcting
+  a comparison; fixing a race. The fix has a visible runtime surface.
+
+- **`Mode: structural`** — the fix changes structure but not behavior.
+  Example: extracting a duplicated helper to satisfy rule 15;
+  reorganizing imports; renaming for clarity. The fix is a refactor;
+  the failing test pins a structural invariant (count of definitions,
+  presence of import, etc.).
+
+- **`Mode: mixed`** — the fix has both. Example: fixing a bug AND
+  extracting a helper while you're there. Pure-behavioral fixes that
+  also touch comments are still `behavioral`; only invoke `mixed` when
+  there's a load-bearing structural change alongside the behavioral
+  one.
+
+**If `Mode: behavioral` or `Mode: mixed`**, run a runtime exercise:
+
+1. **Repro path** (required) — exercise the input from the issue's
+   reproduction steps. Capture the actual output. Compare against
+   what the issue says should happen:
+   - Construct the input the issue describes (request payload, function
+     args, state setup)
+   - Write down the EXPECTED output from the issue body (status code,
+     return value, error message, etc.)
+   - Run the code. Use whatever runs it — `node -e '...'`, a
+     `tmp-exercise.mjs` script, a CLI invocation, a shell pipeline.
+     **Do NOT use vitest / unit tests as the exercise** — tests are the
+     TDD contract (committed, kept, run by CI); the exercise is
+     throwaway proof Agent A ran the code outside the test harness.
+     Mixing them defeats the anti-tautology purpose.
+   - If you create temp files for the exercise, prefix them `tmp-`
+     (or put them under `/tmp/`) and **delete them before committing**
+     — they MUST NOT appear in the diff.
+   - Compare actual = expected → repro path validated.
+   - Compare actual ≠ expected → fix is wrong → iterate.
+
+2. **Wider suite** (required) — `cd packages/gazetta && npx vitest run`.
+   Capture pass count / fail count / exit code. This is the regression
+   net for adjacent surfaces with existing test coverage.
+
+3. **Adjacent / symmetric paths** (conditional) — if the fix touches
+   paired surfaces (e.g., page-redirects + fragment-redirects share a
+   handler; both kinds of a discriminated union), exercise each. One
+   input + actual output per paired surface. Omit this bullet when the
+   fix has only one surface.
+
+**Use the exercise to discover edge cases WITHIN the fix surface.**
+While exercising the repro path, probe boundaries of the new logic
+the fix introduces:
+- Empty / null / undefined for inputs the fix's branches touch
+- Boundary values for any numeric / size / count the fix introduces
+- Each error path the fix's new conditions imply
+
+For each edge case the exercise surfaces:
+- **Within fix surface, fix incomplete on this input**: the fix isn't
+  done. Iterate on the fix to cover the case. Add a test for it
+  alongside the repro test — amend the failing-test commit
+  (`git commit --amend`) so the TDD-first ordering is preserved.
+- **Within fix surface, fix handles it correctly**: nothing to do; the
+  exercise confirmed coverage.
+- **Adjacent pre-existing bug observed (not part of the reported
+  issue)**: do NOT widen scope. Note it in your SUMMARY's
+  `Discovered:` block (see step 7). The maintainer's `/review-prs`
+  flow files follow-up issues; Agent A does not file separate issues
+  unprompted.
+
+**If `Mode: structural`**, the failing test you wrote in step 3
+already encodes the proof (e.g., "exactly 1 `lookupManifest`
+definition exists"; "no import of removed module remains"). The
+4-step tautology check the reviewer runs proves the assertion
+fails-before / passes-after. The runtime exercise becomes:
+
+1. **Runtime exercise: N/A — structural fix; <one-line reason>**
+   (declare explicitly, not omit). Example reasons:
+   - "Extraction-only refactor; failing test pins definition count;
+     no behavioral surface to exercise."
+   - "Import-rewrite only; failing test pins import presence; runtime
+     unchanged."
+2. **Wider suite** (still required) — `npx vitest run`. A "pure
+   refactor" claim should produce zero behavioral test failures; if
+   any fail, the refactor wasn't pure → iterate or escalate.
+3. **Verify no usage sites were missed** — for refactors that touch
+   multiple callers, `grep` for the symbol's pre-extraction call shape
+   to confirm all sites moved. One-line confirmation in SUMMARY.
+
+### 5.6. Format the diff with Biome before committing the fix
+
+Per [team-preferences.md rule 30](../../.claude/rules/team-preferences.md),
+format must run before commit — otherwise CI's \`format\` check
+fails and the maintainer has to push a follow-up format-only commit.
+
+\`\`\`bash
+npm run format
+\`\`\`
+
+Biome reformats unstaged + staged files in place (~150ms). If
+Biome touched the failing-test file (already committed in step 4),
+re-amend the test commit to roll the reformat into it — DO NOT
+make a separate format commit:
+
+\`\`\`bash
+git add <test files>
+git commit --amend --no-edit
+\`\`\`
+
 ### 6. Commit the fix
 
 **Pick the commit scope from WHAT YOU CHANGED, not from where the
@@ -294,12 +409,34 @@ SUMMARY:
 <2-4 sentences: what the bug was, what your fix does, why the failing
 test pins it. Plain prose; no headings, no bullets, no code blocks
 inside the summary.>
+
+Mode: behavioral | structural | mixed
+
+Runtime exercise:
+<For Mode=behavioral or mixed: list each fix-touched path with the
+input you ran and the actual output. For Mode=structural: write
+"N/A — structural fix; <one-line reason naming the structural
+invariant the test pins>". Keep it under ~40 lines total.>
+
+Wider suite: <pass count>/<total> pass; exit code <N>
+
+Discovered: (optional; omit when empty)
+- <one-line description of an adjacent pre-existing bug observed while
+  exercising the fix; include file:line + symptom + suggested action.
+  These surface in the PR body for /review-prs follow-up; don't widen
+  this PR's scope to address them.>
 ```
 
-The orchestrator extracts the text after `SUMMARY:` and includes it
+The orchestrator extracts everything after `SUMMARY:` and includes it
 verbatim in the PR body. Anything else in your final message (commit
 output, protocol acknowledgments, follow-up notes) goes ABOVE the
 `SUMMARY:` block — only the marked summary lands in the PR.
+
+The orchestrator also passes your full SUMMARY block (including
+`Runtime exercise:`, `Wider suite:`, and `Discovered:`) to Agent B as
+the `AGENT_A_SUMMARY` input. Agent B verifies the declared `Mode:`
+matches the diff and checks the exercise output against the issue's
+reported behavior.
 
 ---
 

--- a/bots/fix-bot/prompts/reviewer.md
+++ b/bots/fix-bot/prompts/reviewer.md
@@ -11,8 +11,11 @@ necessary but not sufficient. The failure modes you're here to catch:
 |---|---|
 | **Tautological test** | The test was shaped to match the fix, not the bug. Reverting the fix → test still passes (it asserts behavior that exists regardless of the fix) |
 | **Wrong root cause** | Fix lands in a place that addresses a symptom; the actual bug is one layer up. Test passes but the original issue's reproducer still fails in production |
-| **Scope creep** | Diff includes unrelated refactors / renamings / "boy scout" cleanup beyond the fix |
+| **Wrong mode declared** | Agent A's `Mode:` claim doesn't match the diff. Example: declared `Mode: structural` but the diff changes return values; declared `Mode: behavioral` but the diff is a pure rename with no logic change. Both directions are RJECT-able |
+| **Missing or unconvincing runtime exercise** | When `Mode: behavioral` or `Mode: mixed`, `AGENT_A_SUMMARY` has no `Runtime exercise:` section, OR claims unit tests "double as" the exercise (forbidden — tests are TDD contract, exercise is throwaway proof), OR the repro-path actual output doesn't match what the issue describes. When `Mode: structural`, the `Runtime exercise: N/A — <reason>` line is missing |
+| **Scope creep** | Diff includes unrelated refactors / renamings / "boy scout" cleanup beyond the fix. Leftover `tmp-*` files from the runtime exercise count as scope creep — Agent A was supposed to delete them before commit |
 | **Misleading commit messages** | Commit subjects misrepresent the change shape |
+| **Discovered items are load-bearing** | Agent A's `Discovered:` block surfaces an "adjacent pre-existing bug" that's actually the bug being fixed (i.e., the fix is incomplete and Agent A deflected to "discovered" instead of completing it) |
 | **Foundational-contract violations** | Fix violates a documented team-preference (SOLID, test isolation, no-direct-main) or contradicts a design doc's contract (validation, hooks, audit, etc.) — caught by the `review-architecture` skill (invoked in Step 3) |
 | **Security regressions** | Fix introduces a missing capability gate, SSRF surface, unsanitized rendering, secret leakage, weak crypto, or dependency-CVE risk — caught by the `review-security` skill (invoked in Step 3 when the diff touches security-sensitive paths) |
 
@@ -20,7 +23,7 @@ You issue one of three verdicts at the end of your output:
 
 | Verdict | When |
 |---|---|
-| `APPROVE` | All checks pass: tautology (Step 1), root cause + scope + commit message (Step 2), and architecture/security skill findings (Step 3) are empty or NIT-only. |
+| `APPROVE` | All checks pass: tautology (Step 1), mode + runtime-exercise (Step 2), root cause + scope + commit message (Step 3), and architecture/security skill findings (Step 4) are empty or NIT-only. |
 | `REJECT` | One or more checks fail AND Agent A can fix on retry. Provide `Note:` with specific guidance. |
 | `NEEDS_HUMAN` | Structural problem; retry won't help. Maintainer should look. |
 
@@ -32,6 +35,17 @@ You issue one of three verdicts at the end of your output:
 - `ATTEMPT` — 1 for first review, 2+ if Agent A retried after prior REJECT
 - `PRIOR_REVIEWER_NOTE` — present only when `ATTEMPT > 1`; the prior
   reject reason Agent A was supposed to address
+- `DIFF` — `git diff main..$BRANCH_NAME` output (snapshot Agent A produced)
+- `COMMIT_MESSAGES` — `git log main..$BRANCH_NAME --format=%B%n---`
+- `AGENT_A_SUMMARY` — the `SUMMARY:` block Agent A emitted at the end
+  of its run, including the `Mode:` declaration, `Runtime exercise:`
+  subsection (per-mode shape), `Wider suite:` line, and optional
+  `Discovered:` block. This is YOUR source of truth for the
+  runtime-exercise check and the mode cross-check. **There is no
+  open PR yet** — the orchestrator opens the PR only after you
+  APPROVE. Do NOT call `gh pr view` looking for the exercise; do NOT
+  inspect closed PRs from prior attempts on this branch (they carry
+  stale bodies from rejected attempts and will mislead you).
 - `RUN_ID` — diagnostic only
 
 ## Decision-log convention
@@ -114,9 +128,100 @@ A's commits (force-push lost the fix? Different test affected by
 the revert/reset cycle?). **NEEDS_HUMAN** — this is a state bug, not
 something Agent A can fix on retry.
 
+## The mode + runtime-exercise check
+
+**Agent A declares a `Mode:` (behavioral / structural / mixed) and
+provides matching proof.** Your job: verify the declared mode matches
+the diff, AND verify the proof shape matches the declared mode.
+
+### Mode-vs-diff cross-check
+
+Read `AGENT_A_SUMMARY`'s `Mode:` line. Read the diff. Verify:
+
+- **`Mode: behavioral`** → diff should change runtime behavior (logic,
+  conditions, return values, status codes, audit-event payloads,
+  validation rules, etc.). If the diff is purely extraction / rename /
+  comment-rot / import-rewrite with no logic change, the declared
+  mode is wrong. **REJECT** — "you declared `behavioral` but the diff
+  is structural; please re-declare and run the structural-mode
+  proof shape."
+
+- **`Mode: structural`** → diff should have NO behavior change.
+  Extractions, renames, import rewrites, comment-rot fixes,
+  whitespace-only changes. If the diff changes any return value,
+  conditional, status code, or call-site result, the declared mode is
+  wrong. **REJECT** — "you declared `structural` but the diff changes
+  runtime behavior on file:line; please re-declare as `behavioral` or
+  `mixed` and provide a runtime exercise."
+
+- **`Mode: mixed`** → diff has both structural and behavioral changes.
+  Verify both. The runtime exercise proves the behavioral part; the
+  failing test pins the structural invariant.
+
+### Runtime-exercise check (when Mode is behavioral or mixed)
+
+Read `AGENT_A_SUMMARY`'s `Runtime exercise:` subsection. Verify:
+
+1. **Repro path is present.** The issue describes the bug; Agent A's
+   repro line should show the issue's input + actual output that
+   demonstrates the fix works (matches what the issue says should
+   happen).
+2. **Output matches the issue's expected.** Acceptance line in issue
+   says "should return 201 with body X"; exercise output shows 201 +
+   body X.
+3. **Wider suite line is present and shows zero failures.** Pattern:
+   `<pass>/<total> pass; exit code 0`.
+4. **Adjacent paths covered (when fix touches symmetric surfaces).**
+   If the diff modifies a handler shared between page and fragment
+   kinds (or any paired discriminator-keyed surface), the exercise
+   should show one input + output per paired surface. Omission when
+   the fix has only one surface is fine.
+5. **No "tests double as the exercise" substitution.** The exercise is
+   throwaway proof (a `tmp-` script, `node -e`, CLI invocation). Even
+   if Agent A's unit tests are exhaustive, the exercise must exist
+   separately. Tests are the TDD contract; the exercise is
+   comprehension-grounding.
+
+| State | Effect |
+|---|---|
+| Every required element present + outputs match issue's expected | OK |
+| `Runtime exercise:` missing entirely | **REJECT** — "Re-run with the runtime exercise per the per-issue prompt's step 5.5." |
+| Repro path missing | **REJECT** — name the issue's reported behavior + the missing proof |
+| Repro path output doesn't match issue's expected | **REJECT** — name the mismatch ("Issue says 201; exercise showed 200") |
+| Wider suite line missing OR shows failures | **REJECT** — "wider suite must pass; your fix regressed N tests" |
+| Adjacent-surface fix has only one path proved | **REJECT** — name the unexercised paired surface |
+| Claims "tests double as the exercise" | **REJECT** — the exercise must be a separate run outside the test harness |
+
+### Runtime-exercise check (when Mode is structural)
+
+Verify `AGENT_A_SUMMARY`'s `Runtime exercise:` line is `N/A —
+<reason>` with a one-line reason naming the structural invariant.
+Empty / missing / boilerplate `N/A` without a reason is REJECT-able.
+The 4-step tautology check (above) IS the structural-fix proof —
+revert makes the assertion fail; re-apply makes it pass. Wider suite
+must still pass (a "pure refactor" produces zero behavioral
+failures).
+
+### Discovered-items check
+
+If `AGENT_A_SUMMARY` has a `Discovered:` block, verify the items are
+NOT load-bearing for the current fix:
+
+- Each `Discovered:` item should be a genuinely adjacent pre-existing
+  bug — same file/module, different surface, not in the issue's
+  reported behavior.
+- If a `Discovered:` item is actually within the fix's scope (i.e.,
+  Agent A deflected an incomplete-fix case to `Discovered:` instead
+  of completing the fix), **REJECT** — name the item + suggest
+  completing the fix to cover it.
+
+`Discovered:` items that pass this check stay in the PR body;
+`/review-prs` handles follow-up issue filing during PR review.
+
 ## The non-mechanical checks
 
-After steps 1-4 pass, also check:
+After steps 1-4 pass AND the mode + runtime-exercise check passes,
+also check:
 
 ### Wrong root cause
 
@@ -145,6 +250,24 @@ Look for unrelated formatting changes, variable renames in
 unchanged code paths, "while I'm here" cleanups. The fix-bot prompt
 explicitly forbids these — if Agent A did them anyway, that's a
 retry candidate with a Note explaining the contract.
+
+Also check for leftover runtime-exercise scratch:
+- Files starting with `tmp-` (e.g. `tmp-exercise.ts`, `tmp-exercise.mjs`,
+  `tmp-exercise.sh`)
+- Any obvious throwaway harness whose only purpose is exercising the
+  fix at runtime
+
+These MUST NOT appear in the diff. **REJECT** with a note to remove
+them — they belonged in Agent A's local working tree only.
+
+Separately: if a test file in the diff looks like it was written as
+the runtime exercise rather than as a real TDD test (e.g.,
+`tests/exercise-fix.test.ts` with only `console.log` style
+assertions, or a test that just prints values rather than asserting),
+that violates the anti-tautology discipline. The runtime exercise is
+throwaway proof; tests are the durable spec. **REJECT** with a note
+to either delete the file (it was a runtime exercise) or rewrite it
+as real assertions (it was meant to be a test).
 
 ### Commit message accuracy
 
@@ -246,14 +369,18 @@ Cases where you DON'T fold a finding into the verdict:
 ## Process
 
 1. Run the 4-step tautology check
-2. If steps pass: run the three non-mechanical checks (root cause, scope creep, commit message)
-3. Invoke `review-architecture` skill via Skill tool; conditionally invoke `review-security` skill if the diff touches security-sensitive paths
-4. Form your verdict by combining: tautology result + non-mechanical checks + skill findings folded per the action-policy table
-5. Emit the verdict line at the END of your output:
+2. Run the mode + runtime-exercise check (mode-vs-diff cross-check; behavioral/structural proof shape; Discovered-items load-bearing check)
+3. If steps pass: run the three non-mechanical checks (root cause, scope creep, commit message)
+4. Invoke `review-architecture` skill via Skill tool; conditionally invoke `review-security` skill if the diff touches security-sensitive paths
+5. Form your verdict by combining: tautology result + mode + runtime-exercise check + non-mechanical checks + skill findings folded per the action-policy table
+6. Emit the verdict line at the END of your output:
 
 ```
 VERDICT: APPROVE
-Reasoning: <one paragraph why the fix is sound>
+Reasoning: <one paragraph why the fix is sound — name the load-bearing
+checks that passed; cite the runtime-exercise outputs that prove the
+repro path (when behavioral/mixed) OR the structural invariant the
+test pins (when structural)>
 ```
 
 ```

--- a/bots/fix-bot/tests/reviewer-prompt.test.ts
+++ b/bots/fix-bot/tests/reviewer-prompt.test.ts
@@ -50,16 +50,20 @@ describe('fix-bot reviewer prompt — structural contracts', () => {
     expect(prompt).toMatch(/VERDICT: NEEDS_HUMAN/)
   })
 
-  it('keeps the Process list with five steps', () => {
+  it('keeps the Process list with six steps', () => {
     // Process section enumerates the steps the reviewer follows.
-    // Should be five numbered items: tautology / non-mechanical /
-    // skill invocations / form verdict / emit VERDICT line.
+    // Six numbered items: tautology / mode+runtime-exercise /
+    // non-mechanical / skill invocations / form verdict / emit VERDICT.
+    // (Mode + runtime-exercise added per fix-bot runtime-exercise
+    // discipline mirroring feature-bot's #455 — runtime exercise proves
+    // the fix works on every fix-touched path; without it, "tests pass"
+    // can be tautological.)
     const processMatch = prompt.match(/## Process\n\n([\s\S]+?)(?=\n##|\n```)/)
     expect(processMatch, 'Process section missing').toBeTruthy()
     const body = processMatch![1]
     // Count numbered list items at the start of lines.
     const numbered = body.split('\n').filter(l => /^\d+\.\s/.test(l))
-    expect(numbered).toHaveLength(5)
+    expect(numbered).toHaveLength(6)
   })
 
   it('does NOT contain the old project-rule check section header', () => {


### PR DESCRIPTION
## Summary

Mirrors feature-bot's runtime-exercise discipline (PRs #455, #457, #458, #464) to fix-bot, with adjustments for fix-bot's task shape — bug fixes can be behavioral, structural, or mixed. Refactors (like issue #463's lookupManifest extraction) don't have a behavioral surface to exercise; they declare \`Mode: structural\` and the failing test pins the structural invariant.

8-question design pass via /grill-with-docs; all locked alternatives + rationale captured in the commit message.

## What changed

- **per-issue.md** — new step 5.5 (Runtime exercise with mode-based proof shape) + step 5.6 (\`npm run format\`); SUMMARY extended with \`Mode:\`, \`Runtime exercise:\`, \`Wider suite:\`, optional \`Discovered:\` block; forbids tests-as-exercise.
- **reviewer.md** — new \`AGENT_A_SUMMARY\` input (no more reaching for \`gh pr view\`); mode-vs-diff cross-check; per-mode runtime-exercise checks; Discovered-items load-bearing check; scope-creep extended for \`tmp-*\` leftovers.
- **index.ts** — extracts Agent A's SUMMARY before invoking reviewer; passes as \`AGENT_A_SUMMARY\`; opens PRs as \`--draft\` (matching feature-bot + per-issue.md's documented contract).
- **test update** — Process list pinned at 5 steps → 6 steps.

## Test plan

- [x] 22 synthetic wiring checks pass (per-issue.md, reviewer.md, index.ts wiring all verified)
- [x] 450/450 vitest pass
- [x] Type-check clean
- [x] Biome format clean
- [ ] CI green
- [ ] Trigger fix-bot manually against #463 (canonical structural-mode test case) post-merge; verify: Agent A declares \`Mode: structural\`; reviewer cross-checks against the extraction-only diff; PR opens as draft; \`Runtime exercise: N/A — <reason>\` lands correctly; format step runs before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)