### PR TITLE
feat(feature-bot): single commit at end; Agent B separates impl/tests by path

### DIFF
--- a/.claude/rules/design-feature-bot.md
+++ b/.claude/rules/design-feature-bot.md
@@ -16,7 +16,7 @@ Autonomous bot that implements feature cuts following the project's design pass.
 - Bot reads GitHub "cut sub-issues" labeled `enhancement` + `ready-for-agent` + `area: X` (no new labels — reuses existing vocabulary)
 - Picks the next cut whose dependencies are all closed
 - Generator-critic loop (Agent A implements, Agent B reviews) — same pattern as fix-bot + dead-code-watcher
-- Agent A flow: tests → impl → SOLID research+fix loop → runtime validation → improve/fix tests → verify comments (rot-proof bar) (no TDD-first; soft two-commit shape; Agent B is the sole anti-tautology gate — see the loop in "Design" below)
+- Agent A flow: tests → impl → SOLID research+fix loop → runtime validation → improve/fix tests → verify comments (rot-proof bar) → ONE commit at the end (no TDD-first; single atomic commit; Agent B is the sole anti-tautology gate, separating impl from tests by path — see the loop in "Design" below)
 - One PR per cut
 - Durable memory: skip-list + reviewer-log (same shape as fix-bot)
 
@@ -97,7 +97,7 @@ Bot's TS orchestrator parses two one-line key-value fields via regex:
 - `**Feature**: <slug>` → picks the right design doc reference
 - `**Depends on**: #N, #M` (optional) → cron-time gate; skip until all referenced sub-issues close
 
-Everything else (`## Spec`, `## Acceptance`) is passed to Agent A as prose context. Agent A is responsible for reading the linked design doc, deciding files + tests, and committing in the soft two-commit shape (tests, then impl).
+Everything else (`## Spec`, `## Acceptance`) is passed to Agent A as prose context. Agent A is responsible for reading the linked design doc, deciding files + tests, and making one atomic commit (tests + impl) once all its checks pass.
 
 **Schema enforcement** lives in Agent A's prompt discipline, not at filing time:
 - If `## Spec` or `## Acceptance` is missing or vague → Agent A fails loud, posts "spec incomplete" comment on the sub-issue + closes with reason. Reviewer-loop's existing escalation mechanism handles it.
@@ -474,16 +474,16 @@ Cron (daily 04:30 UTC, after fix-bot at 04:00):
 3. Pick oldest unblocked cut.
     ↓
 4. Generator-critic loop (max 5 attempts):
-   - Agent A: tests commit → impl (GREEN) → **SOLID research+fix loop
+   - Agent A: write tests + impl (GREEN) → **SOLID research+fix loop
      (≤3 converge rounds)** → **runtime validation (prove every path)**
      → **improve/fix tests (logic-direct, data-driven, de-dup,
      schema-smell, + edge cases the exercise surfaced)** → **verify
      comments (rot-proof bar — every comment survives an arbitrary
-     rewrite, else rewrite to the WHY or delete)** → push. Test
+     rewrite, else rewrite to the WHY or delete)** → **ONE commit** (all
+     work stays uncommitted in the working tree until every check passes,
+     then a single atomic commit of tests + impl) → push. Test
      improvement comes AFTER runtime validation so it's informed by what
-     the exercise found. SOLID fixes roll into the impl commit; all
-     tests live in the tests commit (soft two-commit shape for B's
-     revert check).
+     the exercise found.
    - Agent B: review diff, vote APPROVE / REJECT / NEEDS_HUMAN —
      runs the **tautology check (the SOLE anti-tautology gate)**,
      **independently judges SOLID**, and **scrutinizes test removals**
@@ -493,19 +493,25 @@ Cron (daily 04:30 UTC, after fix-bot at 04:00):
 
    **No TDD-first discipline on Agent A (2026-06-07 change).** Agent A
    no longer writes-failing-test-first or keeps tests frozen — it builds
