### PR TITLE
chore(ci): move producer-bot crons off contended :00/:30 minutes

### DIFF
--- a/.github/workflows/discovery-prep-bot.yml
+++ b/.github/workflows/discovery-prep-bot.yml
@@ -11,13 +11,13 @@ name: Discovery prep bot
 # file. The label is the idempotency contract.
 on:
   schedule:
-    # 04:00 UTC daily = 06:00 CEST / 05:00 CET. Runs after triage-bot
-    # (03:00 UTC) so today's freshly-classified enhancements are visible
-    # this morning, not tomorrow. Parallel with fix-bot (also 04:00 UTC)
-    # — they consume different label sets (enhancement vs bug + ready-
-    # for-agent) so no race. Worst-case skew lands results by ~09:00
-    # CEST, the maintainer's review window.
-    - cron: '0 4 * * *'
+    # 03:47 UTC daily (~05:47 CEST / 04:47 CET). Runs after triage-bot
+    # (03:00 UTC) so today's freshly-classified enhancements are visible,
+    # and just before fix-bot (04:03) / feature-bot (04:17) which consume
+    # its research. Off the contended :00/:30 cron minutes (GitHub
+    # deprioritizes those under load — the old 04:00 cluster was getting
+    # skipped). Lands well before the 10:00 CET review window.
+    - cron: '47 3 * * *'
   workflow_dispatch:
     inputs:
       issue:

--- a/.github/workflows/feature-bot.yml
+++ b/.github/workflows/feature-bot.yml
@@ -18,11 +18,13 @@ name: Feature bot
 # Concurrency invariant: ADR-0011 (single-instance via group: feature-bot)
 on:
   schedule:
-    # 04:30 UTC daily = 06:30 CEST / 05:30 CET. Runs AFTER fix-bot's 04:00
+    # 04:17 UTC daily (~06:17 CEST / 05:17 CET). Runs AFTER fix-bot (04:03)
     # so today's freshly-shipped fixes don't race with feature-bot's branch
     # ops, and so the maintainer's morning review window sees both bots'
-    # output in one pass.
-    - cron: '30 4 * * *'
+    # output in one pass. Off the contended :00/:30 cron minutes (GitHub
+    # deprioritizes those under load — the 04:00/04:30 cluster was getting
+    # skipped); 04:17 lands well before the 10:00 CET review window.
+    - cron: '17 4 * * *'
   workflow_dispatch:
     inputs:
       issue:

--- a/.github/workflows/fix-bot.yml
+++ b/.github/workflows/fix-bot.yml
@@ -16,10 +16,11 @@ on:
     # (02:00 UTC) and triage-bot (03:00 UTC) so today's freshly-filed
     # bug + ready-for-agent issues from BOTH producer bots and triage's
     # confident-bug auto-advance are visible in the same morning's run.
-    # Parallel with discovery-prep-bot (also 04:00 UTC) — different
-    # label inputs so no race. Worst-case skew lands the PR by ~09:00
-    # CEST, the maintainer's review window.
-    - cron: '0 4 * * *'
+    # 04:03 UTC daily. After discovery-prep-bot (03:47) — different label
+    # inputs so no race. Off the contended :00 cron minute (GitHub
+    # deprioritizes :00/:30 under load — the 04:00 cluster was getting
+    # skipped). Lands the PR well before the 10:00 CET review window.
+    - cron: '3 4 * * *'
   workflow_dispatch:
     inputs:
       issue:

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -11,11 +11,12 @@ name: Review bot
 # layout are in place when the pipeline implementation lands.
 on:
   schedule:
-    # 04:30 UTC daily = 06:30 CEST. Runs after fix-bot (04:00 UTC) so
-    # today's freshly-merged PRs are visible in the same morning's
-    # review-bot run. Daily skew lands the PR by ~09:00 CEST review
+    # 04:31 UTC daily (~06:31 CEST / 05:31 CET). Runs last in the producer
+    # chain, after fix-bot (04:03) + feature-bot (04:17). Off the contended
+    # :00/:30 cron minutes (GitHub deprioritizes those under load — the old
+    # 04:30 cluster was getting skipped). Lands before the 10:00 CET review
     # window.
-    - cron: '30 4 * * *'
+    - cron: '31 4 * * *'
   workflow_dispatch:
     inputs:
       area:


### PR DESCRIPTION
## Why

On 2026-06-08 the **fix-bot / feature-bot / review-bot** scheduled runs (all on the 04:00–04:30 UTC cluster) were **silently skipped**, while the earlier 02:00/03:00 watchers ran fine. Cause: GitHub deprioritizes scheduled workflows on the contended top-of-hour / half-hour minutes under load, and the whole producer chain was jammed onto `:00` and `:30`.

## Change

Spread the four producers onto distinct off-peak minutes, **preserving dependency order** (discovery-prep → fix → feature → review):

| Bot | Before (UTC) | After (UTC) |
|---|---|---|
| discovery-prep-bot | `0 4` | `47 3` (03:47) |
| fix-bot | `0 4` | `3 4` (04:03) |
| feature-bot | `30 4` | `17 4` (04:17) |
| review-bot | `30 4` | `31 4` (04:31) |

Everything still completes by **~04:35 UTC — well before the 10:00 CET review window** in both CET (UTC+1) and CEST (UTC+2).

## Scope

- Watchers/triage (flake 02:00, mutation 03:00, triage 03:00) **unchanged** — they run early and weren't affected.
- Weekly jobs (dead-code, mutation-area-picker, bots-compact) **left as-is** per request.
- Comments in each workflow updated to the new times + off-peak rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)