### PR TITLE
fix(bots): reviewer-log restore-key matching — follow-up to #582

### DIFF
--- a/.github/workflows/dead-code-watcher.yml
+++ b/.github/workflows/dead-code-watcher.yml
@@ -90,13 +90,17 @@ jobs:
       # restore + save pair (not the combined `actions/cache@vN`) is
       # load-bearing: the combined step skips its post-step save on a
       # cache HIT, breaking the append-write-back pattern. See #581.
+      # Primary `key` uses ${{ github.run_id }} so exact-key match ALWAYS
+      # misses at restore time — forcing fall-through to restore-keys.
+      # The restore-keys prefix ends with '-' to disambiguate per-run
+      # entries from any stale pre-#582 static blob. See #582 follow-up.
       - name: Restore reviewer-log cache
         uses: actions/cache/restore@v6
         with:
           path: bots/dead-code-watcher/reviewer-log.jsonl
-          key: dead-code-watcher-reviewer-log-v1
+          key: dead-code-watcher-reviewer-log-v1-${{ github.run_id }}
           restore-keys: |
-            dead-code-watcher-reviewer-log-v1
+            dead-code-watcher-reviewer-log-v1-
 
       - name: Run dead-code-watcher
         env:

--- a/.github/workflows/fix-bot.yml
+++ b/.github/workflows/fix-bot.yml
@@ -102,13 +102,17 @@ jobs:
       # per-run save key sidesteps the trap — every run produces its
       # own immutable cache entry; restore matches via `restore-keys`
       # prefix. See #581 and ADR-0011.
+      # Primary `key` uses ${{ github.run_id }} so exact-key match ALWAYS
+      # misses at restore time — forcing fall-through to restore-keys.
+      # The restore-keys prefix ends with '-' to disambiguate per-run
+      # entries from any stale pre-#582 static blob. See #582 follow-up.
       - name: Restore reviewer-log cache
         uses: actions/cache/restore@v6
         with:
           path: bots/fix-bot/reviewer-log.jsonl
-          key: fix-bot-reviewer-log-v1
+          key: fix-bot-reviewer-log-v1-${{ github.run_id }}
           restore-keys: |
-            fix-bot-reviewer-log-v1
+            fix-bot-reviewer-log-v1-
 
       - name: Run fix bot
         env:

--- a/.github/workflows/mutation-area-picker.yml
+++ b/.github/workflows/mutation-area-picker.yml
@@ -91,13 +91,20 @@ jobs:
       # the primary key, which breaks the append-write-back pattern.
       # Without this fix, the bot reports the same `Bootstrap week`
       # indefinitely (countWeeklyRuns reads a frozen cache). See #581.
+      # Primary `key` uses ${{ github.run_id }} so exact-key match ALWAYS
+      # misses at restore time — forcing fall-through to restore-keys.
+      # The restore-keys prefix ends with '-' to disambiguate per-run
+      # entries (`{bot}-reviewer-log-v1-{run_id}`) from the stale pre-#582
+      # static blob (`{bot}-reviewer-log-v1`). Without the trailing hyphen,
+      # actions/cache prefix-matched the old blob and every run since
+      # 2026-06-14 restored the 467-byte 1-entry file frozen at that date.
       - name: Restore reviewer-log cache
         uses: actions/cache/restore@v6
         with:
           path: bots/mutation-area-picker/reviewer-log.jsonl
-          key: mutation-area-picker-reviewer-log-v1
+          key: mutation-area-picker-reviewer-log-v1-${{ github.run_id }}
           restore-keys: |
-            mutation-area-picker-reviewer-log-v1
+            mutation-area-picker-reviewer-log-v1-
 
       - name: Run mutation-area-picker
         env:

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -88,13 +88,17 @@ jobs:
       # pair (not the combined `actions/cache@vN`) is load-bearing: the
       # combined step skips its post-step save on a cache HIT, breaking
       # the append-write-back pattern. See #581.
+      # Primary `key` uses ${{ github.run_id }} so exact-key match ALWAYS
+      # misses at restore time — forcing fall-through to restore-keys.
+      # The restore-keys prefix ends with '-' to disambiguate per-run
+      # entries from any stale pre-#582 static blob. See #582 follow-up.
       - name: Restore reviewer-log cache
         uses: actions/cache/restore@v6
         with:
           path: bots/review-bot/reviewer-log.jsonl
-          key: review-bot-reviewer-log-v1
+          key: review-bot-reviewer-log-v1-${{ github.run_id }}
           restore-keys: |
-            review-bot-reviewer-log-v1
+            review-bot-reviewer-log-v1-
 
       - name: Run review-bot
         env:

--- a/bots/_lib/tests/workflows-cache-strategy.test.ts
+++ b/bots/_lib/tests/workflows-cache-strategy.test.ts
@@ -76,6 +76,47 @@ describe('memoryful bots — reviewer-log cache strategy', () => {
         )
       })
 