-   and freely rewrites/removes tests (the test-quality pass). The
-   anti-tautology guarantee moves ENTIRELY to Agent B's revert check
-   (revert impl → tests must fail → reapply → pass). A soft two-commit
-   shape (tests, then impl) is kept ONLY so B's `revert HEAD` cleanly
-   separates impl from tests.
+   and freely rewrites/removes tests (the test-quality pass), commits
+   nothing until all checks pass, then makes ONE atomic commit. The
+   anti-tautology guarantee lives ENTIRELY at Agent B's revert check
+   (revert the impl files → tests must fail → restore → pass). Agent B
+   separates impl from tests **by path** (test files = `*.test.ts` /
+   `*.spec.ts` / `tests/**`), so no special commit shape is needed —
+   reverting `git checkout main -- <impl files>` leaves the tests in
+   place. (The earlier soft-two-commit scaffolding was dropped in favor
+   of this path-based separation, which is simpler and commit-count-
+   agnostic.)
 
    **SOLID research is Agent A self-work, not a separate agent.** A
    separate SOLID agent between A and B was rejected because (a) editing
-   the diff mid-loop breaks the two-commit shape B's revert depends on,
-   (b) "fresh eyes" from a separate Claude session is weak (same model,
-   cleared context), and (c) the independent SOLID check already exists
-   at Agent B. A researches + fixes its own structure (discovery, not
-   just the declared `## SOLID` lenses), converging in ≤3 rounds.
+   the diff mid-loop would muddy the single-commit / path-based revert B
+   relies on, (b) "fresh eyes" from a separate Claude session is weak
+   (same model, cleared context), and (c) the independent SOLID check
+   already exists at Agent B. A researches + fixes its own structure
+   (discovery, not just the declared `## SOLID` lenses), converging in
+   ≤3 rounds.
 
    **The test-quality pass has unbounded edit authority — recorded
    residual risk.** A may rewrite (schema-only-smell → logic-direct),

--- a/bots/feature-bot/prompts/per-cut.md
+++ b/bots/feature-bot/prompts/per-cut.md
@@ -68,29 +68,33 @@ Locked decisions are the contract you implement.
 
 ## TEST + COMMIT CONTRACT
 
-You write tests and implementation for the cut. You do NOT have to write
-tests first or keep them frozen — you may rewrite, restructure, and
-improve tests freely (see the test-quality step). Anti-tautology is
-**not** your discipline to self-enforce; it is **Agent B's job** — the
-reviewer independently verifies your tests are load-bearing (revert the
-implementation, the tests must fail; reapply, they must pass).
+You write tests and implementation for the cut. You do NOT write tests
+first or keep them frozen — you may rewrite, restructure, and improve
+tests freely (see the test-quality step). Anti-tautology is **not** your
+discipline to self-enforce; it is **Agent B's job** — the reviewer
+independently verifies your tests are load-bearing (it reverts your impl
+files, the tests must fail; restore, they must pass).
 
-Two requirements only:
+**Commit ONCE, at the very end, only after every check has passed.** Do
+all your work in the working tree — write tests + impl, run the suite,
+SOLID research+fix, runtime validation, improve/fix tests, verify
+comments — and make **a single commit** (tests + impl together) as the
+final step. Do NOT commit incrementally; do NOT make a separate tests
+commit; do NOT amend. The cut is one atomic change = one commit.
+
+Two requirements:
 
 1. **Cover the cut's `## Tests` section.** It names the specific test
    files + behaviors to test. Your final test set must exercise them.
