### PR TITLE
fix(feature-bot): correct stale PR-body template (single-commit) + require reviewer Reasoning

### DIFF
--- a/bots/feature-bot/index.ts
+++ b/bots/feature-bot/index.ts
@@ -26,7 +26,7 @@
  *   2. Checks idempotency via `decideIdempotency`.
  *   3. Loads lessons-learned (currently empty placeholder).
  *   4. Generator-critic loop (MAX_ATTEMPTS=5):
- *      - Agent A reads design doc + cut body, commits TDD-first.
+ *      - Agent A reads design doc + cut body, builds + self-checks, then one commit.
  *      - Agent A signals: APPROVE_IMPLICIT (commits) / NEEDS_INPUT / NEEDS_HUMAN.
  *      - On APPROVE_IMPLICIT: Agent B reviews + verdicts.
  *      - `routeAttemptOutcome` decides the next step.
@@ -111,7 +111,7 @@ async function main(): Promise<void> {
   printBanner({
     name: 'feature-bot',
     tagline: 'implementer (Cut 3 — generator-critic loop)',
-    purpose: 'Implement `enhancement + ready-for-agent` cut sub-issues with TDD-first commit ordering.',
+    purpose: 'Implement `enhancement + ready-for-agent` cut sub-issues (build → SOLID → runtime validation → improve tests → verify comments → one commit).',
     inputs: [
       'Open issues with `enhancement` AND `ready-for-agent`',
       'AND no `ready-for-human` / `wontfix` / `needs-info`',
@@ -576,9 +576,10 @@ Implements cut #${issueNumber} for the \`${featureSlug}\` feature.
 
 Closes #${issueNumber}.
 
-After implementation by Agent A and independent review by Agent B
-(both Claude Code sessions), this PR ships the cut as a TDD-first
-two-commit contract.
+Implemented by Agent A, then independently reviewed by Agent B (both
+Claude Code sessions). Agent A's flow: write tests + impl, SOLID
+research+fix, runtime validation, improve/fix tests, verify comments —
+then one atomic commit.
 
 ## What Agent A did
 
@@ -588,19 +589,16 @@ ${agentASummary || '(no Agent A summary captured)'}
 
 ${reviewerReasoning || '(no reviewer reasoning captured)'}
 
-The reviewer ran the tautology check (revert impl → tests fail; re-apply
-→ tests pass), verified each cut sub-issue \`## Acceptance\` bullet is
-pinned, checked the \`## SOLID\` declarations (when present), and
-verified the diff implements the design doc's Locked decisions.
+Agent B is the sole anti-tautology gate: it separated impl from tests by
+path, reverted only the impl (tests must fail), restored (tests must
+pass), verified each \`## Acceptance\` bullet is pinned, independently
+checked SOLID, scrutinized any test removals, and verified the diff
+implements the design doc's Locked decisions.
 
 ## Verification
 
-This PR has two commits:
-
-1. **Failing tests** — pin the cut's acceptance criteria
-2. **Implementation** — minimal change that turns tests green
-
-CI re-verifies both commits.
+One atomic commit (tests + impl together). CI re-runs the full suite;
+Agent B's revert check already proved the tests are load-bearing.
 
 ## What if this is wrong?
 

--- a/bots/feature-bot/prompts/reviewer.md
+++ b/bots/feature-bot/prompts/reviewer.md
@@ -498,6 +498,12 @@ checks that passed, including which runtime-exercise outputs prove
 which acceptance bullets>
 ```
 
+The `Reasoning:` line is **required on APPROVE**, not optional — the
+orchestrator puts it in the PR's "Reviewer's assessment" section, so
+omitting it leaves that section blank. Even a clean approve needs one
+sentence ("tautology check held — reverting impl failed N load-bearing
+tests; all acceptance bullets pinned; SOLID lenses honored").
+
 ```
 VERDICT: REJECT
 Note: <specific, actionable feedback Agent A can use on retry — cite


### PR DESCRIPTION
## What

Reviewing PR #547's **description** surfaced doc-rot in `openCutPR()`'s static template — it still described the OLD commit model after #546 switched to single-commit:
- "ships the cut as a **TDD-first two-commit** contract" — no longer true
- "## Verification: This PR has **two commits**: 1. Failing tests 2. Implementation" — contradicts the actual single commit (#547 has exactly 1, verified)

These static sections would mislead every future PR's reader (the per-run SUMMARY blocks were accurate; only the boilerplate was stale). Corrected to the single-commit + path-based-revert model, plus two stale header comments.

## Also

#547's **"Reviewer's assessment" was blank** ("no reasoning provided") — Agent B emitted `VERDICT: APPROVE` with no trailing `Reasoning:` line (its analysis lived in earlier Decision lines). The prompt already requested `Reasoning:`; strengthened it to **required on APPROVE, not optional**, so that PR section is never empty.

## Files

- `bots/feature-bot/index.ts` — PR-body template (Summary / Reviewer's assessment / Verification) + two header comments.
- `bots/feature-bot/prompts/reviewer.md` — `Reasoning:` required on APPROVE.

Prompt + bot-template only; `bots tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)