### PR TITLE
fix(feature-bot): require Note: on REJECT (symmetric to #548 APPROVE Reasoning)

### DIFF
--- a/bots/feature-bot/prompts/reviewer.md
+++ b/bots/feature-bot/prompts/reviewer.md
@@ -510,6 +510,15 @@ Note: <specific, actionable feedback Agent A can use on retry — cite
 the failing check + the location>
 ```
 
+The `Note:` line is **required on REJECT, never omit it.** Agent A
+retries using your Note as its only feedback; a REJECT with no Note is
+unactionable and the orchestrator escalates the cut to NEEDS_HUMAN
+(a dead-end for a possibly-fixable cut). If you're rejecting, you have a
+reason — write it: the failing check + where + what would fix it. "Tests
+pass but the schema is missing the `enabled` field per the design doc's
+Configuration block" is actionable; a bare `VERDICT: REJECT` burns the
+cut.
+
 ```
 VERDICT: NEEDS_HUMAN
 Note: <why a human needs to look — what's structurally questionable>


### PR DESCRIPTION
## Bug (surfaced by #517's escalation today)

#517 (Cut 3) was escalated to **NEEDS_HUMAN / `wrong-root-cause`** with the note: *"Reviewer voted REJECT but provided no Note: explanation. Cannot retry without feedback."*

Agent B rejected the attempt but emitted a bare `VERDICT: REJECT` with **no `Note:`** → the orchestrator had nothing to feed Agent A for a retry → it dead-ended a possibly-fixable cut to a human. #517's only dependency (#515) is shipped — it's legitimately ready, not blocked.

This is the **same class of gap #548 fixed for the APPROVE path** (empty `Reasoning:`) — the REJECT path had the identical hole.

## Fix

`reviewer.md`: `Note:` is now **required on REJECT, never omit it** — a no-Note REJECT is unactionable and burns the cut to NEEDS_HUMAN instead of retrying with feedback.

## Cleanup done alongside (via gh)

- Closed #517's bad skip-list PR (#555) + deleted its branch.
- Relabeled #517 back to `ready-for-agent` (removed `ready-for-human` + `feature-bot-attempted`) so the bot retries it.
- Left #533's escalation (#556, missing-prereq) **intact** — Cut 19 genuinely depends on unshipped cuts 4-18.

Prompt only; `bots tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)