### PR TITLE
fix(fix-bot): delegate review-architecture/security to subagents (keeps VERDICT line emitted)

### DIFF
--- a/bots/fix-bot/index.ts
+++ b/bots/fix-bot/index.ts
@@ -422,12 +422,18 @@ RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
     const bResult = await runClaude({
       prompt: reviewerPrompt,
       transcriptPath: reviewerTranscript,
-      // Reviewer needs Bash to run the tautology check (git revert +
-      // vitest), Read to inspect source + rule files on demand, and
-      // Skill to invoke /review-architecture + conditionally
-      // /review-security per design-code-review.md Step 3.
+      // Reviewer needs:
+      //   - Bash for tautology check (git revert + vitest)
+      //   - Read for source + rule files on demand
+      //   - Agent for delegating review-architecture + review-security
+      //     to subagents (keeps the skills' heavy context out of Agent
+      //     B's window — without this delegation the skills' findings
+      //     fence reads as a natural terminator and Agent B stops
+      //     before emitting the required VERDICT: line; see #469)
+      //   - Skill kept so the subagents (spawned via Agent) can invoke
+      //     the skills they need
       // Explicitly NOT Write/Edit — reviewer doesn't modify code.
-      allowedTools: ['Bash', 'Read', 'Skill'],
+      allowedTools: ['Bash', 'Read', 'Agent', 'Skill'],
     })
     if (!bResult.success) {
       printWarning(`Agent B exited ${bResult.exitCode} on attempt ${attempt}; treating as needs-human.`)

--- a/bots/fix-bot/prompts/reviewer.md
+++ b/bots/fix-bot/prompts/reviewer.md
@@ -280,45 +280,79 @@ Read the commit messages (`git log main..$BRANCH_NAME --format=%B`).
 **Don't nitpick wording.** REJECT only when the message is materially
 wrong (says "fix bug X" but the diff doesn't touch the area).
 
-## The architecture-review check (Step 3)
+## The architecture-review check (Step 4)
 
 The repo's foundational-dimension contracts (`design-audit.md`,
 `design-validation.md`, `design-hooks.md`, etc.) + the
 team-preferences rules + ADRs together form the architectural
 review surface. Rather than maintain a per-rule path table inside
-this prompt, **invoke the `review-architecture` skill** via the
-`Skill` tool. The skill body owns the path-to-design-doc mapping,
-the hybrid context-loading strategy (always-load CLAUDE.md +
-dev-glossary.md + the 13-dimension list; on-demand load max 2
-per-area design docs), and the finding format (JSONL findings
-fence with severity + file + line + confidence + category + rule
-+ message + suggestion).
+this prompt, **delegate this check to a subagent via the `Agent`
+tool.** The subagent runs the `review-architecture` skill body
+which owns the path-to-design-doc mapping, the hybrid
+context-loading strategy (always-load CLAUDE.md + dev-glossary.md +
+the 13-dimension list; on-demand load max 2 per-area design docs),
+and the finding format (JSONL findings fence with severity + file
++ line + confidence + category + rule + message + suggestion).
+
+**Why a subagent and not the Skill tool directly**: invoking
+`review-architecture` via Skill loads its heavy context (multiple
+design docs + glossary) into YOUR context window. When the skill
+finishes and emits the `findings` fence, the fence reads as a
+natural terminator and you tend to stop without emitting the
+required `VERDICT:` line — the orchestrator's parser then has no
+verdict to read and escalates to `needs-human` regardless of what
+you concluded. Subagents keep that context out of your window: the
+subagent loads the design docs, emits its fence, returns it as a
+tool result. You read the fence as a short text artifact, fold per
+action policy, and proceed cleanly to your VERDICT line.
+
+Invoke:
 
 ```
-Skill: review-architecture
-Args: review the diff at git diff main..$BRANCH_NAME against
-      foundational contracts + ADRs
+Agent({
+  subagent_type: 'general-purpose',
+  description: 'review-architecture against diff',
+  prompt: \`Invoke the review-architecture skill via the Skill tool
+against this diff:
+
+git diff main..${BRANCH_NAME}
+
+Run the skill's analysis. Return ONLY the skill's prose + the
+\\\`findings\\\` fence at the end. Do not add commentary beyond
+what the skill emits.\`
+})
 ```
 
-The skill emits a JSONL `findings` fence — possibly empty — at the
-end of its output. Read that fence and fold each finding into your
-verdict per the action-policy table below.
+The subagent's final message contains the skill's prose + a JSONL
+`findings` fence — possibly empty. Read that fence and fold each
+finding into your verdict per the action-policy table below.
 
 When the diff touches a security-sensitive path
 (`admin-api/`, `providers/`, `*sanitize*`, `*capability*`,
 `*auth*`, `package.json`, or content referencing
-`fetch(`/`exec(`/`child_process`), ALSO invoke the
-`review-security` skill via the `Skill` tool. Same input shape,
-same JSONL findings-fence output.
+`fetch(`/`exec(`/`child_process`), ALSO spawn a subagent for
+`review-security`. Same shape:
 
 ```
-Skill: review-security
-Args: same diff scope
+Agent({
+  subagent_type: 'general-purpose',
+  description: 'review-security against diff',
+  prompt: \`Invoke the review-security skill via the Skill tool
+against the same diff scope. Return ONLY the skill's prose + the
+\\\`findings\\\` fence.\`
+})
 ```
 
