### PR TITLE
refactor(assets): de-export the per-kind resolver trio symmetrically (#654/#655/#656)

### DIFF
--- a/.claude/rules/design-media.md
+++ b/.claude/rules/design-media.md
@@ -571,7 +571,13 @@ Walker reads the default manifest first (to discover `kind`), then dispatches:
 
 URL composition happens via the resolver context's `transformAdapter` (defaults to `sharpAdapter`). Adapter is required, never branched on within the resolver.
 
-**Per-kind resolver signatures (called from the walker):**
+**Per-kind resolver signatures (walker-internal helpers):**
+
+The three per-kind resolvers are **file-scoped** — the walker (`resolveAssetRefs`)
+is the only public entry point. They form a symmetric dispatch group but are not
+exported; nothing outside `resolve.ts` imports them (tests exercise the walker
+end-to-end, not the per-kind functions directly). Keeping the three symmetric
+means they're de-exported as a set, not individually.
 
 ```ts
 resolveEmbeddedRef(ref, defaultManifest, effectiveOverride, selector, ctx) → ResolvedEmbeddedAsset

--- a/packages/gazetta/src/assets/resolve.ts
+++ b/packages/gazetta/src/assets/resolve.ts
@@ -113,7 +113,7 @@ interface FontRefShape {
  * Throws on manifest not-found or corrupt — caller (the walker) catches
  * and substitutes a placeholder.
  */
-export async function resolveEmbeddedRef(
+async function resolveEmbeddedRef(
   ref: EmbeddedRefShape,
   defaultManifest: import('../schema/types.js').AssetManifest,
   effectiveOverride: Partial<import('../schema/types.js').AssetManifest> | null,
@@ -180,7 +180,7 @@ export async function resolveEmbeddedRef(
  * semantics as embedded; different resolved shape (no srcset, no
  * focal-point, has title/description).
  */
-export async function resolveDownloadableRef(
+async function resolveDownloadableRef(
   ref: DownloadableRefShape,
   defaultManifest: import('../schema/types.js').AssetManifest,
   effectiveOverride: Partial<import('../schema/types.js').AssetManifest> | null,
@@ -250,7 +250,7 @@ export interface FontVariantEntry {
   manifest: import('../schema/types.js').FontLocaleAdditiveManifest
 }
 
-export async function resolveFontRef(
+async function resolveFontRef(
   _ref: FontRefShape,
   defaultManifest: import('../schema/types.js').AssetManifest,
   variants: readonly FontVariantEntry[],


### PR DESCRIPTION
Coordinated resolution of the `resolve.ts` per-kind resolver trio that three bot PRs (#654 de-export, #655/#656 skip) handled inconsistently.

## What & why

`resolveEmbeddedRef` / `resolveDownloadableRef` / `resolveFontRef` are the walker's per-kind dispatch targets (`resolve.ts:436/440/445`), documented as a symmetric group in `design-media.md:574-582`. None have external callers — the walker `resolveAssetRefs` is the public API; tests exercise it end-to-end (a pre-step-17 comment records the per-kind fns were once called directly, but the locale/theme refactor made them walker-internal).

knip flagged all three as unused exports across separate runs. #654 proposed de-exporting `resolveEmbeddedRef` alone; #655/#656 correctly declined to touch the two siblings because de-exporting one of a documented symmetric trio breaks the parallelism. This PR does the structurally-correct thing: **de-export all three together** + a design-media.md note marking them file-scoped.

## Verification

- `tsc --noEmit` clean (proves no external importer — de-export would fail compilation otherwise)
- `assets-resolve.test.ts` 17/17 pass (walker-level tests unaffected; export keyword was the only removal)
- Repo-wide grep: no `import` of the three functions outside `resolve.ts`

Closes #654, #655, #656.

> *This was generated by AI during PR review.*