### PR TITLE
feat(feature-bot): drop TDD-first; add test-quality pass; Agent B is sole anti-tautology gate

### DIFF
--- a/.claude/rules/design-feature-bot.md
+++ b/.claude/rules/design-feature-bot.md
@@ -16,7 +16,7 @@ Autonomous bot that implements feature cuts following the project's design pass.
 - Bot reads GitHub "cut sub-issues" labeled `enhancement` + `ready-for-agent` + `area: X` (no new labels — reuses existing vocabulary)
 - Picks the next cut whose dependencies are all closed
 - Generator-critic loop (Agent A implements, Agent B reviews) — same pattern as fix-bot + dead-code-watcher
-- Agent A flow: tests → impl → SOLID research+fix loop → test-quality pass → runtime exercise (no TDD-first; soft two-commit shape; Agent B is the sole anti-tautology gate — see the loop in "Design" below)
+- Agent A flow: tests → impl → SOLID research+fix loop → runtime validation → improve/fix tests (no TDD-first; soft two-commit shape; Agent B is the sole anti-tautology gate — see the loop in "Design" below)
 - One PR per cut
 - Durable memory: skip-list + reviewer-log (same shape as fix-bot)
 
@@ -475,10 +475,13 @@ Cron (daily 04:30 UTC, after fix-bot at 04:00):
     ↓
 4. Generator-critic loop (max 5 attempts):
    - Agent A: tests commit → impl (GREEN) → **SOLID research+fix loop