-Spawn both skills via Skill tool calls. If they can run in
-parallel, do so (a single message with multiple Skill calls);
-otherwise sequential is fine.
+When both subagents are needed, spawn them **SEQUENTIALLY** — first
+`review-architecture`, then `review-security` after the first
+returns. Each subagent has an isolated context window so the
+skills' contents stay out of yours, but they share the working
+tree with you and with each other. The tautology check (step 1)
+already mutates the tree via `git revert` + `git reset`; any
+sub-skill that mutates the tree would race against a parallel
+sibling. Sequential keeps the invariant simple: at most one
+subagent touches the working tree at a time. The wall-clock cost
+is small (~30s each) and the safety margin is worth it.
 
 ### Action policy for skill findings
 
@@ -339,7 +373,7 @@ new audit event omits `outcome` field"). Keep your Note tight —
 the skill output already has full per-finding detail; you're
 relaying the action, not the whole finding.
 
-### When to skip the skill invocations
+### When to skip the subagent spawns
 
 - Trivial one-line fixes that touch only a comment or a typo — the
   skills will emit empty fences; skipping saves a Claude call.
@@ -348,10 +382,10 @@ relaying the action, not the whole finding.
   tautology check; v1 doesn't invoke `review-tests` from this
   reviewer — see `design-code-review.md` for the v1 scope).
 - Diffs entirely within `bots/` — the bot infrastructure is dev-process,
-  not foundational; invoking review-architecture would surface noise
-  about producer/consumer discipline that you've already covered in
-  your non-mechanical checks. Skip review-architecture; consider
-  review-security if a bot touches new exec/spawn surfaces.
+  not foundational; spawning the review-architecture subagent would
+  surface noise about producer/consumer discipline that you've already
+  covered in your non-mechanical checks. Skip review-architecture;
+  spawn review-security only if a bot touches new exec/spawn surfaces.
 
 ### When NOT to fold a finding
 
@@ -371,7 +405,7 @@ Cases where you DON'T fold a finding into the verdict:
 1. Run the 4-step tautology check
 2. Run the mode + runtime-exercise check (mode-vs-diff cross-check; behavioral/structural proof shape; Discovered-items load-bearing check)
 3. If steps pass: run the three non-mechanical checks (root cause, scope creep, commit message)
-4. Invoke `review-architecture` skill via Skill tool; conditionally invoke `review-security` skill if the diff touches security-sensitive paths
+4. **Spawn subagents** via the `Agent` tool for `review-architecture` and conditionally `review-security` (when the diff touches security-sensitive paths). Spawn in parallel when both are needed. Read each subagent's returned `findings` fence as a short text artifact; do NOT re-narrate the skill's analysis in your own output.
 5. Form your verdict by combining: tautology result + mode + runtime-exercise check + non-mechanical checks + skill findings folded per the action-policy table
 6. **EMIT THE VERDICT LINE** — this is the load-bearing terminator. After the architecture/security skills' `findings` fences, you MUST write exactly one of these three blocks as the FINAL output:
 

