### PR TITLE
feat(feature-bot): Agent A self-researches SOLID (≤3 converge rounds) before review

### DIFF
--- a/.claude/rules/design-feature-bot.md
+++ b/.claude/rules/design-feature-bot.md
@@ -474,10 +474,25 @@ Cron (daily 04:30 UTC, after fix-bot at 04:00):
 3. Pick oldest unblocked cut.
     ↓
 4. Generator-critic loop (max 5 attempts):
-   - Agent A: write failing test commit → write fix commit → push branch
-   - Agent B: review diff, vote APPROVE / REJECT / NEEDS_HUMAN
+   - Agent A: write failing test commit → impl → **SOLID research+fix
+     loop (≤3 converge rounds) on its own diff, rolled into the impl
+     commit** → push branch
+   - Agent B: review diff, vote APPROVE / REJECT / NEEDS_HUMAN —
+     **independently judges SOLID** (declared lenses + violations A's
+     self-research missed); A self-grading is the bias B covers
    - APPROVE → open PR; REJECT → reset + retry with reviewer note;
      NEEDS_HUMAN → close sub-issue + post-comment + skip-list entry
+
+   **SOLID research is Agent A self-work, not a separate agent.** Walked
+   the alternatives (2026-06-07): a separate SOLID agent between A and B
+   was rejected because (a) editing the diff mid-loop breaks the clean
+   test+impl commit shape the reviewer's tautology check depends on,
+   (b) "fresh eyes" from a separate Claude session is weak — same model,
+   cleared context, not a real second reviewer, and (c) the genuine
+   independent SOLID check already exists at Agent B. So A researches +
+   fixes its own structure (discovery, not just honoring the cut's
+   declared `## SOLID` lenses), converging in ≤3 rounds; B remains the
+   independent judge.
     ↓
 5. PR opens with Fixes #<cut-sub-issue-N>. Merge closes sub-issue,
    advances tracking issue tasklist.

--- a/bots/feature-bot/prompts/per-cut.md
+++ b/bots/feature-bot/prompts/per-cut.md
@@ -103,7 +103,61 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    ```
 4. Implement the cut. Verify GREEN.
 5. Run the wider test suite. Confirm no regressions.
-6. **RUNTIME EXERCISE — prove the code works on every execution path.**
+6. **SOLID RESEARCH + FIX — improve the structure you just wrote (converge, ≤3 rounds).**
+
+   Your implementation is GREEN, but "passes tests" ≠ "well-structured."
+   Before proving paths, research your OWN diff for SOLID problems and
+   fix them. This is **discovery**, not just honoring the cut's declared
+   `## SOLID` lenses — find structural smells the cut spec didn't name.
+
+   Run up to **3 rounds**. Each round:
+
+   a. **Research the diff with each SOLID lens.** Read your `git diff`
+      and ask, per lens:
+      - **SRP** — does any module/function you added or grew now have
+        more than one reason to change? (e.g. a route handler that also
+        owns validation logic; a file fusing two concerns.)
+      - **OCP** — to add the next variant (validator, provider, adapter,
+        state), would someone edit a switch/if-chain you wrote, or drop
+        in a new file? Prefer the latter where the design implies growth.
+      - **LSP** — any stub that throws `not implemented` to satisfy an
+        interface? Any subtype that can't stand in for its base? That's
+        a capability that should be a separate interface + type guard.
+      - **ISP** — did you add a wide interface where consumers only use
+        part? Split it.
+      - **DIP** — does a high-level module you touched depend on a
+        concrete low-level one where an injected abstraction belongs?
+      Emit a one-line `> Decision:` per real finding (what + which lens).
+
+   b. **Fix what you found**, in the working tree. Stay within the cut's
+      scope — SOLID fixes refine the structure of THIS cut's code; they
+      do NOT refactor adjacent code you didn't touch (that's scope creep,
+      per the Conventions below). Re-run the cut's tests + wider suite;
+      they MUST stay GREEN. A SOLID fix that breaks a test means the fix
+      is wrong — revert it and reconsider.
+
+   c. **Convergence check.** If this round found NO new SOLID issues,
+      STOP — you've converged. Otherwise continue to the next round
+      (up to 3 total). State `> Decision: SOLID converged (round N, no
+      new findings)` or `> Decision: SOLID round N fixed <X>; another
+      round` so the transcript shows the loop's reasoning.
+
+   **All SOLID fixes land in the working tree BEFORE the impl commit
+   (step 10) — they roll INTO that single impl commit.** Do NOT create a
+   separate "solid" or "refactor" commit; the two-commit shape (test,
+   then impl) is what the reviewer's tautology check depends on. Do NOT
+   touch the failing-test commit's assertions during SOLID work — if a
+   structural change genuinely requires a different test shape, that's a
+   signal to reconsider the change (or emit NEEDS_INPUT), not to weaken
+   the test.
+
+   The cap is 3 rounds: bounded effort, not a quality gate. Whatever the
+   structure is at convergence-or-cap goes forward; Agent B independently
+   judges SOLID (it checks the declared `## SOLID` lenses + flags
+   violations it sees) — so this self-research raises the floor, and
+   Agent B remains the independent check, not your own sign-off.
+
+7. **RUNTIME EXERCISE — prove the code works on every execution path.**
 
    After tests pass, run the code with concrete inputs that prove EACH
    execution path the acceptance criteria imply. Most acceptance bullets
