### PR TITLE
fix(feature-bot): re-attempt builds branch fresh from origin/main (no stale reuse)

### DIFF
--- a/.claude/rules/design-feature-bot.md
+++ b/.claude/rules/design-feature-bot.md
@@ -504,6 +504,17 @@ Cron (daily 04:30 UTC, after fix-bot at 04:00):
    of this path-based separation, which is simpler and commit-count-
    agnostic.)
 
+   **Deterministic branch start (2026-06-09 fix).** Each attempt builds
+   the `feat/cut-NNN` branch fresh from `origin/main` (`git checkout -B
+   $BRANCH_NAME origin/main`) and pushes with `--force-with-lease`, so a
+   re-attempt NEVER builds on a stale leftover branch of the same name
+   from a prior run. The bug this fixes (#550): a leftover remote
+   `feat/cut-516` from an earlier run was reused — Agent A's `checkout`
+   landed on it and the plain `git push` (rejected as non-fast-forward
+   against the diverged stale branch) left the PR pointing at the stale
+   commits, even though the PR body was freshly (and contradictorily)
+   generated. Re-attempts are now reproducible from clean main.
+
    **SOLID research is Agent A self-work, not a separate agent.** A
    separate SOLID agent between A and B was rejected because (a) editing
    the diff mid-loop would muddy the single-commit / path-based revert B

--- a/bots/feature-bot/index.ts
+++ b/bots/feature-bot/index.ts
@@ -555,7 +555,17 @@ async function countPriorInputCycles(
 
 function pushBranch(branchName: string): void {
   try {
-    execFileSync('git', ['push', '-u', 'origin', branchName], { cwd: REPO_ROOT, stdio: 'inherit' })
+    // Force-with-lease so a freshly-built branch (created from origin/main
+    // this run) always replaces any STALE leftover of the same name on
+    // origin from a prior run. A plain `git push` would be rejected as
+    // non-fast-forward against a diverged stale branch and the PR would
+    // then point at the stale commits (the bug behind #550). `--force-
+    // with-lease` is safe here: feature-bot owns `feat/cut-NNN` branches,
+    // and lease still guards against clobbering a push we didn't expect.
+    execFileSync('git', ['push', '-u', '--force-with-lease', 'origin', branchName], {
+      cwd: REPO_ROOT,
+      stdio: 'inherit',
+    })
   } catch (err) {
     printWarning(`git push ${branchName} failed: ${err}`)
   }

--- a/bots/feature-bot/prompts/per-cut.md
+++ b/bots/feature-bot/prompts/per-cut.md
@@ -94,10 +94,16 @@ discovered.
 ### APPROVE path (most common — happy path)
 
 1. Read inputs + design doc + companion docs (mandatory).
-2. Create the branch (no commit yet — you commit once, at the end):
+2. Create the branch fresh from `origin/main` (no commit yet — you commit
+   once, at the end). **Force-reset it to `origin/main`** so a re-attempt
+   never builds on a stale leftover branch from a prior run:
    ```bash
-   git checkout -b $BRANCH_NAME 2>/dev/null || git checkout $BRANCH_NAME
+   git fetch origin main
+   git checkout -B $BRANCH_NAME origin/main
    ```
+   (`-B` creates-or-resets; combined with `origin/main` this discards any
+   local OR remote stale state on `$BRANCH_NAME`. Do NOT `git reset --hard
+   origin/$BRANCH_NAME` — that would re-adopt the stale remote branch.)
 3. Write tests per `## Tests` — exercise the behaviors it names. (Write
    them before or alongside the impl as suits you; they'll be refined in
    the test-quality step. Do NOT commit them yet.)


### PR DESCRIPTION
## Bug (surfaced by PR #550)

Re-triggering cut #516 **reused a leftover remote `feat/cut-516` branch from a prior run** instead of starting clean. Two compounding causes:

1. `per-cut.md` step 2 did `git checkout -b $BRANCH || git checkout $BRANCH` — the fallback lands on the existing stale branch.
2. `pushBranch()` did a plain `git push -u` — **rejected as non-fast-forward** against the diverged stale remote branch, so the catch-and-warn left the PR pointing at **yesterday's commits**.

Result: PR #550's body was freshly generated (single-commit text, current-flow reviewer reasoning) but its commits were the stale 2-commit attempt — a provenance contradiction, and the cut never ran today's comment-verify step.

## Fix

- **`per-cut.md`**: `git fetch origin main` + `git checkout -B $BRANCH origin/main` (force-reset to main — discards local OR remote stale state) + explicit "do NOT `reset --hard origin/$BRANCH`" note.
- **`index.ts` `pushBranch()`**: `--force-with-lease` so a freshly-built branch always replaces a stale remote one. Safe — feature-bot owns `feat/cut-NNN` branches; lease still guards concurrent surprises.
- **`design-feature-bot.md`**: documents the deterministic-branch-start fix.

Re-attempts are now reproducible from clean main. Prompt + bot + doc only; `bots tsc --noEmit` clean.

## Next

After this merges: close #550, delete the stale branch, clear `feature-bot-attempted` on #516, re-trigger — which will now build #516 fresh through the full current flow (single commit + comment-verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)