### PR TITLE
docs(bots): sharpen comment-discipline + add malformed-input exercise

### DIFF
--- a/bots/feature-bot/prompts/per-cut.md
+++ b/bots/feature-bot/prompts/per-cut.md
@@ -327,8 +327,13 @@ discovered.
      anchors (local symbol names, line numbers, "the function below",
      example outputs).
    - **No → keep.** Survives only if it states something the code can't:
-     a non-obvious WHY, an externally-imposed constraint, a durable
-     design linkage (design-doc section or `ADR-NNNN`), or a warning.
+     a non-obvious constraint or invariant, an externally-imposed
+     requirement, a durable design linkage (design-doc section or
+     `ADR-NNNN`), or a warning. It must NOT merely argue *why you chose
+     this approach* ("deliberate", "we need", "load-bearing because…") —
+     that rationale belongs in the commit message, not in source; a
+     comment that reads like a line from the PR description is rot-prone
+     by a different name. Delete it.
    - **Resolved TODO/FIXME → remove.**
 
    Comment edits stay in the working tree (still nothing committed).

--- a/bots/fix-bot/prompts/per-issue.md
+++ b/bots/fix-bot/prompts/per-issue.md
@@ -267,14 +267,18 @@ Per project rule \"Don't add features, refactor, or introduce abstractions
 beyond what the task requires\" ([CLAUDE.md](../../CLAUDE.md)): a bug
 fix doesn't need surrounding cleanup.
 
-**Code comments name the WHY only.** If you add a doc comment to a
-new module, function, or constant, the comment captures the rationale
-that's non-obvious from the identifier — not the failure mode,
-historical incident, error message text, or PR-description recap.
-Failure-mode details (e.g. "produces EBADENGINE pointing at
-write-file-atomic") belong in the PR body, not in source.
+**Code comments capture a non-obvious CONSTRAINT, not the RATIONALE
+for a choice.** A comment earns its place when a cold reader would be
+surprised by the code without it — a hidden constraint, subtle
+invariant, workaround, or load-bearing marker. It does NOT argue *why
+you made a decision* ("deliberate", "we need", "the load-bearing half
+because…") — that rationale, like the failure mode, historical
+incident, error-message text, or PR-description recap, belongs in the
+commit message / PR body, not in source. Test: if the comment reads
+like a line from your PR description, delete it.
 Per [CLAUDE.md](../../CLAUDE.md): "Only add a comment when the WHY
-is non-obvious."
+is non-obvious" — and the WHY that belongs in source is a constraint
+the reader can't infer, not a justification for your approach.
 
 Run the test locally to confirm GREEN:
 ```bash
@@ -350,6 +354,11 @@ the fix introduces:
 - Empty / null / undefined for inputs the fix's branches touch
 - Boundary values for any numeric / size / count the fix introduces
 - Each error path the fix's new conditions imply
+- Malformed / valid-but-unanticipated-shape input — when the fix parses
+  or matches a format, feed plausible variants of that format the
+  matcher might not handle (extra whitespace, alternate delimiters,
+  different-but-legal spellings). A parser stricter than its real input
+  silently mishandles the variant; the exercise is where you catch it.
 
 For each edge case the exercise surfaces:
 - **Within fix surface, fix incomplete on this input**: the fix isn't


### PR DESCRIPTION
## What

Two prompt refinements for the generator bots (fix-bot + feature-bot), distilled from this session's `sweep-comments` / `sweep-runtime` runs on the drift-gate work (#690). Applied symmetrically per rule 38.

## Comment discipline — rationale → commit, not comment

Both bots already forbade incident-narrative / failure-mode / PR-recap prose in source. But their *keep*-criteria said "capture the WHY" / "a non-obvious WHY" — without distinguishing:
- **good WHY** = a constraint/invariant the reader can't infer from the code → **keep**
- **bad WHY** = rationale defending a decision ("deliberate", "we need", "the load-bearing half because…") → **delete; goes in the commit**

The `sweep-comments` run this session cut ~36 lines from #690, nearly all of it my own *rationale-defense* prose that the existing keep-criterion would technically have permitted. Tightened both bots' criteria (fix-bot §5, feature-bot §9) with the sharper distinction + the "reads like a PR-description line → delete" test.

## Malformed-input runtime exercise

fix-bot's edge-case exercise list (§5.5) covered empty / null / boundary / error paths but **not valid-but-unanticipated-shape input** — the class where a parser stricter than its real input silently mishandles a variant. `sweep-runtime` found exactly this on #690 (a gate regex missed indented headers + `*`/`+` bullets — all plausible LLM output). Added a bullet steering the exercise to feed plausible format variants when the fix parses/matches a format.

## Scope

Prompt-file (`.md`) edits only — no bot behavior code touched. These encode, as *prevention at the source*, the lessons two interactive sweeps surfaced — rather than adding the mutating sweeps to automated review (coverage is already handled post-merge by the mutation pipeline for core code; comment-bloat is better prevented than reviewed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)