@@ -181,19 +235,19 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
      emit `NEEDS_INPUT` per Q6 lock, citing the discovered edge case.
      Don't guess; ask.
 
-   **Capture the exercise output in your `SUMMARY:` block** (step 10) under
+   **Capture the exercise output in your `SUMMARY:` block** (step 11) under
    a `Runtime exercise:` heading. Show each acceptance bullet, then each
    path of that bullet with its input + actual output. Use brief prose;
    the orchestrator surfaces this in the PR body for maintainer review.
 
-7. **Refine your tests** if the exercise surfaced edge cases worth
+8. **Refine your tests** if the exercise surfaced edge cases worth
    covering. Tests-first (per rule 31) pinned the acceptance contract;
    tests added after the exercise pin the edge cases the spec didn't
    enumerate. Amend the test commit (`git commit --amend`) to include
    the new test cases — keep them in the failing-test commit so the
    TDD-first ordering is preserved.
 
-8. **Format the diff with Biome** before committing the impl. Per
+9. **Format the diff with Biome** before committing the impl. Per
    [team-preferences.md rule 30](../../.claude/rules/team-preferences.md),
    format must run before commit — otherwise CI's `format` check
    fails and the maintainer has to push a follow-up format-only
@@ -202,7 +256,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    npm run format
    ```
    Biome reformats unstaged + staged files in place (~150ms). If
-   Biome touched the failing-test file (step 7's amend already
+   Biome touched the failing-test file (step 8's amend already
    landed), re-amend the test commit to roll the reformat into it
    — DO NOT make a separate format commit:
    ```bash
@@ -210,7 +264,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    git commit --amend --no-edit
    ```
 
-9. Commit:
+10. Commit:
    ```bash
    git add <impl files>
    git commit -m "feat(<area>): cut #$ISSUE_NUMBER — <short summary>
@@ -221,13 +275,20 @@ Closes #$ISSUE_NUMBER
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    ```
-10. End with a `SUMMARY:` block as your last output:
+11. End with a `SUMMARY:` block as your last output:
 
    ```
    SUMMARY:
    <2-4 sentences: what the cut delivered, how the failing test pins it,
    which design-doc locked decisions it implements. Plain prose; no
    headings, no bullets, no code blocks inside the summary.>
+
+   SOLID research:
+   <One line per round: what each round found + fixed, and the round it
+   converged. e.g. "Round 1: split route handler's validation into a
+   separate module (SRP). Round 2: converged, no new findings." If no
+   issues were found in round 1, say "Converged round 1 — no SOLID
+   findings." Keep it to ≤3 lines.>
 
    Runtime exercise:
    <For each acceptance bullet, list each execution path it implies

--- a/bots/feature-bot/prompts/reviewer.md
+++ b/bots/feature-bot/prompts/reviewer.md
@@ -225,6 +225,18 @@ For each lens declared, look at the diff. Did Agent A honor it?
 When `## SOLID` is absent, this check is N/A — pure-data-shape and
 pure-docs cuts often don't have SOLID concerns.
 
+**Agent A self-researched SOLID before you — you are still the
+independent gate.** Per the per-cut prompt, Agent A runs a SOLID
+research+fix loop (≤3 converge rounds) on its own diff and reports it in
+the `SOLID research:` block of `AGENT_A_SUMMARY`. That raises the floor;
+it does NOT replace your check — A grading its own structure is the bias
+this check exists to cover. Read A's `SOLID research:` summary for
+context (what it claims to have fixed), then verify the diff yourself
+against the declared lenses AND any violation A's self-research missed.
+If A's summary says "converged, no findings" but you see a clear
+SRP/LSP/etc violation, REJECT — A's self-research was incomplete, which
+is exactly why you run independently.
+
 ## The locked-decisions check
 
 Read the design doc's `## Locked decisions` (or "Q1 / Q2 / ..." section).


### PR DESCRIPTION
## What

Adds a **SOLID research+fix loop** to feature-bot's Agent A. After the impl is GREEN, Agent A reads its **own diff** through each SOLID lens (SRP/OCP/LSP/ISP/DIP), **discovers** structural issues (not just the cut's declared `## SOLID` lenses), fixes them, and **converges** — up to **3 rounds**, early-exit when a round finds nothing. Fixes roll into the single impl commit (preserves the test+impl shape the tautology check depends on).

## Why wired into Agent A, not a separate agent

Walked the alternatives (all-POV). A separate SOLID agent between A and B was rejected:
- (a) editing the diff mid-loop **breaks the clean test+impl commit history** the reviewer's tautology check (revert-HEAD) depends on;
- (b) **"fresh eyes" is weak** — a separate Claude session is the same model with cleared context, not a real second reviewer;
- (c) the **genuine independent SOLID check already exists at Agent B**.

So A self-researches (raises the floor); **B remains the independent judge** (covers A's self-grading bias — reviewer.md now says: if A claims "converged" but a violation is visible, REJECT).

## Files

- `bots/feature-bot/prompts/per-cut.md` — new step 6 (SOLID research+fix converge-loop, ≤3 rounds, converge-or-cap, rolls into impl commit); SUMMARY gains a `SOLID research:` line; steps renumbered + cross-refs fixed.
- `bots/feature-bot/prompts/reviewer.md` — Agent B note: A self-researched upstream, B is still the independent gate.
- `.claude/rules/design-feature-bot.md` — loop diagram + the self-work-not-separate-agent rationale.

Prompt + doc only; no `index.ts` change (the loop is Claude-executed in Agent A's prompt). `bots tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)