### PR TITLE
docs(adr-0016): adopt Storybook for bot-executable UX specs; pick review-workflow #199 as next feature-bot candidate

### DIFF
--- a/.claude/rules/css-theming.md
+++ b/.claude/rules/css-theming.md
@@ -191,7 +191,7 @@ We tried a Playwright `toHaveScreenshot` baseline for PublishDialog and dropped 
 |---|---|
 | Catch unintended visual changes in core admin | Playwright `toHaveScreenshot` with CI-generated baselines. Gate to `process.platform === 'linux'` and commit only Linux PNGs. Regenerate via `docker run mcr.microsoft.com/playwright:vX.Y.Z-jammy ... --update-snapshots` |
 | Explore component variants while designing | The existing `/admin/dev` playground. Extend with fixture props if needed. |
-| Design-system-level visual review | Storybook or Histoire. Not worth the setup until there are 40+ components or a design-systems contributor |
+| Design-system-level visual review | Storybook or Histoire. (This row spoke only to *visual-regression* review — still deferred.) Storybook is now adopted for a **different** use case — design-then-spec-then-bot-execute for admin-shell components — per [ADR-0016](../../docs/adr/0016-storybook-for-bot-executable-ux-specs.md). That ADR carries the DevPlayground-vs-Storybook coherence split. |
 | Site developers catching their own regressions | They write their own Playwright tests against the running admin using our `data-testid` attributes |
 
 **When to reintroduce:**

--- a/.claude/rules/design-review-workflow.md
+++ b/.claude/rules/design-review-workflow.md
@@ -266,6 +266,24 @@ How review workflow composes with each of the other 12 foundational dimensions p
 - When collaboration ships, approver behavior expands: "leave non-blocking comments on content + approve" or "reject with reason" (current path).
 - Combined-action ("Submit & approve") UX stays as-is; collaboration adds the conversation layer alongside, not replacing the state machine.
 
