### PR TITLE
feat: cut #448 — redirect-ui Cut 5: CreateRedirectDialog capability-gap badges

### DIFF
--- a/apps/admin/src/client/components/CreateRedirectDialog.vue
+++ b/apps/admin/src/client/components/CreateRedirectDialog.vue
@@ -28,7 +28,7 @@ import RadioButton from 'primevue/radiobutton'
 import { useRedirectsApi } from '../composables/api.js'
 import { useSiteStore } from '../stores/site.js'
 import { useArchivedConflict } from '../composables/useArchivedConflict.js'
-import type { CreateRedirectRequest } from '../api/client.js'
+import { api, type CreateRedirectRequest, type TargetInfo } from '../api/client.js'
 import ArchivedNameConflictPrompt from './ArchivedNameConflictPrompt.vue'
 
 const props = defineProps<{ visible: boolean }>()
@@ -40,6 +40,25 @@ const redirectsApi = useRedirectsApi()
 const kind = ref<'page' | 'fragment'>('page')
 const fromInput = ref('')
 const toInput = ref('')
+
+/**
+ * Per-target capability info — surface #2 of the four-point
+ * capability-gap UX pattern (per `feature-design-process.md` non-
+ * foundational disciplines + `design-soft-delete.md` Q10 lock).
+ *
+ * Manual Redirects are bytes-identical on disk to Rename Redirects
+ * (archive manifest with `aliasOf`), so the same capability gap
+ * applies: plain-static targets (no worker, no `redirects.format`)
+ * can't emit the 301 redirect. The author sees the gap inline before
+ * confirming — informational, not blocking; the operator may
+ * legitimately accept the limitation. The other three surfaces
+ * (boot validate / scanner / publish gate) cover downstream.
+ *
+ * Mirrors `ArchiveModal.vue`'s pattern: load /api/targets at mount,
+ * compute the gapped subset, render a warning row only when the
+ * gap set is non-empty (Krug rule 23 — absence is the state).
+ */
+const targets = ref<TargetInfo[]>([])
 
 /**
  * Match design-redirect-ui.md Q4: derive route only for display preview;
@@ -105,6 +124,21 @@ const {
   },
 })
 
+/**
+ * Targets that can't serve redirects — drives the warning row.
+ * Krug-aligned: only render rows that need attention; empty list ⇒
+ * no warning section at all.
+ */
+const targetsWithGaps = computed(() =>
+  targets.value
+    .filter(t => t.capabilities.gaps.some(g => g.capability === 'redirects'))
+    .map(t => ({
+      name: t.name,
+      environment: t.environment,
+      gaps: t.capabilities.gaps,
+    })),
+)
+
 const canSubmit = computed(
   () => !creating.value && fromInput.value.trim().length > 0 && toInput.value.trim().length > 0,
 )
@@ -127,8 +161,16 @@ function onKeydown(event: KeyboardEvent) {
   }
 }
 
