### PR TITLE
fix(bots): apply reviewer-log cache-persistence fix to feature-bot

### DIFF
--- a/.github/workflows/feature-bot.yml
+++ b/.github/workflows/feature-bot.yml
@@ -103,13 +103,23 @@ jobs:
       # verdicts on every loop iteration; the cache keeps the file
       # across runs so the monthly compactor has cross-issue signal
       # to work with. See bots/README.md "Reviewer-log persistence".
-      # Cache miss is fine — tailReviewerLog returns []. Bump the
-      # -v1 suffix if the JSONL schema ever changes.
+      # Cache miss is fine — tailReviewerLog returns [].
+      #
+      # Uses the restore + save split (not combined `actions/cache@vN`)
+      # because the combined action skips its post-step save on a
+      # cache HIT against the primary key, which breaks the append-
+      # write-back pattern (see #581). Primary `key` uses ${{ github.run_id }}
+      # so exact-key match ALWAYS misses at restore time — forcing
+      # fall-through to restore-keys. The restore-keys prefix ends
+      # with '-' to disambiguate per-run entries from any stale
+      # pre-fix static blob (see #620).
       - name: Restore reviewer-log cache
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: bots/feature-bot/reviewer-log.jsonl
-          key: feature-bot-reviewer-log-v1
+          key: feature-bot-reviewer-log-v1-${{ github.run_id }}
+          restore-keys: |
+            feature-bot-reviewer-log-v1-
 
       - name: Run feature-bot
         env:
@@ -130,6 +140,16 @@ jobs:
           BUDGET_MS: ${{ inputs.budget_ms || '3000000' }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: npm run feature-bot -w @gazetta/bots
+
+      # if: always() so we persist Agent B verdicts even when the bot
+      # run itself fails — losing the log on failure would silently
+      # drop verdict signal that informed the failure.
+      - name: Save reviewer-log cache
+        if: always()
+        uses: actions/cache/save@v6
+        with:
+          path: bots/feature-bot/reviewer-log.jsonl
+          key: feature-bot-reviewer-log-v1-${{ github.run_id }}
 
       - name: Upload transcripts
         if: always()

--- a/bots/_lib/tests/workflows-cache-strategy.test.ts
+++ b/bots/_lib/tests/workflows-cache-strategy.test.ts
@@ -24,6 +24,7 @@ const REPO = resolve(HERE, '..', '..', '..')
 
 const BOTS = [
   { name: 'fix-bot', logPath: 'bots/fix-bot/reviewer-log.jsonl' },
+  { name: 'feature-bot', logPath: 'bots/feature-bot/reviewer-log.jsonl' },
   { name: 'dead-code-watcher', logPath: 'bots/dead-code-watcher/reviewer-log.jsonl' },
   { name: 'review-bot', logPath: 'bots/review-bot/reviewer-log.jsonl' },
   { name: 'mutation-area-picker', logPath: 'bots/mutation-area-picker/reviewer-log.jsonl' },


### PR DESCRIPTION
## Summary

- feature-bot was missed in #582 (initial split restore+save) and #620 (per-run key + trailing-hyphen restore-keys)
- Its workflow still used the combined \`actions/cache@v6\` shape with a static primary key
- Result: every feature-bot run since the reviewer-log was introduced has silently discarded Agent B verdicts at job teardown

## Fix

Same pattern as the other four memoryful bots:
- \`actions/cache/restore@v6\` with per-run \`key\` (forces fall-through to restore-keys)
- \`actions/cache/save@v6\` with \`if: always()\` and matching per-run key
- \`restore-keys:\` prefix with trailing hyphen to disambiguate per-run entries from any stale static blob

## Test plan

- [x] \`workflows-cache-strategy.test.ts\` extended to cover 5 bots — all 7 assertions × 5 bots = 35/35 pass
- [x] Live-verified via smoke-test run 28618715473 (2026-07-02) which ran under the OLD combined shape — log line \`Cache not found for input keys: feature-bot-reviewer-log-v1\` confirmed the pre-fix state
- [ ] Next feature-bot cron produces \`Cache saved with key: feature-bot-reviewer-log-v1-{run_id}\` log line

Fixes: the second half of the memoryful-bot cache-persistence gap (#582, #620 covered the other four)

🤖 Generated with [Claude Code](https://claude.com/claude-code)