### PR TITLE
fix(review-bot): graceful push/PR-creation failure handling (rule 38 symmetric audit)

### DIFF
--- a/bots/review-bot/index.ts
+++ b/bots/review-bot/index.ts
@@ -209,20 +209,42 @@ async function main(): Promise<void> {
 
     if (verdict.kind === 'approve') {
       printNotice(`Verdict: APPROVE. Pushing ${branchName} + opening PR...`)
-      await phase5Push(
-        branchName,
-        candidate,
-        fingerprint,
-        {
-          attempt,
-          approveReasoning: verdict.reasoning,
-          agentASummary: agentAResult.summary ?? '(no summary)',
-        },
-        octokit,
-        repo,
-      )
-      approved = true
-      break
+      try {
+        await phase5Push(
+          branchName,
+          candidate,
+          fingerprint,
+          {
+            attempt,
+            approveReasoning: verdict.reasoning,
+            agentASummary: agentAResult.summary ?? '(no summary)',
+          },
+          octokit,
+          repo,
+        )
+        approved = true
+        break
+      } catch (err) {
+        // git push or PR creation crashed AFTER Agent A + Agent B both
+        // succeeded — the work is done locally but couldn't ship. Without
+        // this catch the throw escapes uncaught, the bot crashes with
+        // exit 1, no skip-list entry is recorded, and the next cron
+        // redoes all of Agent A + Agent B work + crashes again on the
+        // same root cause. Record needs-human + exit cleanly so the
+        // maintainer can investigate. See review-bot run 26707064619
+        // (2026-05-31) where an unsanitized branch name caused
+        // `fatal: invalid refspec` at push time; the fix (#477) closed
+        // the root cause but the bot still needs graceful handling for
+        // any future push/PR-create failure (network, auth, permissions,
+        // remote rejection, etc.).
+        printWarning(`Push + PR creation failed for ${branchName}: ${err}`)
+        const updated = recordSkipListEntry(skipList, fingerprint, {
+          reason: 'needs-human',
+          reasonNote: `Agent A + Agent B succeeded (verdict APPROVE) but push or PR creation crashed: ${err}. Branch state is local; maintainer can inspect or recover.`,
+        })
+        writeSkipList(SKIPLIST_PATH, updated)
+        process.exit(0)
+      }
     }
     if (verdict.kind === 'needs-human') {
       printWarning(`Verdict: NEEDS_HUMAN. Recording skip-list entry + exiting.`)

--- a/bots/review-bot/tests/push-failure-handling.test.ts
+++ b/bots/review-bot/tests/push-failure-handling.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Structural test for review-bot's push-failure handling.
+ *
+ * Run #26707064619 (2026-05-31) reached APPROVE, then crashed at
+ * `git push` with `fatal: invalid refspec` because of an unsanitized
+ * branch name. The root cause was fixed in #477. But the orchestrator
+ * also had no try/catch around `phase5Push`, so any future push or
+ * PR-create failure (network, auth, remote rejection, refspec issues)
+ * would crash the bot with exit 1 + no skip-list entry → next cron
+ * redoes all the work + crashes again.
+ *
+ * fix-bot's `pushBranch` wraps `execFileSync('git', ['push', ...])` in
+ * try/catch + `printWarning`. Rule 38 (audit symmetric bots when
+ * fixing a pattern bug) says: when review-bot crashes on a shape that
+ * fix-bot handles gracefully, the symmetric fix lands here.
+ *
+ * This is a structural test per rule 40: assert the catch path is
+ * present at the `phase5Push` call site. The catch must record a
+ * needs-human skip-list entry + exit cleanly. Compiler can't enforce
+ * either invariant — both are pure runtime behavior reachable only
+ * via execFileSync failure paths, which can't be cheaply exercised
+ * in a unit test without mocking the entire orchestrator.
+ */
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const INDEX_PATH = join(__dirname, '..', 'index.ts')
+
+describe('review-bot phase5Push failure handling', () => {
+  it('wraps the phase5Push call in try/catch with a needs-human skip-list write', async () => {
+    const source = await readFile(INDEX_PATH, 'utf8')
+
+    // The APPROVE-verdict branch must call phase5Push inside a try
+    // block; the catch must record a needs-human skip-list entry
+    // before exiting. We assert the structural shape with a single
+    // multi-line regex that captures the contract:
+    //
+    //   try {
+    //     await phase5Push(...)
+    //     ...
+    //   } catch (err) {
+    //     ...
+    //     recordSkipListEntry(skipList, fingerprint, { reason: 'needs-human', ... })
+    //     ...
+    //     process.exit(0)
+    //   }
+    //
+    // We don't pin the exact whitespace / variable names — just the
+    // load-bearing structural invariant.
+    const approvePath = source.match(
+      /verdict\.kind === 'approve'[\s\S]*?try \{[\s\S]*?await phase5Push\([\s\S]*?\} catch \([\s\S]*?recordSkipListEntry\([\s\S]*?reason: 'needs-human'[\s\S]*?process\.exit\(0\)[\s\S]*?\}/,
+    )
+    expect(
+      approvePath,
+      'phase5Push call must be wrapped in try/catch that records needs-human + exits cleanly',
+    ).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

Rule 38 symmetric audit triggered by review-bot run #26707064619: when the bot crashed at \`git push\` after Agent A + Agent B both succeeded, the throw escaped uncaught → exit 1 → no skip-list entry recorded → next cron would redo all the work + crash again on the same root cause.

#477 fixed the specific root cause (branch-name sanitization). This PR closes the broader pattern: any push or PR-create failure (network, auth, remote rejection, refspec issues) is now handled gracefully.

## What changed

Wraps the \`phase5Push\` call site in try/catch. On failure: records a \`needs-human\` skip-list entry with the error message + exits cleanly. Mirrors fix-bot's \`pushBranch\` (try/catch + \`printWarning\`).

## TDD contract

- **Commit 1** (\`1096878\`): structural test that fails when the catch path is missing. Per rule 40 sub-case 3d — the contract can't be unit-tested cheaply without mocking \`execFileSync\` + octokit; the structural shape IS the load-bearing invariant.
- **Commit 2** (\`0c69741\`): the fix.

## Validation

- 1/1 new test fails when fix is reverted, passes when restored (TDD contract holds)
- 452/452 wider bot suite pass
- Biome format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)