-2. **Soft two-commit shape — tests, then implementation.** Make a tests
-   commit, then an implementation commit. This is NOT a red-first ritual
-   (you don't need to commit failing tests before writing code); it
-   exists so Agent B's tautology check can cleanly separate "the tests"
-   from "the implementation" by reverting the impl commit. Keep test
-   files in the tests commit and source files in the impl commit. If the
-   test-quality step rewrites tests after the impl is written, amend the
-   tests commit (`git commit --amend`) so the two-commit shape holds.
+2. **One commit, made last.** Build → all checks green → format → commit.
+   Agent B separates your test files from impl files BY PATH (test files
+   = `*.test.ts` / `*.spec.ts` / under `tests/`) to run its check, so you
+   don't need any special commit shape — just keep test code in test
+   files and implementation in source files, as usual.
 
 Write tests that exercise BEHAVIOR — call the function, assert on its
-output / side effects / errors. The reviewer will revert your impl and
-expect them to fail; tests that pass against reverted impl are
+output / side effects / errors. Agent B will revert your impl files and
+expect the tests to fail; tests that pass against reverted impl are
 tautological and get REJECTED.
 
 ## Three terminal states (per Q6 lock)
@@ -101,20 +105,13 @@ discovered.
 ### APPROVE path (most common — happy path)
 
 1. Read inputs + design doc + companion docs (mandatory).
-2. Write tests per `## Tests` — exercise the behaviors it names. (No
-   red-first requirement; write them before or alongside the impl as
-   suits you. They'll be refined in the test-quality step regardless.)
-3. Commit the tests:
+2. Create the branch (no commit yet — you commit once, at the end):
    ```bash
    git checkout -b $BRANCH_NAME 2>/dev/null || git checkout $BRANCH_NAME
-   git add <test files>
-   git commit -m "test: tests for cut #$ISSUE_NUMBER ($FEATURE_SLUG)
-
-Tests the behaviors from cut #$ISSUE_NUMBER's ## Tests section.
-The impl follows in the next commit.
-
-Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
    ```
+3. Write tests per `## Tests` — exercise the behaviors it names. (Write
+   them before or alongside the impl as suits you; they'll be refined in
+   the test-quality step. Do NOT commit them yet.)
 4. Implement the cut. Verify GREEN.
 5. Run the wider test suite. Confirm no regressions.
 6. **SOLID RESEARCH + FIX — improve the structure you just wrote (converge, ≤3 rounds).**
@@ -156,16 +153,14 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
       new findings)` or `> Decision: SOLID round N fixed <X>; another
       round` so the transcript shows the loop's reasoning.
 
-   **All SOLID fixes land in the working tree BEFORE the impl commit
-   (step 11) — they roll INTO that single impl commit.** Do NOT create a
-   separate "solid" or "refactor" commit; the two-commit shape (tests,
-   then impl) is what the reviewer's tautology check depends on. SOLID
-   work is a pure structural refactor — the tests should stay GREEN
-   throughout without changing them. Test *improvement* (rewriting,
-   data-driving, de-duping) is the job of step 8 (improve/fix tests),
-   which runs after runtime validation — not this step. If a SOLID
-   refactor seems to require changing a test assertion, that's a signal
-   the refactor changed behavior (not just structure) — reconsider it.
+   **SOLID fixes happen in the working tree — nothing is committed yet
+   (you commit once, at the end, step 11).** SOLID work is a pure
+   structural refactor — the tests should stay GREEN throughout without
+   changing them. Test *improvement* (rewriting, data-driving, de-duping)
+   is the job of step 8 (improve/fix tests), which runs after runtime
+   validation — not this step. If a SOLID refactor seems to require
+   changing a test assertion, that's a signal the refactor changed
+   behavior (not just structure) — reconsider it.
 
    The cap is 3 rounds: bounded effort, not a quality gate. Whatever the
    structure is at convergence-or-cap goes forward; Agent B independently
@@ -299,8 +294,8 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
       load-bearing; keep it).
 
    After all edits: **re-run the cut's tests + the wider suite — all
-   GREEN.** Amend the **tests commit** (`git commit --amend`) so the
-   two-commit shape (tests, then impl) holds for Agent B's revert check.
+   GREEN.** (Still nothing committed — all edits stay in the working
+   tree until the single commit at step 11.)
 
    **Authority + the residual risk (recorded decision, 2026-06-07):**
    You have unbounded authority to rewrite and remove tests here. Agent
@@ -341,32 +336,26 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
      design linkage (design-doc section or `ADR-NNNN`), or a warning.
    - **Resolved TODO/FIXME → remove.**
 
-   Comment edits go into whichever commit owns the file (test file →
-   amend the tests commit; source → the impl commit). Re-run the suite
-   (comments don't change behavior, but confirm no fat-fingered code
-   line). **Capture in the SUMMARY's `Comments:` block** what you
-   fixed/removed (one line; "no changes" if clean).
+   Comment edits stay in the working tree (still nothing committed).
+   Re-run the suite (comments don't change behavior, but confirm no
+   fat-fingered code line). **Capture in the SUMMARY's `Comments:`
+   block** what you fixed/removed (one line; "no changes" if clean).
 
-10. **Format the diff with Biome** before committing the impl. Per
+10. **Format with Biome** before the commit. Per
    [team-preferences.md rule 30](../../.claude/rules/team-preferences.md),
-   format must run before commit — otherwise CI's `format` check
-   fails and the maintainer has to push a follow-up format-only
-   commit (which adds noise + bypasses the CI gate). Run:
+   format must run before commit — otherwise CI's `format` check fails.
+   Run:
    ```bash
    npm run format
    ```
-   Biome reformats unstaged + staged files in place (~150ms). If
-   Biome touched the test file (step 8's amend already
-   landed), re-amend the test commit to roll the reformat into it
-   — DO NOT make a separate format commit:
-   ```bash
-   git add <test files>
-   git commit --amend --no-edit
-   ```
+   Biome reformats the working tree in place (~150ms). Nothing to amend —
+   the reformat is just more uncommitted working-tree change that rolls
+   into the single commit at step 11.
 
-11. Commit:
+11. **Make the single commit** — tests + impl together, the only commit
+   for this cut:
    ```bash
-   git add <impl files>
+   git add -A
    git commit -m "feat(<area>): cut #$ISSUE_NUMBER — <short summary>
 
 <one-paragraph what changed + why per the design doc>
@@ -481,17 +470,19 @@ Future crons honor the skip-list and don't re-attempt.
 
 You may write, rewrite, and remove tests freely (you don't keep a frozen
 failing-test). But your tests MUST genuinely exercise behavior, because
-**Agent B independently verifies it** — it reverts your impl commit and
-re-runs the tests, which MUST fail; then re-applies and they MUST pass:
+**Agent B independently verifies it** — from your single commit it
+separates impl files from test files BY PATH (test files = `*.test.ts` /
+`*.spec.ts` / under `tests/`), reverts only the impl files, re-runs the
+tests (which MUST fail), then restores (they MUST pass):
 
 ```bash
-git revert HEAD --no-edit              # revert impl (last commit)
+# (Agent B's check, sketch) — revert impl only, keep tests in place
+git checkout HEAD~1 -- <impl files>    # or stash the non-test paths
 cd packages/gazetta && npx vitest run  # tests MUST fail here
-git reset --hard origin/$BRANCH_NAME   # re-apply
+git checkout HEAD -- <impl files>      # restore
 cd packages/gazetta && npx vitest run  # tests MUST pass here
 ```
 
-(This is why the impl is the LAST commit — soft two-commit convention.)
 Both halves must hold or B REJECTS. So write tests that exercise
 BEHAVIOR — call the function, assert on its output, side effects, errors
 — not on observed strings from your own impl. A test that passes against
@@ -512,13 +503,13 @@ removed-coverage gap is a known risk you must not exploit.
 
 ## Rules
 
-- **Soft two-commit shape: tests commit, then impl commit.** Not a
-  red-first ritual — it's so Agent B can revert the impl to run its
-  tautology check. The impl must be the LAST commit.
+- **Commit ONCE, at the very end, after all checks pass.** Tests + impl
+  in a single commit. No incremental commits, no separate tests commit,
+  no amend. Agent B separates tests from impl by path for its check.
 - **Tests must exercise behavior, not echo your impl.** Agent B's
   revert check is the gate; tautological tests get REJECTED.
 - **Never remove a test to ease passing.** Remove only genuine
-  duplicates (test-quality step check d).
+  duplicates (test-quality step check e).
 - **DO NOT push or open the PR.** The orchestrator does that after
   reviewer approval.
 - **Never push to main.** Always to `$BRANCH_NAME`.

--- a/bots/feature-bot/prompts/per-cut.md
+++ b/bots/feature-bot/prompts/per-cut.md
@@ -68,34 +68,23 @@ Locked decisions are the contract you implement.
 
 ## TEST + COMMIT CONTRACT
 
-You write tests and implementation for the cut. You do NOT write tests
-first or keep them frozen — you may rewrite, restructure, and improve
-tests freely (see the test-quality step). Anti-tautology is **not** your
-discipline to self-enforce; it is **Agent B's job** — the reviewer
-independently verifies your tests are load-bearing (it reverts your impl
-files, the tests must fail; restore, they must pass).
+You write tests and implementation freely — no test-first, no frozen
+tests, rewrite as you go. Anti-tautology is **Agent B's** job, not yours:
+it reverts your impl files and checks the tests then fail.
 
-**Commit ONCE, at the very end, only after every check has passed.** Do
-all your work in the working tree — write tests + impl, run the suite,
-SOLID research+fix, runtime validation, improve/fix tests, verify
-comments — and make **a single commit** (tests + impl together) as the
-final step. Do NOT commit incrementally; do NOT make a separate tests
-commit; do NOT amend. The cut is one atomic change = one commit.
+**Commit ONCE, at the very end, after every check passes.** Everything —
+tests, impl, SOLID fixes, test improvements, comment edits — stays in the
+working tree until the final step, then lands as one commit. No
+incremental commits, no separate tests commit, no amend.
 
-Two requirements:
-
-1. **Cover the cut's `## Tests` section.** It names the specific test
-   files + behaviors to test. Your final test set must exercise them.
-2. **One commit, made last.** Build → all checks green → format → commit.
-   Agent B separates your test files from impl files BY PATH (test files
-   = `*.test.ts` / `*.spec.ts` / under `tests/`) to run its check, so you
-   don't need any special commit shape — just keep test code in test
-   files and implementation in source files, as usual.
+You must **cover the cut's `## Tests` section** (the test files +
+behaviors it names). No special commit shape is needed — Agent B
+separates tests from impl by path (`*.test.ts` / `*.spec.ts` / `tests/**`),
+so just keep test code in test files and implementation in source files.
 
 Write tests that exercise BEHAVIOR — call the function, assert on its