-onMounted(() => {
+onMounted(async () => {
   document.addEventListener('keydown', onKeydown)
+  // Load per-target capability info — surface #2. Failure leaves
+  // targets empty; we degrade silently rather than blocking the
+  // dialog over a transient /api/targets error.
+  try {
+    targets.value = await api.getTargets()
+  } catch {
+    targets.value = []
+  }
 })
 
 onUnmounted(() => {
@@ -195,6 +237,33 @@ onUnmounted(() => {
         </datalist>
         <span v-if="toPreview" class="create-hint">Will redirect to: {{ toPreview }}</span>
       </div>
+
+      <!--
+        Capability-gap surface #2 — per-target warnings only when the
+        target can't serve 301 redirects. Krug rule 23: absence is
+        the "all good" state; only render rows that need attention.
+        The warning is informational (Cut 5 acceptance): the operator
+        can still submit. Worker-served targets fire the redirect;
+        plain-static targets fall through to the host's natural 404.
+      -->
+      <div v-if="targetsWithGaps.length > 0" class="create-gaps" data-testid="redirect-capability-gaps">
+        <p class="create-gaps-title">
+          <i class="pi pi-exclamation-triangle" /> Some targets won't emit this redirect
+        </p>
+        <ul class="create-gaps-list">
+          <li v-for="t in targetsWithGaps" :key="t.name">
+            <strong>{{ t.name }}</strong> <span class="env-tag">({{ t.environment }})</span>:
+            <span v-for="gap in t.gaps" :key="gap.capability" class="gap-reason">
+              {{ gap.reason }}
+            </span>
+          </li>
+        </ul>
+        <p class="create-gaps-note">
+          You can still create the redirect — see
+          <a href="https://gazetta.studio/docs/runtime-capabilities" target="_blank" rel="noopener">runtime capabilities</a>
+          for resolution paths.
+        </p>
+      </div>
     </div>
 
     <!-- Lifted out of `.create-content` so the message is visible both
@@ -231,4 +300,12 @@ onUnmounted(() => {
 
 .create-kind-row { display: flex; gap: 1rem; align-items: center; }
 .create-kind-option { display: flex; gap: 0.375rem; align-items: center; cursor: pointer; font-size: 0.875rem; }
+
+.create-gaps { background: var(--color-warning-bg); border: 1px solid var(--color-warning-fg); border-radius: 4px; padding: 0.75rem; }
+.create-gaps-title { margin: 0 0 0.5rem; font-weight: 600; font-size: 0.875rem; color: var(--color-warning-fg); display: flex; align-items: center; gap: 0.375rem; }
+.create-gaps-list { margin: 0; padding-left: 1.25rem; font-size: 0.8125rem; color: var(--color-fg); }
+.create-gaps-list li { margin-bottom: 0.25rem; }
+.gap-reason { font-style: italic; }
+.env-tag { font-size: 0.75rem; color: var(--color-muted); }
+.create-gaps-note { margin: 0.5rem 0 0; font-size: 0.75rem; color: var(--color-muted); }
 </style>

--- a/apps/admin/tests/CreateRedirectDialog-capability-gap.test.ts
+++ b/apps/admin/tests/CreateRedirectDialog-capability-gap.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Cut 5 — CreateRedirectDialog capability-gap badges.
+ *
+ * Pins the Cut 5 acceptance criteria from issue #448. Per
+ * `design-redirect-ui.md` "Foundational checks" → existing four-point
+ * capability-gap UX pattern (Q10 lock of design-soft-delete.md). The
+ * dialog mirrors ArchiveModal's per-target capability badges so the
+ * author sees the gap BEFORE confirming the redirect.
+ *
+ * What's pinned:
+ *   - Plain-static target (no worker, no redirects.format) → dialog
+ *     renders a capability-gap warning row identifying that target.
+ *   - Worker-served / static-with-redirects target → no gap warning
+ *     (Krug "absence is the state"; only render rows that need
+ *     attention).
+ *   - Submit succeeds on a target-set that includes a plain-static
+ *     gap — the gap is informational, NOT blocking. Operator can
+ *     proceed knowing the gap; the four-point pattern handles
+ *     downstream surfaces (validator scanner, publish gate).
+ *
+ * Mocking note: the dialog loads /api/targets at mount-time via the
+ * direct `api` import (mirrors ArchiveModal). vi.spyOn on api.getTargets
+ * stubs the load without touching component injection.
+ */
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import PrimeVue from 'primevue/config'
+import CreateRedirectDialog from '../src/client/components/CreateRedirectDialog.vue'
+import { useSiteStore } from '../src/client/stores/site.js'
+import { REDIRECTS_API, type RedirectsApi } from '../src/client/composables/api.js'
+import { api, type CreateRedirectResponse, type TargetInfo } from '../src/client/api/client.js'
+
+beforeAll(() => {
+  if (typeof window.matchMedia !== 'function') {
+    window.matchMedia = (query: string) =>
+      ({
+        matches: false,
+        media: query,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+        onchange: null,
+      }) as unknown as MediaQueryList
+  }
+})
+
+function makeRedirectsApi(overrides: Partial<RedirectsApi> = {}): RedirectsApi {
+  return {
+    createPageRedirect: vi.fn().mockRejectedValue(new Error('not stubbed: createPageRedirect')),
+    createFragmentRedirect: vi.fn().mockRejectedValue(new Error('not stubbed: createFragmentRedirect')),
+    ...overrides,
+  }
+}
+
+function successResponse(overrides: Partial<CreateRedirectResponse> = {}): CreateRedirectResponse {
+  return {
+    ok: true,
+    from: 'old-products',
+    to: 'products/featured',
+    kind: 'page',
+    route: '/old-products',
+    targetRoute: '/products/featured',
+    ...overrides,
+  }
+}
+
+function seedSite() {
+  const site = useSiteStore()
+  site.pages = [
+    { name: 'products/featured', route: '/products/featured', template: 'product', dir: 'pages' } as any,
+    { name: 'home', route: '/', template: 'home', dir: 'pages' } as any,
+  ]
+  site.fragments = []
+  return site
+}
+
+function mountDialog(api: RedirectsApi) {
+  return mount(CreateRedirectDialog, {
+    props: { visible: true },
+    attachTo: document.body,
+    global: {
+      plugins: [PrimeVue],
+      provide: { [REDIRECTS_API as symbol]: api },
+    },
+  })
+}
+
+function plainStaticTarget(name: string): TargetInfo {
+  // Plain-static: type=static, no redirects.format, no worker → both
+  // 'redirects' and 'gone-status' capabilities missing per
+  // inspectTarget().
+  return {
+    name,
+    environment: 'production',
+    type: 'static',
+    editable: false,
+    altText: { available: false, auto: false },
+    capabilities: {
+      has: [],
+      gaps: [
+        {
+          capability: 'redirects',
+          reason:
+            "plain-static target has no worker and no `redirects.format` configured; archived URLs return the host's natural 404 instead of a 301 redirect",
+        },
+        {
+          capability: 'gone-status',
+          reason:
+            "no worker runtime available to emit `410 Gone` for archived-no-alias items; falls back to the host's natural 404",
+        },
+      ],
+    },
+  }
+}
+
+function workerServedTarget(name: string, environment: TargetInfo['environment'] = 'local'): TargetInfo {
+  // Worker-served (type=dynamic) → has redirects + gone-status.
+  return {
+    name,
+    environment,
+    type: 'dynamic',
+    editable: environment === 'local',
+    altText: { available: false, auto: false },
+    capabilities: {
+      has: ['redirects', 'gone-status'],
+      gaps: [],
+    },
+  }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  document.body.innerHTML = ''
+})
+
+describe('CreateRedirectDialog — capability-gap badges (Cut 5)', () => {
+  it('plain-static target → dialog renders a capability-gap warning row identifying the target', async () => {
+    seedSite()
+    vi.spyOn(api, 'getTargets').mockResolvedValue([
+      workerServedTarget('local', 'local'),
+      plainStaticTarget('production-static'),
+    ])
+
+    const wrapper = mountDialog(makeRedirectsApi())
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    // The gap-warning surface marks the section so authors can see
+    // "Some targets won't emit redirects" at a glance.
+    const gapSection = document.querySelector('[data-testid="redirect-capability-gaps"]')
+    expect(gapSection).not.toBeNull()
+    // The plain-static target is named explicitly — operator can map
+    // the warning to their config without help text.
+    expect(gapSection!.textContent ?? '').toContain('production-static')
+    // The gap reason surfaces inline; operator sees WHY without
+    // hovering or clicking through (Krug — no help-tooltip-as-bandaid).
+    expect(gapSection!.textContent?.toLowerCase() ?? '').toMatch(/redirect|301|natural 404/)
+
+    wrapper.unmount()
+  })
+
+  it('worker-served target only → no capability-gap warning rendered (absence is the state)', async () => {
+    seedSite()
+    vi.spyOn(api, 'getTargets').mockResolvedValue([workerServedTarget('local', 'local')])
+
+    const wrapper = mountDialog(makeRedirectsApi())
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    // Krug rule 23 — only render rows that need attention. With
+    // every configured target capable of emitting 301/410, the
+    // capability-gap section is absent.
+    expect(document.querySelector('[data-testid="redirect-capability-gaps"]')).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('submit succeeds when a plain-static target is in the gap list (informational, not blocking)', async () => {
+    seedSite()
+    vi.spyOn(api, 'getTargets').mockResolvedValue([
+      workerServedTarget('local', 'local'),
+      plainStaticTarget('production-static'),
+    ])
+    const createPage = vi.fn().mockResolvedValue(successResponse())
+    const api2 = makeRedirectsApi({ createPageRedirect: createPage })
+
+    const wrapper = mountDialog(api2)
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    // Sanity — the gap warning IS rendered (the precondition of
+    // this test).
+    expect(document.querySelector('[data-testid="redirect-capability-gaps"]')).not.toBeNull()
+
+    // Fill the inputs + submit. The gap row is informational only;
+    // the submit button stays enabled and the POST fires.
+    const fromInput = document.querySelector('[data-testid="create-redirect-from-input"]') as HTMLInputElement
+    const toInput = document.querySelector('[data-testid="create-redirect-to-input"]') as HTMLInputElement
+    fromInput.value = '/old-products'
+    fromInput.dispatchEvent(new Event('input'))
+    toInput.value = 'products/featured'
+    toInput.dispatchEvent(new Event('input'))
+    await wrapper.vm.$nextTick()
+
+    const submit = document.querySelector('[data-testid="create-redirect-submit"]') as HTMLButtonElement
+    submit.click()
+    await flushPromises()
+
+    // Submit fired; gap was informational, not gating.
+    expect(createPage).toHaveBeenCalledTimes(1)
+    expect(createPage).toHaveBeenCalledWith({ from: '/old-products', to: 'products/featured' }, undefined)
+
+    wrapper.unmount()
+  })
+})

--- a/packages/gazetta/tests/redirect-ui-capability-gap.test.ts
+++ b/packages/gazetta/tests/redirect-ui-capability-gap.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Cut 5 — capability-gap composition for Manual Redirects.
+ *
+ * Per `design-redirect-ui.md` "Foundational checks" and the cut sub-
+ * issue acceptance: Manual Redirects are bytes-identical on disk to
+ * Rename Redirects (archive manifest with `aliasOf`, no `template`).
+ * The existing capability-gap surfaces (P4 validator scanner, publish-
+ * audit endpoint) already key on `archived: true` — this cut pins
+ * that the composition holds when the manifest was authored via the
+ * Manual Redirect path (NO preceding rename), so a future refactor
+ * that tightens the validator's scope (e.g. require `template` to be
+ * present) would break Manual Redirects loudly here.
+ *
+ * Tests:
+ *   - `archive-not-supported-on-target` (P4) fires for a Manual
+ *     Redirect manifest on a plain-static target. Same surface the
+ *     site-health drawer reads from Cut 2's background scanner.
+ *   - `POST /api/publish/audit` surfaces `capabilities` when the
+ *     publish set includes a Manual Redirect manifest. Same surface
+ *     PublishPanel reads to render the pre-publish capability
+ *     warning.
+ *
+ * Per rule 26 (test-isolation paranoia): fresh memoryStorage + fresh
+ * createAdminApp per test.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { Hono } from 'hono'
+import { createAdminApp } from '../src/admin-api/index.js'
+import { createSourceContext } from '../src/admin-api/source-context.js'
+import { archiveNotSupportedOnTarget } from '../src/validation/validators/archive-not-supported-on-target.js'
+import { createValidatorRegistry } from '../src/validation/registry.js'
+import type { PageManifest, SiteManifest } from '../src/types.js'
+import type { Site } from '../src/site-loader.js'
+import { createContentRoot } from '../src/content-root.js'
+import { memoryStorage, type MemoryStorage } from './_helpers/memory-storage.js'
+
+/**
+ * Manual Redirect manifest shape per design-redirect-ui.md Q2 + Cut 3
+ * route implementation: archive fields set, NO template field, name
+ * matches the from-route. Distinct from a Rename Redirect because no
+ * preceding live page existed — operator created this manifest via
+ * `POST /api/page-redirects`.
+ */
+function makeManualRedirectPageManifest(aliasOf: string): PageManifest {
+  return {
+    archived: true,
+    archivedAt: '2026-06-01T10:00:00Z',
+    archivedBy: 'alice@example.com',
+    aliasOf,
+    // No template field — the schema refinement (Cut 1) makes
+    // template optional when archived: true.
+  } as PageManifest
+}
+
+describe('Cut 5 — Manual Redirects compose with the four-point capability-gap UX', () => {
+  describe('surface #3 (validator scanner) — P4 fires for Manual Redirect on plain-static', () => {
+    it('archive-not-supported-on-target warns for a Manual Redirect manifest on a plain-static target', async () => {
+      const storage = memoryStorage()
+      const manifest: SiteManifest = {
+        name: 'test-site',
+        targets: {
+          'production-static': { storage, type: 'static' },
+        },
+      }
+      const site: Site = {
+        manifest,
+        pages: new Map(),
+        pageLocales: new Map(),
+        fragments: new Map(),
+        fragmentLocales: new Map(),
+        contentRoot: createContentRoot(storage, ''),
+        storage,
+        siteDir: '',
+        templatesDir: '',
+      } as Site
+
+      const issues = await archiveNotSupportedOnTarget.validate({
+        stage: 'background',
+        site,
+        contentRoot: site.contentRoot,
+        storage,
+        scope: {
+          kind: 'background',
+          item: {
+            kind: 'page',
+            name: 'old-promo',
+            itemPath: 'pages/old-promo/page.json',
+          },
+          manifest: makeManualRedirectPageManifest('home'),
+        },
+      })
+
+      // Manual Redirects are archived manifests; the P4 validator
+      // contract — warn-severity per archived item that would lose
+      // its redirect on a gapped target — applies regardless of
+      // whether the archive came from rename or from a Manual
+      // Redirect create.
+      expect(issues.length).toBeGreaterThan(0)
+      expect(issues[0].validator).toBe('archive-not-supported-on-target')
+      expect(issues[0].severity).toBe('warn')
+      // The gapped target name surfaces in the message so the site-
+      // health drawer can group issues per target.
+      expect(issues[0].message).toContain('production-static')
+    })
+
+    it('archive-not-supported-on-target does NOT warn when the only target is worker-served', async () => {
+      const storage = memoryStorage()
+      const manifest: SiteManifest = {
+        name: 'test-site',
+        targets: {
+          // type: dynamic means hasWorker=true → no gaps per
+          // inspectTarget().
+          local: { storage, type: 'dynamic' },
+        },
+      }
+      const site: Site = {
+        manifest,
+        pages: new Map(),
+        pageLocales: new Map(),
+        fragments: new Map(),
+        fragmentLocales: new Map(),
+        contentRoot: createContentRoot(storage, ''),
+        storage,
+        siteDir: '',
+        templatesDir: '',
+      } as Site
+
+      const issues = await archiveNotSupportedOnTarget.validate({
+        stage: 'background',
+        site,
+        contentRoot: site.contentRoot,
+        storage,
+        scope: {
+          kind: 'background',
+          item: {
+            kind: 'page',
+            name: 'old-promo',
+            itemPath: 'pages/old-promo/page.json',
+          },
+          manifest: makeManualRedirectPageManifest('home'),
+        },
+      })
+
+      // Worker-served target — no capability gap → no warning.
+      // Pins that the validator's logic is target-capability driven,
+      // not Manual-Redirect-blind.
+      expect(issues).toEqual([])
+    })
+  })
+
+  describe('surface #4 (publish gate) — /api/publish/audit includes capabilities for Manual Redirects', () => {
+    let app: Hono
+    let storage: MemoryStorage
+
+    beforeEach(() => {
+      storage = memoryStorage()
+      // Seed a Manual Redirect manifest at pages/old-promo. The
+      // alias target (`home`) is live so the manifest passes
+      // referential validity; what we're testing is whether the
+      // publish-audit response surfaces the capability gap for the
+      // destination target.
+      storage.seed({
+        'pages/old-promo/page.json': JSON.stringify(makeManualRedirectPageManifest('home')),
+        'pages/home/page.json': JSON.stringify({
+          template: 'page-default',
+          content: { title: 'Home' },
+        }),
+      })
+
+      const targetConfigs = {
+        local: {
+          storage,
+          type: 'dynamic' as const,
+          environment: 'local' as const,
+          editable: true,
+        },
+        'production-static': {
+          storage,
+          type: 'static' as const,
+          environment: 'production' as const,
+          // No `redirects.format` → plain-static → both 'redirects'
+          // and 'gone-status' missing.
+        },
+      }
+
+      const source = createSourceContext({
+        storage,
+        siteDir: '',
+        projectSiteDir: '/test-project',
+        manifest: {
+          name: 'test-site',
+          targets: targetConfigs,
+        },
+      })
+
+      app = createAdminApp({
+        source,
+        siteDir: '/test-project',
+        templatesDir: '/test-project/templates',
+        targets: new Map([
+          ['local', storage],
+          ['production-static', storage],
+        ]),
+        targetConfigs,
+        disableCacheStatsLogger: true,
+        // Registry of one — composes with the publish gate even
+        // when other validators aren't wired.
+        validators: createValidatorRegistry([archiveNotSupportedOnTarget]),
+      })
+    })
+
+    it('publish-audit surfaces capabilities when a Manual Redirect is in the publish set on a gapped target', async () => {
+      const res = await app.request('/api/publish/audit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          target: 'production-static',
+          items: [{ kind: 'page', name: 'old-promo' }],
+        }),
+      })
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as {
+        capabilities?: {
+          has: string[]
+          gaps: Array<{ capability: string; reason: string }>
+        }
+      }
+
+      // The publish-gate's includesArchived predicate checks the
+      // manifest's archived field — Manual Redirects have it set
+      // identically to renames, so the capability surfaces here.
+      expect(body.capabilities).toBeDefined()
+      expect(body.capabilities!.has).not.toContain('redirects')
+      const gapKinds = body.capabilities!.gaps.map(g => g.capability)
+      expect(gapKinds).toContain('redirects')
+      expect(gapKinds).toContain('gone-status')
+    })
+
+    it('publish-audit omits capabilities when only live items are in the publish set (conditional surface)', async () => {
+      // Publish only the live `home` page (not the Manual Redirect)
+      // → the includesArchived predicate sees no archived items →
+      // capabilities omitted. Pins the "only surfaces when relevant"
+      // contract from publish.ts so the dialog doesn't spam warnings
+      // for non-redirect publishes.
+      const res = await app.request('/api/publish/audit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          target: 'production-static',
+          items: [{ kind: 'page', name: 'home' }],
+        }),
+      })
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { capabilities?: unknown }
+      expect(body.capabilities).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Implements cut #448 (redirect-ui Cut 5 — capability-gap UX, surface #2). Closes #448.

## Provenance

Salvaged from feature-bot's attempt on #448 (was PR #491). Feature-bot escalated to NEEDS_HUMAN because Agent B voted REJECT **with no Note** — the bot couldn't determine why and auto-labeled it `wrong-root-cause`. On review (during `/review-prs`), the attempt is correct: the REJECT was a false negative. This PR carries the two good commits (test + feat) without the skip-list entry; #491 is closed.

## What it does

Adds surface #2 of the four-point capability-gap pattern (per `design-redirect-ui.md` Foundational checks + `design-soft-delete.md` Q10) to `CreateRedirectDialog.vue`: per-target capability-gap badges shown before submit when a target can't emit 301 redirects (plain-static, no worker). Informational, not blocking — the operator can still create the redirect.

## Verification (done during review)

- Mirrors `ArchiveModal.vue`'s established pattern exactly: `api.getTargets()` at mount, filter `capabilities.gaps`, render warning only when non-empty (Krug "absence is the state").
- References real contracts: `api.getTargets` (client.ts:419), `TargetInfo`, `CapabilityGapSchema.{capability,reason}` (schemas/targets.ts:44-57). All verified to exist.
- Graceful degradation: `/api/targets` failure leaves the gap list empty, doesn't block the dialog.
- TDD-first: test commit (`43c476e`) fails red (2/3) before the feat commit; feat commit greens it.
- Both test files pass (3 + 4); `npm run build` clean (full tsc emit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)