+## UX implementation foundation (Storybook + primitives)
+
+Decided 2026-06-07 during the UX-grilling pass (Phase 2a, which the original design pass skipped — that's why cuts 8–10 were High-risk). Per [ADR-0016](../../docs/adr/0016-storybook-for-bot-executable-ux-specs.md), the review-workflow UI components are designed as **Storybook stories** that become feature-bot's executable spec. Two additive UI primitives are extracted first so the review components compose named, typed building blocks rather than re-deriving banner/badge markup from prose (verified extraction-cheap + additive against the shipped admin in a recon pass):
+
+- **`<StateBadge variant color label? tooltip?>`** — extracts the dot/pill pattern duplicated verbatim across `SiteTree.vue` + `ComponentTree.vue` (dirty dot, validation dot, locale pill). **Cheap, pure-CSS DRY.** The review-state SiteTree badge (Cut 8) consumes it.
+- **`<Banner severity role icon? :dismissible>` + content/actions slots** — extracts the icon+message+actions+dismiss skeleton shared by `ValidationBanner` / `ArchiveBanner` / `OfflineBanner` / `StorageQuotaBanner`. **Moderate, ~30–40 LOC, strictly additive** — the four shipped banners are **not** refactored onto it (recon confirmed migration is non-mandatory; ValidationBanner's nested issue-list resists generic slots, so leaving it inline is correct). ReviewBanner (Cut 8) is the first consumer.
+
+**No `<ActionButton>` primitive.** PrimeVue `<Button>` is already the de-facto action-button primitive — conventions (label/icon/`size="small"`/severity/`:loading`/`data-testid`) are uniform across the admin. The review components use `<Button>` directly; stories cite its conventions.
+
+This is *not* the design-system work deferred by [`css-theming.md`](css-theming.md): no token taxonomy, no primitive library, no refactor of shipped components. Two additive primitives, scoped to what review-workflow needs, justified by *bot-codegen reliability* (a different rationale than the visual-regression rationale that deferral addressed).
+
+**Consequence for the cut sequence:** two foundational UI cuts prepend the UX cuts —
+
+1. **Extract `<StateBadge>` + story** (cheap; additive; SiteTree/ComponentTree may opt in via Boy-Scout later, not required)
+2. **Extract `<Banner>` + Storybook setup + story** (moderate; additive; shipped banners untouched)
+
+— after which cuts 8–10 become compositions: ReviewBanner = `<Banner>` + `<Button>`s; ReviewActions = `<Button>` group; tree state badge = `<StateBadge>`; publish-approval gate composes the same. The cut specs become "build component X to match `X.stories.tsx`," and the bot implements to green stories. These two cuts land in the design doc's `## Cut sequence` table when the impl doc is migrated to the tracking-issue + sub-issue model.
+
 ## Migration
 
 Targets without `reviewWorkflow.enabled` continue today's behavior (no review). Adding the flag opts in. Existing items become `draft` by default; items already published stay `published`.

--- a/.claude/rules/design-review-workflow.md
+++ b/.claude/rules/design-review-workflow.md
@@ -8,7 +8,7 @@ paths:
 
 Foundational dimension #6 of 13. Content review state machine + per-target publish approval. Operators with team workflows (content quality review, release management gates, compliance approvals) configure their flow per target; solo / small-team workflows bypass.
 
-**Status**: design pass complete (2026-05). Implementation phases sit in Tier 3.
+**Status**: design pass complete (2026-05). Selected as the next feature-bot candidate (2026-06-07) — it is the top committed **Phase-2** feature in [`ROADMAP.md`](../../ROADMAP.md) ("Next, this quarter") with all foundations (AuthIdentity + Audit + Hooks) shipped. The "Tier 3" status line in earlier passes was written before those foundations landed; ROADMAP is the live prioritization artifact and it places this in Phase-2. Before migration to a tracking issue + cut sub-issues, the three High-risk UX cuts (8 ReviewBanner/ReviewActions + state badges; 9 publish-approval gate; 10 per-target publish-approval UX) get a **UX-grilling pass** (Phase 2a of [`feature-design-process.md`](feature-design-process.md), which the original design pass skipped — that's *why* they're High-risk). The grilling output is **Storybook stories** (per [ADR-0016](../../docs/adr/0016-storybook-for-bot-executable-ux-specs.md)) that lock each component's states + layout + copy + `data-testid`s. The stories become the cut's executable spec; feature-bot implements components to green stories rather than inventing UX. With the UX locked in stories, all 15 cuts stay bot work.
 
 **Companion docs**:
 - [`feature-design-process.md`](feature-design-process.md) — defines the **Review check** every new feature design must answer

--- a/.claude/rules/design-review-workflow.md
+++ b/.claude/rules/design-review-workflow.md
@@ -282,7 +282,50 @@ This is *not* the design-system work deferred by [`css-theming.md`](css-theming.
 1. **Extract `<StateBadge>` + story** (cheap; additive; SiteTree/ComponentTree may opt in via Boy-Scout later, not required)
 2. **Extract `<Banner>` + Storybook setup + story** (moderate; additive; shipped banners untouched)
 
-— after which cuts 8–10 become compositions: ReviewBanner = `<Banner>` + `<Button>`s; ReviewActions = `<Button>` group; tree state badge = `<StateBadge>`; publish-approval gate composes the same. The cut specs become "build component X to match `X.stories.tsx`," and the bot implements to green stories. These two cuts land in the design doc's `## Cut sequence` table when the impl doc is migrated to the tracking-issue + sub-issue model.
+— after which cuts 8–10 become compositions (story specs below). The cut specs become "build component X to match `X.stories.tsx`," and the bot implements to green stories. These two cuts land in the design doc's `## Cut sequence` table when the impl doc is migrated to the tracking-issue + sub-issue model.
+
+### UX surface decisions (UX-grill 2026-06-07)
+
+Three surfaces were grilled into locked story specs. Each named story = one Storybook story = one bot spec variant.
+
+**Surface 1 — `ReviewBanner.vue`** (= `<Banner>` + inline `<Button>` actions; mounts above the editor à la `ArchiveBanner`; renders only when the active target has `reviewWorkflow.enabled` — absence-as-state otherwise). **`ReviewActions` is folded in** — no separate component. The design doc's earlier two-component naming was unjustified enumeration (rule 25); every POV (discoverability, SRP, bot-risk, Krug) favored fusion, matching the `ArchiveBanner` precedent where the banner hosts its own actions. The 9 stories below *are* the action spec (each names its buttons); a separate `ReviewActions.vue` would only add a coordination bug class (banner/actions out of sync) that fusion eliminates by construction.
+
+Root testid `review-banner` with `data-state` (the `OfflineBanner` pattern). The 9 stories enumerate content-state × actor-capability × config; **draft has two visible variants** — clean (fresh/withdrawn, no message) vs. with-note (rejected or auto-invalidated, shows the reason). The rejected variant is load-bearing: without it the author never sees *why* content bounced (the hole the first-draft matrix missed).
+
+| Story | Content state | Viewer | Severity / copy | Buttons (testid) |
+|---|---|---|---|---|
+| `DraftClean` | draft (fresh/withdrawn) | has `review:submit` | info — "Draft — not yet submitted for review." | **Submit for review** (`review-submit`); + **Submit & approve** (`review-submit-approve`) when also `review:approve` + `allowSelfApproval` + `requiredApprovers:1` |
+| `DraftRejected` | draft (post-reject) | has `review:submit` | warning — "Changes requested by {actor}: '{comment}'." | **Submit for review** (`review-submit`) |
+| `DraftInvalidated` | draft (was approved, edited) | has `review:submit` | info — "Approval cleared by your edit. Re-submit when ready." | **Submit for review** (`review-submit`) |
+| `DraftNoCap` | draft | lacks `review:submit` | info — "Draft. You don't have permission to submit for review." | none |
+| `PendingAsSubmitter` | pending-review | submitter | warning — "Pending review — submitted {time}. Editing is locked until reviewed." | **Withdraw** (`review-withdraw`) |
+| `PendingAsApprover` | pending-review | has `review:approve`, not voted | warning — "Pending review — {N} of {required} approvals." | **Approve** (`review-approve`), **Reject** (`review-reject` → `ReviewRejectDialog`) |
+| `PendingApproverVoted` | pending-review | has `review:approve`, voted, threshold unmet | warning — "You approved. Waiting for {remaining} more." | none (no retraction — see below) |
+| `PendingSelfNoSelfApproval` | pending-review | submitter w/ `review:approve`, `allowSelfApproval:false` | warning — "Your submission — you can't approve your own content." | **Withdraw** (`review-withdraw`) |
+| `PendingReadOnly` | pending-review | no review caps | warning — "Pending review — {N} of {required} approvals." | none |
+| `Approved` | approved | any | success — "Approved {time} by {actor}." | none (publish is a separate surface) |
+
+Each action button has an in-flight `:loading` variant (the `archive.status === 'unarchiving'` pattern) — stories include the loading state for `PendingAsApprover` (approving / rejecting) and `DraftClean` (submitting).
+
+**`ReviewRejectDialog.vue`** (small companion) — a PrimeVue `Dialog` with a required textarea + **Reject** (`review-reject-confirm`) / **Cancel** (`review-reject-cancel`). Reject comment is mandatory (locked invariant); a dialog (not inline-expand) matches how the codebase does confirmable actions and keeps the banner clean.
+
+**Q-A — no approval retraction in v1.** Once cast, an approval is final while `pending-review`. The audit enum has no `review-unapprove`; adding one is scope creep. An approver who changes their mind rejects instead (reject-after-own-approve is the escape hatch). `PendingApproverVoted` therefore shows no action.
+
+**Q-B — no "reopen to draft" button on `Approved`.** Editing approved content auto-invalidates it back to draft via `invalidateOnSave` (default `content-diff`). An explicit reopen button is redundant — the author just edits, and the save knocks it to `DraftInvalidated`. The banner stays purely informational when approved.
+
+**Surface 2 — folded into Surface 1** (see above).
+
+**Surface 3 — publish-approval gate = extend `PublishPanel` destination rows** (only when a target has `requiresPublishApproval: true`). Per-content gate, composed into the shipped `PublishPanel` (not a new top-level surface). The walk revealed this is distinct from the cross-content "what's waiting for me" approver queue — that queue is its own concern (the existing `### Pending review queue at scale` + `/api/reviews?action=publish-pending`), serving *both* content-review and publish-approval pending lists, and lands as its own cut. Stories = `PublishPanel` destination row in each publish-approval state:
+
+| Story | Destination-row state | Shows |
+|---|---|---|
+| `DestNoGate` | target without `requiresPublishApproval` | normal **Publish** |
+| `DestRequestable` | gated, viewer has `publish:request`, no open request | **Request publish approval** (`publish-request`) |
+| `DestPending` | gated, request open, threshold unmet | `<StateBadge>` "Pending {N}/{required}"; **Approve**/**Reject** (`publish-approve`/`publish-reject`) inline when viewer has `publish:approve` |
+| `DestApproved` | gated, threshold met | `<StateBadge>` "Approved"; **Publish** enabled |
+| `DestNoCap` | gated, viewer lacks `publish:request` | `<StateBadge>` "Requires publish approval" (informational) |
+
+The cross-content approver queue (Cut 13) is **not** part of the gate cut — approvers acting on *this* content's publish do so inline in `PublishPanel`; finding pending requests *across all content* is the queue's job.
 
 ## Migration
 

--- a/.claude/rules/dev-glossary.md
+++ b/.claude/rules/dev-glossary.md
@@ -28,6 +28,29 @@ convenience. Walks actor scenarios, flow sketches, "what can I remove?"
 (Krug-aligned), failure-mode UX, capability-gap surfaces. Output: the design
 doc's "UX check" section.
 
+**Story-as-spec** (design-then-spec-then-bot-execute):
+The pattern for getting feature-bot to implement UX cuts reliably. The bot
+is fine at *implementing* Vue components but bad at *designing* them — so the
+UX design decision is moved into a prior, human-authored, executable artifact:
+a Storybook story enumerating the component's states. The human (or a
+UX-grilling pass) authors the stories; the bot implements the component to
+satisfy them. This makes [team-preferences.md rule 31](team-preferences.md)
+(TDD-first when delegating to AI) cover UI: the story is the failing spec, the
+implementation turns it green. The cut sub-issue's `## Tests` section then
+reads "component renders correctly for every state in `X.stories.tsx`." Per
+[ADR-0016](../../docs/adr/0016-storybook-for-bot-executable-ux-specs.md).
+
+**DevPlayground vs Storybook** (the two component-isolation surfaces):
+Two surfaces, no overlap, per [ADR-0016](../../docs/adr/0016-storybook-for-bot-executable-ux-specs.md).
+**DevPlayground** (`/admin/dev`) — template live-preview *with real content*;
+template-developer turf ("does my template render this page correctly?").
+**Storybook** — admin-shell component states (banners, dialogs, badges,
+action bars) *as design + bot spec*; CMS-developer turf ("what are this
+component's states, and is its implementation correct against them?"). A
+component goes in Storybook when it's admin chrome with discrete states a
+human designs and a bot implements; in DevPlayground when it's a content
+template previewed against author content.
+
 **5K-envelope gate**:
 Pre-implementation checkpoint validating that proposed primitives hold at
 the documented operating envelope (5,000 pages, 20,000 assets, 50 components

--- a/docs/adr/0016-storybook-for-bot-executable-ux-specs.md
+++ b/docs/adr/0016-storybook-for-bot-executable-ux-specs.md
@@ -1,0 +1,50 @@
+# Storybook hosts admin-shell component states as bot-executable UX specs
+
+> Context: this decision came out of the "next feature-bot candidate" grilling (2026-06-07). The candidate chosen is review-workflow MVP ([#199](https://github.com/gazetta-studio/gazetta-studio/issues/199)); this ADR captures the load-bearing tooling decision that de-risks its UX cuts. The review-workflow specifics live in [`.claude/rules/design-review-workflow.md`](../../.claude/rules/design-review-workflow.md).
+
+We adopt **Storybook** as the surface where admin-shell UI components are designed (states, layout, copy) and where those designs are captured as **stories that serve as the bot's executable spec**. A human authors the stories (the design decision); feature-bot implements the component to satisfy them (the mechanical work). This makes [team-preferences.md rule 31](../../.claude/rules/team-preferences.md) (TDD-first when delegating to AI) cover UI cuts: the story is the failing spec, the component implementation turns it green.
+
+This reverses the standing "no Storybook" call in [`css-theming.md`](../../.claude/rules/css-theming.md) ("Design-system-level visual review → Storybook or Histoire. Not worth the setup until there are 40+ components or a design-systems contributor"). That call was made about **visual-regression testing** — a different use case than **design-then-spec-for-bot-execution**. The trigger it waited for ("40+ components") is plausibly crossed by the committed UX-heavy feature wave this quarter (review-workflow UX, collaboration v1 comments UI, per-field translation UI, [#196](https://github.com/gazetta-studio/gazetta-studio/issues/196) large-site editor, [#103](https://github.com/gazetta-studio/gazetta-studio/issues/103) creation UX). Adopting Storybook now is prioritize-enablers timing, not heavyweight-for-3-components.
+
+## The decision in one line
+
+The bottleneck for feature-bot on UX cuts was never "the bot can't write Vue" — it was "the bot would *invent* UX." Storybook moves the UX design decision into a prior, human-authored, executable artifact (the story), leaving the bot a mechanical implement-to-green task.
+
+## Why Storybook over the alternatives
+
+Three approaches were walked from maintainer / bot / ROADMAP / process / cold-pickup POVs:
+
+| | Approach | Executable spec? | Setup cost | Coherence cost |
+|---|---|---|---|---|
+| **A (chosen)** | Storybook; stories = bot spec | **Yes** — stories + play functions are a test artifact the bot runs | High (net-new tooling) | Needs a DevPlayground-vs-Storybook split story |
+| B | Extend the existing DevPlayground to host component states | Partial — live preview, not a runnable test artifact | Medium | Low (one surface) |
+| C | Lock specs as static artifacts (ASCII mockups, states, copy, testids) in the design doc | No — prose | Low | None |
+
+We picked **A** because:
+
+1. **Executable spec beats prose spec for the bot.** A `.stories.tsx` file is machine-readable, enumerates every component state, and runs as a test. That is exactly the rule-31 TDD-first contract applied to UI — the bot implements against green stories, it does not guess at states. B's live preview isn't a runnable artifact; C's prose isn't executable at all.
+2. **The UX wave justifies the investment.** A is "heavyweight for 3 components" only if review-workflow's UX is a one-off. It isn't — a wave of UX-heavy features is committed this quarter, and Storybook is shared infrastructure for all of them. The pilot is review-workflow; the payoff is the wave.
+3. **It removes the risk wholesale rather than routing around it.** The discarded fallback (file the UX cuts as `ready-for-human`, bot does only backend) keeps the risky cuts off the bot but also keeps 3 cuts off the bot permanently. Locking the UX in stories first lets **all** of a feature's cuts stay bot work.
+
+## The coherence split (DevPlayground vs Storybook)
+
+This repo already has a component-isolation surface — the **DevPlayground** (`/admin/dev`), which `design-validation.md` extends with an Impact tab. Adding Storybook creates two surfaces, so the split must be explicit:
+
+- **DevPlayground** — template live-preview *with real content*. Template-developer turf: "does my template render this page's content correctly?" Stays as-is.
+- **Storybook** — admin-shell component states (banners, dialogs, badges, action bars) *as design + bot spec*. CMS-developer turf: "what are this component's states, and is its implementation correct against them?"
+
+A component belongs in Storybook when it's admin-shell chrome with discrete states a human designs and a bot implements. It belongs in DevPlayground when it's a content template previewed against author content. The two do not overlap.
+
+## Consequences
+
+The feature-design-process gains a step for UX-bearing features: **UX-grill the surfaces → author Storybook stories (the locked spec) → run the pre-filing cut audit → migrate cuts → bot implements against stories.** The story-authoring is human work (design); the component implementation is bot work (mechanical). This is captured in `feature-design-process.md` and `dev-glossary.md`.
+
+The bot writes components, not stories. Stories are design artifacts authored by a human (or a UX-grilling pass). A cut sub-issue for a UX component references its story file as the spec; the bot's `## Tests` is "component renders correctly for every state in `X.stories.tsx`."
+
+Review-workflow #199 is the pilot. Its three High-risk UX cuts (ReviewBanner / ReviewActions + state badges; publish-approval gate; per-target publish-approval UX) were High-risk *because* their design was unlocked — the review-workflow design pass skipped Phase 2a UX-grilling and left them as judgment calls. They get a UX-grilling pass producing stories before the migration files them as bot cuts.
+
+Reversing this is meaningful cost: Storybook config, the stories written against it, and CI wiring would all be removed, and the design-then-spec workflow would revert to prose specs. Tooling lock-in plus workflow change — the ADR bar (hard to reverse, surprising without context, real trade-off) is met.
+
+Storybook setup cost is real and front-loaded. If the UX wave does *not* materialize as committed, this decision was premature and B (extend DevPlayground) would have been right. The contingency was confirmed at decision time (2026-06-07): the wave is committed for this quarter. If a future quarter's roadmap shows the UX wave stalled and Storybook underused, revisit whether to retire it back into DevPlayground.
+
+A future reader seeing both `/admin/dev` and a Storybook setup needs the coherence split above to not read it as accretion. The split lives in this ADR and in `css-theming.md` (which is updated to point here rather than asserting "no Storybook").


### PR DESCRIPTION
## What

Grilling outcome (2026-06-07): the **next feature-bot candidate is review-workflow MVP (#199)** — top committed Phase-2 feature, all foundations (AuthIdentity + Audit + Hooks) shipped, complete 15-cut design. The design-doc "Tier 3" status line was stale; ROADMAP is the live artifact and places it in Phase-2.

Load-bearing decision (**ADR-0016**): adopt **Storybook** as the design-then-spec-then-bot-execute surface for admin-shell components. The bot is bad at *designing* UX but fine at *implementing* it — so the design decision moves into a human-authored Storybook story (executable spec) and the bot implements to green stories. Rule 31 TDD-first now covers UI. This keeps **all 15** review-workflow cuts as bot work instead of routing the 3 High-risk UX cuts to a human.

## Files

- `docs/adr/0016-storybook-for-bot-executable-ux-specs.md` (new) — decision, A/B/C trade-off walk, DevPlayground-vs-Storybook coherence split, review-workflow as pilot
- `.claude/rules/css-theming.md` — "Storybook deferred" row points at ADR-0016 (visual-regression stays deferred; design-then-spec adopted)
- `.claude/rules/dev-glossary.md` — new entries: **Story-as-spec**, **DevPlayground vs Storybook**
- `.claude/rules/design-review-workflow.md` — status line: next candidate; Tier-3-vs-Phase-2 resolved; UX-grill→stories path for cuts 8–10 before migration

## Not in this PR (next steps)

UX-grill #199's 3 UX surfaces → author Storybook stories → set up Storybook → pre-filing cut audit → migrate to tracking issue + 15 cut sub-issues → feature-bot picks up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)