-output / side effects / errors. Agent B will revert your impl files and
-expect the tests to fail; tests that pass against reverted impl are
-tautological and get REJECTED.
+output / side effects / errors. Tests that pass with the impl reverted
+are tautological and get REJECTED (see "Anti-tautology" below).
 
 ## Three terminal states (per Q6 lock)
 
@@ -368,9 +357,9 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 
    ```
    SUMMARY:
-   <2-4 sentences: what the cut delivered, how the failing test pins it,
-   which design-doc locked decisions it implements. Plain prose; no
-   headings, no bullets, no code blocks inside the summary.>
+   <2-4 sentences: what the cut delivered, how the tests pin it, which
+   design-doc locked decisions it implements. Plain prose; no headings,
+   no bullets, no code blocks inside the summary.>
 
    (Blocks below mirror Agent A's step order: SOLID → runtime → tests → comments.)
 

--- a/bots/feature-bot/prompts/reviewer.md
+++ b/bots/feature-bot/prompts/reviewer.md
@@ -75,33 +75,57 @@ follow your verification.
 
 Run this procedure every time, in this exact order:
 
-### Step 1: confirm both commits exist on the branch
+### Step 1: classify the commit's files into impl vs tests (by path)
+
+Agent A makes **one commit** (tests + impl together). List its files and
+split them by path:
 
 ```bash