--- a/bots/fix-bot/tests/reviewer-prompt.test.ts
+++ b/bots/fix-bot/tests/reviewer-prompt.test.ts
@@ -27,13 +27,18 @@ describe('fix-bot reviewer prompt — structural contracts', () => {
     expect(prompt).toMatch(/### Commit message accuracy/)
   })
 
-  it('invokes review-architecture skill in Step 3 (replaces previous project-rule check)', () => {
-    expect(prompt).toMatch(/## The architecture-review check \(Step 3\)/)
-    expect(prompt).toMatch(/Skill: review-architecture/)
+  it('delegates review-architecture to a subagent in Step 4 (replaces previous project-rule check)', () => {
+    // Step 4 (numbered after mode + runtime-exercise was added in Step 2).
+    // Spawned via Agent tool, not invoked directly via Skill — keeps the
+    // skill's heavy context out of Agent B's window so the findings
+    // fence doesn't read as a natural terminator. See #469 + follow-up.
+    expect(prompt).toMatch(/## The architecture-review check \(Step 4\)/)
+    expect(prompt).toMatch(/review-architecture/)
+    expect(prompt).toMatch(/Agent\(\{/)
   })
 
-  it('conditionally invokes review-security skill in Step 3', () => {
-    expect(prompt).toMatch(/Skill: review-security/)
+  it('conditionally spawns review-security subagent in Step 4', () => {
+    expect(prompt).toMatch(/review-security/)
     expect(prompt).toMatch(/security-sensitive path/)
   })
 
@@ -73,7 +78,11 @@ describe('fix-bot reviewer prompt — structural contracts', () => {
     expect(prompt).not.toMatch(/## The project-rule check/)
   })
 
-  it('declares Skill tool as needed (documented in prose)', () => {
-    expect(prompt).toMatch(/via the `Skill` tool/)
+  it('declares Agent tool as needed (documented in prose)', () => {
+    // Reviewer spawns subagents via the Agent tool for review-architecture
+    // and review-security; this isolates the skills' heavy context from
+    // Agent B's window so the findings fence doesn't pull Agent B toward
+    // early termination before emitting VERDICT. See #469 + follow-up.
+    expect(prompt).toMatch(/via the `Agent`\s*\n?\s*tool/)
   })
 })


### PR DESCRIPTION
## Summary

Two attempts of #463 with #469's prompt-strengthening still produced the same failure: Agent B completed all checks but stopped before writing the \`VERDICT:\` line. Stronger imperative prose couldn't break through.

**Root cause is structural, not prose-strength.** Invoking \`review-architecture\` via the Skill tool loads the skill's heavy context (CLAUDE.md + dev-glossary + per-area design docs) into Agent B's window. When the skill emits its findings fence, the fence reads as a natural terminator for Agent B's local context — Agent B stops.

**Fix: delegate to subagents.** Each subagent has an isolated context window — the skill's heavy context never enters Agent B's. Agent B reads the subagent's returned findings fence as a short text artifact, folds per action policy, and proceeds cleanly to VERDICT.

## What changed

- **reviewer.md** — Skill-tool invocations replaced with \`Agent({ subagent_type: 'general-purpose', ... })\` for both review-architecture and review-security. New \"Why a subagent\" paragraph documenting the failure mode. **Sequential spawning** (not parallel) — tautology check (step 1) mutates the tree via \`git revert\` + \`git reset\`; sequential keeps \"at most one subagent touches the tree at a time\" as a simple invariant.
- **index.ts** — \`allowedTools\` adds \`'Agent'\`. \`'Skill'\` kept so subagents can invoke skills internally.
- **Tests** — 3 reviewer-prompt assertions updated for the new step number, Agent-tool invocation shape, and prose wording.

## Validation

- 9/9 reviewer-prompt tests pass
- 450/450 bot suite pass
- Biome format clean

## Test plan post-merge

- [ ] Re-trigger fix-bot against #463
- [ ] Verify Agent B spawns review-architecture subagent (sequential)
- [ ] Verify Agent B emits \`VERDICT: APPROVE\` line after the subagent returns
- [ ] Verify orchestrator parses APPROVE; opens draft PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)