### PR TITLE
style(bots): biome-format knip-parse.test.ts import (unblock format CI)

### DIFF
--- a/bots/dead-code-watcher/tests/knip-parse.test.ts
+++ b/bots/dead-code-watcher/tests/knip-parse.test.ts
@@ -3,7 +3,13 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { filterStableFindings, gitLastModifiedDays, parseKnipReport, rankFindings, type Finding } from '../knip-parse.js'
+import {
+  filterStableFindings,
+  gitLastModifiedDays,
+  parseKnipReport,
+  rankFindings,
+  type Finding,
+} from '../knip-parse.js'
 
 // Most parser tests stub `repoRoot` to a non-git directory → git log
 // returns NaN → findings get filtered out. `gitLastModifiedDays` itself


### PR DESCRIPTION
## What

Wraps a long import line in `bots/dead-code-watcher/tests/knip-parse.test.ts` to the multi-line shape Biome's formatter wants.

## Why

The file landed via #705 (commit `9edf321`) as a single long import line, never run through `npm run format`. Biome's `format:check` CI gate has been **failing on main** since that merge, which surfaces as a `format` failure on every open PR (#708, #709, #711 all show it — they inherit the broken main).

This restores a green format gate. Only change; `npm run format:check` passes (960 files checked, no fixes applied).

## Note

Process miss: #705 was merged while main's format gate was red — its CI green-read didn't include a completed `format` job. Verifying the *complete* status of the *correct* run (rule 34e) before merge would have caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)