-     (≤3 converge rounds)** → **test-quality pass (logic-direct,
-     data-driven, de-dup, schema-smell)** → runtime exercise → push.
-     Both passes roll into the impl commit; tests live in the tests
-     commit (soft two-commit shape for B's revert check).
+     (≤3 converge rounds)** → **runtime validation (prove every path)**
+     → **improve/fix tests (logic-direct, data-driven, de-dup,
+     schema-smell, + edge cases the exercise surfaced)** → push. Tests
+     improvement comes AFTER runtime validation so it's informed by what
+     the exercise found. SOLID fixes roll into the impl commit; all
+     tests live in the tests commit (soft two-commit shape for B's
+     revert check).
    - Agent B: review diff, vote APPROVE / REJECT / NEEDS_HUMAN —
      runs the **tautology check (the SOLE anti-tautology gate)**,
      **independently judges SOLID**, and **scrutinizes test removals**

--- a/.claude/rules/design-feature-bot.md
+++ b/.claude/rules/design-feature-bot.md
@@ -16,7 +16,7 @@ Autonomous bot that implements feature cuts following the project's design pass.
 - Bot reads GitHub "cut sub-issues" labeled `enhancement` + `ready-for-agent` + `area: X` (no new labels — reuses existing vocabulary)
 - Picks the next cut whose dependencies are all closed
 - Generator-critic loop (Agent A implements, Agent B reviews) — same pattern as fix-bot + dead-code-watcher
-- TDD-first commit ordering per rule 31
+- Agent A flow: tests → impl → SOLID research+fix loop → test-quality pass → runtime exercise (no TDD-first; soft two-commit shape; Agent B is the sole anti-tautology gate — see the loop in "Design" below)
 - One PR per cut
 - Durable memory: skip-list + reviewer-log (same shape as fix-bot)
 
@@ -97,7 +97,7 @@ Bot's TS orchestrator parses two one-line key-value fields via regex:
 - `**Feature**: <slug>` → picks the right design doc reference
 - `**Depends on**: #N, #M` (optional) → cron-time gate; skip until all referenced sub-issues close
 
-Everything else (`## Spec`, `## Acceptance`) is passed to Agent A as prose context. Agent A is responsible for reading the linked design doc, deciding files + tests, and writing TDD-first commits.
+Everything else (`## Spec`, `## Acceptance`) is passed to Agent A as prose context. Agent A is responsible for reading the linked design doc, deciding files + tests, and committing in the soft two-commit shape (tests, then impl).
 
 **Schema enforcement** lives in Agent A's prompt discipline, not at filing time:
 - If `## Spec` or `## Acceptance` is missing or vague → Agent A fails loud, posts "spec incomplete" comment on the sub-issue + closes with reason. Reviewer-loop's existing escalation mechanism handles it.
@@ -474,25 +474,44 @@ Cron (daily 04:30 UTC, after fix-bot at 04:00):
 3. Pick oldest unblocked cut.
     ↓
 4. Generator-critic loop (max 5 attempts):
-   - Agent A: write failing test commit → impl → **SOLID research+fix
-     loop (≤3 converge rounds) on its own diff, rolled into the impl
-     commit** → push branch
+   - Agent A: tests commit → impl (GREEN) → **SOLID research+fix loop
+     (≤3 converge rounds)** → **test-quality pass (logic-direct,
+     data-driven, de-dup, schema-smell)** → runtime exercise → push.
+     Both passes roll into the impl commit; tests live in the tests
+     commit (soft two-commit shape for B's revert check).
    - Agent B: review diff, vote APPROVE / REJECT / NEEDS_HUMAN —
-     **independently judges SOLID** (declared lenses + violations A's
-     self-research missed); A self-grading is the bias B covers
+     runs the **tautology check (the SOLE anti-tautology gate)**,
+     **independently judges SOLID**, and **scrutinizes test removals**
+     (the removed-coverage backstop).
    - APPROVE → open PR; REJECT → reset + retry with reviewer note;
      NEEDS_HUMAN → close sub-issue + post-comment + skip-list entry
 
-   **SOLID research is Agent A self-work, not a separate agent.** Walked
-   the alternatives (2026-06-07): a separate SOLID agent between A and B
-   was rejected because (a) editing the diff mid-loop breaks the clean
-   test+impl commit shape the reviewer's tautology check depends on,
-   (b) "fresh eyes" from a separate Claude session is weak — same model,
-   cleared context, not a real second reviewer, and (c) the genuine
-   independent SOLID check already exists at Agent B. So A researches +
-   fixes its own structure (discovery, not just honoring the cut's
-   declared `## SOLID` lenses), converging in ≤3 rounds; B remains the
-   independent judge.
+   **No TDD-first discipline on Agent A (2026-06-07 change).** Agent A
+   no longer writes-failing-test-first or keeps tests frozen — it builds
+   and freely rewrites/removes tests (the test-quality pass). The
+   anti-tautology guarantee moves ENTIRELY to Agent B's revert check
+   (revert impl → tests must fail → reapply → pass). A soft two-commit
+   shape (tests, then impl) is kept ONLY so B's `revert HEAD` cleanly
+   separates impl from tests.
+
+   **SOLID research is Agent A self-work, not a separate agent.** A
+   separate SOLID agent between A and B was rejected because (a) editing
+   the diff mid-loop breaks the two-commit shape B's revert depends on,
+   (b) "fresh eyes" from a separate Claude session is weak (same model,
+   cleared context), and (c) the independent SOLID check already exists
+   at Agent B. A researches + fixes its own structure (discovery, not
+   just the declared `## SOLID` lenses), converging in ≤3 rounds.
+
+   **The test-quality pass has unbounded edit authority — recorded
+   residual risk.** A may rewrite (schema-only-smell → logic-direct),
+   data-drive (`it.each`), and REMOVE tests. Agent B's revert check
+   proves *surviving* tests are load-bearing but is **blind to removed
+   coverage** (a deleted test that would have caught a bug). Mitigations:
+   A is told never to remove a test to ease passing (only genuine
+   duplicates), and B scrutinizes suspicious removals (test deleted in
+   the same diff that adds the code it covers). Best-effort, not a
+   guarantee — the maintainer accepted this risk to get autonomous
+   test-quality improvement.
     ↓
 5. PR opens with Fixes #<cut-sub-issue-N>. Merge closes sub-issue,
    advances tracking issue tasklist.

--- a/bots/feature-bot/prompts/per-cut.md
+++ b/bots/feature-bot/prompts/per-cut.md
@@ -157,15 +157,15 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
       round` so the transcript shows the loop's reasoning.
 
    **All SOLID fixes land in the working tree BEFORE the impl commit
-   (step 11) — they roll INTO that single impl commit.** Do NOT create a
+   (step 10) — they roll INTO that single impl commit.** Do NOT create a
    separate "solid" or "refactor" commit; the two-commit shape (tests,
    then impl) is what the reviewer's tautology check depends on. SOLID
    work is a pure structural refactor — the tests should stay GREEN
    throughout without changing them. Test *improvement* (rewriting,
-   data-driving, de-duping) is the NEXT step's job (test-quality pass),
-   not this one. If a SOLID refactor seems to require changing a test
-   assertion, that's a signal the refactor changed behavior (not just
-   structure) — reconsider it.
+   data-driving, de-duping) is the job of step 8 (improve/fix tests),
+   which runs after runtime validation — not this step. If a SOLID
+   refactor seems to require changing a test assertion, that's a signal
+   the refactor changed behavior (not just structure) — reconsider it.
 
    The cap is 3 rounds: bounded effort, not a quality gate. Whatever the
    structure is at convergence-or-cap goes forward; Agent B independently
@@ -173,65 +173,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
    violations it sees) — so this self-research raises the floor, and
    Agent B remains the independent check, not your own sign-off.
 
-7. **TEST-QUALITY PASS — make the tests test logic, directly, without redundancy.**
-
-   Your tests are GREEN and the structure is SOLID-clean. Now improve
-   the TESTS themselves. You have full authority to rewrite, restructure,
-   and remove tests here — there is no frozen failing-test to protect
-   (anti-tautology is Agent B's job, see below). Apply four checks:
-
-   a. **No schema-only-by-accident tests.** A test that only asserts "the
-      Zod schema accepts/rejects this shape" is a *smell to investigate*,
-      not an automatic deletion. Ask: **is the schema THE logic of this
-      cut, or does it guard behavior the test should exercise instead?**
-      - Config/schema cut (the schema IS the deliverable — e.g.
-        "accepts archetypes A–E, rejects `requiredApprovers: 0`"):
-        schema-acceptance IS the logic. KEEP it.
-      - Schema guards real behavior downstream (a resolver, a handler,
-        a state transition): rewrite the test to exercise THAT behavior
-        directly, not just the schema gate.
-
-   b. **Tests exercise logic directly.** Each test should call the
-      function / hit the route / drive the state machine and assert on
-      its OUTPUT, SIDE EFFECTS, or ERRORS — not on incidental shape or
-      on strings you copied from your own impl. Rewrite any test that
-      asserts on observed-output-of-my-own-code (tautological shape)
-      into one that asserts the behavior the spec promises.
-
-   c. **Convert repetitive tests to data-driven.** When several tests
-      run the same logic with different inputs/expected-outputs, collapse
-      them into one `it.each([...])` (or `describe.each`) table. One
-      table row per case; the assertion body written once. This makes
-      the cases scannable and the intent obvious.
-
-   d. **Remove redundant tests.** Delete a test only when another test
-      provably covers the same behavior. Before deleting, satisfy
-      yourself the surviving test would fail for the same reason the
-      deleted one would (otherwise it's not redundant — it's
-      load-bearing; keep it).
-
-   After all edits: **re-run the cut's tests + the wider suite — all
-   GREEN.** Amend the **tests commit** (`git commit --amend`) so the
-   two-commit shape (tests, then impl) holds for Agent B's revert check.
-
-   **Authority + the residual risk (recorded decision, 2026-06-07):**
-   You have unbounded authority to rewrite and remove tests here. Agent
-   B is the anti-tautology gate (it reverts your impl and re-runs the
-   surviving tests). **Known limitation:** B verifies the *surviving*
-   tests are load-bearing but cannot detect a test you *removed* that
-   would have caught a real bug — removed coverage is invisible to the
-   revert check. Do NOT exploit this: never remove a test to make the
-   suite easier to pass. Remove only genuine duplicates (check d). B
-   will scrutinize suspicious removals (tests deleted in the same diff
-   that adds the code they'd cover) and REJECT if it smells like
-   dropping coverage to pass.
-
-   **Capture what you did** in the SUMMARY's `Test-quality:` block: which
-   tests you rewrote (and why — schema-only / not-logic-direct), which
-   you made data-driven, which you removed (and the surviving test that
-   keeps the coverage).
-
-8. **RUNTIME EXERCISE — prove the code works on every execution path.**
+7. **RUNTIME EXERCISE — prove the code works on every execution path.**
 
    After tests pass, run the code with concrete inputs that prove EACH
    execution path the acceptance criteria imply. Most acceptance bullets
@@ -309,20 +251,76 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
      emit `NEEDS_INPUT` per Q6 lock, citing the discovered edge case.
      Don't guess; ask.
 
-   **Capture the exercise output in your `SUMMARY:` block** (step 12) under
+   **Capture the exercise output in your `SUMMARY:` block** (step 11) under
    a `Runtime exercise:` heading. Show each acceptance bullet, then each
    path of that bullet with its input + actual output. Use brief prose;
    the orchestrator surfaces this in the PR body for maintainer review.
 
-9. **Refine your tests** if the exercise surfaced edge cases worth
-   covering. The test-quality pass (step 7) already made the tests
-   logic-direct and non-redundant; here you add tests for edge cases the
-   runtime exercise discovered that the spec didn't enumerate. Amend the
-   **tests commit** (`git commit --amend`) to include the new cases —
-   keep all tests in the tests commit so the two-commit shape (tests,
-   then impl) holds for Agent B's revert check.
+8. **IMPROVE / FIX TESTS — make them test logic directly, add what the exercise found, cut redundancy.**
 
-10. **Format the diff with Biome** before committing the impl. Per
+   Now — *after* runtime validation, so you're informed by what the
+   exercise actually surfaced — improve the TESTS. You have full
+   authority to rewrite, restructure, add, and remove tests here (there
+   is no frozen failing-test to protect — anti-tautology is Agent B's
+   job, see below). Do both the quality pass and the edge-case additions:
+
+   a. **No schema-only-by-accident tests.** A test that only asserts "the
+      Zod schema accepts/rejects this shape" is a *smell to investigate*,
+      not an automatic deletion. Ask: **is the schema THE logic of this
+      cut, or does it guard behavior the test should exercise instead?**
+      - Config/schema cut (the schema IS the deliverable — e.g.
+        "accepts archetypes A–E, rejects `requiredApprovers: 0`"):
+        schema-acceptance IS the logic. KEEP it.
+      - Schema guards real behavior downstream (a resolver, a handler,
+        a state transition): rewrite the test to exercise THAT behavior
+        directly, not just the schema gate.
+
+   b. **Tests exercise logic directly.** Each test should call the
+      function / hit the route / drive the state machine and assert on
+      its OUTPUT, SIDE EFFECTS, or ERRORS — not on incidental shape or
+      on strings you copied from your own impl. Rewrite any test that
+      asserts on observed-output-of-my-own-code (tautological shape)
+      into one that asserts the behavior the spec promises.
+
+   c. **Add the edge cases the runtime exercise discovered.** Step 7
+      probed boundaries the spec didn't enumerate (empty/null, off-by-one,
+      locale/theme variants, every error path). Add a test for each
+      spec-silent edge case whose behavior the exercise confirmed.
+
+   d. **Convert repetitive tests to data-driven.** When several tests
+      run the same logic with different inputs/expected-outputs, collapse
+      them into one `it.each([...])` (or `describe.each`) table. One
+      table row per case; the assertion body written once.
+
+   e. **Remove redundant tests.** Delete a test only when another test
+      provably covers the same behavior. Before deleting, satisfy
+      yourself the surviving test would fail for the same reason the
+      deleted one would (otherwise it's not redundant — it's
+      load-bearing; keep it).
+
+   After all edits: **re-run the cut's tests + the wider suite — all
+   GREEN.** Amend the **tests commit** (`git commit --amend`) so the
+   two-commit shape (tests, then impl) holds for Agent B's revert check.
+
+   **Authority + the residual risk (recorded decision, 2026-06-07):**
+   You have unbounded authority to rewrite and remove tests here. Agent
+   B is the anti-tautology gate (it reverts your impl and re-runs the
+   surviving tests). **Known limitation:** B verifies the *surviving*
+   tests are load-bearing but cannot detect a test you *removed* that
+   would have caught a real bug — removed coverage is invisible to the
+   revert check. Do NOT exploit this: never remove a test to make the
+   suite easier to pass. Remove only genuine duplicates (check e). B
+   will scrutinize suspicious removals (tests deleted in the same diff
+   that adds the code they'd cover) and REJECT if it smells like
+   dropping coverage to pass.
+
+   **Capture what you did** in the SUMMARY's `Test-quality:` block: which
+   tests you rewrote (and why — schema-only / not-logic-direct), which
+   edge-case tests you added from the exercise, which you made
+   data-driven, which you removed (and the surviving test that keeps the
+   coverage).
+
+9. **Format the diff with Biome** before committing the impl. Per
    [team-preferences.md rule 30](../../.claude/rules/team-preferences.md),
    format must run before commit — otherwise CI's `format` check
    fails and the maintainer has to push a follow-up format-only
@@ -331,7 +329,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
    npm run format
    ```
    Biome reformats unstaged + staged files in place (~150ms). If
-   Biome touched the test file (step 9's amend already
+   Biome touched the test file (step 8's amend already
    landed), re-amend the test commit to roll the reformat into it
    — DO NOT make a separate format commit:
    ```bash
@@ -339,7 +337,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
    git commit --amend --no-edit
    ```
 
-11. Commit:
+10. Commit:
    ```bash
    git add <impl files>
    git commit -m "feat(<area>): cut #$ISSUE_NUMBER — <short summary>
@@ -350,7 +348,7 @@ Closes #$ISSUE_NUMBER
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    ```
-12. End with a `SUMMARY:` block as your last output:
+11. End with a `SUMMARY:` block as your last output:
 
    ```
    SUMMARY:

--- a/bots/feature-bot/prompts/per-cut.md
+++ b/bots/feature-bot/prompts/per-cut.md
@@ -66,20 +66,32 @@ This is non-negotiable. Read these in this order:
 Only AFTER reading 1-3 do you begin writing code. The design doc's
 Locked decisions are the contract you implement.
 
-## TDD-FIRST CONTRACT
+## TEST + COMMIT CONTRACT
 
-**Your first commit MUST be a failing test that pins the cut's
-acceptance criteria** (per `team-preferences.md` rule 31).
+You write tests and implementation for the cut. You do NOT have to write
+tests first or keep them frozen — you may rewrite, restructure, and
+improve tests freely (see the test-quality step). Anti-tautology is
+**not** your discipline to self-enforce; it is **Agent B's job** — the
+reviewer independently verifies your tests are load-bearing (revert the
+implementation, the tests must fail; reapply, they must pass).
 
-Read the cut sub-issue body's `## Tests` section — it names the
-specific test files to write. Write those tests first. Verify they
-FAIL locally. Then implement. Verify they PASS locally. Two commits,
-in this order: test, then implementation.
+Two requirements only:
 
-DO NOT modify the failing tests during implementation. The orchestrator
-verifies via reviewer that reverting the impl commit re-fails the tests
-— if you weakened the assertions to make red → green, the reviewer's
-tautology check will catch it and REJECT.
+1. **Cover the cut's `## Tests` section.** It names the specific test
+   files + behaviors to test. Your final test set must exercise them.
+2. **Soft two-commit shape — tests, then implementation.** Make a tests
+   commit, then an implementation commit. This is NOT a red-first ritual
+   (you don't need to commit failing tests before writing code); it
+   exists so Agent B's tautology check can cleanly separate "the tests"
+   from "the implementation" by reverting the impl commit. Keep test
+   files in the tests commit and source files in the impl commit. If the
+   test-quality step rewrites tests after the impl is written, amend the
+   tests commit (`git commit --amend`) so the two-commit shape holds.
+
+Write tests that exercise BEHAVIOR — call the function, assert on its
+output / side effects / errors. The reviewer will revert your impl and
+expect them to fail; tests that pass against reverted impl are
+tautological and get REJECTED.
 
 ## Three terminal states (per Q6 lock)
 
@@ -89,17 +101,19 @@ discovered.
 ### APPROVE path (most common — happy path)
 
 1. Read inputs + design doc + companion docs (mandatory).
-2. Write failing tests per `## Tests`. Verify RED.
-3. Commit:
+2. Write tests per `## Tests` — exercise the behaviors it names. (No
+   red-first requirement; write them before or alongside the impl as
+   suits you. They'll be refined in the test-quality step regardless.)
+3. Commit the tests:
    ```bash
    git checkout -b $BRANCH_NAME 2>/dev/null || git checkout $BRANCH_NAME
    git add <test files>
-   git commit -m "test: failing tests for cut #$ISSUE_NUMBER ($FEATURE_SLUG)
+   git commit -m "test: tests for cut #$ISSUE_NUMBER ($FEATURE_SLUG)
 
-Captures the acceptance criteria from cut #$ISSUE_NUMBER as failing tests.
-The impl follows in the next commit; this commit is RED in CI.
+Tests the behaviors from cut #$ISSUE_NUMBER's ## Tests section.
+The impl follows in the next commit.
 
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
    ```
 4. Implement the cut. Verify GREEN.
 5. Run the wider test suite. Confirm no regressions.
@@ -143,13 +157,15 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
       round` so the transcript shows the loop's reasoning.
 
    **All SOLID fixes land in the working tree BEFORE the impl commit
-   (step 10) — they roll INTO that single impl commit.** Do NOT create a
-   separate "solid" or "refactor" commit; the two-commit shape (test,
-   then impl) is what the reviewer's tautology check depends on. Do NOT
-   touch the failing-test commit's assertions during SOLID work — if a
-   structural change genuinely requires a different test shape, that's a
-   signal to reconsider the change (or emit NEEDS_INPUT), not to weaken
-   the test.
+   (step 11) — they roll INTO that single impl commit.** Do NOT create a
+   separate "solid" or "refactor" commit; the two-commit shape (tests,
+   then impl) is what the reviewer's tautology check depends on. SOLID
+   work is a pure structural refactor — the tests should stay GREEN
+   throughout without changing them. Test *improvement* (rewriting,
+   data-driving, de-duping) is the NEXT step's job (test-quality pass),
+   not this one. If a SOLID refactor seems to require changing a test
+   assertion, that's a signal the refactor changed behavior (not just
+   structure) — reconsider it.
 
    The cap is 3 rounds: bounded effort, not a quality gate. Whatever the
    structure is at convergence-or-cap goes forward; Agent B independently
@@ -157,7 +173,65 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    violations it sees) — so this self-research raises the floor, and
    Agent B remains the independent check, not your own sign-off.
 
-7. **RUNTIME EXERCISE — prove the code works on every execution path.**
+7. **TEST-QUALITY PASS — make the tests test logic, directly, without redundancy.**
+
+   Your tests are GREEN and the structure is SOLID-clean. Now improve
+   the TESTS themselves. You have full authority to rewrite, restructure,
+   and remove tests here — there is no frozen failing-test to protect
+   (anti-tautology is Agent B's job, see below). Apply four checks:
+
+   a. **No schema-only-by-accident tests.** A test that only asserts "the
+      Zod schema accepts/rejects this shape" is a *smell to investigate*,
+      not an automatic deletion. Ask: **is the schema THE logic of this
+      cut, or does it guard behavior the test should exercise instead?**
+      - Config/schema cut (the schema IS the deliverable — e.g.
+        "accepts archetypes A–E, rejects `requiredApprovers: 0`"):
+        schema-acceptance IS the logic. KEEP it.
+      - Schema guards real behavior downstream (a resolver, a handler,
+        a state transition): rewrite the test to exercise THAT behavior
+        directly, not just the schema gate.
+
+   b. **Tests exercise logic directly.** Each test should call the
+      function / hit the route / drive the state machine and assert on
+      its OUTPUT, SIDE EFFECTS, or ERRORS — not on incidental shape or
+      on strings you copied from your own impl. Rewrite any test that
+      asserts on observed-output-of-my-own-code (tautological shape)
+      into one that asserts the behavior the spec promises.
+
+   c. **Convert repetitive tests to data-driven.** When several tests
+      run the same logic with different inputs/expected-outputs, collapse
+      them into one `it.each([...])` (or `describe.each`) table. One
+      table row per case; the assertion body written once. This makes
+      the cases scannable and the intent obvious.
+
+   d. **Remove redundant tests.** Delete a test only when another test
+      provably covers the same behavior. Before deleting, satisfy
+      yourself the surviving test would fail for the same reason the
+      deleted one would (otherwise it's not redundant — it's
+      load-bearing; keep it).
+
+   After all edits: **re-run the cut's tests + the wider suite — all
+   GREEN.** Amend the **tests commit** (`git commit --amend`) so the
+   two-commit shape (tests, then impl) holds for Agent B's revert check.
+
+   **Authority + the residual risk (recorded decision, 2026-06-07):**
+   You have unbounded authority to rewrite and remove tests here. Agent
+   B is the anti-tautology gate (it reverts your impl and re-runs the
+   surviving tests). **Known limitation:** B verifies the *surviving*
+   tests are load-bearing but cannot detect a test you *removed* that
+   would have caught a real bug — removed coverage is invisible to the
+   revert check. Do NOT exploit this: never remove a test to make the
+   suite easier to pass. Remove only genuine duplicates (check d). B
+   will scrutinize suspicious removals (tests deleted in the same diff
+   that adds the code they'd cover) and REJECT if it smells like
+   dropping coverage to pass.
+
+   **Capture what you did** in the SUMMARY's `Test-quality:` block: which
+   tests you rewrote (and why — schema-only / not-logic-direct), which
+   you made data-driven, which you removed (and the surviving test that
+   keeps the coverage).
+
+8. **RUNTIME EXERCISE — prove the code works on every execution path.**
 
    After tests pass, run the code with concrete inputs that prove EACH
    execution path the acceptance criteria imply. Most acceptance bullets
@@ -195,7 +269,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
      - A shell pipeline orchestrating multiple steps
      - Anything else that gets real bytes through the code
      **Do NOT use vitest / unit tests as the runtime exercise.** Tests
-     are the TDD contract (committed, kept, run by CI); the runtime
+     are the committed suite (kept, run by CI); the runtime
      exercise is comprehension-grounding (throwaway, never committed).
      Mixing them defeats the anti-tautology purpose — the test you
      would have written to "prove" the path is the same test that
@@ -235,19 +309,20 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
      emit `NEEDS_INPUT` per Q6 lock, citing the discovered edge case.
      Don't guess; ask.
 
-   **Capture the exercise output in your `SUMMARY:` block** (step 11) under
+   **Capture the exercise output in your `SUMMARY:` block** (step 12) under
    a `Runtime exercise:` heading. Show each acceptance bullet, then each
    path of that bullet with its input + actual output. Use brief prose;
    the orchestrator surfaces this in the PR body for maintainer review.
 
-8. **Refine your tests** if the exercise surfaced edge cases worth
-   covering. Tests-first (per rule 31) pinned the acceptance contract;
-   tests added after the exercise pin the edge cases the spec didn't
-   enumerate. Amend the test commit (`git commit --amend`) to include
-   the new test cases — keep them in the failing-test commit so the
-   TDD-first ordering is preserved.
+9. **Refine your tests** if the exercise surfaced edge cases worth
+   covering. The test-quality pass (step 7) already made the tests
+   logic-direct and non-redundant; here you add tests for edge cases the
+   runtime exercise discovered that the spec didn't enumerate. Amend the
+   **tests commit** (`git commit --amend`) to include the new cases —
+   keep all tests in the tests commit so the two-commit shape (tests,
+   then impl) holds for Agent B's revert check.
 
-9. **Format the diff with Biome** before committing the impl. Per
+10. **Format the diff with Biome** before committing the impl. Per
    [team-preferences.md rule 30](../../.claude/rules/team-preferences.md),
    format must run before commit — otherwise CI's `format` check
    fails and the maintainer has to push a follow-up format-only
@@ -256,7 +331,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    npm run format
    ```
    Biome reformats unstaged + staged files in place (~150ms). If
-   Biome touched the failing-test file (step 8's amend already
+   Biome touched the test file (step 9's amend already
    landed), re-amend the test commit to roll the reformat into it
    — DO NOT make a separate format commit:
    ```bash
@@ -264,7 +339,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    git commit --amend --no-edit
    ```
 
-10. Commit:
+11. Commit:
    ```bash
    git add <impl files>
    git commit -m "feat(<area>): cut #$ISSUE_NUMBER — <short summary>
@@ -275,7 +350,7 @@ Closes #$ISSUE_NUMBER
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    ```
-11. End with a `SUMMARY:` block as your last output:
+12. End with a `SUMMARY:` block as your last output:
 
    ```
    SUMMARY:
@@ -289,6 +364,13 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    separate module (SRP). Round 2: converged, no new findings." If no
    issues were found in round 1, say "Converged round 1 — no SOLID
    findings." Keep it to ≤3 lines.>
+
+   Test-quality:
+   <What the test-quality pass did: tests rewritten (schema-only→logic /
+   not-logic-direct→behavior), tests made data-driven (it.each), tests
+   removed (name the surviving test that keeps the coverage). If nothing
+   needed changing, say "Tests already logic-direct + non-redundant; no
+   changes." Keep it to ≤3 lines.>
 
    Runtime exercise:
    <For each acceptance bullet, list each execution path it implies
@@ -362,23 +444,27 @@ The orchestrator records a skip-list entry with the reason code, posts
 an escalation comment, applies `ready-for-human`, closes the sub-issue.
 Future crons honor the skip-list and don't re-attempt.
 
-## Anti-tautology discipline
+## Anti-tautology — Agent B's gate, not yours to self-enforce
 
-The failing tests you commit are the spec. They MUST fail when the
-impl commit is reverted. If your "fix" is just "edit the test until it
-matches the code," the reviewer's tautology check will catch it and
-REJECT. The reviewer runs:
+You may write, rewrite, and remove tests freely (you don't keep a frozen
+failing-test). But your tests MUST genuinely exercise behavior, because
+**Agent B independently verifies it** — it reverts your impl commit and
+re-runs the tests, which MUST fail; then re-applies and they MUST pass:
 
 ```bash
-git revert HEAD --no-edit              # revert impl
+git revert HEAD --no-edit              # revert impl (last commit)
 cd packages/gazetta && npx vitest run  # tests MUST fail here
 git reset --hard origin/$BRANCH_NAME   # re-apply
 cd packages/gazetta && npx vitest run  # tests MUST pass here
 ```
 
-Both halves must hold. Write tests that exercise BEHAVIOR — call the
-function, assert on its output, on its side effects, on errors it
-throws. Don't assert on observed strings from your own impl.
+(This is why the impl is the LAST commit — soft two-commit convention.)
+Both halves must hold or B REJECTS. So write tests that exercise
+BEHAVIOR — call the function, assert on its output, side effects, errors
+— not on observed strings from your own impl. A test that passes against
+reverted impl is tautological and gets REJECTED. **Never remove a test
+to make the suite easier to pass:** B scrutinizes removals and the
+removed-coverage gap is a known risk you must not exploit.
 
 ## Conventions
 
@@ -393,9 +479,13 @@ throws. Don't assert on observed strings from your own impl.
 
 ## Rules
 
-- **TDD-first is non-negotiable.** Failing test commit BEFORE impl
-  commit, always.
-- **DO NOT modify the failing tests during impl.** That's tautology.
+- **Soft two-commit shape: tests commit, then impl commit.** Not a
+  red-first ritual — it's so Agent B can revert the impl to run its
+  tautology check. The impl must be the LAST commit.
+- **Tests must exercise behavior, not echo your impl.** Agent B's
+  revert check is the gate; tautological tests get REJECTED.
+- **Never remove a test to ease passing.** Remove only genuine
+  duplicates (test-quality step check d).
 - **DO NOT push or open the PR.** The orchestrator does that after
   reviewer approval.
 - **Never push to main.** Always to `$BRANCH_NAME`.

--- a/bots/feature-bot/prompts/reviewer.md
+++ b/bots/feature-bot/prompts/reviewer.md
@@ -9,8 +9,12 @@ the implementation:
 3. **Implements the design doc's locked decisions** correctly
 4. **Stays within scope** of the one cut
 
-Agent A's TDD contract already gates "tests pass after fix." That's
-necessary but not sufficient. The failure modes you catch:
+**Agent A does NOT follow a TDD-first discipline** — it writes and
+freely rewrites/removes its own tests (including a test-quality pass that
+restructures them). So you are the SOLE anti-tautology gate: your
+revert-check (below) is the only thing guaranteeing the tests are
+load-bearing. Run it every time; don't assume Agent A enforced anything.
+The failure modes you catch:
 
 | Failure | What it looks like |
 |---|---|
@@ -77,10 +81,12 @@ Run this procedure every time, in this exact order:
 git log main..$BRANCH_NAME --oneline
 ```
 
-Expected: 2 commits — one prefixed `test:`, `failing test:`, or
-similar; one prefixed `feat:`/`fix:`/`refactor:`/etc. If anything else
-(1 commit, 3+ commits, commits in wrong order): **REJECT** with a note
-explaining the commit shape was wrong.
+Expected: 2 commits — a tests commit (prefixed `test:`) FIRST, then an
+implementation commit (`feat:`/`fix:`/`refactor:`/etc.) as HEAD. Agent A
+is no longer red-first, but the **soft two-commit shape is still
+required** so that reverting HEAD (step 2) cleanly removes the impl and
+leaves the tests. If anything else (1 commit, 3+ commits, impl not last):
+**REJECT** with a note that the commit shape breaks the revert check.
 
 ### Step 2: revert the impl commit; test must FAIL
 
@@ -124,6 +130,35 @@ spec and Agent A didn't push a broken state.
 If tests fail on re-application: state bug, not something Agent A can
 fix on retry. **NEEDS_HUMAN**.
 
+### Step 5: scrutinize test REMOVALS (the removed-coverage backstop)
+
+Agent A may rewrite and remove tests (it runs a test-quality pass with
+unbounded edit authority). Your revert-check proves the *surviving*
+tests are load-bearing — but it is **blind to a test Agent A deleted
+that would have caught a real bug.** You are the only check on removals.
+
+```bash
+git diff main..$BRANCH_NAME -- '*.test.ts' 'tests/**' | grep -E '^-' | head -60
+```
+
+For any test the diff DELETES, ask:
+- Is the same behavior still covered by another test in the final suite?
+  (Agent A's `Test-quality:` SUMMARY block should name the surviving
+  test for each removal — check it's true.)
+- Does the removal coincide suspiciously with the impl it would test —
+  i.e. a test deleted in the same diff that adds/changes the very code
+  the test would exercise? That smells like dropping coverage to pass.
+
+| State | Effect |
+|---|---|
+| Removals are genuine duplicates, coverage demonstrably kept | OK |
+| A removed test's behavior is NOT covered by any surviving test | **REJECT** — name the deleted test + the now-uncovered behavior |
+| Removal smells like coverage-dropping-to-pass (deleted test ↔ added code) | **REJECT** — cite the suspicious pairing |
+
+This is best-effort, not a guarantee (removed coverage is fundamentally
+hard to detect). When in doubt about a removal, REJECT and ask Agent A
+to justify it or restore the test.
+
 ## The acceptance check (Cut 5 refinement)
 
 Read the cut sub-issue's `## Acceptance` section. For each bullet,
@@ -149,8 +184,8 @@ acceptance bullets promise, for each path each bullet implies. The
 proof. A bullet with three error paths needs four proofs (happy + three
 error). A bullet with two branches needs two proofs. One per path.
 
-**Unit tests are NOT the runtime exercise.** Tests are the TDD contract
-(committed, kept, run by CI); the exercise is throwaway proof Agent A
+**Unit tests are NOT the runtime exercise.** Tests are the committed
+suite (kept, run by CI); the exercise is throwaway proof Agent A
 ran the code outside the test harness. Even if Agent A's tests are
 exhaustive, you cannot accept "the Zod-parse tests double as the
 runtime exercise" or "the tests cover each path so no separate


### PR DESCRIPTION
## What

Two coupled changes to feature-bot's **Agent A** flow:

1. **Remove TDD-first discipline.** Agent A no longer writes-failing-test-first or keeps tests frozen — it builds and freely rewrites/removes its own tests. The anti-tautology guarantee moves **entirely to Agent B's revert check** (revert impl → tests must fail → reapply → pass). A **soft two-commit shape** (tests, then impl) is kept only so B's `revert HEAD` cleanly separates impl from tests.

2. **Add a test-quality pass** (new step 7, after the SOLID loop):
   - **No schema-only-by-accident tests** — a smell to *investigate*, not a ban (keep it when the schema IS the cut's logic, e.g. a config-schema cut).
   - **Tests exercise logic directly** — assert on output/side-effects/errors, not on shape echoed from the impl.
   - **Convert repetitive tests to data-driven** (`it.each`).
   - **Remove redundant tests** (only when a survivor provably keeps the coverage).

## Recorded residual risk (maintainer-accepted)

The test-quality pass has **unbounded edit authority**. Agent B's revert check proves *surviving* tests are load-bearing but is **blind to removed coverage** (a deleted test that would have caught a bug). Mitigations:
- Agent A is told **never to remove a test to ease passing** (only genuine duplicates).
- Agent B gets a **new step-5 "scrutinize test removals"** check — REJECT if a removed test's behavior isn't covered by a survivor, or if a removal smells like coverage-dropping-to-pass.

This was a deliberate maintainer decision to get autonomous test-quality improvement; the risk is documented, not hidden.

## Files

- `bots/feature-bot/prompts/per-cut.md` — TEST+COMMIT contract replaces TDD-FIRST; new step 7; renumbered; SUMMARY `Test-quality:` block; Anti-tautology reframed.
- `bots/feature-bot/prompts/reviewer.md` — tautology check is the sole gate; new removal-scrutiny step.
- `.claude/rules/design-feature-bot.md` — loop diagram + no-TDD note + recorded residual risk.

Prompt + doc only; `bots tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)