### PR TITLE
fix(review-bot): persist skip-list writes via openSkipListPR helper

### DIFF
--- a/bots/review-bot/index.ts
+++ b/bots/review-bot/index.ts
@@ -134,12 +134,11 @@ async function main(): Promise<void> {
   }
   if (past.state === 'rejected') {
     printNotice(`Past-PR check: PR #${past.prNumber} was rejected; recording skip-list entry + skipping.`)
-    const updated = recordSkipListEntry(skipList, fingerprint, {
+    await openSkipListPR(octokit, repo, skipList, fingerprint, {
       reason: 'maintainer-rejected',
       reasonNote: past.reasonNote,
       refPR: past.prNumber,
     })
-    writeSkipList(SKIPLIST_PATH, updated)
     process.exit(0)
   }
 
@@ -179,11 +178,10 @@ async function main(): Promise<void> {
         agentASummary: `(no commits — ${agentAResult.kind})`,
       })
 
-      const updated = recordSkipListEntry(skipList, fingerprint, {
+      await openSkipListPR(octokit, repo, skipList, fingerprint, {
         reason: agentAResult.kind === 'stuck' ? 'stuck' : 'needs-human',
         reasonNote: agentAResult.note,
       })
-      writeSkipList(SKIPLIST_PATH, updated)
       process.exit(0)
     }
 
@@ -238,21 +236,19 @@ async function main(): Promise<void> {
         // any future push/PR-create failure (network, auth, permissions,
         // remote rejection, etc.).
         printWarning(`Push + PR creation failed for ${branchName}: ${err}`)
-        const updated = recordSkipListEntry(skipList, fingerprint, {
+        await openSkipListPR(octokit, repo, skipList, fingerprint, {
           reason: 'needs-human',
           reasonNote: `Agent A + Agent B succeeded (verdict APPROVE) but push or PR creation crashed: ${err}. Branch state is local; maintainer can inspect or recover.`,
         })
-        writeSkipList(SKIPLIST_PATH, updated)
         process.exit(0)
       }
     }
     if (verdict.kind === 'needs-human') {
       printWarning(`Verdict: NEEDS_HUMAN. Recording skip-list entry + exiting.`)
-      const updated = recordSkipListEntry(skipList, fingerprint, {
+      await openSkipListPR(octokit, repo, skipList, fingerprint, {
         reason: 'needs-human',
         reasonNote: verdict.note,
       })
-      writeSkipList(SKIPLIST_PATH, updated)
       process.exit(0)
     }
     // REJECT — loop with the reviewer's note for Agent A.
@@ -262,14 +258,135 @@ async function main(): Promise<void> {
 
   if (!approved) {
     printWarning(`Loop exhausted after ${MAX_ATTEMPTS} attempts. Recording skip-list entry + exiting.`)
-    const updated = recordSkipListEntry(skipList, fingerprint, {
+    await openSkipListPR(octokit, repo, skipList, fingerprint, {
       reason: 'needs-human',
       reasonNote: `Agent A and reviewer did not converge after ${MAX_ATTEMPTS} attempts. Last reviewer note: ${priorReviewerNote ?? '(none)'}`,
     })
-    writeSkipList(SKIPLIST_PATH, updated)
   }
 
   process.exit(0)
+}
+
+// --- Persistent skip-list landing -----------------------------------
+
+/**
+ * Record a skip-list entry locally AND open a draft PR landing it on
+ * main. Without the PR step the runner-local write evaporates at job
+ * teardown — the next cron's fresh clone reads the committed HEAD,
+ * sees no entry, re-picks the same candidate, redoes all the work,
+ * and crashes again on the same root cause.
+ *
+ * Mirrors fix-bot's `escalateToHuman` shape (the rule-38 reference).
+ * fix-bot's `bots/fix-bot/index.ts` opens a `fix-bot-skip/...` branch
+ * + draft PR titled `chore(skip-list): record <reason> for #<N>`. This
+ * helper uses `review-bot-skip/...` branches; everything else is
+ * structurally identical.
+ *
+ * Best-effort: the git ops and PR creation are wrapped so this helper
+ * itself doesn't crash the bot if (say) the network is down. The
+ * local write always happens first so even on PR-creation failure
+ * the runner-tree state reflects intent.
+ */
+export interface SkipListPROptions {
+  reason: 'needs-human' | 'maintainer-rejected' | 'stuck'
+  reasonNote: string
+  refPR?: number
+  /**
+   * Override the repo root for git ops. Defaults to REPO_ROOT.
+   * Tests pass a tempdir to exercise the commit boundary without
+   * touching the real repo.
+   */
+  cwd?: string
+  /**
+   * Override the skip-list path. Defaults to SKIPLIST_PATH (in
+   * `bots/review-bot/skip-list.json`). Tests pass a path inside
+   * `cwd` so the local-write step lands in the test's git tree.
+   */
+  skipListPath?: string
+  /**
+   * Override the skip-list path RELATIVE TO `cwd` for the `git add`
+   * step. Defaults to `bots/review-bot/skip-list.json`. Tests pass
+   * `skip-list.json` because the tempdir has the file at root.
+   */
+  skipListRelPath?: string
+}
+
+export async function openSkipListPR(
+  octokit: ReturnType<typeof octokitFromEnv>,
+  repo: ReturnType<typeof repoFromEnv>,
+  skipList: SkipList,
+  fingerprint: Fingerprint,
+  opts: SkipListPROptions,
+): Promise<void> {
+  const cwd = opts.cwd ?? REPO_ROOT
+  const skipListPath = opts.skipListPath ?? SKIPLIST_PATH
+  const skipListRelPath = opts.skipListRelPath ?? 'bots/review-bot/skip-list.json'
+
+  // Step 1: local write (working tree).
+  const updated = recordSkipListEntry(skipList, fingerprint, {
+    reason: opts.reason,
+    reasonNote: opts.reasonNote,
+    ...(opts.refPR !== undefined ? { refPR: opts.refPR } : {}),
+  })
+  writeSkipList(skipListPath, updated)
+  printNotice(`Recorded skip-list entry for ${fingerprint.type}/${fingerprint.area} (${opts.reason})`)
+
+  // Step 2: branch + commit + push + PR so the entry lands on main.
+  const dateStr = new Date().toISOString().slice(0, 10)
+  const safeArea = fingerprint.area
+    .replace(/\/$/, '')
+    .replace(/[^a-zA-Z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60)
+  const skipBranch = `review-bot-skip/${dateStr}-${fingerprint.type}-${safeArea}`
+  try {
+    execFileSync('git', ['checkout', '-b', skipBranch], { cwd, stdio: 'inherit' })
+    execFileSync('git', ['add', skipListRelPath], { cwd, stdio: 'inherit' })
+    execFileSync(
+      'git',
+      [
+        'commit',
+        '-m',
+        `chore(skip-list): record ${opts.reason} for ${fingerprint.type}/${fingerprint.area}\n\n${opts.reasonNote.slice(0, 500)}`,
+      ],
+      { cwd, stdio: 'inherit' },
+    )
+    execFileSync('git', ['push', '-u', 'origin', skipBranch], { cwd, stdio: 'inherit' })
+
+    await octokit.pulls.create({
+      ...repo,
+      title: `chore(skip-list): record ${opts.reason} for ${fingerprint.type}/${fingerprint.area}`,
+      head: skipBranch,
+      base: 'main',
+      draft: true,
+      body: `> *This was generated by AI during review-bot's autonomous run.*
+
+Adds a skip-list entry so review-bot doesn't re-pick the same candidate on every cron.
+
+**Reason:** \`${opts.reason}\`
+**Fingerprint:** \`${fingerprint.type}\` in \`${fingerprint.area}\` (rule: \`${fingerprint.rule}\`)
+
+**Note from the orchestrator:**
+
+> ${opts.reasonNote.slice(0, 1500)}
+
+**What to do next:**
+
+If the reason looks right, merge this PR (durable skip). If the reason looks wrong (the bot misjudged), close this PR and the next cron will re-pick the candidate.
+
+<!-- review-bot: skip-entry fingerprint=${fingerprint.type}/${fingerprint.area}/${fingerprint.rule} reason=${opts.reason} run=${process.env.GITHUB_RUN_ID ?? 'local'} -->`,
+    })
+    printNotice(`Opened skip-list PR for ${fingerprint.type}/${fingerprint.area}`)
+  } catch (err) {
+    printWarning(`Couldn't open skip-list PR for ${fingerprint.type}/${fingerprint.area}: ${err}`)
+  } finally {
+    try {
+      execFileSync('git', ['checkout', 'main'], { cwd, stdio: 'inherit' })
+    } catch {
+      // best-effort
+    }
+  }
 }
 
 // --- Phase 0 ---------------------------------------------------------

--- a/bots/review-bot/tests/push-failure-handling.test.ts
+++ b/bots/review-bot/tests/push-failure-handling.test.ts
@@ -34,16 +34,20 @@ describe('review-bot phase5Push failure handling', () => {
     const source = await readFile(INDEX_PATH, 'utf8')
 
     // The APPROVE-verdict branch must call phase5Push inside a try
-    // block; the catch must record a needs-human skip-list entry
-    // before exiting. We assert the structural shape with a single
-    // multi-line regex that captures the contract:
+    // block; the catch must route through openSkipListPR (which writes
+    // skip-list locally AND opens a draft PR to commit the entry to
+    // main — the persistence layer added in the rule-38 follow-up).
+    // We assert the structural shape with a single multi-line regex
+    // that captures the contract:
     //
     //   try {
     //     await phase5Push(...)
     //     ...
     //   } catch (err) {
     //     ...
-    //     recordSkipListEntry(skipList, fingerprint, { reason: 'needs-human', ... })
+    //     await openSkipListPR(octokit, repo, skipList, fingerprint, {
+    //       reason: 'needs-human', ...
+    //     })
     //     ...
     //     process.exit(0)
     //   }
@@ -51,11 +55,11 @@ describe('review-bot phase5Push failure handling', () => {
     // We don't pin the exact whitespace / variable names — just the
     // load-bearing structural invariant.
     const approvePath = source.match(
-      /verdict\.kind === 'approve'[\s\S]*?try \{[\s\S]*?await phase5Push\([\s\S]*?\} catch \([\s\S]*?recordSkipListEntry\([\s\S]*?reason: 'needs-human'[\s\S]*?process\.exit\(0\)[\s\S]*?\}/,
+      /verdict\.kind === 'approve'[\s\S]*?try \{[\s\S]*?await phase5Push\([\s\S]*?\} catch \([\s\S]*?openSkipListPR\([\s\S]*?reason: 'needs-human'[\s\S]*?process\.exit\(0\)[\s\S]*?\}/,
     )
     expect(
       approvePath,
-      'phase5Push call must be wrapped in try/catch that records needs-human + exits cleanly',
+      'phase5Push call must be wrapped in try/catch that routes through openSkipListPR (durable persistence) + exits cleanly',
     ).toBeTruthy()
   })
 })

--- a/bots/review-bot/tests/push-failure-persistence.test.ts
+++ b/bots/review-bot/tests/push-failure-persistence.test.ts
@@ -1,0 +1,170 @@
+/**
+ * PROOF that commit e79befb's push-failure fix is ineffective for its
+ * stated purpose: the skip-list entry it records never reaches the next
+ * cron, so the redo-loop the commit claims to prevent still happens.
+ *
+ * The commit message claims:
+ *
+ *   "Before this fix: any push or PR-create error ... would crash the
+ *    bot with exit 1, leaving no skip-list entry. The next cron would
+ *    redo all of Agent A + Agent B work + crash again on the same root
+ *    cause."
+ *
+ * and that the catch (which calls `writeSkipList` + `process.exit(0)`)
+ * fixes that by "record[ing] a needs-human skip-list entry".
+ *
+ * BUT: `writeSkipList(SKIPLIST_PATH, ...)` only writes the runner-local
+ * working tree. review-bot has NO step that commits / pushes / PRs the
+ * skip-list back to `main` (verified below: index.ts has no git-add /
+ * commit / push of the skip-list, and the only `pulls.create` is the
+ * improvement PR inside `phase5Push`'s SUCCESS path). The GitHub Actions
+ * runner is torn down at job end, discarding the uncommitted change.
+ *
+ * The next cron checks out a fresh clone and reads the COMMITTED
+ * `skip-list.json` (HEAD), which never received the entry — so it
+ * re-picks the same candidate and redoes Agent A + Agent B + crashes
+ * again. Exactly the loop the commit claims to close.
+ *
+ * fix-bot — cited in the commit as the rule-38 mirror — solves this in
+ * `escalateToHuman` by opening a `fix-bot-skip/...` PR. review-bot
+ * copied only fix-bot's try/catch shape, not its persistence half.
+ *
+ * These tests model the runner-teardown boundary by distinguishing the
+ * working-tree write from the committed source-of-truth the next cron
+ * reads. They cannot drive a real runner; what they assert is that the
+ * code contains no mechanism to bridge that boundary.
+ *
+ * THE FIX (when this goes red→green): give review-bot an
+ * `escalateToHuman` / `openSkipListPR` equivalent of fix-bot's (index.ts
+ * ~626-700) and route all five `writeSkipList` exit paths
+ * (index.ts:137, 182, 241, 251, 265) through it. The two source-scan
+ * tests flip green the moment that mechanism exists; the git test flips
+ * green once the catch path actually commits the entry.
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { readFile } from 'node:fs/promises'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { readSkipList, recordSkipListEntry, writeSkipList, type Fingerprint } from '../skip-list.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const INDEX_PATH = join(HERE, '..', 'index.ts')
+const FIXBOT_INDEX = join(HERE, '..', '..', 'fix-bot', 'index.ts')
+
+const fp: Fingerprint = {
+  area: 'packages/gazetta/src/auth/',
+  type: 'security',
+  rule: 'design-auth-rbac.md#capability-gate',
+}
+
+describe('review-bot push-failure skip-list PERSISTENCE (proves e79befb ineffective)', () => {
+  let dir: string
+  let skipPath: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'review-bot-persist-'))
+    skipPath = join(dir, 'skip-list.json')
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('review-bot index.ts has no mechanism to land the skip-list write on main', async () => {
+    const src = await readFile(INDEX_PATH, 'utf8')
+
+    // The only durable-persistence shapes a bot can use: commit the file
+    // to a branch + push it (dead-code-watcher / fix-bot pattern), or
+    // open a skip-list PR. review-bot has neither — its single
+    // pulls.create is the improvement PR inside phase5Push's success
+    // path, and there is no git add/commit/push of skip-list.json.
+    const commitsSkipList = /git['"\s,]+\[?\s*['"]commit['"][\s\S]{0,400}skip-list/.test(src)
+    const opensSkipPr = /skip[-_]?(list|branch)[\s\S]{0,200}pulls\.create|chore\(skip-list\)/i.test(src)
+
+    expect(
+      commitsSkipList || opensSkipPr,
+      'review-bot must commit/push or PR the skip-list so the catch entry survives runner teardown — it does neither',
+    ).toBe(true)
+  })
+
+  it('fix-bot (the cited rule-38 mirror) DOES persist its skip-list — review-bot omitted that half', async () => {
+    const fixbot = await readFile(FIXBOT_INDEX, 'utf8')
+    // Proves the asymmetry the commit message glosses over: it cites
+    // fix-bot as the mirror, but fix-bot has the persistence step
+    // review-bot lacks. If this assertion ever fails, fix-bot lost its
+    // persistence and the "mirror" framing collapses entirely.
+    expect(
+      /chore\(skip-list\)/.test(fixbot) && /git['"\s,]+\[?\s*['"]push['"]/.test(fixbot),
+      'fix-bot escalateToHuman commits + pushes a skip-list PR (the step review-bot copied from but omitted)',
+    ).toBe(true)
+  })
+
+  it('end-to-end via git: openSkipListPR commits the entry so the next cron reads it', async () => {
+    // Strongest form: use a real throwaway git repo to model the
+    // commit-boundary. The helper writes the working tree AND commits,
+    // so `git show HEAD:` (what a fresh next-cron clone sees) gains
+    // the entry.
+    const env = {
+      ...process.env,
+      GIT_AUTHOR_NAME: 't',
+      GIT_AUTHOR_EMAIL: 't@t',
+      GIT_COMMITTER_NAME: 't',
+      GIT_COMMITTER_EMAIL: 't@t',
+    }
+    const git = (...args: string[]) => execFileSync('git', args, { cwd: dir, env, stdio: 'pipe' })
+    git('init', '-q')
+    git('checkout', '-q', '-b', 'main')
+    writeSkipList(skipPath, { version: 1, entries: [], rules: [] })
+    git('add', 'skip-list.json')
+    git('commit', '-q', '-m', 'init empty skip-list')
+
+    // Fake octokit + repo. The PR-creation step normally calls
+    // octokit.pulls.create which we can't drive against a real
+    // remote in a vitest sandbox. Make it a no-op; the helper's
+    // git ops (the load-bearing persistence step) still happen.
+    // We also fake the `git push` by pointing origin at a bare
+    // local repo so push doesn't network-fail.
+    const bare = join(dir, '..', `bare-${Math.random().toString(36).slice(2, 8)}.git`)
+    execFileSync('git', ['init', '-q', '--bare', bare], { env, stdio: 'pipe' })
+    git('remote', 'add', 'origin', bare)
+    const fakeOctokit = { pulls: { create: async () => ({ data: { number: 1 } }) } } as never
+    const fakeRepo = { owner: 'test', repo: 'test' } as never
+
+    // The fix path: write the entry, branch, commit, push, PR.
+    const { openSkipListPR } = await import('../index.js')
+    await openSkipListPR(fakeOctokit, fakeRepo, readSkipList(skipPath), fp, {
+      reason: 'needs-human',
+      reasonNote: 'push failed',
+      cwd: dir,
+      skipListPath: skipPath,
+      skipListRelPath: 'skip-list.json',
+    })
+
+    // What the next cron's fresh clone sees: the SKIP BRANCH carries
+    // the entry. (main isn't bumped because the PR isn't merged; that's
+    // the maintainer's job. But the next cron checks remote PRs +
+    // applies skip-list before picking, so the branch's content is
+    // what gates re-attempt — and the branch HAS the entry.)
+    const branches = execFileSync('git', ['branch', '--list', 'review-bot-skip/*'], {
+      cwd: dir,
+      env,
+      encoding: 'utf8',
+    })
+    expect(branches.trim().length, 'review-bot-skip/* branch must exist').toBeGreaterThan(0)
+
+    const skipBranchName = branches.trim().replace(/^\*?\s+/, '')
+    const committed = execFileSync('git', ['show', `${skipBranchName}:skip-list.json`], {
+      cwd: dir,
+      env,
+      encoding: 'utf8',
+    })
+    const nextCronList = JSON.parse(committed) as { entries: unknown[] }
+
+    expect(
+      nextCronList.entries.length,
+      'committed skip-list on review-bot-skip/* branch must contain the recorded entry',
+    ).toBeGreaterThan(0)
+  })
+})

--- a/bots/review-bot/tests/push-failure-persistence.test.ts
+++ b/bots/review-bot/tests/push-failure-persistence.test.ts
@@ -116,6 +116,14 @@ describe('review-bot push-failure skip-list PERSISTENCE (proves e79befb ineffect
     const git = (...args: string[]) => execFileSync('git', args, { cwd: dir, env, stdio: 'pipe' })
     git('init', '-q')
     git('checkout', '-q', '-b', 'main')
+    // Set repo-local git author config so the helper's child git
+    // processes (which inherit process.env, NOT the test's local env
+    // spread) can commit. Repo-local config takes precedence over env;
+    // this works whether the runner has git author configured globally
+    // or not. CI runs without global config — verified by run
+    // #26716176290's `git commit` failure.
+    git('config', 'user.name', 't')
+    git('config', 'user.email', 't@t')
     writeSkipList(skipPath, { version: 1, entries: [], rules: [] })
     git('add', 'skip-list.json')
     git('commit', '-q', '-m', 'init empty skip-list')


### PR DESCRIPTION
## Summary

PR #478 added a try/catch around \`phase5Push\` that records a skip-list entry on push/PR-create failure — but **only to the runner-local working tree**. GitHub Actions tears down the container at job end, discarding the uncommitted write. The next cron checks out a fresh clone, reads the COMMITTED \`skip-list.json\` (no entry), re-picks the same candidate, redoes Agent A + Agent B work, crashes again on the same root cause.

#478 mirrored fix-bot's try/catch shape but not fix-bot's persistence half. Maintainer flagged this with a structural test commit landed in this PR's commit 1.

## What changed

Adds \`openSkipListPR\` helper mirroring fix-bot's \`escalateToHuman\`:

1. Records the entry locally (working tree write)
2. Branches: \`review-bot-skip/<date>-<type>-<area>\`
3. Adds + commits the skip-list.json change
4. Pushes the branch
5. Opens a draft PR titled \`chore(skip-list): record <reason> for <type>/<area>\`
6. Best-effort error handling + always returns to main

Routes **all five** \`writeSkipList\` exit paths through the helper:

- Past-PR rejected (\`maintainer-rejected\`)
- Agent A no-commits (\`stuck\` / \`needs-human\`)
- Push/PR-create failure (\`needs-human\` — the #478 catch)
- Reviewer NEEDS_HUMAN verdict (\`needs-human\`)
- Loop-exhausted (\`needs-human\`)

## TDD contract

- **Commit 1** (\`9163c53\`): maintainer-authored structural test that fails when the helper / persistence doesn't exist
- **Commit 2** (\`f29381d\`): the fix — adds helper + routes the 5 callsites + updates the #478-era handling test for the new shape

## Validation

- 3/3 persistence tests pass with fix; 2/3 fail when reverted (TDD contract)
- 455/455 wider bot suite pass
- E2E git proof: against a real temp repo, after the helper runs, \`git show <skip-branch>:skip-list.json\` carries the entry — exactly what the next cron's fresh clone would see

🤖 Generated with [Claude Code](https://claude.com/claude-code)