### PR TITLE
feat(feature-bot): comment-verification step (rot-proof bar) + promote to review-comments skill

### DIFF
--- a/.claude/rules/design-feature-bot.md
+++ b/.claude/rules/design-feature-bot.md
@@ -16,7 +16,7 @@ Autonomous bot that implements feature cuts following the project's design pass.
 - Bot reads GitHub "cut sub-issues" labeled `enhancement` + `ready-for-agent` + `area: X` (no new labels — reuses existing vocabulary)
 - Picks the next cut whose dependencies are all closed
 - Generator-critic loop (Agent A implements, Agent B reviews) — same pattern as fix-bot + dead-code-watcher
-- Agent A flow: tests → impl → SOLID research+fix loop → runtime validation → improve/fix tests (no TDD-first; soft two-commit shape; Agent B is the sole anti-tautology gate — see the loop in "Design" below)
+- Agent A flow: tests → impl → SOLID research+fix loop → runtime validation → improve/fix tests → verify comments (rot-proof bar) (no TDD-first; soft two-commit shape; Agent B is the sole anti-tautology gate — see the loop in "Design" below)
 - One PR per cut
 - Durable memory: skip-list + reviewer-log (same shape as fix-bot)
 
@@ -477,7 +477,9 @@ Cron (daily 04:30 UTC, after fix-bot at 04:00):
    - Agent A: tests commit → impl (GREEN) → **SOLID research+fix loop
      (≤3 converge rounds)** → **runtime validation (prove every path)**
      → **improve/fix tests (logic-direct, data-driven, de-dup,
-     schema-smell, + edge cases the exercise surfaced)** → push. Tests
+     schema-smell, + edge cases the exercise surfaced)** → **verify
+     comments (rot-proof bar — every comment survives an arbitrary
+     rewrite, else rewrite to the WHY or delete)** → push. Test
      improvement comes AFTER runtime validation so it's informed by what
      the exercise found. SOLID fixes roll into the impl commit; all
      tests live in the tests commit (soft two-commit shape for B's

--- a/.claude/skills/review-comments/SKILL.md
+++ b/.claude/skills/review-comments/SKILL.md
@@ -11,10 +11,19 @@ Comments are technical debt that compounds quietly. This angle catches comment r
 
 See [`design-code-review.md`](../../rules/design-code-review.md) for the full design + skill family.
 
+## The governing bar: a comment must be impossible to rot
+
+The standard is **not "accurate today" — it is "survives an arbitrary rewrite of the code beneath it."** A comment that correctly describes the code now is still a finding if a future rewrite would falsify it. For every comment ask:
+
+> **"If someone rewrites this code, does the comment go stale?"**
+
+- **Yes → rot-prone.** Flag it: rewrite to the durable WHY behind it, or remove. Rot-prone shapes (flag even when accurate today): restates WHAT the code does (`// increment i` over `i++`), describes the current algorithm, or names volatile anchors — local symbol names, line numbers, "the function below", quoted example output.
+- **No → keep.** A comment survives only by stating what the code can't: a non-obvious WHY, an externally-imposed constraint (spec, protocol, platform quirk, locked design decision), a durable design linkage (design-doc section or `ADR-NNNN` — durable anchors are fine, line numbers and local symbols are not), or a warning about a non-obvious consequence.
+
 ## What this angle owns
 
+- **Rot-prone comments** — accurate today but a rewrite would stale them (the governing bar)
 - Comments that contradict the code they sit next to ("returns null when empty" but the code throws)
-- Comments that restate obvious code (`// increment i` next to `i++`) — per CLAUDE.md "default to writing no comments"
 - Stale references to functions/variables that have been renamed or removed
 - Examples in JSDoc that don't compile or call deleted APIs
 - TODOs / FIXMEs whose underlying issue appears resolved by this same diff
@@ -24,7 +33,7 @@ See [`design-code-review.md`](../../rules/design-code-review.md) for the full de
 
 - Documentation files (`docs/**.md`, `README.md`) — those are reviewed as content, not as code comments
 - Comments inside test files describing test intent — those are part of test quality (`review-tests`)
-- Whether NEW comments should exist at all (that's per-line judgment the author makes); we review whether comments that exist are accurate
+- Whether NEW comments should exist at all (that's per-line judgment the author makes); we review whether comments that exist meet the rot-proof bar
 
 ## Reads (always)
 
@@ -36,6 +45,7 @@ See [`design-code-review.md`](../../rules/design-code-review.md) for the full de
 
 Look at lines starting with `//`, `/*`, `*`, `#`, or `<!--` that were added or modified. For each, ask:
 
+- **Rot-proofness** (the governing bar): would a future rewrite of the code beneath this comment falsify it? If yes, it's rot-prone — flag it even if it's accurate today.
 - **Accuracy**: does the comment match what the adjacent code actually does?
 - **Necessity**: would removing the comment hide a non-obvious WHY? If no, the comment is redundant per CLAUDE.md.
 - **Currency**: does the comment reference functions / variables / behavior that still exist?
@@ -53,7 +63,7 @@ For each candidate finding:
 |---|---|
 | **CRITICAL** | Comment actively misleads in a way that would cause a user/maintainer to write incorrect code (e.g., "this function is async" but it's sync; a usage example that calls a deleted function) |
 | **IMPORTANT** | Comment is materially wrong but obvious from the code (e.g., "returns true on success" but the code returns the result) |
-| **NIT** | Comment restates obvious code (CLAUDE.md violation); minor wording drift |
+| **NIT** | Comment restates obvious code (CLAUDE.md violation); rot-prone but accurate today (describes the impl / names volatile anchors); minor wording drift |
 
 Confidence threshold ≥ 80 to emit.
 
@@ -120,6 +130,16 @@ function createUser(name: string, opts: CreateUserOpts) {
 function find(id: string) {
   return arr.find(x => x.id === id)  // actually O(n)
 }
+```
+
+**Rot-prone though accurate-today (fails the governing bar):**
+```ts
+// Loops over targets and merges each one's reviewWorkflow into the result
+function resolve(site, target) {
+  return target.reviewWorkflow ?? site.reviewWorkflow  // describes an impl
+}                                                       // a rewrite would stale
+// → rewrite to the WHY ("per-target override is atomic per
+//   design-review-workflow.md — no field merge"), or delete.
 ```
 
 ## What NOT to flag

--- a/bots/feature-bot/prompts/per-cut.md
+++ b/bots/feature-bot/prompts/per-cut.md
@@ -157,7 +157,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
       round` so the transcript shows the loop's reasoning.
 
    **All SOLID fixes land in the working tree BEFORE the impl commit
-   (step 10) — they roll INTO that single impl commit.** Do NOT create a
+   (step 11) — they roll INTO that single impl commit.** Do NOT create a
    separate "solid" or "refactor" commit; the two-commit shape (tests,
    then impl) is what the reviewer's tautology check depends on. SOLID
    work is a pure structural refactor — the tests should stay GREEN
@@ -251,7 +251,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
      emit `NEEDS_INPUT` per Q6 lock, citing the discovered edge case.
      Don't guess; ask.
 
-   **Capture the exercise output in your `SUMMARY:` block** (step 11) under
+   **Capture the exercise output in your `SUMMARY:` block** (step 12) under
    a `Runtime exercise:` heading. Show each acceptance bullet, then each
    path of that bullet with its input + actual output. Use brief prose;
    the orchestrator surfaces this in the PR body for maintainer review.
@@ -320,7 +320,34 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
    data-driven, which you removed (and the surviving test that keeps the
    coverage).
 
-9. **Format the diff with Biome** before committing the impl. Per
+9. **VERIFY COMMENTS — every comment must be impossible to rot.**
+
+   Review **every comment in the files this cut touched** (yours and
+   pre-existing — a deliberate Boy-Scout exception to "stay minimal":
+   comment cleanup is cheap and zero-risk). Apply the `review-comments`
+   skill's rot-proof bar.
+
+   The bar is not "accurate today" — it is **"survives an arbitrary
+   rewrite of the code beneath it."** For each comment ask: *if someone
+   rewrites this code, does the comment go stale?*
+
+   - **Yes → rot-prone.** Rewrite it to the durable WHY behind it, or
+     delete it if there's no durable why. Rot-prone = restates what the
+     code does, describes the current algorithm, or names volatile
+     anchors (local symbol names, line numbers, "the function below",
+     example outputs).
+   - **No → keep.** Survives only if it states something the code can't:
+     a non-obvious WHY, an externally-imposed constraint, a durable
+     design linkage (design-doc section or `ADR-NNNN`), or a warning.
+   - **Resolved TODO/FIXME → remove.**
+
+   Comment edits go into whichever commit owns the file (test file →
+   amend the tests commit; source → the impl commit). Re-run the suite
+   (comments don't change behavior, but confirm no fat-fingered code
+   line). **Capture in the SUMMARY's `Comments:` block** what you
+   fixed/removed (one line; "no changes" if clean).
+
+10. **Format the diff with Biome** before committing the impl. Per
    [team-preferences.md rule 30](../../.claude/rules/team-preferences.md),
    format must run before commit — otherwise CI's `format` check
    fails and the maintainer has to push a follow-up format-only
@@ -337,7 +364,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
    git commit --amend --no-edit
    ```
 
-10. Commit:
+11. Commit:
    ```bash
    git add <impl files>
    git commit -m "feat(<area>): cut #$ISSUE_NUMBER — <short summary>
@@ -348,13 +375,15 @@ Closes #$ISSUE_NUMBER
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    ```
-11. End with a `SUMMARY:` block as your last output:
+12. End with a `SUMMARY:` block as your last output:
 
    ```
    SUMMARY:
    <2-4 sentences: what the cut delivered, how the failing test pins it,
    which design-doc locked decisions it implements. Plain prose; no
    headings, no bullets, no code blocks inside the summary.>
+
+   (Blocks below mirror Agent A's step order: SOLID → runtime → tests → comments.)
 
    SOLID research:
    <One line per round: what each round found + fixed, and the round it
@@ -363,6 +392,12 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    issues were found in round 1, say "Converged round 1 — no SOLID
    findings." Keep it to ≤3 lines.>
 
+   Runtime exercise:
+   <For each acceptance bullet, list each execution path it implies
+   (happy + every error / branch / variant) with the input you ran and
+   the actual output. Keep it under ~50 lines total. The orchestrator
+   includes this in the PR body for maintainer review.>
+
    Test-quality:
    <What the test-quality pass did: tests rewritten (schema-only→logic /
    not-logic-direct→behavior), tests made data-driven (it.each), tests
@@ -370,11 +405,11 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
    needed changing, say "Tests already logic-direct + non-redundant; no
    changes." Keep it to ≤3 lines.>
 
-   Runtime exercise:
-   <For each acceptance bullet, list each execution path it implies
-   (happy + every error / branch / variant) with the input you ran and
-   the actual output. Keep it under ~50 lines total. The orchestrator
-   includes this in the PR body for maintainer review.>
+   Comments:
+   <What the comment-verification pass did: rot-prone comments rewritten
+   to the durable WHY, redundant/restate-obvious comments removed,
+   resolved TODOs removed. If nothing needed changing, say "Comments
+   already rot-proof; no changes." Keep it to ≤2 lines.>
    ```
 
 The orchestrator extracts `SUMMARY:` and puts it in the PR body.


### PR DESCRIPTION
## What

New **Agent A step 9** — *verify comments* — between improve/fix-tests and format. Every comment in the touched files must meet the **rot-proof bar**.

The bar is not "accurate today" — it is **"survives an arbitrary rewrite of the code beneath it."** A comment that correctly describes the implementation *now* is still flagged, because a future rewrite would stale it. For each comment: *if someone rewrites this code, does the comment go stale?*
- **Yes → rot-prone** — rewrite to the durable WHY, or delete. (Restates what the code does, describes the algorithm, or names volatile anchors: local symbols, line numbers, "the function below", example output.)
- **No → keep** — non-obvious WHY, external constraint, durable design linkage (design-doc section / `ADR-NNNN`), or a warning.
- Resolved TODO/FIXME → remove.

File-scoped (a deliberate Boy-Scout exception to "stay minimal" — comment cleanup is cheap and zero-risk, unlike code refactoring).

## Promoted to the shared standard

The rot-proof bar is baked into the **`review-comments` skill** so Agent B's review angle + interactive `/review-comments` enforce the same standard, not just feature-bot. Skill gains a "governing bar" section, a NIT row for rot-prone-but-accurate, and an anti-pattern example.

## Files

- `bots/feature-bot/prompts/per-cut.md` — step 9; renumbered (format→10, commit→11, SUMMARY→12); `Comments:` SUMMARY block; SUMMARY reordered to mirror step order.
- `.claude/skills/review-comments/SKILL.md` — governing rot-proof bar; de-duped.
- `.claude/rules/design-feature-bot.md` — flow bullet + loop diagram.

Prompt + skill + doc only; `bots tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)