### PR TITLE
docs(review-prs): verify fast CI jobs, not just slow-job aggregate

### DIFF
--- a/.claude/skills/review-prs/SKILL.md
+++ b/.claude/skills/review-prs/SKILL.md
@@ -225,6 +225,8 @@ The newest run's `runId` will be the highest number. If all of its jobs show `SU
 
 **Monitor scripts that aggregate "all pass" can produce false-failure signals from cancelled-run artifacts.** When this happens, manually verify with the `runId` grouping above before assuming the PR is broken.
 
+**A green aggregate is not a green gate — verify the fast jobs completed, not just that the slow ones passed.** The `format` job (Biome, ~seconds) is far faster than `test` / `e2e` (minutes). A monitor whose exit condition is "all jobs non-pending" can fire the instant the *slow* jobs settle green — while `format` either hasn't reported yet or has already failed and scrolled past. This bit us: #705 (2026-08) merged with its `format` job red, landing an unformatted file on **main**, which then failed the `format` gate on *every* subsequent PR until a fix-forward (#713) caught it a session later. Before merging a bot PR, confirm the current run's `format` job specifically shows `SUCCESS` — not just that the run has no pending jobs. A red `format` on main is especially costly because it's silent: nothing re-runs main's CI, so it stays red (and blocks every open PR's `format` check) until someone notices. **If several open PRs all show an identical single-job failure, suspect a red gate on main before suspecting the PRs** — check whether that job fails on a fresh `main` checkout (`npm run format:check`), and if so fix-forward on main (via PR) rather than chasing each PR.
+
 ## Recommend merge / close / changes
 
 Before recommending, consider:


### PR DESCRIPTION
## What

Adds a paragraph to `review-prs` SKILL.md's "Reading mixed-run CI status" section: verify the fast `format` job specifically shows `SUCCESS` before merging a bot PR — a monitor exiting on "all jobs non-pending" can fire while `format` hasn't reported or has already failed.

## Why

This `/review-prs` pass discovered main's `format` gate had been **red since #705 merged last session** — #705 landed an unformatted `knip-parse.test.ts` (never run through `npm run format`), and its `format` job failed after the aggregate CI read green. Nothing re-runs main's CI, so it stayed red silently, failing the `format` check on every open PR (#708/#709/#711) until fix-forward #713 caught it.

The insight is a review-prs-specific sharpening of team-preferences rule 34e (verify the complete status of the correct run) — the general rule didn't make the fast-job-fails-after-aggregate-green mechanism salient, and this pass proved that gap costs a full session of silent main-breakage. Captured per the skill's own pass-end self-improvement protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)