-git log main..$BRANCH_NAME --oneline
+git log main..$BRANCH_NAME --oneline           # expect ONE commit
+git show --stat --name-only HEAD
 ```
 
-Expected: 2 commits — a tests commit (prefixed `test:`) FIRST, then an
-implementation commit (`feat:`/`fix:`/`refactor:`/etc.) as HEAD. Agent A
-is no longer red-first, but the **soft two-commit shape is still
-required** so that reverting HEAD (step 2) cleanly removes the impl and
-leaves the tests. If anything else (1 commit, 3+ commits, impl not last):
-**REJECT** with a note that the commit shape breaks the revert check.
+- **Test files** = paths matching `*.test.ts`, `*.spec.ts`, or under a
+  `tests/` directory (per the repo's test-location convention).
+- **Impl files** = everything else in the commit.
 
-### Step 2: revert the impl commit; test must FAIL
+Edge cases:
+- **More than one commit:** acceptable as long as you can still split by
+  path; classify the union of all the branch's changed files. (Agent A is
+  told to make one commit; extra commits aren't a hard REJECT, but note
+  it.)
+- **No test files in the commit:** the cut's `## Tests` contract is unmet
+  → **REJECT** ("no tests for this cut").
+- **No impl files (tests-only / docs-only cut):** the tautology check is
+  N/A — skip steps 2-4, note "tautology check N/A (no impl to revert)",
+  proceed to the other checks.
+- **A "test helper" lives outside `tests/`** (e.g. a fixture imported by
+  tests): if reverting an "impl" file breaks test *imports* rather than
+  test *assertions*, it's test-support — treat it as a test file, restore
+  it, and re-run.
+
+### Step 2: revert ONLY the impl files; tests must FAIL
+
+Restore the impl files to their pre-cut state while leaving the tests in
+place, then run the tests:
 
 ```bash
-git revert --no-edit HEAD
-cd packages/gazetta && npx vitest run <path-to-the-new-test-files>
+git checkout main -- <impl files>             # revert impl only; tests stay
+cd packages/gazetta && npx vitest run <path-to-the-test-files>
 ```
 
 **Expected: the tests FAIL.** That proves the tests exercise behavior
