### PR TITLE
fix(dead-code-watcher): deterministic Signal-count drift gate on compaction

### DIFF
--- a/bots/dead-code-watcher/compact.ts
+++ b/bots/dead-code-watcher/compact.ts
@@ -168,12 +168,8 @@ RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
     printWarning(`compact threw: ${err}; transcript at ${transcriptPath}`)
   }
 
-  // Deterministic drift gate (per design-self-learning.md): Claude
-  // writes lessons-learned.md directly, so verify the arithmetic it
-  // can't be trusted to self-check. Any `**Signal:** N` header whose
-  // per-shape sub-tallies don't sum to N fails the run — the PR never
-  // opens with the #686→#688 drift. Runs only when Claude wrote the
-  // file, and BEFORE the prune so a bad file doesn't lose its input.
+  // Must run only when Claude wrote the file, and BEFORE the prune —
+  // a drifting file has to fail the run before its input is pruned away.
   if (claudeSucceeded) {
     const written = existsSync(LESSONS_ABS) ? readFileSync(LESSONS_ABS, 'utf-8') : ''
     const violations = findSignalCountViolations(written)

--- a/bots/dead-code-watcher/compact.ts
+++ b/bots/dead-code-watcher/compact.ts
@@ -34,6 +34,7 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { runClaude } from '../_lib/claude.js'
 import { pruneReviewerLog, REVIEWER_LOG_PATH, tailReviewerLog } from './reviewer-log.js'
+import { findSignalCountViolations } from './signal-count-guard.js'
 import { readSkipList, SKIP_LIST_PATH } from './skip-list.js'
 import { printBanner, printNotice, printRunSummary, printTranscriptPath, printWarning } from '../_lib/ui.js'
 
@@ -165,6 +166,28 @@ RUN_ID=${process.env.GITHUB_RUN_ID ?? 'local'}`
     }
   } catch (err) {
     printWarning(`compact threw: ${err}; transcript at ${transcriptPath}`)
+  }
+
+  // Deterministic drift gate (per design-self-learning.md): Claude
+  // writes lessons-learned.md directly, so verify the arithmetic it
+  // can't be trusted to self-check. Any `**Signal:** N` header whose
+  // per-shape sub-tallies don't sum to N fails the run — the PR never
+  // opens with the #686→#688 drift. Runs only when Claude wrote the
+  // file, and BEFORE the prune so a bad file doesn't lose its input.
+  if (claudeSucceeded) {
+    const written = existsSync(LESSONS_ABS) ? readFileSync(LESSONS_ABS, 'utf-8') : ''
+    const violations = findSignalCountViolations(written)
+    if (violations.length > 0) {
+      for (const v of violations) {
+        printWarning(
+          `Signal-count drift in ${LESSONS_PATH}: header says ${v.header}, sub-tallies sum to ${v.sum} — "${v.line.trim()}"`,
+        )
+      }
+      printWarning(
+        `${violations.length} Signal-count violation(s) — failing the compaction run so the PR does not open with drift. Fix lessons-learned.md so each Signal header equals the sum of its sub-tallies.`,
+      )
+      process.exit(1)
+    }
   }
 
   // Prune the reviewer-log to a bounded window AFTER Claude succeeds.

--- a/bots/dead-code-watcher/prompts/compact.md
+++ b/bots/dead-code-watcher/prompts/compact.md
@@ -154,6 +154,14 @@ before proceeding, OR when to switch to SKIP needs-human>
 ### <Next pattern...>
 ```
 
+**Count arithmetic (enforced by a post-run gate):** if you break a
+`**Signal:** N` count into per-shape sub-tally bullets of the form
+`- <label> (K): ...`, then **N MUST equal the sum of the K values**.
+A deterministic check parses this file after you write it and FAILS
+the run on any mismatch — so compute the sum explicitly and set the
+header to it. Do not hand-count. (This gate exists because run #686
+shipped `Signal: 14` over sub-tallies summing to 13.)
+
 **Threshold per pattern:** at least 2 reviewer-log entries must
 share the failure mode for it to land as a lesson. Single-instance
 observations stay in the reviewer-log; they're not yet patterns.

--- a/bots/dead-code-watcher/signal-count-guard.ts
+++ b/bots/dead-code-watcher/signal-count-guard.ts
@@ -40,9 +40,9 @@ export interface SignalCountViolation {
 const SIGNAL_HEADER = /^\s*\*\*Signal:\*\*\s+(\d+)\b/
 /**
  * Matches a sub-tally bullet `- <label> (6): ...` — captures the count.
- * Accepts both `-` and `*` bullet markers (Markdown permits either).
+ * Accepts `-`, `*`, and `+` bullet markers (Markdown permits all three).
  */
-const SUB_TALLY = /^\s*[-*]\s+.*\((\d+)\):/
+const SUB_TALLY = /^\s*[-*+]\s+.*\((\d+)\):/
 
 /**
  * Find every Signal header whose per-shape sub-tallies don't sum to

--- a/bots/dead-code-watcher/signal-count-guard.ts
+++ b/bots/dead-code-watcher/signal-count-guard.ts
@@ -30,10 +30,19 @@ export interface SignalCountViolation {
   line: string
 }
 
-/** Matches `**Signal:** 14 ...` — captures the leading integer. */
-const SIGNAL_HEADER = /^\*\*Signal:\*\*\s+(\d+)\b/
-/** Matches a sub-tally bullet `- <label> (6): ...` — captures the count. */
-const SUB_TALLY = /^\s*-\s+.*\((\d+)\):/
+/**
+ * Matches `**Signal:** 14 ...` — captures the leading integer.
+ * Leading whitespace is tolerated: Claude authors this file freely and
+ * may indent, and a false-clean (drift slips past the gate) is the worst
+ * failure mode for a guard, so the matchers accept plausible LLM
+ * formatting variants rather than the strictest possible shape.
+ */
+const SIGNAL_HEADER = /^\s*\*\*Signal:\*\*\s+(\d+)\b/
+/**
+ * Matches a sub-tally bullet `- <label> (6): ...` — captures the count.
+ * Accepts both `-` and `*` bullet markers (Markdown permits either).
+ */
+const SUB_TALLY = /^\s*[-*]\s+.*\((\d+)\):/
 
 /**
  * Find every Signal header whose per-shape sub-tallies don't sum to

--- a/bots/dead-code-watcher/signal-count-guard.ts
+++ b/bots/dead-code-watcher/signal-count-guard.ts
@@ -1,0 +1,76 @@
+/**
+ * Deterministic post-generation gate for lessons-learned.md.
+ *
+ * The monthly compactor (`compact.ts`) lets Claude write
+ * lessons-learned.md directly. In run #686 Claude authored a
+ * `**Signal:** 14 ...` header whose per-shape sub-tallies summed to
+ * 13; a later compaction (#688) had to self-correct it a month on.
+ *
+ * This guard makes that class of drift impossible to SHIP: after
+ * Claude writes the file, `compact.ts` parses it and fails the run
+ * (non-zero exit) if any Signal header disagrees with the sum of its
+ * per-shape sub-tallies. The prompt instruction is the belt; this
+ * code gate is the suspenders — and the load-bearing half, because
+ * the prompt instruction is exactly what the LLM ignored.
+ *
+ * Scope (per design-self-learning.md, Y-now-X-later): this checks
+ * header-vs-sub-tally arithmetic only — the one drift actually
+ * observed. A lone Signal count with no sub-tallies has nothing to
+ * cross-check and is left alone; if a lone count ever drifts, that's
+ * the evidence to justify the larger code-renders-the-file
+ * restructure (option X).
+ */
+
+export interface SignalCountViolation {
+  /** The number stated in the `**Signal:** N ...` header. */
+  header: number
+  /** Sum of the per-shape sub-tally counts under that header. */
+  sum: number
+  /** The header line, for the failure message. */
+  line: string
+}
+
+/** Matches `**Signal:** 14 ...` — captures the leading integer. */
+const SIGNAL_HEADER = /^\*\*Signal:\*\*\s+(\d+)\b/
+/** Matches a sub-tally bullet `- <label> (6): ...` — captures the count. */
+const SUB_TALLY = /^\s*-\s+.*\((\d+)\):/
+
+/**
+ * Find every Signal header whose per-shape sub-tallies don't sum to
+ * the header count. Returns one violation per offending header;
+ * empty when the file is consistent (or has no cross-checkable
+ * headers).
+ *
+ * A header's sub-tallies are the `- label (K):` bullets that follow
+ * it, up to the next `**Signal:**` header or the next `##` heading.
+ */
+export function findSignalCountViolations(markdown: string): SignalCountViolation[] {
+  const lines = markdown.split('\n')
+  const violations: SignalCountViolation[] = []
+
+  for (let i = 0; i < lines.length; i++) {
+    const headerMatch = lines[i].match(SIGNAL_HEADER)
+    if (!headerMatch) continue
+
+    const header = Number(headerMatch[1])
+    const subTallies: number[] = []
+
+    // Scan forward for this header's sub-tally bullets, stopping at
+    // the next Signal header or the next section heading.
+    for (let j = i + 1; j < lines.length; j++) {
+      if (SIGNAL_HEADER.test(lines[j]) || lines[j].startsWith('## ')) break
+      const tallyMatch = lines[j].match(SUB_TALLY)
+      if (tallyMatch) subTallies.push(Number(tallyMatch[1]))
+    }
+
+    // No sub-tallies → nothing to cross-check (lone count, out of scope).
+    if (subTallies.length === 0) continue
+
+    const sum = subTallies.reduce((a, b) => a + b, 0)
+    if (sum !== header) {
+      violations.push({ header, sum, line: lines[i] })
+    }
+  }
+
+  return violations
+}

--- a/bots/dead-code-watcher/signal-count-guard.ts
+++ b/bots/dead-code-watcher/signal-count-guard.ts
@@ -1,57 +1,27 @@
 /**
- * Deterministic post-generation gate for lessons-learned.md.
+ * Deterministic gate over lessons-learned.md: flags any `**Signal:** N`
+ * header whose per-shape sub-tallies don't sum to N. `compact.ts` runs
+ * it after Claude writes the file and fails the run on a violation.
  *
- * The monthly compactor (`compact.ts`) lets Claude write
- * lessons-learned.md directly. In run #686 Claude authored a
- * `**Signal:** 14 ...` header whose per-shape sub-tallies summed to
- * 13; a later compaction (#688) had to self-correct it a month on.
- *
- * This guard makes that class of drift impossible to SHIP: after
- * Claude writes the file, `compact.ts` parses it and fails the run
- * (non-zero exit) if any Signal header disagrees with the sum of its
- * per-shape sub-tallies. The prompt instruction is the belt; this
- * code gate is the suspenders — and the load-bearing half, because
- * the prompt instruction is exactly what the LLM ignored.
- *
- * Scope (per design-self-learning.md, Y-now-X-later): this checks
- * header-vs-sub-tally arithmetic only — the one drift actually
- * observed. A lone Signal count with no sub-tallies has nothing to
- * cross-check and is left alone; if a lone count ever drifts, that's
- * the evidence to justify the larger code-renders-the-file
- * restructure (option X).
+ * Scope is header-vs-sub-tally arithmetic only. A lone Signal count with
+ * no sub-tallies is intentionally left alone (see the empty-subtally
+ * skip below).
  */
 
 export interface SignalCountViolation {
-  /** The number stated in the `**Signal:** N ...` header. */
   header: number
-  /** Sum of the per-shape sub-tally counts under that header. */
   sum: number
-  /** The header line, for the failure message. */
   line: string
 }
 
-/**
- * Matches `**Signal:** 14 ...` — captures the leading integer.
- * Leading whitespace is tolerated: Claude authors this file freely and
- * may indent, and a false-clean (drift slips past the gate) is the worst
- * failure mode for a guard, so the matchers accept plausible LLM
- * formatting variants rather than the strictest possible shape.
- */
+/** Captures the integer in `**Signal:** 14 ...`; leading indent tolerated. */
 const SIGNAL_HEADER = /^\s*\*\*Signal:\*\*\s+(\d+)\b/
-/**
- * Matches a sub-tally bullet `- <label> (6): ...` — captures the count.
- * Accepts `-`, `*`, and `+` bullet markers (Markdown permits all three).
- */
+/** Captures the count in a `- label (6):` sub-tally; `-`/`*`/`+` bullets. */
 const SUB_TALLY = /^\s*[-*+]\s+.*\((\d+)\):/
 
 /**
- * Find every Signal header whose per-shape sub-tallies don't sum to
- * the header count. Returns one violation per offending header;
- * empty when the file is consistent (or has no cross-checkable
- * headers).
- *
- * A header's sub-tallies are the `- label (K):` bullets that follow
- * it, up to the next `**Signal:**` header or the next `##` heading.
+ * A header's sub-tallies are the `- label (K):` bullets following it, up
+ * to the next `**Signal:**` header or the next `##` heading.
  */
 export function findSignalCountViolations(markdown: string): SignalCountViolation[] {
   const lines = markdown.split('\n')
@@ -64,8 +34,6 @@ export function findSignalCountViolations(markdown: string): SignalCountViolatio
     const header = Number(headerMatch[1])
     const subTallies: number[] = []
 
-    // Scan forward for this header's sub-tally bullets, stopping at
-    // the next Signal header or the next section heading.
     for (let j = i + 1; j < lines.length; j++) {
       if (SIGNAL_HEADER.test(lines[j]) || lines[j].startsWith('## ')) break
       const tallyMatch = lines[j].match(SUB_TALLY)

--- a/bots/dead-code-watcher/signal-count-guard.ts
+++ b/bots/dead-code-watcher/signal-count-guard.ts
@@ -3,9 +3,8 @@
  * header whose per-shape sub-tallies don't sum to N. `compact.ts` runs
  * it after Claude writes the file and fails the run on a violation.
  *
- * Scope is header-vs-sub-tally arithmetic only. A lone Signal count with
- * no sub-tallies is intentionally left alone (see the empty-subtally
- * skip below).
+ * Scope is header-vs-sub-tally arithmetic only; a lone Signal count with
+ * no sub-tallies is out of scope.
  */
 
 export interface SignalCountViolation {

--- a/bots/dead-code-watcher/tests/signal-count-guard.test.ts
+++ b/bots/dead-code-watcher/tests/signal-count-guard.test.ts
@@ -93,4 +93,39 @@ describe('findSignalCountViolations', () => {
   it('returns empty for a lessons file with no Signal headers', () => {
     expect(findSignalCountViolations('# lessons\n\nSome prose.\n')).toHaveLength(0)
   })
+
+  // Edge cases from the runtime sweep: Claude authors this file freely,
+  // so the guard must tolerate plausible LLM formatting variants — a
+  // false-clean (drift ships) is the worst failure mode for a gate.
+
+  it('catches drift under a leading-whitespace-indented Signal header', () => {
+    const md = `  **Signal:** 9 across 6 runs, by shape:
+
+  - Internal type reference (2): \`a\`, \`b\`
+  - Default parameter fallback (3): \`c\`
+`
+    const v = findSignalCountViolations(md)
+    expect(v).toHaveLength(1)
+    expect(v[0]).toMatchObject({ header: 9, sum: 5 })
+  })
+
+  it('catches drift when sub-tallies use `*` bullets instead of `-`', () => {
+    const md = `**Signal:** 9 by shape:
+
+* Shape A (2): x
+* Shape B (3): y
+`
+    const v = findSignalCountViolations(md)
+    expect(v).toHaveLength(1)
+    expect(v[0]).toMatchObject({ header: 9, sum: 5 })
+  })
+
+  it('accepts a consistent header+tallies with `*` bullets and indentation', () => {
+    const md = `  **Signal:** 5 by shape:
+
+  * Shape A (2): x
+  * Shape B (3): y
+`
+    expect(findSignalCountViolations(md)).toHaveLength(0)
+  })
 })

--- a/bots/dead-code-watcher/tests/signal-count-guard.test.ts
+++ b/bots/dead-code-watcher/tests/signal-count-guard.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import { findSignalCountViolations } from '../signal-count-guard.js'
+
+/**
+ * Guards against the #686→#688 compaction drift: an LLM-authored
+ * `**Signal:** N ...` header whose per-shape sub-tallies do not sum
+ * to N. The compactor lets Claude write lessons-learned.md directly,
+ * so this is a deterministic POST-generation gate — a mismatch fails
+ * the compaction run before the PR opens.
+ *
+ * A "sub-tally" is a bullet of the shape `- <label> (K): ...` under a
+ * Signal header. When a header has NO sub-tally bullets, there is
+ * nothing to cross-check and the header is left alone (a lone count is
+ * out of this guard's scope — see design-self-learning.md Y-now-X-later).
+ */
+describe('findSignalCountViolations', () => {
+  it('flags the exact #686 drift: header 14 vs sub-tallies summing to 13', () => {
+    const md = `## 1. Un-export beats delete
+
+**Signal:** 14 first-attempt approves across 6 runs, by shape:
+
+- Internal type reference (6): \`HreflangAlternate\`, \`SvgSanitizeWarning\`
+- Default parameter fallback (3): \`ANTHROPIC_DEFAULT_MODEL\`
+- Formula/expression use (2): \`CHARS_PER_TOKEN\`, \`MIN_MAX_TOKENS\`
+- Sister-function dispatch (1): \`resolveEmbeddedRef\`
+- Internal helper class (1): \`AssetApiError\`
+`
+    const violations = findSignalCountViolations(md)
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({ header: 14, sum: 13 })
+  })
+
+  it('accepts a header whose sub-tallies sum correctly (the #688 fix state)', () => {
+    const md = `## 1. Un-export beats delete
+
+**Signal:** 13 first-attempt approves across 6 runs, by shape:
+
+- Internal type reference (6): \`a\`, \`b\`
+- Default parameter fallback (3): \`c\`
+- Formula/expression use (2): \`d\`, \`e\`
+- Sister-function dispatch (1): \`f\`
+- Internal helper class (1): \`g\`
+`
+    expect(findSignalCountViolations(md)).toHaveLength(0)
+  })
+
+  it('leaves a lone Signal count (no sub-tallies) alone — out of scope', () => {
+    const md = `## 2. Verify both public-surface paths
+
+**Signal:** cited in every approval across the current log window.
+
+**Guidance:** a symbol is public if EITHER ...
+`
+    expect(findSignalCountViolations(md)).toHaveLength(0)
+  })
+
+  it('handles a Signal count with a plain number but no "by shape" sub-tallies', () => {
+    const md = `## 3. Barrel re-exports are dead
+
+**Signal:** 6 approvals — \`SharpAdapterOptions\`, \`CloudflareAdapterOptions\`;
+\`AIAdapterFailedError\`, \`AIAdapterUnavailableError\`.
+
+**Guidance:** trace where consumers import from.
+`
+    // Inline comma-list is prose, not `- label (K):` sub-tally bullets → no cross-check.
+    expect(findSignalCountViolations(md)).toHaveLength(0)
+  })
+
+  it('flags each drifting header independently across multiple lessons', () => {
+    const md = `## 1. First
+
+**Signal:** 10 approves, by shape:
+
+- Shape A (4): x
+- Shape B (3): y
+
+## 2. Second
+
+**Signal:** 5 approves, by shape:
+
+- Shape C (2): z
+- Shape D (2): w
+`
+    const violations = findSignalCountViolations(md)
+    // #1: header 10 vs 4+3=7 → violation; #2: header 5 vs 2+2=4 → violation
+    expect(violations).toHaveLength(2)
+    expect(violations.map(v => ({ header: v.header, sum: v.sum }))).toEqual([
+      { header: 10, sum: 7 },
+      { header: 5, sum: 4 },
+    ])
+  })
+
+  it('returns empty for a lessons file with no Signal headers', () => {
+    expect(findSignalCountViolations('# lessons\n\nSome prose.\n')).toHaveLength(0)
+  })
+})

--- a/bots/dead-code-watcher/tests/signal-count-guard.test.ts
+++ b/bots/dead-code-watcher/tests/signal-count-guard.test.ts
@@ -120,6 +120,17 @@ describe('findSignalCountViolations', () => {
     expect(v[0]).toMatchObject({ header: 9, sum: 5 })
   })
 
+  it('catches drift when sub-tallies use `+` bullets', () => {
+    const md = `**Signal:** 9 by shape:
+
++ Shape A (2): x
++ Shape B (3): y
+`
+    const v = findSignalCountViolations(md)
+    expect(v).toHaveLength(1)
+    expect(v[0]).toMatchObject({ header: 9, sum: 5 })
+  })
+
   it('accepts a consistent header+tallies with `*` bullets and indentation', () => {
     const md = `  **Signal:** 5 by shape:
 

--- a/bots/dead-code-watcher/tests/signal-count-guard.test.ts
+++ b/bots/dead-code-watcher/tests/signal-count-guard.test.ts
@@ -28,6 +28,9 @@ describe('findSignalCountViolations', () => {
     const violations = findSignalCountViolations(md)
     expect(violations).toHaveLength(1)
     expect(violations[0]).toMatchObject({ header: 14, sum: 13 })
+    // The `line` field carries the offending header into the gate's
+    // failure message — pin it so a refactor can't silently blank it.
+    expect(violations[0].line).toContain('**Signal:** 14')
   })
 
   it('accepts a header whose sub-tallies sum correctly (the #688 fix state)', () => {
@@ -96,36 +99,17 @@ describe('findSignalCountViolations', () => {
 
   // Edge cases from the runtime sweep: Claude authors this file freely,
   // so the guard must tolerate plausible LLM formatting variants — a
-  // false-clean (drift ships) is the worst failure mode for a gate.
-
-  it('catches drift under a leading-whitespace-indented Signal header', () => {
-    const md = `  **Signal:** 9 across 6 runs, by shape:
-
-  - Internal type reference (2): \`a\`, \`b\`
-  - Default parameter fallback (3): \`c\`
-`
-    const v = findSignalCountViolations(md)
-    expect(v).toHaveLength(1)
-    expect(v[0]).toMatchObject({ header: 9, sum: 5 })
-  })
-
-  it('catches drift when sub-tallies use `*` bullets instead of `-`', () => {
-    const md = `**Signal:** 9 by shape:
-
-* Shape A (2): x
-* Shape B (3): y
-`
-    const v = findSignalCountViolations(md)
-    expect(v).toHaveLength(1)
-    expect(v[0]).toMatchObject({ header: 9, sum: 5 })
-  })
-
-  it('catches drift when sub-tallies use `+` bullets', () => {
-    const md = `**Signal:** 9 by shape:
-
-+ Shape A (2): x
-+ Shape B (3): y
-`
+  // false-clean (drift ships) is the worst failure mode for a gate. The
+  // table below pins the invariant: EVERY plausible formatting variant
+  // (indentation, each Markdown bullet marker) catches the same drift.
+  it.each([
+    {
+      variant: 'leading-whitespace-indented header + `-` bullets',
+      md: '  **Signal:** 9 across 6 runs, by shape:\n\n  - Internal type reference (2): `a`, `b`\n  - Default parameter fallback (3): `c`\n',
+    },
+    { variant: '`*` bullets', md: '**Signal:** 9 by shape:\n\n* Shape A (2): x\n* Shape B (3): y\n' },
+    { variant: '`+` bullets', md: '**Signal:** 9 by shape:\n\n+ Shape A (2): x\n+ Shape B (3): y\n' },
+  ])('catches drift regardless of formatting variant ($variant): header 9 vs sub-tallies 5', ({ md }) => {
     const v = findSignalCountViolations(md)
     expect(v).toHaveLength(1)
     expect(v[0]).toMatchObject({ header: 9, sum: 5 })
@@ -138,5 +122,44 @@ describe('findSignalCountViolations', () => {
   * Shape B (3): y
 `
     expect(findSignalCountViolations(md)).toHaveLength(0)
+  })
+
+  // Scan-boundary coverage: sub-tally collection stops at the next
+  // section heading OR the next Signal header. Without these two tests,
+  // dropping either break condition in the guard survives the suite
+  // (verified: a mutation removing the `## ` break passes all other cases).
+
+  it('stops sub-tally collection at the next `## ` heading — bullets in the next section do not leak in', () => {
+    const md = `## 1. First
+
+**Signal:** 4 by shape:
+
+- Shape A (2): x
+- Shape B (2): y
+
+## 2. Unrelated section with its own bullets
+
+- Not a sub-tally of lesson 1 (99): noise
+`
+    // header 4 == 2+2 → consistent; the (99) bullet lives past the `## `
+    // boundary and must not be folded into lesson 1's sum.
+    expect(findSignalCountViolations(md)).toHaveLength(0)
+  })
+
+  it('stops the scan at the next Signal header even with no `## ` between them', () => {
+    const md = `**Signal:** 3 by shape:
+
+- Shape A (1): x
+- Shape B (2): y
+
+**Signal:** 10 by shape:
+
+- Shape C (4): z
+`
+    // First: 3 == 1+2 (clean). Second: 10 != 4 (drift). If the scan didn't
+    // break at the 2nd Signal header, the first would fold in C's 4 too.
+    const v = findSignalCountViolations(md)
+    expect(v).toHaveLength(1)
+    expect(v[0]).toMatchObject({ header: 10, sum: 4 })
   })
 })


### PR DESCRIPTION
## What

The monthly dead-code-watcher compactor lets Claude write `lessons-learned.md` **directly** (via the Edit tool). In run #686 Claude authored a `**Signal:** 14 ...` header whose per-shape sub-tallies summed to **13**; a later compaction (#688, merged this session) had to self-correct it a month on. This PR makes that drift class **impossible to ship**.

## How it activates

- **`signal-count-guard.ts`** (new) — pure fn `findSignalCountViolations(md)` parses `lessons-learned.md` and returns any `**Signal:** N` header whose `- label (K):` sub-tallies don't sum to `N`.
- **`compact.ts`** — after Claude writes the file (and **before** the reviewer-log prune, so a bad file doesn't lose its input), run the guard and `process.exit(1)` on any violation. The compaction run fails → the PR never opens with drift.
- **`compact.md`** — prompt instruction to compute the sum explicitly, noting a post-run gate enforces it. The prompt is the belt; **the code gate is the load-bearing suspenders** — the prompt is exactly what the LLM ignored in #686.

## Scope (deliberate, per grilling)

Header-vs-sub-tally arithmetic **only** — the one drift actually observed. A lone `Signal:` count with no sub-tallies has nothing to cross-check and is left alone. If a lone count ever drifts, *that's* the evidence to justify the larger code-renders-the-file restructure (option X). This is the Y-now-X-later decision: kill the observed class structurally, write the trigger for the unobserved one, don't build bigger blind.

## Verification

- New test pins the exact #686 case (14 vs 6+3+2+1+1=13) + lone-count / inline-prose / multi-lesson / empty cases. **TDD-ordered** (failing-test commit precedes fix).
- Guard **accepts the current #688-corrected `lessons-learned.md`** (passes on good input — doesn't false-positive on the real file).
- Full bots suite **668/668**; TDD contract confirmed (impl-aside → red, restore → green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)