### PR TITLE
fix(feature-bot): un-red main — reviewer-prompt test + index.ts format drift

### DIFF
--- a/bots/feature-bot/index.ts
+++ b/bots/feature-bot/index.ts
@@ -122,7 +122,8 @@ async function main(): Promise<void> {
   printBanner({
     name: 'feature-bot',
     tagline: 'implementer (Cut 3 — generator-critic loop)',
-    purpose: 'Implement `enhancement + ready-for-agent` cut sub-issues (build → SOLID → runtime validation → improve tests → verify comments → one commit).',
+    purpose:
+      'Implement `enhancement + ready-for-agent` cut sub-issues (build → SOLID → runtime validation → improve tests → verify comments → one commit).',
     inputs: [
       'Open issues with `enhancement` AND `ready-for-agent`',
       'AND no `ready-for-human` / `wontfix` / `needs-info`',

--- a/bots/feature-bot/tests/reviewer-prompt.test.ts
+++ b/bots/feature-bot/tests/reviewer-prompt.test.ts
@@ -14,11 +14,11 @@ const PROMPT_PATH = resolve(__dirname, '..', 'prompts', 'reviewer.md')
 const prompt = readFileSync(PROMPT_PATH, 'utf-8')
 
 describe('feature-bot reviewer prompt — structural contracts', () => {
-  it('keeps the four-step tautology check', () => {
-    expect(prompt).toMatch(/### Step 1: confirm both commits exist/)
-    expect(prompt).toMatch(/### Step 2: revert the impl commit/)
+  it('keeps the four-step path-based tautology check', () => {
+    expect(prompt).toMatch(/### Step 1: classify the commit's files into impl vs tests/)
+    expect(prompt).toMatch(/### Step 2: revert ONLY the impl files/)
     expect(prompt).toMatch(/### Step 3: verify the failure matches/)
-    expect(prompt).toMatch(/### Step 4: re-apply/)
+    expect(prompt).toMatch(/### Step 4: restore the impl/)
   })
 
   it('keeps the acceptance + runtime-exercise + SOLID + locked-decisions sections', () => {


### PR DESCRIPTION
## What

Two commits, both un-red the `bots` jobs on `main`:

1. **reviewer-prompt test** — #553 rewrote `reviewer.md`'s tautology check from commit-based wording (`Step 1: confirm both commits exist`, `revert the impl commit`, `re-apply`) to path-based (`classify files into impl vs tests`, `revert ONLY the impl files`, `restore the impl`) but missed `reviewer-prompt.test.ts`, which still asserted the old headings. The `test` job has been red since #553. Updated the 4 assertions + the `it()` name to match the shipped prompt. Rule 30 — forward-compat changes must touch every projection layer; here the layer was the test asserting the prompt's text.

2. **index.ts format drift** — a long `purpose:` string-literal argument was unwrapped; `npm run format` wraps it. The `format:check` CI gate was red on this line. Boy-Scout fix (rule 19) alongside the test repair.

## Verification

- `npx vitest run` in `bots/` → 473 pass (was 472 pass / 1 fail before commit 1)
- `npm run format:check` clean after commit 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)