-the impl changes — a real spec, not a tautology.
+the impl provides — a real spec, not a tautology.
 
-If tests PASS after reverting: **REJECT** with a Note that names the
-specific assertion: "The test on line N still passes after reverting
-the impl on line M. Please write a test that asserts behavior that
-fails without the impl."
+If tests PASS after reverting the impl: **REJECT** with a Note that names
+the specific assertion: "The test on line N still passes with the impl
+reverted. Write a test that asserts behavior that fails without the
+impl."
+
+(If reverting an impl file makes a test fail to *compile/import* rather
+than *assert-fail*, that file was test-support — restore it per the Step 1
+edge case and re-run; don't count a compile error as the tautology
+failure.)
 
 ### Step 3: verify the failure matches the cut's acceptance criteria
 
@@ -117,11 +141,11 @@ If the failure mode is generic (timeout, "undefined is not a function")
 and doesn't match acceptance: the test might exercise the wrong thing.
 **REJECT** with a Note describing the mismatch.
 
-### Step 4: re-apply the impl; tests must PASS
+### Step 4: restore the impl; tests must PASS
 
 ```bash
-git reset --hard origin/$BRANCH_NAME
-cd packages/gazetta && npx vitest run <path-to-the-new-test-files>
+git checkout HEAD -- <impl files>      # restore (or: git reset --hard origin/$BRANCH_NAME)
+cd packages/gazetta && npx vitest run <path-to-the-test-files>
 ```
 
 **Expected: tests PASS.** Confirms the impl actually implements the


### PR DESCRIPTION
## What

Two coupled changes to feature-bot's commit model:

1. **Agent A commits nothing until every check passes, then ONE atomic commit** (tests + impl together). All work — write tests+impl, run suite, SOLID research+fix, runtime validation, improve/fix tests, verify comments — happens in the working tree; the commit is the final step. Removes the soft-two-commit scaffolding and the amend-the-tests-commit dance that previously ran after every pass.

2. **Agent B's tautology check no longer assumes `revert HEAD` = revert impl.** From the single commit it separates impl files from test files **by path** (test files = `*.test.ts` / `*.spec.ts` / `tests/**`), reverts only the impl (`git checkout main -- <impl files>`), runs tests → must fail → restore → must pass. Commit-count-agnostic; simpler and more robust than the scaffolding.

## Edge cases (in reviewer.md)

- No test files in the commit → **REJECT** (`## Tests` contract unmet).
- No impl files (tests-only / docs-only cut) → tautology check N/A, skip.
- A test-helper outside `tests/` that breaks test *imports* (not assertions) on revert → treat as test-support, restore + re-run; don't count a compile error as the tautology failure.

## Files

- `bots/feature-bot/prompts/per-cut.md` — TEST+COMMIT contract (commit once, at end); branch-create-no-commit; working-tree-until-the-end notes through SOLID/tests/comments; format step drops amend; single `git add -A && commit`; Anti-tautology + Rules → path-based revert.
- `bots/feature-bot/prompts/reviewer.md` — tautology steps 1-4 rewritten for single-commit + path split + edge cases.
- `.claude/rules/design-feature-bot.md` — loop diagram + flow bullet + rationale.

Prompt + doc only; `bots tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)