### PR TITLE
fix: phase0-collect time-bomb — parseBotPRs sinceDays uses real Date.now() (#613)

### DIFF
--- a/bots/review-bot/phase0-collect.ts
+++ b/bots/review-bot/phase0-collect.ts
@@ -94,8 +94,16 @@ export async function collectBotPRsByArea(
  */
 const CANDIDATE_TYPES = ['correctness', 'security', 'architecture', 'tests', 'types', 'comments', 'style'] as const
 
-/** Pure parser for `gh pr list` JSON output. */
-export function parseBotPRs(stdout: string, sinceDays: number): Map<string, string> {
+/**
+ * Pure parser for `gh pr list` JSON output.
+ *
+ * `now` is the reference time the `sinceDays` cutoff is measured back
+ * from; it defaults to `Date.now()` for production callers. Tests pass
+ * a fixed reference so the cutoff boundary stays deterministic — without
+ * it, fixtures with absolute `createdAt` dates silently age past the
+ * window as wall-clock advances and the assertions rot (issue #613).
+ */
+export function parseBotPRs(stdout: string, sinceDays: number, now: number = Date.now()): Map<string, string> {
   const out = new Map<string, string>()
   let prs: Array<{ headRefName?: string; createdAt?: string }>
   try {
@@ -104,7 +112,7 @@ export function parseBotPRs(stdout: string, sinceDays: number): Map<string, stri
     // Empty output / parse failure → no prior PRs; conservative empty map.
     return out
   }
-  const cutoff = Date.now() - sinceDays * 86_400_000
+  const cutoff = now - sinceDays * 86_400_000
   for (const pr of prs) {
     if (!pr.headRefName || !pr.createdAt) continue
     if (new Date(pr.createdAt).getTime() < cutoff) continue

--- a/bots/review-bot/tests/phase0-collect.test.ts
+++ b/bots/review-bot/tests/phase0-collect.test.ts
@@ -62,13 +62,20 @@ describe('parseBotPRs', () => {
     rule: 'team-preferences.md#26',
   })
 
+  // Fixed reference time the `sinceDays` cutoff is measured back from.
+  // Pinned (not Date.now()) so the May-2026 fixtures stay inside the
+  // window forever — without this the assertions rot as wall-clock
+  // advances past the cutoff (issue #613). Chosen a few days after the
+  // newest fixture so they sit inside both the 30d and 180d windows.
+  const NOW = Date.parse('2026-05-20T00:00:00Z')
+
   it('groups by area path; most-recent timestamp wins for the same area', () => {
     const stdout = JSON.stringify([
       { headRefName: authBranch, createdAt: '2026-05-15T10:00:00Z' },
       { headRefName: auditBranch, createdAt: '2026-05-17T10:00:00Z' },
       { headRefName: adminBranch, createdAt: '2026-05-16T10:00:00Z' },
     ])
-    const result = parseBotPRs(stdout, 180)
+    const result = parseBotPRs(stdout, 180, NOW)
     expect(result.get('packages/gazetta/src/auth/')).toBe('2026-05-17T10:00:00Z')
     expect(result.get('apps/admin/src/')).toBe('2026-05-16T10:00:00Z')
   })
@@ -78,7 +85,7 @@ describe('parseBotPRs', () => {
       { headRefName: authBranch, createdAt: '2024-01-01T00:00:00Z' }, // ancient
       { headRefName: adminBranch, createdAt: '2026-05-17T10:00:00Z' },
     ])
-    const result = parseBotPRs(stdout, 30)
+    const result = parseBotPRs(stdout, 30, NOW)
     expect(result.has('packages/gazetta/src/auth/')).toBe(false)
     expect(result.get('apps/admin/src/')).toBe('2026-05-17T10:00:00Z')
   })
@@ -111,7 +118,7 @@ describe('parseBotPRs', () => {
       rule: 'design-fix-bot.md#some-rule',
     })
     const stdout = JSON.stringify([{ headRefName: branch, createdAt: '2026-05-17T10:00:00Z' }])
-    const result = parseBotPRs(stdout, 30)
+    const result = parseBotPRs(stdout, 30, NOW)
     // The correct area path must be present (along with spurious siblings).
     expect(result.get('bots/fix-bot/')).toBe('2026-05-17T10:00:00Z')
   })


### PR DESCRIPTION
## Summary

Fixes #613. The `bots` CI job has been failing on `main` since ~2026-06-16, blocking every bot PR's checks.

## Root cause

`parseBotPRs(stdout, sinceDays)` in `bots/review-bot/phase0-collect.ts` computes its cutoff as `Date.now() - sinceDays * 86_400_000`. The tests pass fixtures with absolute `createdAt: '2026-05-17T10:00:00Z'` and assert they're *retained* within a 30-day window. Once wall-clock passed ~30 days beyond the fixtures, the cutoff correctly dropped them and the assertions rotted — a time-bomb, not a logic regression.

## Fix

`parseBotPRs` gains an optional `now: number = Date.now()` parameter. Production callers are unchanged (default); the 3 time-sensitive tests pin a fixed `NOW = 2026-05-20` so the cutoff boundary is deterministic regardless of when CI runs. Per team-preferences rule 26 (no wall-clock-relative assertions).

## Verification

- Full `bots` suite: 627/627 pass.
- Red-before-green (rule 31): reverting only the production line (keeping the test changes) re-fails the 2 cutoff tests — the old `Date.now()` path can't satisfy the injected `NOW`. Restoring passes. The impl change is load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)