+      it('primary restore key is per-run (not the stale static key) — issue #582 follow-up', () => {
+        // Original fix used `key: {bot}-reviewer-log-v1` (static). That
+        // triggers actions/cache's exact-key match against the old
+        // pre-fix cache blob (written before we split restore+save),
+        // which still lives in the cache. Exact-key match wins over
+        // restore-keys prefix match, so the per-run save entries are
+        // never read.
+        //
+        // The fix: rotate the primary `key` to a per-run value that
+        // NEVER exists at restore time, forcing fall-through to
+        // restore-keys. The restore-keys prefix then finds the latest
+        // per-run save entry.
+        //
+        // Verified live: 06-14, 06-21, 06-28 mutation-area-picker
+        // runs all restored 467-byte 1-entry blob from the old key.
+        const restoreKeyIsPerRun =
+          /uses:\s*actions\/cache\/restore@v\d+[\s\S]{0,400}key:\s*[^\n]*\$\{\{\s*github\.run_id\s*\}\}/.test(yaml)
+        expect(
+          restoreKeyIsPerRun,
+          `${bot.name}.yml restore step's primary key must be per-run (contains \${{ github.run_id }}) so it always falls through to restore-keys`,
+        ).toBe(true)
+      })
+
+      it('restore-keys prefix ends with a hyphen (so it matches -${run_id} suffix)', () => {
+        // restore-keys prefix `{bot}-reviewer-log-v1` (no trailing
+        // hyphen) is ambiguous — it would match both the old static
+        // `{bot}-reviewer-log-v1` blob AND the per-run
+        // `{bot}-reviewer-log-v1-{run_id}` entries. GitHub returns the
+        // most-recent match, but the old blob interference is real
+        // (see 06-14 through 06-28 mutation-area-picker runs).
+        //
+        // Adding the trailing hyphen (`{bot}-reviewer-log-v1-`) makes
+        // the intent explicit: match only per-run entries.
+        const bulletMatch = yaml.match(/restore-keys:\s*\|([\s\S]*?)\n\n/)
+        expect(bulletMatch, `${bot.name}.yml restore-keys block missing`).toBeTruthy()
+        const restoreKeys = bulletMatch![1]
+        expect(restoreKeys, `${bot.name}.yml restore-keys prefix must end with '-' to disambiguate old static key`).toMatch(
+          /reviewer-log-v1-\s*$/m,
+        )
+      })
+
       it('does NOT use the combined actions/cache@vN for the reviewer-log', () => {
         // Belt-and-suspenders: the combined `actions/cache@vN` shape
         // is the broken pattern. Even if restore+save are also

--- a/bots/_lib/tests/workflows-cache-strategy.test.ts
+++ b/bots/_lib/tests/workflows-cache-strategy.test.ts
@@ -112,9 +112,10 @@ describe('memoryful bots — reviewer-log cache strategy', () => {
         const bulletMatch = yaml.match(/restore-keys:\s*\|([\s\S]*?)\n\n/)
         expect(bulletMatch, `${bot.name}.yml restore-keys block missing`).toBeTruthy()
         const restoreKeys = bulletMatch![1]
-        expect(restoreKeys, `${bot.name}.yml restore-keys prefix must end with '-' to disambiguate old static key`).toMatch(
-          /reviewer-log-v1-\s*$/m,
-        )
+        expect(
+          restoreKeys,
+          `${bot.name}.yml restore-keys prefix must end with '-' to disambiguate old static key`,
+        ).toMatch(/reviewer-log-v1-\s*$/m)
       })
 
       it('does NOT use the combined actions/cache@vN for the reviewer-log', () => {


### PR DESCRIPTION
## Summary

- Follow-up to #582 (cache persistence fix). The split restore+save shape was correct, but the restore step used the same static primary key as the pre-fix cache — and `actions/cache/restore` prefers exact-key match over restore-keys prefix match.
- Every restore since 2026-06-14 returned the 467-byte 1-entry blob written 2026-06-07 by the last pre-fix run.
- Fix rotates the restore key to include \`\${{ github.run_id }}\` so it always misses, forcing fall-through to restore-keys. Adds trailing hyphen to restore-keys prefix to disambiguate per-run entries from any residual old blob.
- Deleted the 5 stale pre-fix cache blobs so they can't interfere with new runs.
- Same shape applied to all four memoryful workflows.

## Evidence

Live-verified on mutation-area-picker runs 06-14, 06-21, 06-28 — all restored the 467-byte 1-entry blob from key \`mutation-area-picker-reviewer-log-v1\` (the pre-fix static blob). Same pattern in fix-bot/review-bot/dead-code-watcher logs.

## Test plan

- [x] 8 new vitest assertions across 4 bots pin per-run key + trailing-hyphen restore-keys
- [x] 5 stale cache blobs deleted (\`gh cache list | grep -v run_id\` now empty for \`-reviewer-log-v1\$\`)
- [ ] Next mutation-area-picker run (2026-07-05 Sat) reports \`2+ historical entries\` and \`Bootstrap week 3/4+\`
- [ ] Next fix-bot / review-bot / dead-code-watcher runs show growing reviewer-log without regression

Fixes #582 (structural completion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)