### PR TITLE
fix(review-bot): sanitize ref-hostile chars in branch name (push crash from run 26707064619)

### DIFF
--- a/bots/review-bot/past-pr.ts
+++ b/bots/review-bot/past-pr.ts
@@ -52,7 +52,21 @@ export type PastOutcome =
  *     → `improve/tests-apps--admin--src-26`
  */
 export function fingerprintToBranch(fp: Fingerprint): string {
-  const safeArea = fp.area.replace(/\/$/, '').replace(/\//g, '--')
+  // Sanitize area for use in a git branch name. Git refs cannot contain
+  // whitespace, parens, or other special chars. Slashes have a separate
+  // meaning (path separators); replace with `--` first to preserve the
+  // path structure visually, then collapse any remaining ref-hostile
+  // characters to `-`. audit-area sometimes emits paired-target areas
+  // like `packages/gazetta/tests/ (paired against ...)` — the post-slash
+  // sanitization must catch the spaces + parens.
+  const safeArea = fp.area
+    .replace(/\/$/, '')
+    // Sanitize ref-hostile chars BEFORE converting slashes to `--`,
+    // otherwise the `--` separator gets collapsed by the subsequent
+    // single-dash sanitization. Order matters: any character that's
+    // not alphanumeric, slash, or dash → dash. THEN slashes → `--`.
+    .replace(/[^a-zA-Z0-9/\-]/g, '-')
+    .replace(/\//g, '--')
   // Prefer the anchor (`#capability-gate`), fall back to the last path
   // segment (`design-audit.md`), then strip .md and sanitize.
   // `split('#').pop()` always returns a string (the whole rule when no #),

--- a/bots/review-bot/tests/past-pr.test.ts
+++ b/bots/review-bot/tests/past-pr.test.ts
@@ -31,6 +31,29 @@ describe('fingerprintToBranch', () => {
     expect(branch).toMatch(/^improve\/architecture-packages--gazetta--src--audit-design-audit/)
   })
 
+  it('sanitizes spaces and parens in area (reproduces review-bot run 26707064619 push crash)', () => {
+    // audit-area sometimes emits a paired-target area with spaces and
+    // parens, e.g. `packages/gazetta/tests/ (paired against
+    // packages/gazetta/src/validation/validators/)`. The 07:56 review-bot
+    // cron on 2026-05-31 reached APPROVE but crashed at `git push` with
+    // `fatal: invalid refspec` because the branch name carried the
+    // unsanitized text verbatim. Git refs cannot contain spaces or parens.
+    const fp: Fingerprint = {
+      area: 'packages/gazetta/tests/ (paired against packages/gazetta/src/validation/validators/)',
+      type: 'tests',
+      rule: 'testing-plan.md#pyramid',
+    }
+    const branch = fingerprintToBranch(fp)
+    // Git refspec invariant — no whitespace, no parens, no other
+    // ref-hostile characters in the branch.
+    expect(branch).not.toMatch(/[\s()~^:?*[\\]/)
+    // Sanity: still starts with the right prefix
+    expect(branch).toMatch(/^improve\/tests-/)
+    // Sanity: paired-target context still visible in some shape (not
+    // completely erased)
+    expect(branch).toMatch(/paired|packages/)
+  })
+
   it('sanitizes non-alphanumeric characters in rule tail', () => {
     const fp: Fingerprint = {
       area: 'packages/gazetta/src/foo/',


### PR DESCRIPTION
## Summary

Review-bot run #26707064619 (2026-05-31 07:56 UTC) completed Agent A + Agent B successfully with verdict APPROVE — then crashed at \`git push\` with \`fatal: invalid refspec\`. The branch name carried unsanitized text from audit-area's candidate output:

\`improve/tests-packages--gazetta--tests-- (paired against packages--gazetta--src--validation--validators--)-stage-...\`

Git refs cannot contain whitespace or parens. \`fingerprintToBranch\` sanitized slashes (→ \`--\`) but left other ref-hostile characters in place.

## Fix

Apply ref-hostile-char sanitization BEFORE the slash→\`--\` conversion in \`safeArea\`. Order matters — sanitizing after slash conversion would collapse the \`--\` separator back to \`-\` (regression caught by existing tests).

## TDD contract

- **Commit 1** (\`7004d05\`): failing test reproducing the production input verbatim. Asserts no ref-hostile chars survive.
- **Commit 2** (\`73eea3e\`): the fix.

## Validation

- 9/9 \`past-pr.test.ts\` pass (including the new regression test)
- 451/451 wider bot suite pass
- Manual runtime exercise: the actual production input now produces a valid git ref (\`improve/tests-packages--gazetta--tests----paired-against-packages--gazetta--src--validation--validators----pyramid\` — 114 chars, no whitespace, no parens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)